### PR TITLE
Repeating group fix for PDF broke options without mappings (static codelists) in PDF

### DIFF
--- a/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
@@ -20,23 +20,26 @@ public class PdfOptionsMapping : IPdfOptionsMapping
     {
         _appOptionsService = appOptionsService;
     }
-    
-    
+
+
     /// <inheritdoc />
-    public async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout, string language, object data, string instanceId)
+    public async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout,
+        string language, object data, string instanceId)
     {
         IEnumerable<JToken> componentsWithOptionsDefined = GetFormComponentsWithOptionsDefined(formLayout);
 
-        Dictionary<string, Dictionary<string, string>> dictionary = new Dictionary<string, Dictionary<string, string>>();
+        Dictionary<string, Dictionary<string, string>>
+            dictionary = new Dictionary<string, Dictionary<string, string>>();
 
         foreach (JToken component in componentsWithOptionsDefined)
         {
-            string optionsId = component.SelectToken("optionsId").Value<string>();
+            string? optionsId = component.SelectToken("optionsId")?.Value<string>();
+            if (optionsId == null)
+                break;
             bool hasMappings = component.SelectToken("mapping") != null;
             var secureToken = component.SelectToken("secure");
             bool isSecureOptions = secureToken != null && secureToken.Value<bool>();
-            Dictionary<string, List<string>> keyValues = new Dictionary<string, List<string>>();
-            keyValues = hasMappings
+            Dictionary<string, List<string>> keyValues = hasMappings
                 ? GetComponentKeyValuePairs(component, data)
                 : new Dictionary<string, List<string>>();
 
@@ -48,7 +51,7 @@ public class PdfOptionsMapping : IPdfOptionsMapping
 
     private async Task GetMappingsForComponent(string language, string instanceId,
         Dictionary<string, List<string>> mappings,
-        bool isSecureOptions, string? optionsId, Dictionary<string, Dictionary<string, string>> dictionary)
+        bool isSecureOptions, string optionsId, Dictionary<string, Dictionary<string, string>> dictionary)
     {
         if (!dictionary.ContainsKey(optionsId))
         {

--- a/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
@@ -23,25 +23,21 @@ public class PdfOptionsMapping : IPdfOptionsMapping
 
 
     /// <inheritdoc />
-    public async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout,
-        string language, object data, string instanceId)
+    public async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout, string language, object data, string instanceId)
     {
         IEnumerable<JToken> componentsWithOptionsDefined = GetFormComponentsWithOptionsDefined(formLayout);
 
-        Dictionary<string, Dictionary<string, string>>
-            dictionary = new Dictionary<string, Dictionary<string, string>>();
+        Dictionary<string, Dictionary<string, string>> dictionary = new Dictionary<string, Dictionary<string, string>>();
 
         foreach (JToken component in componentsWithOptionsDefined)
         {
             string? optionsId = component.SelectToken("optionsId")?.Value<string>();
             if (optionsId == null)
-                break;
+                continue;
             bool hasMappings = component.SelectToken("mapping") != null;
             var secureToken = component.SelectToken("secure");
             bool isSecureOptions = secureToken != null && secureToken.Value<bool>();
-            Dictionary<string, List<string>> keyValues = hasMappings
-                ? GetComponentKeyValuePairs(component, data)
-                : new Dictionary<string, List<string>>();
+            Dictionary<string, List<string>> keyValues = hasMappings ? GetComponentKeyValuePairs(component, data) : new Dictionary<string, List<string>>();
 
             await GetMappingsForComponent(language, instanceId, keyValues, isSecureOptions, optionsId, dictionary);
         }
@@ -49,9 +45,7 @@ public class PdfOptionsMapping : IPdfOptionsMapping
         return dictionary;
     }
 
-    private async Task GetMappingsForComponent(string language, string instanceId,
-        Dictionary<string, List<string>> mappings,
-        bool isSecureOptions, string optionsId, Dictionary<string, Dictionary<string, string>> dictionary)
+    private async Task GetMappingsForComponent(string language, string instanceId, Dictionary<string, List<string>> mappings, bool isSecureOptions, string optionsId, Dictionary<string, Dictionary<string, string>> dictionary)
     {
         if (!dictionary.ContainsKey(optionsId))
         {
@@ -61,8 +55,7 @@ public class PdfOptionsMapping : IPdfOptionsMapping
         var instanceIdentifier = new InstanceIdentifier(instanceId);
         if (mappings.IsNullOrEmpty())
         {
-            AppOptions appOptions = await GetOptions(isSecureOptions, instanceIdentifier, optionsId, language,
-                new Dictionary<string, string>());
+            AppOptions appOptions = await GetOptions(isSecureOptions, instanceIdentifier, optionsId, language, new Dictionary<string, string>());
             AppendOptionsToDictionary(dictionary[optionsId], appOptions.Options);
             return;
         }
@@ -71,29 +64,22 @@ public class PdfOptionsMapping : IPdfOptionsMapping
         {
             foreach (var value in pair.Value)
             {
-                AppOptions appOptions = await GetOptions(isSecureOptions, instanceIdentifier, optionsId, language,
-                    new Dictionary<string, string>() { { pair.Key, value } });
+                AppOptions appOptions = await GetOptions(isSecureOptions, instanceIdentifier, optionsId, language, new Dictionary<string, string>() { { pair.Key, value } });
 
                 AppendOptionsToDictionary(dictionary[optionsId], appOptions.Options);
             }
         }
     }
 
-    private async Task<AppOptions> GetOptions(bool isSecure, InstanceIdentifier instanceIdentifier, string optionsId,
-        string language,
-        Dictionary<string, string> mappings)
+    private async Task<AppOptions> GetOptions(bool isSecure, InstanceIdentifier instanceIdentifier, string optionsId, string language, Dictionary<string, string> mappings)
     {
         if (isSecure)
         {
-            return await _appOptionsService.GetOptionsAsync(instanceIdentifier, optionsId,
-                language,
-                mappings);
+            return await _appOptionsService.GetOptionsAsync(instanceIdentifier, optionsId, language, mappings);
         }
         else
         {
-            return await _appOptionsService.GetOptionsAsync(optionsId,
-                language,
-                mappings);
+            return await _appOptionsService.GetOptionsAsync(optionsId, language, mappings);
         }
     }
 
@@ -163,8 +149,7 @@ public class PdfOptionsMapping : IPdfOptionsMapping
             string select = map.Key.Replace(replaceText, i.ToString());
             if (MappingHasRepeatingGroup(select))
             {
-                selectedDatas.AddRange(GetMappingValues(jsonData,
-                    new KeyValuePair<string, string>(select, map.Value), depth + 1));
+                selectedDatas.AddRange(GetMappingValues(jsonData, new KeyValuePair<string, string>(select, map.Value), depth + 1));
             }
             else
             {

--- a/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Models;
+using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Linq;
 
 namespace Altinn.App.Core.Internal.Pdf;
@@ -7,7 +8,7 @@ namespace Altinn.App.Core.Internal.Pdf;
 /// <summary>
 /// Default implementation of IPdfOptionsMapping
 /// </summary>
-public class PdfOptionsMapping: IPdfOptionsMapping
+public class PdfOptionsMapping : IPdfOptionsMapping
 {
     private readonly IAppOptionsService _appOptionsService;
 
@@ -23,156 +24,171 @@ public class PdfOptionsMapping: IPdfOptionsMapping
     
     /// <inheritdoc />
     public async Task<Dictionary<string, Dictionary<string, string>>> GetOptionsDictionary(string formLayout, string language, object data, string instanceId)
+    {
+        IEnumerable<JToken> componentsWithOptionsDefined = GetFormComponentsWithOptionsDefined(formLayout);
+
+        Dictionary<string, Dictionary<string, string>> dictionary = new Dictionary<string, Dictionary<string, string>>();
+
+        foreach (JToken component in componentsWithOptionsDefined)
         {
-            IEnumerable<JToken> componentsWithOptionsDefined = GetFormComponentsWithOptionsDefined(formLayout);
+            string optionsId = component.SelectToken("optionsId").Value<string>();
+            bool hasMappings = component.SelectToken("mapping") != null;
+            var secureToken = component.SelectToken("secure");
+            bool isSecureOptions = secureToken != null && secureToken.Value<bool>();
+            Dictionary<string, List<string>> keyValues = new Dictionary<string, List<string>>();
+            keyValues = hasMappings
+                ? GetComponentKeyValuePairs(component, data)
+                : new Dictionary<string, List<string>>();
 
-            Dictionary<string, Dictionary<string, string>> dictionary = new Dictionary<string, Dictionary<string, string>>();
-
-            foreach (JToken component in componentsWithOptionsDefined)
-            {
-                string optionsId = component.SelectToken("optionsId").Value<string>();
-                bool hasMappings = component.SelectToken("mapping") != null;
-                var secureToken = component.SelectToken("secure");
-                bool isSecureOptions = secureToken != null && secureToken.Value<bool>();
-                Dictionary<string, List<string>> keyValues = new Dictionary<string, List<string>>();
-                keyValues = hasMappings
-                    ? GetComponentKeyValuePairs(component, data)
-                    : new Dictionary<string, List<string>>();
-
-                await GetMappingsForComponent(language, instanceId, keyValues, isSecureOptions, optionsId, dictionary);
-            }
-
-            return dictionary;
+            await GetMappingsForComponent(language, instanceId, keyValues, isSecureOptions, optionsId, dictionary);
         }
 
-    private async Task GetMappingsForComponent(string language, string instanceId, Dictionary<string, List<string>> keyValues,
+        return dictionary;
+    }
+
+    private async Task GetMappingsForComponent(string language, string instanceId,
+        Dictionary<string, List<string>> mappings,
         bool isSecureOptions, string? optionsId, Dictionary<string, Dictionary<string, string>> dictionary)
     {
+        if (!dictionary.ContainsKey(optionsId))
+        {
+            dictionary.Add(optionsId, new Dictionary<string, string>());
+        }
+
         var instanceIdentifier = new InstanceIdentifier(instanceId);
-        foreach (var pair in keyValues)
+        if (mappings.IsNullOrEmpty())
+        {
+            AppOptions appOptions = await GetOptions(isSecureOptions, instanceIdentifier, optionsId, language,
+                new Dictionary<string, string>());
+            AppendOptionsToDictionary(dictionary[optionsId], appOptions.Options);
+            return;
+        }
+
+        foreach (var pair in mappings)
         {
             foreach (var value in pair.Value)
             {
-                AppOptions appOptions;
-                if (isSecureOptions)
-                {
-                    appOptions = await _appOptionsService.GetOptionsAsync(instanceIdentifier, optionsId,
-                        language,
-                        new Dictionary<string, string>() { { pair.Key, value } });
-                }
-                else
-                {
-                    appOptions = await _appOptionsService.GetOptionsAsync(optionsId,
-                        language,
-                        new Dictionary<string, string>() { { pair.Key, value } });
-                }
-
-                if (!dictionary.ContainsKey(optionsId))
-                {
-                    dictionary.Add(optionsId, new Dictionary<string, string>());
-                }
+                AppOptions appOptions = await GetOptions(isSecureOptions, instanceIdentifier, optionsId, language,
+                    new Dictionary<string, string>() { { pair.Key, value } });
 
                 AppendOptionsToDictionary(dictionary[optionsId], appOptions.Options);
             }
         }
     }
 
+    private async Task<AppOptions> GetOptions(bool isSecure, InstanceIdentifier instanceIdentifier, string optionsId,
+        string language,
+        Dictionary<string, string> mappings)
+    {
+        if (isSecure)
+        {
+            return await _appOptionsService.GetOptionsAsync(instanceIdentifier, optionsId,
+                language,
+                mappings);
+        }
+        else
+        {
+            return await _appOptionsService.GetOptionsAsync(optionsId,
+                language,
+                mappings);
+        }
+    }
+
     private static IEnumerable<JToken> GetFormComponentsWithOptionsDefined(string formLayout)
-        {
-            JObject formLayoutObject = JObject.Parse(formLayout);
+    {
+        JObject formLayoutObject = JObject.Parse(formLayout);
 
-            // @ = Current object, ?(expression) = Filter, the rest is just dot notation ref. https://goessner.net/articles/JsonPath/
-            return formLayoutObject.SelectTokens("*.data.layout[?(@.optionsId)]");
+        // @ = Current object, ?(expression) = Filter, the rest is just dot notation ref. https://goessner.net/articles/JsonPath/
+        return formLayoutObject.SelectTokens("*.data.layout[?(@.optionsId)]");
+    }
+
+    private static Dictionary<string, List<string>> GetComponentKeyValuePairs(JToken component, object data)
+    {
+        var componentKeyValuePairs = new Dictionary<string, List<string>>();
+        JObject jsonData = JObject.FromObject(data);
+
+        Dictionary<string, string> mappings = GetMappingsForComponent(component);
+        foreach (var map in mappings)
+        {
+            var selectedDatas = GetMappingValues(jsonData, map);
+
+            componentKeyValuePairs.Add(map.Value, selectedDatas);
         }
 
-        private static Dictionary<string, List<string>> GetComponentKeyValuePairs(JToken component, object data)
-        {
-            var componentKeyValuePairs = new Dictionary<string, List<string>>();
-            JObject jsonData = JObject.FromObject(data);
+        return componentKeyValuePairs;
+    }
 
-            Dictionary<string, string> mappings = GetMappingsForComponent(component);
-            foreach (var map in mappings)
+    private static Dictionary<string, string> GetMappingsForComponent(JToken component)
+    {
+        var maps = new Dictionary<string, string>();
+        foreach (var jToken in component.SelectToken("mapping")?.Children()!)
+        {
+            var map = (JProperty)jToken;
+            maps.Add(map.Name, map.Value.ToString());
+        }
+
+        return maps;
+    }
+
+    private static void AppendOptionsToDictionary(Dictionary<string, string> dictionary, List<AppOption> options)
+    {
+        foreach (AppOption item in options)
+        {
+            if (!dictionary.ContainsKey(item.Label))
             {
-                var selectedDatas = GetMappingValues(jsonData, map);
-
-                componentKeyValuePairs.Add(map.Value, selectedDatas);
+                dictionary.Add(item.Label, item.Value);
             }
+        }
+    }
 
-            return componentKeyValuePairs;
+
+    private static List<string> GetMappingValues(JObject jsonData, KeyValuePair<string, string> map, int depth = 0)
+    {
+        int count = 1;
+        if (MappingHasRepeatingGroup(map.Key))
+        {
+            var mappingUntilFirstGroup = GetMappingUntilFirstGroup(map.Key);
+            JToken repeatingGroup = jsonData.SelectToken(mappingUntilFirstGroup);
+            count = repeatingGroup.Children().Count();
         }
 
-        private static Dictionary<string, string> GetMappingsForComponent(JToken component)
+        List<string> selectedDatas = new List<string>();
+        for (var i = 0; i < count; i++)
         {
-            var maps = new Dictionary<string, string>();
-            foreach (var jToken in component.SelectToken("mapping")?.Children()!)
+            string replaceText = "{" + depth + "}";
+
+            string select = map.Key.Replace(replaceText, i.ToString());
+            if (MappingHasRepeatingGroup(select))
             {
-                var map = (JProperty)jToken;
-                maps.Add(map.Name, map.Value.ToString());
+                selectedDatas.AddRange(GetMappingValues(jsonData,
+                    new KeyValuePair<string, string>(select, map.Value), depth + 1));
             }
-
-            return maps;
-        }
-
-        private static void AppendOptionsToDictionary(Dictionary<string, string> dictionary, List<AppOption> options)
-        {
-            foreach (AppOption item in options)
+            else
             {
-                if (!dictionary.ContainsKey(item.Label))
-                {
-                    dictionary.Add(item.Label, item.Value);
-                }
+                selectedDatas.Add(jsonData.SelectToken(select).ToString());
             }
         }
 
+        return selectedDatas;
+    }
 
-        
-        private static List<string> GetMappingValues(JObject jsonData, KeyValuePair<string, string> map, int depth = 0)
-        {
-            int count = 1;
-            if (MappingHasRepeatingGroup(map.Key))
-            {
-                var mappingUntilFirstGroup = GetMappingUntilFirstGroup(map.Key);
-                JToken repeatingGroup = jsonData.SelectToken(mappingUntilFirstGroup);
-                count = repeatingGroup.Children().Count();
-            }
+    /// <summary>
+    /// Return true if mapping contains a array replacement start "[{"
+    /// </summary>
+    /// <param name="mapping">Field mapping</param>
+    /// <returns></returns>
+    private static bool MappingHasRepeatingGroup(string mapping)
+    {
+        return mapping.Contains("[{");
+    }
 
-            List<string> selectedDatas = new List<string>();
-            for (var i = 0; i < count; i++)
-            {
-                string replaceText = "{" + depth + "}";
-
-                string select = map.Key.Replace(replaceText, i.ToString());
-                if (MappingHasRepeatingGroup(select))
-                {
-                    selectedDatas.AddRange(GetMappingValues(jsonData,
-                        new KeyValuePair<string, string>(select, map.Value), ++depth));
-                }
-                else
-                {
-                    selectedDatas.Add(jsonData.SelectToken(select).ToString());
-                }
-            }
-
-            return selectedDatas;
-        }
-
-        /// <summary>
-        /// Return true if mapping contains a array replacement start "[{"
-        /// </summary>
-        /// <param name="mapping">Field mapping</param>
-        /// <returns></returns>
-        private static bool MappingHasRepeatingGroup(string mapping)
-        {
-            return mapping.Contains("[{");
-        }
-
-        /// <summary>
-        /// Returns mapping of first element in mapping that is a list with replacement string.
-        /// </summary>
-        /// <param name="mapping"></param>
-        /// <returns></returns>
-        private static string GetMappingUntilFirstGroup(string mapping)
-        {
-            return mapping.Substring(0, mapping.IndexOf("[{"));
-        }
+    /// <summary>
+    /// Returns mapping of first element in mapping that is a list with replacement string.
+    /// </summary>
+    /// <param name="mapping"></param>
+    /// <returns></returns>
+    private static string GetMappingUntilFirstGroup(string mapping)
+    {
+        return mapping.Substring(0, mapping.IndexOf("[{"));
+    }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfOptionsMappingTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfOptionsMappingTests.cs
@@ -9,11 +9,11 @@ namespace Altinn.App.PlatformServices.Tests.Internal.Pdf;
 public class PdfOptionsMappingTests
 {
     [Fact]
-    public async void GetOptionsDictionary_returns_dictionary_for_options()
+    public async void GetOptionsDictionary_returns_dictionary_for_options_with_mapping()
     {
         IPdfOptionsMapping pdfOptionsMapping = new PdfOptionsMapping(new AppOptionsDouble());
         string formlayout = File.ReadAllText(Path.Combine("Internal", "Pdf", "TestData", "formlayout.json"));
-        object o = ReadTestData();
+        object o = ReadTestData("data.xml");
 
         var res = await pdfOptionsMapping.GetOptionsDictionary(formlayout, "nb", o, "512345/cab39d95-7439-4ecb-b908-2fb3726d9295");
         res.Count.Should().Be(2);
@@ -25,11 +25,26 @@ public class PdfOptionsMappingTests
         res["repdropdown"].Should().ContainKey("val");
         res["repdropdown"]["val"].Should().Be("1-repdropdown-nb");
     }
+    
+    [Fact]
+    public async void GetOptionsDictionary_returns_dictionary_for_options_without_mapping()
+    {
+        IPdfOptionsMapping pdfOptionsMapping = new PdfOptionsMapping(new AppOptionsDouble());
+        string formlayout = File.ReadAllText(Path.Combine("Internal", "Pdf", "TestData", "formlayout-nomapping.json"));
+        object o = ReadTestData("data-nomapping.xml");
 
-    private static object ReadTestData()
+        var res = await pdfOptionsMapping.GetOptionsDictionary(formlayout, "nb", o, "512345/cab39d95-7439-4ecb-b908-2fb3726d9295");
+        res.Count.Should().Be(1);
+        res.Should().ContainKeys("fylker");
+        res["fylker"].Count.Should().Be(1);
+        res["fylker"].Should().ContainKey("no-mapping");
+        res["fylker"]["no-mapping"].Should().Be("fylker-nb");
+    }
+
+    private static object ReadTestData(string datafile)
     {
         System.Xml.Serialization.XmlSerializer reader = new System.Xml.Serialization.XmlSerializer(typeof(Skjema));
-        using (StreamReader file = new System.IO.StreamReader(Path.Combine("Internal", "Pdf", "TestData", "data.xml")))
+        using (StreamReader file = new System.IO.StreamReader(Path.Combine("Internal", "Pdf", "TestData", datafile)))
         {
             Skjema s = (Skjema)reader.Deserialize(file);
             file.Close();

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/data-nomapping.xml
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/data-nomapping.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Skjema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <melding>
+    <name>Default</name>
+    <tags>designer</tags>
+    <nested_list>
+      <key>18</key>
+    </nested_list>
+    <nested_list>
+      <key>19</key>
+    </nested_list>
+    <toggle>false</toggle>
+  </melding>
+</Skjema>

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/data.xml
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/data.xml
@@ -16,6 +16,20 @@
       </simple_keyvalues>
     </simple_list>
     <nested_list>
+      <key>1</key>
+      <values>
+        <key>cowboy</key>
+        <doubleValue>0</doubleValue>
+        <intValue>1</intValue>
+      </values>
+      <values>
+        <key>operator</key>
+        <doubleValue>0</doubleValue>
+        <intValue>4</intValue>
+      </values>
+    </nested_list>
+    <nested_list>
+      <key>2</key>
       <values>
         <key>cowboy</key>
         <doubleValue>0</doubleValue>

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/formlayout-nomapping.json
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestData/formlayout-nomapping.json
@@ -1,0 +1,33 @@
+{
+  "Data": {
+    "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+    "data": {
+      "layout": [
+        {
+          "id": "d0b52a5e-3c81-4672-ac8a-1aebcb0164e5",
+          "type": "Group",
+          "children": [
+            "b115d943-43b2-424a-b5ec-3f555779c30g"
+          ],
+          "maxCount": 2,
+          "dataModelBindings": {
+            "group": "melding.nested_list"
+          }
+        },
+        {
+          "id": "b115d943-43b2-424a-b5ec-3f555779c30g",
+          "type": "Dropdown",
+          "textResourceBindings": {
+            "title": "fylker"
+          },
+          "dataModelBindings": {
+            "simpleBinding": "melding.nested_list.key"
+          },
+          "required": true,
+          "readOnly": false,
+          "optionsId": "fylker"
+        }
+      ]
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/AppOptionsDouble.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/AppOptionsDouble.cs
@@ -2,15 +2,25 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Models;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Altinn.App.Core.Internal.Pdf.TestDoubles;
 
 public class AppOptionsDouble: IAppOptionsService
 {
-    public async Task<AppOptions> GetOptionsAsync(string optionId, string language, Dictionary<string, string> keyValuePairs)
+    public async Task<AppOptions> GetOptionsAsync(string optionId, string language, Dictionary<string, string> mappings)
     {
         List<AppOption> options = new List<AppOption>();
-        foreach (var pair in keyValuePairs)
+        if (mappings.IsNullOrEmpty())
+        {
+            options.Add(new AppOption()
+            {
+                Label = "no-mapping",
+                Value = $"{optionId}-{language}"
+            });
+        }
+        
+        foreach (var pair in mappings)
         {
             options.Add(new AppOption()
             {


### PR DESCRIPTION
This fixes two bugs introduced in PDF "fix"
- Repeating group fix broke options without mappings (static codelists)
- Tests revealed unintended side effects when making recursive call

Tests updated to test for both errors

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #21 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
