### PR TITLE
Add logging of exception and stacktrace if the Eformidling startup service fails

### DIFF
--- a/src/Altinn.App.Core/EFormidling/EformidlingStartup.cs
+++ b/src/Altinn.App.Core/EFormidling/EformidlingStartup.cs
@@ -36,9 +36,9 @@ namespace Altinn.App.Core.EFormidling
                 _logger.LogInformation("Successfully subscribed to event {eventType} for app {appIdentifier}. Subscription {subscriptionId} is being used.", eventType, _appIdentifier, subscription.Id);
             }
 
-            catch
+            catch (Exception ex)
             {
-                _logger.LogError("Unable to subscribe to event {eventType} for app {appIdentifier}", eventType, _appIdentifier);
+                _logger.LogError("Unable to subscribe to event {eventType} for app {appIdentifier}. Received exception {exceptionMessage} with {stackTrace}", eventType, _appIdentifier, ex.Message, ex.StackTrace);
                 throw;
             }
         }


### PR DESCRIPTION
Adds more logging in case the startup fails as the exception thrown doesn't seem to be logged when the application starts.

## Related Issue(s)
- #49 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
