### PR TITLE
Backend dynamics cleanup

### DIFF
--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -376,15 +376,9 @@ namespace Altinn.App.Core.Implementation
             foreach (var page in order)
             {
                 var pageBytes = File.ReadAllBytes(Path.Join(folder, page + ".json"));
-                var options = new JsonSerializerOptions()
-                {
-                    // This is the default behaviour from Newtonsoft
-                    AllowTrailingCommas = true,
-                    ReadCommentHandling = JsonCommentHandling.Skip,
-                };
-                // Somewhat ugly (but thread safe) way to pass the page name to the deserializer compoent by associating it with a specific options instance.
-                PageComponentConverter.AddPageName(options, page);
-                layoutModel.Pages[page] = System.Text.Json.JsonSerializer.Deserialize<PageComponent>(pageBytes.RemoveBom(), options) ?? throw new InvalidDataException(page + ".json is \"null\"");
+                // Set the PageName using AsyncLocal before deserializing.
+                PageComponentConverter.SetAsyncLocalPageName(page);
+                layoutModel.Pages[page] = System.Text.Json.JsonSerializer.Deserialize<PageComponent>(pageBytes.RemoveBom(), new JsonSerializerOptions(JsonSerializerDefaults.Web)) ?? throw new InvalidDataException(page + ".json is \"null\"");
             }
 
             return layoutModel;

--- a/src/Altinn.App.Core/Models/Layout/LayoutModel.cs
+++ b/src/Altinn.App.Core/Models/Layout/LayoutModel.cs
@@ -8,7 +8,6 @@ namespace Altinn.App.Core.Models.Layout;
 /// <summary>
 /// Class for handeling a full layout/layoutset
 /// </summary>
-[JsonConverter(typeof(LayoutModelConverter))]
 public class LayoutModel
 {
     /// <summary>

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/ContextListRoot.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/ContextListRoot.cs
@@ -27,6 +27,7 @@ public class ContextListRoot
     public string Name { get; set; } = default!;
 
     [JsonPropertyName("layouts")]
+    [JsonConverter(typeof(LayoutModelConverterFromObject))]
     public LayoutModel ComponentModel { get; set; } = default!;
 
     [JsonPropertyName("dataModel")]

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/ExpressionTestCaseRoot.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/ExpressionTestCaseRoot.cs
@@ -42,6 +42,7 @@ public class ExpressionTestCaseRoot
     public string? ExpectsFailure { get; set; }
 
     [JsonPropertyName("layouts")]
+    [JsonConverter(typeof(LayoutModelConverterFromObject))]
     public LayoutModel ComponentModel { get; set; } = default!;
 
     [JsonPropertyName("dataModel")]

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/LayoutModelConverterFromObject.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/LayoutModelConverterFromObject.cs
@@ -2,10 +2,12 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using Altinn.App.Core.Helpers.Extensions;
-using Altinn.App.Core.Models.Layout.Components;
 using Altinn.App.Core.Models.Expressions;
+using Altinn.App.Core.Models.Layout;
+using Altinn.App.Core.Models.Layout.Components;
 
-namespace Altinn.App.Core.Models.Layout;
+namespace Altinn.App.Core.Tests.LayoutExpressions;
+
 /// <summary>
 /// Custom converter for parsing Layout files in json format to <see cref="LayoutModel" />
 /// </summary>
@@ -14,9 +16,8 @@ namespace Altinn.App.Core.Models.Layout;
 /// standard json parser to convert to an object graph. Using <see cref="Utf8JsonReader"/>
 /// directly I can convert to a more suitable C# representation directly
 /// </remarks>
-public class LayoutModelConverter : JsonConverter<LayoutModel>
+public class LayoutModelConverterFromObject : JsonConverter<LayoutModel>
 {
-
     /// <inheritdoc />
     public override LayoutModel? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -24,7 +25,9 @@ public class LayoutModelConverter : JsonConverter<LayoutModel>
         {
             throw new JsonException();
         }
+
         var componentModel = new LayoutModel();
+
         // Read dictionary of pages
         while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
         {
@@ -32,18 +35,15 @@ public class LayoutModelConverter : JsonConverter<LayoutModel>
             {
                 throw new JsonException(); //Think this is impossible. After a JsonTokenType.StartObject, everything should be JsonTokenType.PropertyName
             }
+
             var pageName = reader.GetString()!;
             reader.Read();
 
-            var pageOptions = new JsonSerializerOptions(options);
-            // Somewhat ugly (but thread safe) way to pass the page name to the deserializer compoent by associating it with a specific options instance.
-            PageComponentConverter.AddPageName(pageOptions, pageName);
+            PageComponentConverter.SetAsyncLocalPageName(pageName);
             var converter = new PageComponentConverter();
 
-            componentModel.Pages[pageName] = converter.ReadNotNull(ref reader, pageName, pageOptions);
+            componentModel.Pages[pageName] = converter.ReadNotNull(ref reader, pageName, options);
         }
-
-
 
         return componentModel;
     }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/LayoutTestUtils.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/LayoutTestUtils.cs
@@ -31,10 +31,9 @@ public static class LayoutTestUtils
             var layout = await File.ReadAllBytesAsync(layoutFile);
             string pageName = layoutFile.Replace(layoutsPath + "/", string.Empty).Replace(".json", string.Empty);
 
-            var pageOptions = new JsonSerializerOptions();
+            var pageOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
 
-            // Somewhat ugly (but thread safe) way to pass the page name to the deserializer compoent by associating it with a specific options instance.
-            PageComponentConverter.AddPageName(pageOptions, pageName);
+            PageComponentConverter.SetAsyncLocalPageName(pageName);
 
             layoutModel.Pages[pageName] = JsonSerializer.Deserialize<PageComponent>(layout.RemoveBom(), pageOptions)!;
         }


### PR DESCRIPTION
No hurry to relase, but this is required when apps start using dotnet 7 version of `System.Text.Json`

[Use AyncLocal instead of ConditionalWeakTable to set PageName](https://github.com/Altinn/app-lib-dotnet/commit/cbf7975a1e397b43a73bfd615c84485c4c9b4995) 

The json for a page does not contain the page name, so it needs to be
passed in a different way to the page constructor. ConditionalWeakTable
with the JsonSerializerOptions does not seem to work in dotnet 7.

I also happened to notice that `LayoutModelConverter` was only used in the Tests project, so I moved it.