### PR TITLE
Ensure that ValidationIssue.Field respects [JsonPropertyName]

### DIFF
--- a/src/Altinn.App.Core/Features/Validation/ValidationAppSI.cs
+++ b/src/Altinn.App.Core/Features/Validation/ValidationAppSI.cs
@@ -221,7 +221,7 @@ namespace Altinn.App.Core.Features.Validation
                 // Add the validation messages from System.ComponentModel.DataAnnotations and IInstanceValidator to the return list
                 if (!validationResults.IsValid)
                 {
-                    messages.AddRange(MapModelStateToIssueList(actionContext.ModelState, instance, dataElement.Id, data));
+                    messages.AddRange(MapModelStateToIssueList(actionContext.ModelState, instance, dataElement.Id, data.GetType()));
                 }
 
             }
@@ -233,7 +233,7 @@ namespace Altinn.App.Core.Features.Validation
             ModelStateDictionary modelState,
             Instance instance,
             string dataElementId,
-            object data)
+            Type modelType)
         {
             List<ValidationIssue> validationIssues = new List<ValidationIssue>();
 
@@ -251,7 +251,7 @@ namespace Altinn.App.Core.Features.Validation
                             InstanceId = instance.Id,
                             DataElementId = dataElementId,
                             Code = severityAndMessage.Message,
-                            Field = ModelKeyToField(modelKey, data.GetType())!,
+                            Field = ModelKeyToField(modelKey, modelType)!,
                             Severity = severityAndMessage.Severity,
                             Description = severityAndMessage.Message
                         });

--- a/src/Altinn.App.Core/Features/Validation/ValidationAppSI.cs
+++ b/src/Altinn.App.Core/Features/Validation/ValidationAppSI.cs
@@ -262,7 +262,12 @@ namespace Altinn.App.Core.Features.Validation
             return validationIssues;
         }
 
-        // Will be obsolete when updating to net70 or higher and activating https://learn.microsoft.com/en-us/aspnet/core/mvc/models/validation?view=aspnetcore-7.0#use-json-property-names-in-validation-errors
+        /// <summary>
+        /// Translate the ModelKey from validation to a field that respects [JsonPropertyName] annotations
+        /// </summary>
+        /// <remarks>
+        ///  Will be obsolete when updating to net70 or higher and activating https://learn.microsoft.com/en-us/aspnet/core/mvc/models/validation?view=aspnetcore-7.0#use-json-property-names-in-validation-errors
+        /// </remarks>
         public static string? ModelKeyToField(string? modelKey, Type data)
         {
             var keyParts = modelKey?.Split('.', 2);
@@ -307,7 +312,6 @@ namespace Altinn.App.Core.Features.Validation
                 return $"{jsonPropertyName}.{rest}";
             }
             return $"{jsonPropertyName}.{ModelKeyToField(rest, childType)}";
-
         }
 
         private List<ValidationIssue> MapModelStateToIssueList(ModelStateDictionary modelState, Instance instance)

--- a/test/Altinn.App.Core.Tests/Features/Validators/ValidationAppSITests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/ValidationAppSITests.cs
@@ -1,0 +1,147 @@
+#nullable enable
+using System.Text.Json.Serialization;
+
+using Altinn.App.Core.Features.Validation;
+using FluentAssertions;
+using Xunit;
+
+namespace Altinn.App.Core.Tests.Features.Validators;
+
+public class ValidationAppSITests
+{
+    [Fact]
+    public void ModelKeyToField_NullInputWithoutType_ReturnsNull()
+    {
+        ValidationAppSI.ModelKeyToField(null, null!).Should().BeNull();
+    }
+
+    [Fact]
+    public void ModelKeyToField_StringInputWithoutType_ReturnsSameString()
+    {
+        ValidationAppSI.ModelKeyToField("null", null!).Should().Be("null");
+    }
+
+    public class TestModel
+    {
+        [JsonPropertyName("level1")]
+        public string FirstLevelProp { get; set; } = default!;
+
+        [JsonPropertyName("sub")]
+        public SubTestModel SubTestModel { get; set; } = default!;
+
+        [JsonPropertyName("subnull")]
+        public SubTestModel? SubTestModelNull { get; set; } = default!;
+
+        [JsonPropertyName("subList")]
+        public List<SubTestModel> SubTestModelList { get; set; } = default!;
+    }
+
+    public class SubTestModel
+    {
+        [JsonPropertyName("decimal")]
+        public decimal DecimalNumber { get; set; } = default!;
+
+        [JsonPropertyName("nullableString")]
+        public string? StringNullable { get; set; } = default!;
+
+        [JsonPropertyName("decimalList")]
+        public List<decimal> ListOfDecimal { get; set; } = default!;
+
+        [JsonPropertyName("nullableDecimalList")]
+        public List<decimal?> ListOfNullableDecimal { get; set; } = default!;
+
+        [JsonPropertyName("subList")]
+        public List<SubTestModel> SubTestModelList { get; set; } = default!;
+    }
+
+    [Fact]
+    public void ModelKeyToField_NullInput_ReturnsNull()
+    {
+        ValidationAppSI.ModelKeyToField(null, typeof(TestModel)).Should().BeNull();
+    }
+
+    [Fact]
+    public void ModelKeyToField_StringInput_ReturnsSameString()
+    {
+        ValidationAppSI.ModelKeyToField("null", typeof(TestModel)).Should().Be("null");
+    }
+    
+    [Fact]
+    public void ModelKeyToField_StringInputWithAttr_ReturnsMappedString()
+    {
+        ValidationAppSI.ModelKeyToField("FirstLevelProp", typeof(TestModel)).Should().Be("level1");
+    }
+    
+    [Fact]
+    public void ModelKeyToField_SubModel_ReturnsMappedString()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModel.DecimalNumber", typeof(TestModel)).Should().Be("sub.decimal");
+    }
+
+    [Fact]
+    public void ModelKeyToField_SubModelNullable_ReturnsMappedString()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModel.StringNullable", typeof(TestModel)).Should().Be("sub.nullableString");
+    }
+
+    [Fact]
+    public void ModelKeyToField_SubModelWithSubmodel_ReturnsMappedString()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModel.StringNullable", typeof(TestModel)).Should().Be("sub.nullableString");
+    }
+
+    [Fact]
+    public void ModelKeyToField_SubModelNull_ReturnsMappedString()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModelNull.DecimalNumber", typeof(TestModel)).Should().Be("subnull.decimal");
+    }
+
+    [Fact]
+    public void ModelKeyToField_SubModelNullNullable_ReturnsMappedString()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModelNull.StringNullable", typeof(TestModel)).Should().Be("subnull.nullableString");
+    }
+
+    [Fact]
+    public void ModelKeyToField_SubModelNullWithSubmodel_ReturnsMappedString()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModelNull.StringNullable", typeof(TestModel)).Should().Be("subnull.nullableString");
+    }
+
+    // Test lists
+    [Fact]
+    public void ModelKeyToField_List_IgnoresMissingIndex()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModelList.StringNullable", typeof(TestModel)).Should().Be("subList.nullableString");
+    }
+
+    [Fact]
+    public void ModelKeyToField_List_ProxiesIndex()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModelList[123].StringNullable", typeof(TestModel)).Should().Be("subList[123].nullableString");
+    }
+
+    [Fact]
+    public void ModelKeyToField_ListOfList_ProxiesIndex()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModelList[123].ListOfDecimal[5]", typeof(TestModel)).Should().Be("subList[123].decimalList[5]");
+    }
+
+    [Fact]
+    public void ModelKeyToField_ListOfList_IgnoresMissing()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModelList[123].ListOfDecimal", typeof(TestModel)).Should().Be("subList[123].decimalList");
+    }
+
+    [Fact]
+    public void ModelKeyToField_ListOfListNullable_IgnoresMissing()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModelList[123].ListOfNullableDecimal", typeof(TestModel)).Should().Be("subList[123].nullableDecimalList");
+    }
+
+    [Fact]
+    public void ModelKeyToField_ListOfListOfListNullable_IgnoresMissingButPropagatesOthers()
+    {
+        ValidationAppSI.ModelKeyToField("SubTestModelList[123].SubTestModelList.ListOfNullableDecimal[123456]", typeof(TestModel)).Should().Be("subList[123].subList.nullableDecimalList[123456]");
+    }
+}

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/Skjema.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/TestDoubles/Skjema.cs
@@ -7,15 +7,15 @@ using Newtonsoft.Json;
 
 namespace Altinn.App.Core.Internal.Pdf.TestDoubles;
 public class Skjema
-  {
+{
     [XmlElement("melding", Order = 1)]
     [JsonProperty("melding")]
     [JsonPropertyName("melding")]
     public Dummy Melding { get; set; }
-  }
+}
 
-  public class Dummy
-  {
+public class Dummy
+{
     [XmlElement("name", Order = 1)]
     [JsonProperty("name")]
     [JsonPropertyName("name")]
@@ -45,18 +45,18 @@ public class Skjema
     [JsonProperty("toggle")]
     [JsonPropertyName("toggle")]
     public bool Toggle { get; set; }
-  }
+}
 
-  public class ValuesList
-  {
+public class ValuesList
+{
     [XmlElement("simple_keyvalues", Order = 1)]
     [JsonProperty("simple_keyvalues")]
     [JsonPropertyName("simple_keyvalues")]
     public List<SimpleKeyvalues> SimpleKeyvalues { get; set; }
-  }
+}
 
-  public class SimpleKeyvalues
-  {
+public class SimpleKeyvalues
+{
     [XmlElement("key", Order = 1)]
     [JsonProperty("key")]
     [JsonPropertyName("key")]
@@ -72,10 +72,10 @@ public class Skjema
     [JsonProperty("intValue")]
     [JsonPropertyName("intValue")]
     public decimal IntValue { get; set; }
-  }
+}
 
-  public class Nested
-  {
+public class Nested
+{
     [XmlElement("key", Order = 1)]
     [JsonProperty("key")]
     [JsonPropertyName("key")]
@@ -85,4 +85,4 @@ public class Skjema
     [JsonProperty("values")]
     [JsonPropertyName("values")]
     public List<SimpleKeyvalues> Values { get; set; }
-  }
+}

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/LayoutModelConverterFromObject.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/LayoutModelConverterFromObject.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -33,7 +34,7 @@ public class LayoutModelConverterFromObject : JsonConverter<LayoutModel>
         {
             if (reader.TokenType != JsonTokenType.PropertyName)
             {
-                throw new JsonException(); //Think this is impossible. After a JsonTokenType.StartObject, everything should be JsonTokenType.PropertyName
+                throw new JsonException(); // Think this is impossible. After a JsonTokenType.StartObject, everything should be JsonTokenType.PropertyName
             }
 
             var pageName = reader.GetString()!;

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/TestDataModel.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/TestDataModel.cs
@@ -256,7 +256,7 @@ public class TestDataModel
                 {
                     new()
                     {
-                        Name = new(){ Value = "Ole"},
+                        Name = new() { Value = "Ole" },
                     }
                 }
             });
@@ -301,7 +301,7 @@ public class TestDataModel
                 {
                     new()
                     {
-                        Name = new(){ Value = "Ole"},
+                        Name = new() { Value = "Ole" },
                     }
                 }
             });
@@ -347,7 +347,7 @@ public class TestDataModel
 
         // non-existant-fields in subfield works, no error
         modelHelper.RemoveField("friends.doesNotExist");
- 
+
         // non-existant-fields in subfield works, no error
         modelHelper.RemoveField("friends[0].doesNotExist");
     }


### PR DESCRIPTION
When there is a mismatch between the C# property name and the `[JsonPropertyName()]`
![image](https://user-images.githubusercontent.com/131616/207063777-ffb2d55a-bc24-4b8f-b36c-ca2f9c7fc9dc.png)
And one of the nested `[System.ComponentModel.DataAnnotations]` rules fails, the `Field` property of `ValidationIssue` is wrong, and frontend can't attach the error to the correct component.

## Description

Some xsd definitions contain property names with illegal characters that can't be used in properties (without ugly escaping)

To solve that conflict, additional properties is added for json and xml serialziation to include the illegal characters. This needs to be respected everywhere.

In net70, this is easily fixed with a configuration change, https://learn.microsoft.com/en-us/aspnet/core/mvc/models/validation?view=aspnetcore-7.0#use-json-property-names-in-validation-errors, but in net60, we need to manually translate the keys.


## Related Issue(s)
- not sure if this has previously been reported.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
