### PR TITLE
Remove EventSubscription http client from setup. 

### DIFF
--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -65,7 +65,6 @@ namespace Altinn.App.Core.Extensions
             services.AddHttpClient<IER, RegisterERClient>();
             services.AddHttpClient<IInstance, InstanceClient>();
             services.AddHttpClient<IInstanceEvent, InstanceEventClient>();
-            services.AddHttpClient<IEventsSubscription, EventsSubscriptionClient>();
             services.AddHttpClient<IEvents, EventsClient>();
             services.AddHttpClient<IPDF, PDFClient>();
             services.AddHttpClient<IProfile, ProfileClient>();


### PR DESCRIPTION
This needs to be configured in the applicatin with the appropriate message handler for authentication. The current setup caused the registration to be overwritten, resulting in an unauthenticated call to Events Service.

## Related Issue(s)
- #49

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
