### PR TITLE
Check content-length not exceeding maxSize set on datatype

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -14,7 +12,6 @@ using Altinn.App.Core.Constants;
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers;
-using Altinn.App.Core.Helpers.Extensions;
 using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Interface;
 using Altinn.App.Core.Internal.AppModel;
@@ -24,7 +21,6 @@ using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 
 namespace Altinn.App.Api.Controllers
 {

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Altinn.App.Api.Helpers.RequestHandling;
 using Altinn.App.Api.Infrastructure.Filters;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Extensions;
@@ -144,9 +146,9 @@ namespace Altinn.App.Api.Controllers
                 }
                 else
                 {
-                    if (!CompliesWithDataRestrictions(dataTypeFromMetadata, out string errorMessage))
+                    if (!DataRestrictionValidation.CompliesWithDataRestrictions(Request, dataTypeFromMetadata, out ActionResult errorResponse))
                     {
-                        return BadRequest($"Invalid data provided. Error: {errorMessage}");
+                        return errorResponse;
                     }
 
                     return await CreateBinaryData(org, app, instance, dataType);
@@ -267,9 +269,9 @@ namespace Altinn.App.Api.Controllers
                 }
 
                 DataType dataTypeFromMetadata = _appResourcesService.GetApplication().DataTypes.FirstOrDefault(e => e.Id.Equals(dataType, StringComparison.InvariantCultureIgnoreCase));
-                if (!CompliesWithDataRestrictions(dataTypeFromMetadata, out string errorMessage))
+                if (!DataRestrictionValidation.CompliesWithDataRestrictions(Request, dataTypeFromMetadata, out ActionResult errorResponse))
                 {
-                    return BadRequest($"Invalid data provided. Error: {errorMessage}");
+                    return errorResponse;
                 }
 
                 return await PutBinaryData(org, app, instanceOwnerPartyId, instanceGuid, dataGuid);
@@ -688,67 +690,6 @@ namespace Altinn.App.Api.Controllers
             }
 
             return false;
-        }
-
-        private bool CompliesWithDataRestrictions(DataType dataType, out string errorMessage)
-        {
-            errorMessage = string.Empty;
-
-            if (!Request.Headers.TryGetValue("Content-Disposition", out StringValues headerValues))
-            {
-                errorMessage = "The request must include a Content-Disposition header";
-                return false;
-            }
-
-            ContentDispositionHeaderValue contentDisposition = ContentDispositionHeaderValue.Parse(headerValues);
-            string filename = contentDisposition.FileNameStar ?? contentDisposition.FileName;
-
-            if (string.IsNullOrEmpty(filename))
-            {
-                errorMessage = "The Content-Disposition header must contain a filename";
-                return false;
-            }
-
-            // We actively remove quotes because we don't want them replaced with '_'.
-            // Quotes around filename in Content-Disposition is valid, but not as part of the filename.
-            filename = filename.Trim('\"').AsFileName(false);
-            string[] splitFilename = filename.Split('.');
-
-            if (splitFilename.Length < 2)
-            {
-                errorMessage = $"Invalid format for filename: {filename}. Filename is expected to end with '.{{filetype}}'.";
-                return false;
-            }
-
-            if (dataType.AllowedContentTypes == null || dataType.AllowedContentTypes.Count == 0)
-            {
-                return true;
-            }
-
-            string filetype = splitFilename[splitFilename.Length - 1];
-            string mimeType = MimeTypeMap.GetMimeType(filetype);
-
-            if (!Request.Headers.TryGetValue("Content-Type", out StringValues contentType))
-            {
-                errorMessage = "Content-Type header must be included in request.";
-                return false;
-            }
-
-            // Verify that file mime type matches content type in request
-            if (!contentType.Equals("application/octet-stream") && !mimeType.Equals(contentType, StringComparison.InvariantCultureIgnoreCase))
-            {
-                errorMessage = $"Content type header {contentType} does not match mime type {mimeType} for uploaded file. Please fix header or upload another file.";
-                return false;
-            }
-
-            // Verify that file mime type is an allowed content-type
-            if (!dataType.AllowedContentTypes.Contains(mimeType, StringComparer.InvariantCultureIgnoreCase) && !dataType.AllowedContentTypes.Contains("application/octet-stream"))
-            {
-                errorMessage = $"Invalid content type: {mimeType}. Please try another file. Permitted content types include: {string.Join(", ", dataType.AllowedContentTypes)}";
-                return false;
-            }
-
-            return true;
         }
     }
 }

--- a/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
+++ b/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Headers;
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Extensions;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+namespace Altinn.App.Api.Helpers.RequestHandling
+{
+    public static class DataRestrictionValidation
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="dataType"></param>
+        /// <param name="errorResponse"></param>
+        /// <returns></returns>
+        public static bool CompliesWithDataRestrictions(HttpRequest request, DataType dataType, out ActionResult errorResponse)
+        {
+            var errorBaseMessage = "Invalid data provided. Error:";
+            errorResponse = null;
+            if (!request.Headers.TryGetValue("Content-Disposition", out StringValues headerValues))
+            {
+                errorResponse = new BadRequestObjectResult($"{errorBaseMessage} The request must include a Content-Disposition header");
+                return false;
+            }
+            
+            var maxSize = (long?)dataType.MaxSize * 1024 * 1024;
+            if (maxSize != null && request.ContentLength > maxSize)
+            {
+                errorResponse = new ObjectResult($"{errorBaseMessage} Binary attachment exceeds limit of {maxSize}")
+                {
+                    StatusCode = (int)HttpStatusCode.RequestEntityTooLarge
+                };
+                return false;
+            }
+
+            ContentDispositionHeaderValue contentDisposition = ContentDispositionHeaderValue.Parse(headerValues);
+            string filename = contentDisposition.FileNameStar ?? contentDisposition.FileName;
+
+            if (string.IsNullOrEmpty(filename))
+            {
+                errorResponse = new BadRequestObjectResult($"{errorBaseMessage} The Content-Disposition header must contain a filename");
+                return false;
+            }
+
+            // We actively remove quotes because we don't want them replaced with '_'.
+            // Quotes around filename in Content-Disposition is valid, but not as part of the filename.
+            filename = filename.Trim('\"').AsFileName(false);
+            string[] splitFilename = filename.Split('.');
+
+            if (splitFilename.Length < 2)
+            {
+                errorResponse = new BadRequestObjectResult($"{errorBaseMessage} Invalid format for filename: {filename}. Filename is expected to end with '.{{filetype}}'.");
+                return false;
+            }
+
+            if (dataType.AllowedContentTypes == null || dataType.AllowedContentTypes.Count == 0)
+            {
+                return true;
+            }
+
+            string filetype = splitFilename[splitFilename.Length - 1];
+            string mimeType = MimeTypeMap.GetMimeType(filetype);
+
+            if (!request.Headers.TryGetValue("Content-Type", out StringValues contentType))
+            {
+                errorResponse = new BadRequestObjectResult($"{errorBaseMessage} Content-Type header must be included in request.");
+                return false;
+            }
+
+            // Verify that file mime type matches content type in request
+            if (!contentType.Equals("application/octet-stream") && !mimeType.Equals(contentType, StringComparison.InvariantCultureIgnoreCase))
+            {
+                errorResponse = new BadRequestObjectResult($"{errorBaseMessage} Content type header {contentType} does not match mime type {mimeType} for uploaded file. Please fix header or upload another file.");
+                return false;
+            }
+
+            // Verify that file mime type is an allowed content-type
+            if (!dataType.AllowedContentTypes.Contains(mimeType, StringComparer.InvariantCultureIgnoreCase) && !dataType.AllowedContentTypes.Contains("application/octet-stream"))
+            {
+                errorResponse = new BadRequestObjectResult($"{errorBaseMessage} Invalid content type: {mimeType}. Please try another file. Permitted content types include: {string.Join(", ", dataType.AllowedContentTypes)}");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
+++ b/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
@@ -45,7 +45,7 @@ namespace Altinn.App.Api.Helpers.RequestHandling
             }
 
             ContentDispositionHeaderValue contentDisposition = ContentDispositionHeaderValue.Parse(headerValues);
-            string filename = contentDisposition.FileNameStar ?? contentDisposition.FileName;
+            string? filename = contentDisposition.FileNameStar ?? contentDisposition.FileName;
 
             if (string.IsNullOrEmpty(filename))
             {

--- a/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
+++ b/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Net;
@@ -11,16 +12,19 @@ using Microsoft.Extensions.Primitives;
 
 namespace Altinn.App.Api.Helpers.RequestHandling
 {
+    /// <summary>
+    /// Check datarestrictions on http requests
+    /// </summary>
     public static class DataRestrictionValidation
     {
         /// <summary>
-        /// 
+        /// Check if a data post/put request complies with restrictions agreed upon for the DataController 
         /// </summary>
-        /// <param name="request"></param>
-        /// <param name="dataType"></param>
-        /// <param name="errorResponse"></param>
-        /// <returns></returns>
-        public static bool CompliesWithDataRestrictions(HttpRequest request, DataType dataType, out ActionResult errorResponse)
+        /// <param name="request">the original http request</param>
+        /// <param name="dataType">datatype the files is beeing uploaded to</param>
+        /// <param name="errorResponse">Null if validation passed, error response if not</param>
+        /// <returns>true with errorResponse = null if all is ok, false with errorResponse if not</returns>
+        public static bool CompliesWithDataRestrictions(HttpRequest request, DataType dataType, out ActionResult? errorResponse)
         {
             var errorBaseMessage = "Invalid data provided. Error:";
             errorResponse = null;

--- a/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
@@ -1,0 +1,209 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Mime;
+using Altinn.App.Api.Helpers.RequestHandling;
+using Altinn.Platform.Storage.Interface.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Altinn.App.Api.Tests.Helpers.RequestHandling;
+
+public class DataRestrictionValidationTests
+{
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_false_with_badrequest_if_contentdisposition_not_set()
+    {
+        var httpContext = new DefaultHttpContext();
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, new DataType(), out ActionResult errorResponse);
+        valid.Should().BeFalse();
+        errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
+        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: The request must include a Content-Disposition header");
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_false_with_413_status_if_contentlength_greater_than_maxSize()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000000000000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test.pdf";
+        var dataType = new DataType()
+        {
+            MaxSize = 1
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeFalse();
+        errorResponse.Should().BeOfType(typeof(ObjectResult));
+        ((ObjectResult)errorResponse).StatusCode.Should().Be(413);
+        ((ObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Binary attachment exceeds limit of 1048576");
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_false_with_badrequest_status_if_filename_not_supplied()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment";
+        var dataType = new DataType()
+        {
+            MaxSize = 1
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeFalse();
+        errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
+        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: The Content-Disposition header must contain a filename");
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_false_with_badrequest_status_if_filename_without_extension()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test";
+        var dataType = new DataType()
+        {
+            MaxSize = 1
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeFalse();
+        errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
+        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Invalid format for filename: test. Filename is expected to end with '.{filetype}'.");
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_true_if_contentdisposition_filesize_and_no_allowed_datatypes_set_on_datatype()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test.pdf";
+        var dataType = new DataType()
+        {
+            MaxSize = 1
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeTrue();
+        errorResponse.Should().BeNull();
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_true_if_contentdisposition_filesize_and_emptylist_allowed_datatypes_set_on_datatype()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test.pdf";
+        var dataType = new DataType()
+        {
+            MaxSize = 1,
+            AllowedContentTypes = new List<string>()
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeTrue();
+        errorResponse.Should().BeNull();
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_false_if_contenttype_not_set_and_allowedcontenttypes_defined()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test.pdf";
+        var dataType = new DataType()
+        {
+            MaxSize = 1,
+            AllowedContentTypes = new List<string>(){"application/pdf"}
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeFalse();
+        errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
+        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Content-Type header must be included in request.");
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_false_if_contenttype_not_defined_in_allowedcontenttypes()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test.json";
+        httpContext.Request.Headers.ContentType = "application/json";
+        var dataType = new DataType()
+        {
+            MaxSize = 1,
+            AllowedContentTypes = new List<string>(){"application/pdf"}
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeFalse();
+        errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
+        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Invalid content type: application/json. Please try another file. Permitted content types include: application/pdf");
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_false_if_fileextension_not_matching_contenttype()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test.json";
+        httpContext.Request.Headers.ContentType = "application/pdf";
+        var dataType = new DataType()
+        {
+            MaxSize = 1,
+            AllowedContentTypes = new List<string>(){"application/pdf", "application/json"}
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeFalse();
+        errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
+        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Content type header application/pdf does not match mime type application/json for uploaded file. Please fix header or upload another file.");
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_true_when_all_checks_pass()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test.json";
+        httpContext.Request.Headers.ContentType = "application/json";
+        var dataType = new DataType()
+        {
+            MaxSize = 1,
+            AllowedContentTypes = new List<string>(){"application/pdf", "application/json"}
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeTrue();
+        errorResponse.Should().BeNull();
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_true_when_octetstream_in_allow_list()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test.json";
+        httpContext.Request.Headers.ContentType = "application/json";
+        var dataType = new DataType()
+        {
+            MaxSize = 1,
+            AllowedContentTypes = new List<string>(){"application/pdf", "application/octet-stream"}
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeTrue();
+        errorResponse.Should().BeNull();
+    }
+    
+    [Fact]
+    public void CompliesWithDataRestrictions_returns_true_when_octetstream_in_allow_list_and_content_type_is_octetstream()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.ContentLength = 1000;
+        httpContext.Request.Headers.ContentDisposition = "attachment; filename=test.json";
+        httpContext.Request.Headers.ContentType = "application/octet-stream";
+        var dataType = new DataType()
+        {
+            MaxSize = 1,
+            AllowedContentTypes = new List<string>(){"application/pdf", "application/octet-stream"}
+        };
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        valid.Should().BeTrue();
+        errorResponse.Should().BeNull();
+    }
+}

--- a/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
@@ -1,12 +1,9 @@
 using System.Collections.Generic;
-using System.Net;
-using System.Net.Mime;
 using Altinn.App.Api.Helpers.RequestHandling;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Altinn.App.Api.Tests.Helpers.RequestHandling;
@@ -17,10 +14,11 @@ public class DataRestrictionValidationTests
     public void CompliesWithDataRestrictions_returns_false_with_badrequest_if_contentdisposition_not_set()
     {
         var httpContext = new DefaultHttpContext();
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, new DataType(), out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, new DataType(), out ActionResult? errorResponse);
         valid.Should().BeFalse();
+        errorResponse.Should().NotBeNull();
         errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
-        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: The request must include a Content-Disposition header");
+        ((BadRequestObjectResult)errorResponse!).Value.Should().BeEquivalentTo("Invalid data provided. Error: The request must include a Content-Disposition header");
     }
     
     [Fact]
@@ -33,10 +31,11 @@ public class DataRestrictionValidationTests
         {
             MaxSize = 1
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeFalse();
+        errorResponse.Should().NotBeNull();
         errorResponse.Should().BeOfType(typeof(ObjectResult));
-        ((ObjectResult)errorResponse).StatusCode.Should().Be(413);
+        ((ObjectResult)errorResponse!).StatusCode.Should().Be(413);
         ((ObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Binary attachment exceeds limit of 1048576");
     }
     
@@ -50,10 +49,11 @@ public class DataRestrictionValidationTests
         {
             MaxSize = 1
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeFalse();
+        errorResponse.Should().NotBeNull();
         errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
-        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: The Content-Disposition header must contain a filename");
+        ((BadRequestObjectResult)errorResponse!).Value.Should().BeEquivalentTo("Invalid data provided. Error: The Content-Disposition header must contain a filename");
     }
     
     [Fact]
@@ -66,10 +66,11 @@ public class DataRestrictionValidationTests
         {
             MaxSize = 1
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeFalse();
+        errorResponse.Should().NotBeNull();
         errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
-        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Invalid format for filename: test. Filename is expected to end with '.{filetype}'.");
+        ((BadRequestObjectResult)errorResponse!).Value.Should().BeEquivalentTo("Invalid data provided. Error: Invalid format for filename: test. Filename is expected to end with '.{filetype}'.");
     }
     
     [Fact]
@@ -82,7 +83,7 @@ public class DataRestrictionValidationTests
         {
             MaxSize = 1
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeTrue();
         errorResponse.Should().BeNull();
     }
@@ -98,7 +99,7 @@ public class DataRestrictionValidationTests
             MaxSize = 1,
             AllowedContentTypes = new List<string>()
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeTrue();
         errorResponse.Should().BeNull();
     }
@@ -114,10 +115,11 @@ public class DataRestrictionValidationTests
             MaxSize = 1,
             AllowedContentTypes = new List<string>(){"application/pdf"}
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeFalse();
+        errorResponse.Should().NotBeNull();
         errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
-        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Content-Type header must be included in request.");
+        ((BadRequestObjectResult)errorResponse!).Value.Should().BeEquivalentTo("Invalid data provided. Error: Content-Type header must be included in request.");
     }
     
     [Fact]
@@ -132,10 +134,11 @@ public class DataRestrictionValidationTests
             MaxSize = 1,
             AllowedContentTypes = new List<string>(){"application/pdf"}
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeFalse();
+        errorResponse.Should().NotBeNull();
         errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
-        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Invalid content type: application/json. Please try another file. Permitted content types include: application/pdf");
+        ((BadRequestObjectResult)errorResponse!).Value.Should().BeEquivalentTo("Invalid data provided. Error: Invalid content type: application/json. Please try another file. Permitted content types include: application/pdf");
     }
     
     [Fact]
@@ -150,10 +153,11 @@ public class DataRestrictionValidationTests
             MaxSize = 1,
             AllowedContentTypes = new List<string>(){"application/pdf", "application/json"}
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeFalse();
+        errorResponse.Should().NotBeNull();
         errorResponse.Should().BeOfType(typeof(BadRequestObjectResult));
-        ((BadRequestObjectResult)errorResponse).Value.Should().BeEquivalentTo("Invalid data provided. Error: Content type header application/pdf does not match mime type application/json for uploaded file. Please fix header or upload another file.");
+        ((BadRequestObjectResult)errorResponse!).Value.Should().BeEquivalentTo("Invalid data provided. Error: Content type header application/pdf does not match mime type application/json for uploaded file. Please fix header or upload another file.");
     }
     
     [Fact]
@@ -168,7 +172,7 @@ public class DataRestrictionValidationTests
             MaxSize = 1,
             AllowedContentTypes = new List<string>(){"application/pdf", "application/json"}
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeTrue();
         errorResponse.Should().BeNull();
     }
@@ -185,7 +189,7 @@ public class DataRestrictionValidationTests
             MaxSize = 1,
             AllowedContentTypes = new List<string>(){"application/pdf", "application/octet-stream"}
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeTrue();
         errorResponse.Should().BeNull();
     }
@@ -202,7 +206,7 @@ public class DataRestrictionValidationTests
             MaxSize = 1,
             AllowedContentTypes = new List<string>(){"application/pdf", "application/octet-stream"}
         };
-        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult errorResponse);
+        bool valid = DataRestrictionValidation.CompliesWithDataRestrictions(httpContext.Request, dataType, out ActionResult? errorResponse);
         valid.Should().BeTrue();
         errorResponse.Should().BeNull();
     }


### PR DESCRIPTION
## Description
- Extracted DataRestrictions check to static class to make it testable.
- Extended checks to check if content-length not larger than maxSize
- Tests for CompliesWithDataRestrictions

## Related Issue(s)
- fixes #120 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
