### PR TITLE
Configure renovate to add dependency label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>Altinn/renovate-config"
-  ]
+  ],
+  "labels": ["dependency"]
 }


### PR DESCRIPTION
Autogenerated releasenotes categorises PRs by labels. Renovate PRs should have the dependency label.
