### PR TITLE
Add a few convenience implementations for UpdateDataValues on IInstance interface

### DIFF
--- a/src/Altinn.App.Core/Interface/IInstance.cs
+++ b/src/Altinn.App.Core/Interface/IInstance.cs
@@ -1,3 +1,4 @@
+using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.Extensions.Primitives;
 
@@ -103,9 +104,8 @@ namespace Altinn.App.Core.Interface
         /// <returns>Returns the updated instance.</returns>
         async Task<Instance> UpdateDataValues(Instance instance, Dictionary<string, string?> dataValues)
         {
-            var instanceOwnerPartyId = int.Parse(instance.Id.Split("/")[0]);
-            var instanceGuid = Guid.Parse(instance.Id.Split("/")[1]);
-            return await UpdateDataValues(instanceOwnerPartyId, instanceGuid, new DataValues{Values = dataValues});
+            var id = new InstanceIdentifier(instance);
+            return await UpdateDataValues(id.InstanceOwnerPartyId, id.InstanceGuid, new DataValues{Values = dataValues});
         }
 
         /// <summary>

--- a/src/Altinn.App.Core/Interface/IInstance.cs
+++ b/src/Altinn.App.Core/Interface/IInstance.cs
@@ -93,6 +93,37 @@ namespace Altinn.App.Core.Interface
         Task<Instance> UpdateDataValues(int instanceOwnerPartyId, Guid instanceGuid, DataValues dataValues);
 
         /// <summary>
+        /// Update data data values.
+        /// </summary>
+        /// <remarks>
+        /// The provided data value will be added with the existing collection of data values on the instance.
+        /// </remarks>
+        /// <param name="instance">The instance</param>
+        /// <param name="dataValues">The data value (null unsets the value)</param>
+        /// <returns>Returns the updated instance.</returns>
+        async Task<Instance> UpdateDataValues(Instance instance, Dictionary<string, string?> dataValues)
+        {
+            var instanceOwnerPartyId = int.Parse(instance.Id.Split("/")[0]);
+            var instanceGuid = Guid.Parse(instance.Id.Split("/")[1]);
+            return await UpdateDataValues(instanceOwnerPartyId, instanceGuid, new DataValues{Values = dataValues});
+        }
+
+        /// <summary>
+        /// Update single data value.
+        /// </summary>
+        /// <remarks>
+        /// The provided data value will be added with the existing collection of data values on the instance.
+        /// </remarks>
+        /// <param name="instance">The instance</param>
+        /// <param name="key">The key of the DataValues collection to be updated.</param>
+        /// <param name="value">The data value (null unsets the value)</param>
+        /// <returns>Returns the updated instance.</returns>
+        async Task<Instance> UpdateDataValue(Instance instance, string key, string? value)
+        {
+            return await UpdateDataValues(instance, new Dictionary<string, string?>{{key, value}});
+        }
+
+        /// <summary>
         /// Delete instance.
         /// </summary>
         /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>

--- a/src/Altinn.App.Core/Models/InstanceIdentifier.cs
+++ b/src/Altinn.App.Core/Models/InstanceIdentifier.cs
@@ -1,3 +1,5 @@
+using Altinn.Platform.Storage.Interface.Models;
+
 namespace Altinn.App.Core.Models
 {
     /// <summary>
@@ -26,6 +28,12 @@ namespace Altinn.App.Core.Models
             (InstanceOwnerPartyId, InstanceGuid) = DeconstructInstanceId(instanceId);
             IsNoInstance = false;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstanceIdentifier"/> class.
+        /// </summary>
+        /// <param name="instance">Is the instance you want to get an idenifier from</param>
+        public InstanceIdentifier(Instance instance) : this(instance.Id) {}
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstanceIdentifier"/> class. For instances without OwnerPartyId and InstanceId, ex: Stateless applications.


### PR DESCRIPTION
Updating `DataValues` on an instance requires rather ugly code in `DataProcessWrite`

```c#
   var instanceOwnerPartyId = int.Parse(instance.Id.Split("/")[0]);
   var instanceGuid = Guid.Parse(instance.Id.Split("/")[1]);
   var dataValues = new Dictionary<string, string?>{{key, value}};
   return await _instanceClient.UpdateDataValues(instanceOwnerPartyId, instanceGuid, new DataValues{Values = dataValues});
```

This PR is intended to simplify the code required, so that it can be written

```c#
    return await _instanceClient.UpdateDataValue(instance, "key", value);
```
Or if you want to update multiple values
```c#
    var dataValues = new Dictionary<string, string?>()
    {
        {"key1", value1},
        {"key2", value2},
    }
    return await _instanceClient.UpdateDataValues(instance, dataValues);
```

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
