### PR TITLE
Altinn2CodeList Retry without language when receiving 404

### DIFF
--- a/src/Altinn.App.Core/Features/Options/Altinn2Provider/Altinn2MetadataApiClient.cs
+++ b/src/Altinn.App.Core/Features/Options/Altinn2Provider/Altinn2MetadataApiClient.cs
@@ -28,6 +28,10 @@ namespace Altinn.App.Core.Features.Options.Altinn2Provider
         public async Task<MetadataCodelistResponse> GetAltinn2Codelist(string id, string langCode, int? version = null)
         {
             var response = await _client.GetAsync($"https://www.altinn.no/api/metadata/codelists/{id}/{version?.ToString() ?? string.Empty}?language={langCode}");
+            if(response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                response = await _client.GetAsync($"https://www.altinn.no/api/metadata/codelists/{id}/{version?.ToString() ?? string.Empty}");
+            }
             response.EnsureSuccessStatusCode();
             var codelist = await response.Content.ReadAsAsync<MetadataCodelistResponse>();
             return codelist;


### PR DESCRIPTION
This is a a problem, if the altinn 2 code list is missing eg, nynorsk (because the values are the same in bokmål)


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
