### PR TITLE
Bug: Ensure that layouts are loaded from the correct location

### DIFF
--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -365,7 +365,7 @@ namespace Altinn.App.Core.Implementation
         /// <inheritdoc />
         public LayoutModel GetLayoutModel(string? layoutSetId = null)
         {
-            string folder = Path.Join(_settings.AppBasePath, _settings.UiFolder, layoutSetId);
+            string folder = Path.Join(_settings.AppBasePath, _settings.UiFolder, layoutSetId, "layouts");
             var order = GetLayoutSettingsForSet(layoutSetId)?.Pages?.Order;
             if (order is null)
             {


### PR DESCRIPTION
Seems like the full tests was lacking, so the file path somehow ended up being wrong.

This issue prevents validation and submission of apps, when `RemoveHiddenDataPreview` is active, so it would be nice if a new version can be made available on nuget pretty quick.