### PR TITLE
Bugfix/21 pdfservice support repeatinggroups

### DIFF
--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -120,6 +120,7 @@ namespace Altinn.App.Core.Extensions
 
         private static void AddPdfServices(IServiceCollection services)
         {
+            services.TryAddTransient<IPdfOptionsMapping, PdfOptionsMapping>();
             services.TryAddTransient<IPdfService, PdfService>();
 
             // In old versions of the app the PdfHandler did not have an interface and

--- a/src/Altinn.App.Core/Internal/Pdf/IPdfOptionsMapping.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/IPdfOptionsMapping.cs
@@ -1,0 +1,18 @@
+namespace Altinn.App.Core.Internal.Pdf;
+
+/// <summary>
+/// Interface for handling mapping dynamic options to PdfService
+/// </summary>
+public interface IPdfOptionsMapping
+{
+    /// <summary>
+    /// Returns dictinary with options mapping for pdf generation
+    /// </summary>
+    /// <param name="formLayout">formlayout to generate mapping for</param>
+    /// <param name="language">language to fetch mappings for</param>
+    /// <param name="data">instance data</param>
+    /// <param name="instanceId">id of instance</param>
+    /// <returns></returns>
+    public Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout,
+        string language, object data, string instanceId);
+}

--- a/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
@@ -4,15 +4,24 @@ using Newtonsoft.Json.Linq;
 
 namespace Altinn.App.Core.Internal.Pdf;
 
+/// <summary>
+/// Default implementation of IPdfOptionsMapping
+/// </summary>
 public class PdfOptionsMapping: IPdfOptionsMapping
 {
     private readonly IAppOptionsService _appOptionsService;
 
+    /// <summary>
+    /// Create new instance of PdfOptionsMapping
+    /// </summary>
+    /// <param name="appOptionsService"><see cref="IAppOptionsService"/> used to fetch mapped value of option</param>
     public PdfOptionsMapping(IAppOptionsService appOptionsService)
     {
         _appOptionsService = appOptionsService;
     }
     
+    
+    /// <inheritdoc />
     public async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout, string language, object data, string instanceId)
         {
             IEnumerable<JToken> componentsWithOptionsDefined = GetFormComponentsWithOptionsDefined(formLayout);
@@ -95,8 +104,9 @@ public class PdfOptionsMapping: IPdfOptionsMapping
         private static Dictionary<string, string> GetMappingsForComponent(JToken component)
         {
             var maps = new Dictionary<string, string>();
-            foreach (JProperty map in component.SelectToken("mapping").Children())
+            foreach (var jToken in component.SelectToken("mapping")?.Children()!)
             {
+                var map = (JProperty)jToken;
                 maps.Add(map.Name, map.Value.ToString());
             }
 

--- a/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
@@ -1,0 +1,168 @@
+using Altinn.App.Core.Features.Options;
+using Altinn.App.Core.Models;
+using Newtonsoft.Json.Linq;
+
+namespace Altinn.App.Core.Internal.Pdf;
+
+public class PdfOptionsMapping: IPdfOptionsMapping
+{
+    private readonly IAppOptionsService _appOptionsService;
+
+    public PdfOptionsMapping(IAppOptionsService appOptionsService)
+    {
+        _appOptionsService = appOptionsService;
+    }
+    
+    public async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout, string language, object data, string instanceId)
+        {
+            IEnumerable<JToken> componentsWithOptionsDefined = GetFormComponentsWithOptionsDefined(formLayout);
+
+            Dictionary<string, Dictionary<string, string>> dictionary = new Dictionary<string, Dictionary<string, string>>();
+
+            foreach (JToken component in componentsWithOptionsDefined)
+            {
+                string optionsId = component.SelectToken("optionsId").Value<string>();
+                bool hasMappings = component.SelectToken("mapping") != null;
+                var secureToken = component.SelectToken("secure");
+                bool isSecureOptions = secureToken != null && secureToken.Value<bool>();
+                Dictionary<string, List<string>> keyValues = new Dictionary<string, List<string>>();
+                keyValues = hasMappings
+                    ? GetComponentKeyValuePairs(component, data)
+                    : new Dictionary<string, List<string>>();
+
+                await GetMappingsForComponent(language, instanceId, keyValues, isSecureOptions, optionsId, dictionary);
+            }
+
+            return dictionary;
+        }
+
+    private async Task GetMappingsForComponent(string language, string instanceId, Dictionary<string, List<string>> keyValues,
+        bool isSecureOptions, string? optionsId, Dictionary<string, Dictionary<string, string>> dictionary)
+    {
+        var instanceIdentifier = new InstanceIdentifier(instanceId);
+        foreach (var pair in keyValues)
+        {
+            foreach (var value in pair.Value)
+            {
+                AppOptions appOptions;
+                if (isSecureOptions)
+                {
+                    appOptions = await _appOptionsService.GetOptionsAsync(instanceIdentifier, optionsId,
+                        language,
+                        new Dictionary<string, string>() { { pair.Key, value } });
+                }
+                else
+                {
+                    appOptions = await _appOptionsService.GetOptionsAsync(optionsId,
+                        language,
+                        new Dictionary<string, string>() { { pair.Key, value } });
+                }
+
+                if (!dictionary.ContainsKey(optionsId))
+                {
+                    dictionary.Add(optionsId, new Dictionary<string, string>());
+                }
+
+                AppendOptionsToDictionary(dictionary[optionsId], appOptions.Options);
+            }
+        }
+    }
+
+    private static IEnumerable<JToken> GetFormComponentsWithOptionsDefined(string formLayout)
+        {
+            JObject formLayoutObject = JObject.Parse(formLayout);
+
+            // @ = Current object, ?(expression) = Filter, the rest is just dot notation ref. https://goessner.net/articles/JsonPath/
+            return formLayoutObject.SelectTokens("*.data.layout[?(@.optionsId)]");
+        }
+
+        private static Dictionary<string, List<string>> GetComponentKeyValuePairs(JToken component, object data)
+        {
+            var componentKeyValuePairs = new Dictionary<string, List<string>>();
+            JObject jsonData = JObject.FromObject(data);
+
+            Dictionary<string, string> mappings = GetMappingsForComponent(component);
+            foreach (var map in mappings)
+            {
+                var selectedDatas = GetMappingValues(jsonData, map);
+
+                componentKeyValuePairs.Add(map.Value, selectedDatas);
+            }
+
+            return componentKeyValuePairs;
+        }
+
+        private static Dictionary<string, string> GetMappingsForComponent(JToken component)
+        {
+            var maps = new Dictionary<string, string>();
+            foreach (JProperty map in component.SelectToken("mapping").Children())
+            {
+                maps.Add(map.Name, map.Value.ToString());
+            }
+
+            return maps;
+        }
+
+        private static void AppendOptionsToDictionary(Dictionary<string, string> dictionary, List<AppOption> options)
+        {
+            foreach (AppOption item in options)
+            {
+                if (!dictionary.ContainsKey(item.Label))
+                {
+                    dictionary.Add(item.Label, item.Value);
+                }
+            }
+        }
+
+
+        
+        private static List<string> GetMappingValues(JObject jsonData, KeyValuePair<string, string> map, int depth = 0)
+        {
+            int count = 1;
+            if (MappingHasRepeatingGroup(map.Key))
+            {
+                var mappingUntilFirstGroup = GetMappingUntilFirstGroup(map.Key);
+                JToken repeatingGroup = jsonData.SelectToken(mappingUntilFirstGroup);
+                count = repeatingGroup.Children().Count();
+            }
+
+            List<string> selectedDatas = new List<string>();
+            for (var i = 0; i < count; i++)
+            {
+                string replaceText = "{" + depth + "}";
+
+                string select = map.Key.Replace(replaceText, i.ToString());
+                if (MappingHasRepeatingGroup(select))
+                {
+                    selectedDatas.AddRange(GetMappingValues(jsonData,
+                        new KeyValuePair<string, string>(select, map.Value), ++depth));
+                }
+                else
+                {
+                    selectedDatas.Add(jsonData.SelectToken(select).ToString());
+                }
+            }
+
+            return selectedDatas;
+        }
+
+        /// <summary>
+        /// Return true if mapping contains a array replacement start "[{"
+        /// </summary>
+        /// <param name="mapping">Field mapping</param>
+        /// <returns></returns>
+        private static bool MappingHasRepeatingGroup(string mapping)
+        {
+            return mapping.Contains("[{");
+        }
+
+        /// <summary>
+        /// Returns mapping of first element in mapping that is a list with replacement string.
+        /// </summary>
+        /// <param name="mapping"></param>
+        /// <returns></returns>
+        private static string GetMappingUntilFirstGroup(string mapping)
+        {
+            return mapping.Substring(0, mapping.IndexOf("[{"));
+        }
+}

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -10,7 +10,6 @@ using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Http;
-using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -33,7 +33,7 @@ namespace Altinn.App.Core.Internal.Pdf
         /// </summary>
         /// <param name="pdfClient">Client for communicating with the Platform PDF service.</param>
         /// <param name="appResources">The service giving access to local resources.</param>
-        /// <param name="appOptionsService">The service responsible for fetching options.</param>
+        /// <param name="pdfOptionsMapping">The service responsible for mapping options.</param>
         /// <param name="dataClient">The data client.</param>
         /// <param name="httpContextAccessor">The httpContextAccessor</param>
         /// <param name="profileClient">The profile client</param>

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -253,7 +253,7 @@ namespace Altinn.App.Core.Internal.Pdf
             Dictionary<string, string> mappings = GetMappingsForComponent(component);
             foreach (var map in mappings)
             {
-                var selectedDatas = GetMappingValues(jsonData, map, 0);
+                var selectedDatas = GetMappingValues(jsonData, map);
 
                 componentKeyValuePairs.Add(map.Value, selectedDatas);
             }
@@ -285,7 +285,7 @@ namespace Altinn.App.Core.Internal.Pdf
 
 
         
-        private static List<string> GetMappingValues(JObject jsonData, KeyValuePair<string, string> map, int depth, int? parentGroupIndex = null)
+        private static List<string> GetMappingValues(JObject jsonData, KeyValuePair<string, string> map, int depth = 0)
         {
             int count = 1;
             if (MappingHasRepeatingGroup(map.Key))
@@ -304,7 +304,7 @@ namespace Altinn.App.Core.Internal.Pdf
                 if (MappingHasRepeatingGroup(select))
                 {
                     selectedDatas.AddRange(GetMappingValues(jsonData,
-                        new KeyValuePair<string, string>(select, map.Value), ++depth, i));
+                        new KeyValuePair<string, string>(select, map.Value), ++depth));
                 }
                 else
                 {

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -41,9 +41,7 @@ namespace Altinn.App.Core.Internal.Pdf
         /// <param name="profileClient">The profile client</param>
         /// <param name="registerClient">The register client</param>
         /// <param name="pdfFormatter">Class for customizing pdf formatting and layout.</param>
-        public PdfService(IPDF pdfClient, IAppResources appResources, IAppOptionsService appOptionsService,
-            IData dataClient, IHttpContextAccessor httpContextAccessor, IProfile profileClient,
-            IRegister registerClient, IPdfFormatter pdfFormatter)
+        public PdfService(IPDF pdfClient, IAppResources appResources, IAppOptionsService appOptionsService, IData dataClient, IHttpContextAccessor httpContextAccessor, IProfile profileClient, IRegister registerClient, IPdfFormatter pdfFormatter)
         {
             _pdfClient = pdfClient;
             _resourceService = appResources;
@@ -56,8 +54,7 @@ namespace Altinn.App.Core.Internal.Pdf
         }
 
         /// <inheritdoc/>
-        public async Task GenerateAndStoreReceiptPDF(Instance instance, string taskId, DataElement dataElement,
-            Type dataElementModelType)
+        public async Task GenerateAndStoreReceiptPDF(Instance instance, string taskId, DataElement dataElement, Type dataElementModelType)
         {
             string app = instance.AppId.Split("/")[1];
             string org = instance.Org;
@@ -70,13 +67,10 @@ namespace Altinn.App.Core.Internal.Pdf
             if (!string.IsNullOrEmpty(layoutSetsString))
             {
                 layoutSets = JsonConvert.DeserializeObject<LayoutSets>(layoutSetsString);
-                layoutSet = layoutSets.Sets.FirstOrDefault(t =>
-                    t.DataType.Equals(dataElement.DataType) && t.Tasks.Contains(taskId));
+                layoutSet = layoutSets.Sets.FirstOrDefault(t => t.DataType.Equals(dataElement.DataType) && t.Tasks.Contains(taskId));
             }
 
-            string layoutSettingsFileContent = layoutSet == null
-                ? _resourceService.GetLayoutSettingsString()
-                : _resourceService.GetLayoutSettingsStringForSet(layoutSet.Id);
+            string layoutSettingsFileContent = layoutSet == null ? _resourceService.GetLayoutSettingsString() : _resourceService.GetLayoutSettingsStringForSet(layoutSet.Id);
 
             LayoutSettings layoutSettings = null;
             if (!string.IsNullOrEmpty(layoutSettingsFileContent))
@@ -92,8 +86,7 @@ namespace Altinn.App.Core.Internal.Pdf
             layoutSettings.Components ??= new();
             layoutSettings.Components.ExcludeFromPdf ??= new();
 
-            object data = await _dataClient.GetFormData(instanceGuid, dataElementModelType, org, app, instanceOwnerId,
-                new Guid(dataElement.Id));
+            object data = await _dataClient.GetFormData(instanceGuid, dataElementModelType, org, app, instanceOwnerId, new Guid(dataElement.Id));
 
             layoutSettings = await _pdfFormatter.FormatPdf(layoutSettings, data);
             XmlSerializer serializer = new XmlSerializer(dataElementModelType);
@@ -129,9 +122,7 @@ namespace Altinn.App.Core.Internal.Pdf
             }
 
             // If layoutset exists pick correct layotFiles
-            string formLayoutsFileContent = layoutSet == null
-                ? _resourceService.GetLayouts()
-                : _resourceService.GetLayoutsForSet(layoutSet.Id);
+            string formLayoutsFileContent = layoutSet == null ? _resourceService.GetLayouts() : _resourceService.GetLayoutsForSet(layoutSet.Id);
 
             TextResource textResource = await _resourceService.GetTexts(org, app, language);
 
@@ -197,13 +188,11 @@ namespace Altinn.App.Core.Internal.Pdf
             return fileName;
         }
 
-        private async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout,
-            string language, object data, string instanceId)
+        private async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout, string language, object data, string instanceId)
         {
             IEnumerable<JToken> componentsWithOptionsDefined = GetFormComponentsWithOptionsDefined(formLayout);
 
-            Dictionary<string, Dictionary<string, string>> dictionary =
-                new Dictionary<string, Dictionary<string, string>>();
+            Dictionary<string, Dictionary<string, string>> dictionary = new Dictionary<string, Dictionary<string, string>>();
 
             foreach (JToken component in componentsWithOptionsDefined)
             {

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -2,7 +2,6 @@
 using System.Xml.Serialization;
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features;
-using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Helpers.Extensions;
 using Altinn.App.Core.Interface;
 using Altinn.App.Core.Models;
@@ -11,7 +10,6 @@ using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Altinn.App.Core.Internal.Pdf
 {
@@ -22,7 +20,7 @@ namespace Altinn.App.Core.Internal.Pdf
     {
         private readonly IPDF _pdfClient;
         private readonly IAppResources _resourceService;
-        private readonly IAppOptionsService _appOptionsService;
+        private readonly IPdfOptionsMapping _pdfOptionsMapping;
         private readonly IData _dataClient;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IProfile _profileClient;
@@ -41,11 +39,11 @@ namespace Altinn.App.Core.Internal.Pdf
         /// <param name="profileClient">The profile client</param>
         /// <param name="registerClient">The register client</param>
         /// <param name="pdfFormatter">Class for customizing pdf formatting and layout.</param>
-        public PdfService(IPDF pdfClient, IAppResources appResources, IAppOptionsService appOptionsService, IData dataClient, IHttpContextAccessor httpContextAccessor, IProfile profileClient, IRegister registerClient, IPdfFormatter pdfFormatter)
+        public PdfService(IPDF pdfClient, IAppResources appResources, IPdfOptionsMapping pdfOptionsMapping, IData dataClient, IHttpContextAccessor httpContextAccessor, IProfile profileClient, IRegister registerClient, IPdfFormatter pdfFormatter)
         {
             _pdfClient = pdfClient;
             _resourceService = appResources;
-            _appOptionsService = appOptionsService;
+            _pdfOptionsMapping = pdfOptionsMapping;
             _dataClient = dataClient;
             _httpContextAccessor = httpContextAccessor;
             _profileClient = profileClient;
@@ -134,7 +132,7 @@ namespace Altinn.App.Core.Internal.Pdf
 
             string textResourcesString = JsonConvert.SerializeObject(textResource);
             Dictionary<string, Dictionary<string, string>> optionsDictionary =
-                await GetOptionsDictionary(formLayoutsFileContent, language, data, instance.Id);
+                await _pdfOptionsMapping.GetOptionsDictionary(formLayoutsFileContent, language, data, instance.Id);
 
             var pdfContext = new PDFContext
             {
@@ -186,153 +184,6 @@ namespace Altinn.App.Core.Internal.Pdf
         {
             fileName = Uri.EscapeDataString(fileName.AsFileName(false));
             return fileName;
-        }
-
-        private async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout, string language, object data, string instanceId)
-        {
-            IEnumerable<JToken> componentsWithOptionsDefined = GetFormComponentsWithOptionsDefined(formLayout);
-
-            Dictionary<string, Dictionary<string, string>> dictionary = new Dictionary<string, Dictionary<string, string>>();
-
-            foreach (JToken component in componentsWithOptionsDefined)
-            {
-                string optionsId = component.SelectToken("optionsId").Value<string>();
-                bool hasMappings = component.SelectToken("mapping") != null;
-                var secureToken = component.SelectToken("secure");
-                bool isSecureOptions = secureToken != null && secureToken.Value<bool>();
-                Dictionary<string, List<string>> keyValues = new Dictionary<string, List<string>>();
-                keyValues = hasMappings
-                    ? GetComponentKeyValuePairs(component, data)
-                    : new Dictionary<string, List<string>>();
-
-                var instanceIdentifier = new InstanceIdentifier(instanceId);
-                foreach (var pair in keyValues)
-                {
-                    foreach (var value in pair.Value)
-                    {
-                        AppOptions appOptions;
-                        if (isSecureOptions)
-                        {
-                            appOptions = await _appOptionsService.GetOptionsAsync(instanceIdentifier, optionsId,
-                                language,
-                                new Dictionary<string, string>() { { pair.Key, value } });
-                        }
-                        else
-                        {
-                            appOptions = await _appOptionsService.GetOptionsAsync(optionsId,
-                                language,
-                                new Dictionary<string, string>() { { pair.Key, value } });
-                        }
-
-                        if (!dictionary.ContainsKey(optionsId))
-                        {
-                            dictionary.Add(optionsId, new Dictionary<string, string>());
-                        }
-
-                        AppendOptionsToDictionary(dictionary[optionsId], appOptions.Options);
-                    }
-                }
-            }
-
-            return dictionary;
-        }
-
-        private static IEnumerable<JToken> GetFormComponentsWithOptionsDefined(string formLayout)
-        {
-            JObject formLayoutObject = JObject.Parse(formLayout);
-
-            // @ = Current object, ?(expression) = Filter, the rest is just dot notation ref. https://goessner.net/articles/JsonPath/
-            return formLayoutObject.SelectTokens("*.data.layout[?(@.optionsId)]");
-        }
-
-        private static Dictionary<string, List<string>> GetComponentKeyValuePairs(JToken component, object data)
-        {
-            var componentKeyValuePairs = new Dictionary<string, List<string>>();
-            JObject jsonData = JObject.FromObject(data);
-
-            Dictionary<string, string> mappings = GetMappingsForComponent(component);
-            foreach (var map in mappings)
-            {
-                var selectedDatas = GetMappingValues(jsonData, map);
-
-                componentKeyValuePairs.Add(map.Value, selectedDatas);
-            }
-
-            return componentKeyValuePairs;
-        }
-
-        private static Dictionary<string, string> GetMappingsForComponent(JToken component)
-        {
-            var maps = new Dictionary<string, string>();
-            foreach (JProperty map in component.SelectToken("mapping").Children())
-            {
-                maps.Add(map.Name, map.Value.ToString());
-            }
-
-            return maps;
-        }
-
-        private static void AppendOptionsToDictionary(Dictionary<string, string> dictionary, List<AppOption> options)
-        {
-            foreach (AppOption item in options)
-            {
-                if (!dictionary.ContainsKey(item.Label))
-                {
-                    dictionary.Add(item.Label, item.Value);
-                }
-            }
-        }
-
-
-        
-        private static List<string> GetMappingValues(JObject jsonData, KeyValuePair<string, string> map, int depth = 0)
-        {
-            int count = 1;
-            if (MappingHasRepeatingGroup(map.Key))
-            {
-                var mappingUntilFirstGroup = GetMappingUntilFirstGroup(map.Key);
-                JToken repeatingGroup = jsonData.SelectToken(mappingUntilFirstGroup);
-                count = repeatingGroup.Children().Count();
-            }
-
-            List<string> selectedDatas = new List<string>();
-            for (var i = 0; i < count; i++)
-            {
-                string replaceText = "{" + depth + "}";
-
-                string select = map.Key.Replace(replaceText, i.ToString());
-                if (MappingHasRepeatingGroup(select))
-                {
-                    selectedDatas.AddRange(GetMappingValues(jsonData,
-                        new KeyValuePair<string, string>(select, map.Value), ++depth));
-                }
-                else
-                {
-                    selectedDatas.Add(jsonData.SelectToken(select).ToString());
-                }
-            }
-
-            return selectedDatas;
-        }
-
-        /// <summary>
-        /// Return true if mapping contains a array replacement start "[{"
-        /// </summary>
-        /// <param name="mapping">Field mapping</param>
-        /// <returns></returns>
-        private static bool MappingHasRepeatingGroup(string mapping)
-        {
-            return mapping.Contains("[{");
-        }
-
-        /// <summary>
-        /// Returns mapping of first element in mapping that is a list with replacement string.
-        /// </summary>
-        /// <param name="mapping"></param>
-        /// <returns></returns>
-        private static string GetMappingUntilFirstGroup(string mapping)
-        {
-            return mapping.Substring(0, mapping.IndexOf("[{"));
         }
     }
 }

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -41,6 +41,12 @@
     <ProjectReference Include="..\..\src\Altinn.App.Core\Altinn.App.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Internal\Pdf\TestData\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <CodeAnalysisRuleSet>..\..\Altinn3.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfOptionsMappingTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfOptionsMappingTests.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using Altinn.App.Core.Internal.Pdf;
+using Altinn.App.Core.Internal.Pdf.TestDoubles;
+using FluentAssertions;
+using Xunit;
+
+namespace Altinn.App.PlatformServices.Tests.Internal.Pdf;
+
+public class PdfOptionsMappingTests
+{
+    [Fact]
+    public async void GetOptionsDictionary_returns_dictionary_for_options()
+    {
+        IPdfOptionsMapping pdfOptionsMapping = new PdfOptionsMapping(new AppOptionsDouble());
+        string formlayout = File.ReadAllText(Path.Combine("Internal", "Pdf", "TestData", "formlayout.json"));
+        object o = ReadTestData();
+
+        var res = await pdfOptionsMapping.GetOptionsDictionary(formlayout, "nb", o, "512345/cab39d95-7439-4ecb-b908-2fb3726d9295");
+        res.Count.Should().Be(2);
+        res.Should().ContainKeys("tags", "repdropdown");
+        res["tags"].Count.Should().Be(1);
+        res["tags"].Should().ContainKey("name");
+        res["tags"]["name"].Should().Be("Default-tags-nb");
+        res["repdropdown"].Count.Should().Be(1);
+        res["repdropdown"].Should().ContainKey("val");
+        res["repdropdown"]["val"].Should().Be("1-repdropdown-nb");
+    }
+
+    private object ReadTestData()
+    {
+        System.Xml.Serialization.XmlSerializer reader = new System.Xml.Serialization.XmlSerializer(typeof(Skjema));
+        using (StreamReader file = new System.IO.StreamReader(Path.Combine("Internal", "Pdf", "TestData", "data.xml")))
+        {
+            Skjema s = (Skjema)reader.Deserialize(file);
+            file.Close();
+            return s;
+        }
+    }
+}

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfOptionsMappingTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfOptionsMappingTests.cs
@@ -26,7 +26,7 @@ public class PdfOptionsMappingTests
         res["repdropdown"]["val"].Should().Be("1-repdropdown-nb");
     }
 
-    private object ReadTestData()
+    private static object ReadTestData()
     {
         System.Xml.Serialization.XmlSerializer reader = new System.Xml.Serialization.XmlSerializer(typeof(Skjema));
         using (StreamReader file = new System.IO.StreamReader(Path.Combine("Internal", "Pdf", "TestData", "data.xml")))

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/data.xml
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/data.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Skjema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <melding>
+    <name>Default</name>
+    <tags>designer</tags>
+    <simple_list>
+      <simple_keyvalues>
+        <key>selfdanger</key>
+        <doubleValue>0</doubleValue>
+        <intValue>1</intValue>
+      </simple_keyvalues>
+      <simple_keyvalues>
+        <key>developer</key>
+        <doubleValue>0</doubleValue>
+        <intValue>2</intValue>
+      </simple_keyvalues>
+    </simple_list>
+    <nested_list>
+      <values>
+        <key>cowboy</key>
+        <doubleValue>0</doubleValue>
+        <intValue>1</intValue>
+      </values>
+      <values>
+        <key>operator</key>
+        <doubleValue>0</doubleValue>
+        <intValue>4</intValue>
+      </values>
+    </nested_list>
+    <toggle>false</toggle>
+  </melding>
+</Skjema>

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/formlayout.json
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/formlayout.json
@@ -1,0 +1,86 @@
+{
+  "Data": {
+    "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+    "data": {
+      "layout": [
+        {
+          "id": "d0b52a5e-3c81-4672-ac8a-1aebcb0164e5",
+          "type": "Group",
+          "children": [
+            "b115d943-43b2-424a-b5ec-3f555779c30g",
+            "0f292c95-b6be-4031-80a4-b580f0625419"
+          ],
+          "maxCount": 2,
+          "dataModelBindings": {
+            "group": "melding.nested_list"
+          }
+        },
+        {
+          "id": "b115d943-43b2-424a-b5ec-3f555779c30g",
+          "type": "Dropdown",
+          "textResourceBindings": {
+            "title": "tags"
+          },
+          "dataModelBindings": {
+            "simpleBinding": "melding.nested_list.key"
+          },
+          "required": true,
+          "readOnly": false,
+          "optionsId": "tags",
+          "mapping": {
+            "melding.name": "name"
+          }
+        },
+        {
+          "id": "0f292c95-b6be-4031-80a4-b580f0625419",
+          "type": "Group",
+          "children": [
+            "b115d943-43b2-424a-b5ec-3f555779c30d",
+            "62548aca-ac5f-4ff4-a445-e9817a5e5f47"
+          ],
+          "maxCount": 2,
+          "dataModelBindings": {
+            "group": "melding.nested_list.values"
+          }
+        },
+        {
+          "id": "b115d943-43b2-424a-b5ec-3f555779c30d",
+          "type": "Input",
+          "textResourceBindings": {
+            "title": "number"
+          },
+          "dataModelBindings": {
+            "simpleBinding": "melding.nested_list.values.intValue"
+          },
+          "required": true,
+          "readOnly": false
+        },
+        {
+          "id": "62548aca-ac5f-4ff4-a445-e9817a5e5f47",
+          "type": "Dropdown",
+          "textResourceBindings": {
+            "title": "dropdown"
+          },
+          "dataModelBindings": {
+            "simpleBinding": "melding.nested_list.values.key"
+          },
+          "required": true,
+          "optionsId": "repdropdown",
+          "mapping": {
+            "melding.nested_list[{0}].values[{1}].intValue": "val"
+          }
+        },
+        {
+          "id": "4d163b5d-2a97-45d1-98f4-f2afaf367bb0",
+          "type": "NavigationButtons",
+          "textResourceBindings": {
+            "next": "next",
+            "back": "back"
+          },
+          "dataModelBindings": {},
+          "showBackButton": true
+        }
+      ]
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/AppOptionsDouble.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/AppOptionsDouble.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Altinn.App.Core.Features.Options;
+using Altinn.App.Core.Models;
+
+namespace Altinn.App.Core.Internal.Pdf.TestDoubles;
+
+public class AppOptionsDouble: IAppOptionsService
+{
+    public async Task<AppOptions> GetOptionsAsync(string optionId, string language, Dictionary<string, string> keyValuePairs)
+    {
+        List<AppOption> options = new List<AppOption>();
+        foreach (var pair in keyValuePairs)
+        {
+            options.Add(new AppOption()
+            {
+                Label = pair.Key,
+                Value = $"{pair.Value}-{optionId}-{language}"
+            });
+        }
+
+        return await Task.FromResult(new AppOptions()
+        {
+            Options = options,
+            IsCacheable = false
+        });
+    }
+
+    public async Task<AppOptions> GetOptionsAsync(InstanceIdentifier instanceIdentifier, string optionId, string language, Dictionary<string, string> keyValuePairs)
+    {
+        List<AppOption> options = new List<AppOption>();
+        foreach (var pair in keyValuePairs)
+        {
+            options.Add(new AppOption()
+            {
+                Label = pair.Key,
+                Value = $"{instanceIdentifier}-{pair.Value}-{optionId}-{language}"
+            });
+        }
+
+        return await Task.FromResult(new AppOptions()
+        {
+            Options = options,
+            IsCacheable = false
+        });
+    }
+}

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/Skjema.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/Skjema.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Newtonsoft.Json;
+
+namespace Altinn.App.Core.Internal.Pdf.TestDoubles;
+public class Skjema
+  {
+    [XmlElement("melding", Order = 1)]
+    [JsonProperty("melding")]
+    [JsonPropertyName("melding")]
+    public Dummy Melding { get; set; }
+
+  }
+
+  public class Dummy
+  {
+    [XmlElement("name", Order = 1)]
+    [JsonProperty("name")]
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [XmlElement("random", Order = 2)]
+    [JsonProperty("random")]
+    [JsonPropertyName("random")]
+    public string Random { get; set; }
+
+    [XmlElement("tags", Order = 3)]
+    [JsonProperty("tags")]
+    [JsonPropertyName("tags")]
+    public string Tags { get; set; }
+
+    [XmlElement("simple_list", Order = 4)]
+    [JsonProperty("simple_list")]
+    [JsonPropertyName("simple_list")]
+    public ValuesList SimpleList { get; set; }
+
+    [XmlElement("nested_list", Order = 5)]
+    [JsonProperty("nested_list")]
+    [JsonPropertyName("nested_list")]
+    public List<Nested> NestedList { get; set; }
+
+    [XmlElement("toggle", Order = 6)]
+    [JsonProperty("toggle")]
+    [JsonPropertyName("toggle")]
+    public bool Toggle { get; set; }
+
+  }
+
+  public class ValuesList
+  {
+    [XmlElement("simple_keyvalues", Order = 1)]
+    [JsonProperty("simple_keyvalues")]
+    [JsonPropertyName("simple_keyvalues")]
+    public List<SimpleKeyvalues> SimpleKeyvalues { get; set; }
+
+  }
+
+  public class SimpleKeyvalues
+  {
+    [XmlElement("key", Order = 1)]
+    [JsonProperty("key")]
+    [JsonPropertyName("key")]
+    public string Key { get; set; }
+
+    [XmlElement("doubleValue", Order = 2)]
+    [JsonProperty("doubleValue")]
+    [JsonPropertyName("doubleValue")]
+    public decimal DoubleValue { get; set; }
+
+    [Range(int.MinValue,int.MaxValue)]
+    [XmlElement("intValue", Order = 3)]
+    [JsonProperty("intValue")]
+    [JsonPropertyName("intValue")]
+    public decimal IntValue { get; set; }
+
+  }
+
+  public class Nested
+  {
+    [XmlElement("key", Order = 1)]
+    [JsonProperty("key")]
+    [JsonPropertyName("key")]
+    public string Key { get; set; }
+
+    [XmlElement("values", Order = 2)]
+    [JsonProperty("values")]
+    [JsonPropertyName("values")]
+    public List<SimpleKeyvalues> Values { get; set; }
+
+  }

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/Skjema.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/Skjema.cs
@@ -12,7 +12,6 @@ public class Skjema
     [JsonProperty("melding")]
     [JsonPropertyName("melding")]
     public Dummy Melding { get; set; }
-
   }
 
   public class Dummy
@@ -46,7 +45,6 @@ public class Skjema
     [JsonProperty("toggle")]
     [JsonPropertyName("toggle")]
     public bool Toggle { get; set; }
-
   }
 
   public class ValuesList
@@ -55,7 +53,6 @@ public class Skjema
     [JsonProperty("simple_keyvalues")]
     [JsonPropertyName("simple_keyvalues")]
     public List<SimpleKeyvalues> SimpleKeyvalues { get; set; }
-
   }
 
   public class SimpleKeyvalues
@@ -75,7 +72,6 @@ public class Skjema
     [JsonProperty("intValue")]
     [JsonPropertyName("intValue")]
     public decimal IntValue { get; set; }
-
   }
 
   public class Nested
@@ -89,5 +85,4 @@ public class Skjema
     [JsonProperty("values")]
     [JsonPropertyName("values")]
     public List<SimpleKeyvalues> Values { get; set; }
-
   }


### PR DESCRIPTION
## Description
Having dynamic options inside a repeating group caused the PDFService to fail.
This bugfix handles the replacement of index placeholders.

## Related Issue(s)
- #21 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
