### PR TITLE
Added support for delayed delete of dataElements

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>5.2.0</Version>
-    <AssemblyVersion>5.2.0.0</AssemblyVersion>
+    <Version>5.3.0-alpha.1</Version>
+    <AssemblyVersion>5.3.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
     <Description>
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.39" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.10.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -118,7 +118,7 @@ namespace Altinn.App.Api.Controllers
                     return Forbid();
                 }
 
-                bool appLogic = dataTypeFromMetadata.AppLogic != null;
+                bool appLogic = dataTypeFromMetadata.AppLogic?.ClassRef != null;
 
                 Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
                 if (instance == null)
@@ -453,7 +453,7 @@ namespace Altinn.App.Api.Controllers
 
         private async Task<ActionResult> DeleteBinaryData(string org, string app, int instanceOwnerId, Guid instanceGuid, Guid dataGuid)
         {
-            bool successfullyDeleted = await _dataClient.DeleteBinaryData(org, app, instanceOwnerId, instanceGuid, dataGuid);
+            bool successfullyDeleted = await _dataClient.DeleteData(org, app, instanceOwnerId, instanceGuid, dataGuid, false);
 
             if (successfullyDeleted)
             {
@@ -472,7 +472,7 @@ namespace Altinn.App.Api.Controllers
             try
             {
                 Application application = _appResourcesService.GetApplication();
-                appLogic = application.DataTypes.Where(e => e.Id == dataType).Select(e => e.AppLogic != null).First();
+                appLogic = application.DataTypes.Where(e => e.Id == dataType).Select(e => e.AppLogic?.ClassRef != null).First();
             }
             catch (Exception)
             {

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -501,7 +501,7 @@ namespace Altinn.App.Api.Controllers
             Guid sourceInstanceGuid = Guid.Parse(sourceSplit[1]);
 
             List<DataType> dts = application.DataTypes
-                .Where(dt => dt.AppLogic != null)
+                .Where(dt => dt.AppLogic?.ClassRef != null)
                 .Where(dt => dt.TaskId != null && dt.TaskId.Equals(targetInstance.Process.CurrentTask.ElementId))
                 .ToList();
             List<string> excludedDataTypes = application.CopyInstanceSettings.ExcludedDataTypes;
@@ -847,7 +847,7 @@ namespace Altinn.App.Api.Controllers
                 DataType dataType = appInfo.DataTypes.Find(d => d.Id == part.Name);
 
                 DataElement dataElement;
-                if (dataType.AppLogic != null)
+                if (dataType.AppLogic?.ClassRef != null)
                 {
                     _logger.LogInformation($"Storing part {part.Name}");
 

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -11,24 +11,19 @@ using Altinn.App.Common.Process.Elements;
 using Altinn.App.Core.Interface;
 using Altinn.App.Core.Models;
 using Altinn.App.PlatformServices.Helpers;
-using Altinn.App.PlatformServices.Interface;
-using Altinn.App.PlatformServices.Models;
-using Altinn.App.Services.Configuration;
 using Altinn.App.Services.Helpers;
 using Altinn.App.Services.Interface;
 using Altinn.App.Services.Models.Validation;
-
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Helpers;
 using Altinn.Common.PEP.Interfaces;
-using Altinn.Platform.Storage.Interface.Enums;
 using Altinn.Platform.Storage.Interface.Models;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+
 using Newtonsoft.Json;
 
 namespace Altinn.App.Api.Controllers
@@ -300,7 +295,7 @@ namespace Altinn.App.Api.Controllers
 
                 bool authorized = false;
                 if (processSequenceFlowType.Equals(ProcessSequenceFlowType.CompleteCurrentMoveToNext))
-                { 
+                {
                     authorized = await AuthorizeAction(altinnTaskType, org, app, instanceOwnerPartyId, instanceGuid);
                 }
                 else
@@ -333,7 +328,7 @@ namespace Altinn.App.Api.Controllers
                 return ExceptionResponse(exception, "Process next failed.");
             }
         }
-       
+
         /// <summary>
         /// Attemts to end the process by running next until an end event is reached.
         /// Notice that process must have been started.

--- a/src/Altinn.App.Common/Altinn.App.Common.csproj
+++ b/src/Altinn.App.Common/Altinn.App.Common.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>5.2.0</Version>
-    <AssemblyVersion>5.2.0.0</AssemblyVersion>
+    <Version>5.3.0-alpha.1</Version>
+    <AssemblyVersion>5.3.0.0</AssemblyVersion>
     <PackageId>Altinn.App.Common</PackageId>
     <PackageTags>Altinn;Studio;App;Common</PackageTags>
     <Description>
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.10.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.11.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
+++ b/src/Altinn.App.PlatformServices/Altinn.App.PlatformServices.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Version>5.2.0</Version>
-    <AssemblyVersion>5.2.0.0</AssemblyVersion>
+    <Version>5.3.0-alpha.1</Version>
+    <AssemblyVersion>5.3.0.0</AssemblyVersion>
     <PackageId>Altinn.App.PlatformServices</PackageId>
     <PackageTags>Altinn;Studio;App;Services;Platform</PackageTags>
     <Description>
@@ -31,7 +31,7 @@
     <PackageReference Include="Altinn.Common.PEP" Version="1.0.39" />
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.2.0" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.1.1" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.10.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.11.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />

--- a/src/Altinn.App.PlatformServices/Implementation/DataClient.cs
+++ b/src/Altinn.App.PlatformServices/Implementation/DataClient.cs
@@ -243,8 +243,14 @@ namespace Altinn.App.Services.Implementation
         /// <inheritdoc />
         public async Task<bool> DeleteBinaryData(string org, string app, int instanceOwnerPartyId, Guid instanceGuid, Guid dataGuid)
         {
+            return await DeleteData(org, app, instanceOwnerPartyId, instanceGuid, dataGuid, false);
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> DeleteData(string org, string app, int instanceOwnerPartyId, Guid instanceGuid, Guid dataGuid, bool delayed)
+        {
             string instanceIdentifier = $"{instanceOwnerPartyId}/{instanceGuid}";
-            string apiUrl = $"instances/{instanceIdentifier}/data/{dataGuid}";
+            string apiUrl = $"instances/{instanceIdentifier}/data/{dataGuid}?delayed={delayed}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
             HttpResponseMessage response = await _client.DeleteAsync(token, apiUrl);
@@ -254,7 +260,7 @@ namespace Altinn.App.Services.Implementation
                 return true;
             }
 
-            _logger.LogError($"Deleting form attachment {dataGuid} for instance {instanceGuid} failed with status code {response.StatusCode}");
+            _logger.LogError($"Deleting data element {dataGuid} for instance {instanceIdentifier} failed with status code {response.StatusCode}");
             throw await PlatformHttpException.CreateAsync(response);
         }
 

--- a/src/Altinn.App.PlatformServices/Implementation/ValidationAppSI.cs
+++ b/src/Altinn.App.PlatformServices/Implementation/ValidationAppSI.cs
@@ -180,7 +180,7 @@ namespace Altinn.App.Services.Implementation
                 messages.Add(message);
             }
 
-            if (dataType.AppLogic != null)
+            if (dataType.AppLogic?.ClassRef != null)
             {
                 Type modelType = _altinnApp.GetAppModelType(dataType.AppLogic.ClassRef);
                 Guid instanceGuid = Guid.Parse(instance.Id.Split("/")[1]);

--- a/src/Altinn.App.PlatformServices/Interface/IData.cs
+++ b/src/Altinn.App.PlatformServices/Interface/IData.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+
 using Altinn.App.Services.Models;
 using Altinn.Platform.Storage.Interface.Models;
+
 using Microsoft.AspNetCore.Http;
 
 namespace Altinn.App.Services.Interface
@@ -89,7 +91,19 @@ namespace Altinn.App.Services.Interface
         /// <param name="instanceOwnerPartyId">The instance owner id</param>
         /// <param name="instanceGuid">The instance id</param>
         /// <param name="dataGuid">The attachment id</param>
+        [Obsolete("Use method DeleteData with delayed=false instead.")]
         Task<bool> DeleteBinaryData(string org, string app, int instanceOwnerPartyId, Guid instanceGuid, Guid dataGuid);
+        
+        /// <summary>
+        /// Method that removes a data elemen from disk/storage immediatly or marks it as deleted.
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <param name="instanceOwnerPartyId">The instance owner id</param>
+        /// <param name="instanceGuid">The instance id</param>
+        /// <param name="dataGuid">The attachment id</param>
+        /// <param name="delayed">A boolean indicating whether or not the delete should be executed immediately or delayed</param>
+        Task<bool> DeleteData(string org, string app, int instanceOwnerPartyId, Guid instanceGuid, Guid dataGuid, bool delayed);
 
         /// <summary>
         /// Method that saves a form attachments to disk/storage and returns the new data element.
@@ -123,7 +137,7 @@ namespace Altinn.App.Services.Interface
         /// <param name="stream">the stream to stream</param>
         /// <returns></returns>
         Task<DataElement> InsertBinaryData(string instanceId, string dataType, string contentType, string filename, Stream stream);
-        
+
         /// <summary>
         /// Updates the data element metadata object.
         /// </summary>

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -8,7 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.10.0" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />


### PR DESCRIPTION
Moved from app-template-dotnet on behalf of @acn-sbuad.

Original PR: https://github.com/Altinn/app-template-dotnet/pull/98

## Description
- Updated appBase with logic for hardDeleting dataElement on task end
- Removed newtonsoft dependency from DataMockSI
- Cleaned up testdata, ensuring instanceGuid for dataElements

## Related Issue(s)
- #66

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
~~- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~ will be in place before final nugets are pushed
