### PR TITLE
Expressions: Tests for `dataModel` lookups against arrays and null

### DIFF
--- a/test/Altinn.App.Core.Tests/Helpers/JsonDataModel.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/JsonDataModel.cs
@@ -45,7 +45,9 @@ public class JsonDataModel : IDataModelAccessor
                 JsonValueKind.Number => currentModel.GetDouble(),
                 JsonValueKind.True => true,
                 JsonValueKind.False => false,
-                JsonValueKind.Object => null, // TODO: Verify correct
+                JsonValueKind.Object => null,
+                JsonValueKind.Array => null,
+                JsonValueKind.Null => null,
                 _ => throw new NotImplementedException($"Get Data is not implemented for {currentModel.ValueKind}"),
             };
         }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/dataModel/array-is-null.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/dataModel/array-is-null.json
@@ -1,0 +1,32 @@
+{
+  "name": "Looking up an array returns null",
+  "expression": ["dataModel", "a"],
+  "expects": null,
+  "dataModel": {
+    "a": [
+      {
+        "value": "ABC"
+      },
+      {
+        "other": "DEF"
+      }
+    ]
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/dataModel/null-is-null.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/dataModel/null-is-null.json
@@ -1,0 +1,25 @@
+{
+  "name": "Looking up null returns null",
+  "expression": ["dataModel", "a"],
+  "expects": null,
+  "dataModel": {
+    "a": null
+  },
+  "layouts": {
+    "Page1": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "current-component",
+            "type": "Paragraph"
+          }
+        ]
+      }
+    }
+  },
+  "context": {
+    "component": "current-component",
+    "currentLayout": "Page1"
+  }
+}


### PR DESCRIPTION
## Description
These lookups should return `null` as long as we don't have support for these data types in expressions (yet).

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/pull/696

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
  - https://github.com/Altinn/altinn-studio-docs/pull/749
