### PR TITLE
Add interface for Process Task start to allow apps to add custom logic

### DIFF
--- a/src/Altinn.App.Core/Features/IProcessTaskStart.cs
+++ b/src/Altinn.App.Core/Features/IProcessTaskStart.cs
@@ -1,0 +1,17 @@
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.Core.Features;
+
+/// <summary>
+/// IProcessTaskStart defines a implementation for running logic when a task starts in the apps process
+/// </summary>
+public interface IProcessTaskStart
+{
+    /// <summary>
+    /// Method for defining custom logic when a process task is started
+    /// </summary>
+    /// <param name="taskId">The taskId</param>
+    /// <param name="instance">The instance</param>
+    /// <param name="prefill">Prefill data</param>
+    public Task Start(string taskId, Instance instance, Dictionary<string, string> prefill);   
+}

--- a/src/Altinn.App.Core/Implementation/DefaultTaskEvents.cs
+++ b/src/Altinn.App.Core/Implementation/DefaultTaskEvents.cs
@@ -23,6 +23,7 @@ public class DefaultTaskEvents : ITaskEvents
     private readonly IAppModel _appModel;
     private readonly IInstantiationProcessor _instantiationProcessor;
     private readonly IInstance _instanceClient;
+    private readonly IEnumerable<IProcessTaskStart> _taskStarts;
     private readonly IEnumerable<IProcessTaskEnd> _taskEnds;
     private readonly IEnumerable<IProcessTaskAbandon> _taskAbandons;
     private readonly IPdfService _pdfService;
@@ -40,6 +41,7 @@ public class DefaultTaskEvents : ITaskEvents
         IAppModel appModel,
         IInstantiationProcessor instantiationProcessor,
         IInstance instanceClient,
+        IEnumerable<IProcessTaskStart> taskStarts,
         IEnumerable<IProcessTaskEnd> taskEnds,
         IEnumerable<IProcessTaskAbandon> taskAbandons,
         IPdfService pdfService,
@@ -53,6 +55,7 @@ public class DefaultTaskEvents : ITaskEvents
         _appModel = appModel;
         _instantiationProcessor = instantiationProcessor;
         _instanceClient = instanceClient;
+        _taskStarts = taskStarts;
         _taskEnds = taskEnds;
         _taskAbandons = taskAbandons;
         _pdfService = pdfService;
@@ -64,6 +67,11 @@ public class DefaultTaskEvents : ITaskEvents
     public async Task OnStartProcessTask(string taskId, Instance instance, Dictionary<string, string> prefill)
     {
         _logger.LogInformation($"OnStartProcessTask for {instance.Id}");
+
+        foreach (var taskStart in _taskStarts)
+        {
+            await taskStart.Start(taskId, instance, prefill);
+        }
 
         // If this is a revisit to a previous task we need to unlock data
         foreach (DataType dataType in _appMetadata.DataTypes.Where(dt => dt.TaskId == taskId))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make it possible to add custom logic on process task start before default logic in process is executed.

Follows the same pattern as for Process Task end and abandon

## Related Issue(s)
- #32 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
