### PR TITLE
Add property ["instanceContext", "instanceOwnerPartyType"]

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -175,10 +175,10 @@ public class LayoutEvaluatorState
             "instanceId" => _instanceContext.Id,
             "instanceOwnerPartyType" => 
             (
-                !string.IsNullOrWhiteSpace(_instanceContext.InstanceOwner.PersonNumber)
-                ? "person"
-                : !string.IsNullOrWhiteSpace(_instanceContext.InstanceOwner.OrganisationNumber)
+                !string.IsNullOrWhiteSpace(_instanceContext.InstanceOwner.OrganisationNumber)
                 ? "org"
+                : !string.IsNullOrWhiteSpace(_instanceContext.InstanceOwner.PersonNumber)
+                ? "person"
                 : !string.IsNullOrWhiteSpace(_instanceContext.InstanceOwner.Username)
                 ? "selfIdentified"
                 : "unknown"

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -173,6 +173,16 @@ public class LayoutEvaluatorState
             "instanceOwnerPartyId" => _instanceContext.InstanceOwner.PartyId,
             "appId" => _instanceContext.AppId,
             "instanceId" => _instanceContext.Id,
+            "instanceOwnerPartyType" => 
+            (
+                !string.IsNullOrWhiteSpace(_instanceContext.InstanceOwner.PersonNumber)
+                ? "person"
+                : !string.IsNullOrWhiteSpace(_instanceContext.InstanceOwner.OrganisationNumber)
+                ? "org"
+                : !string.IsNullOrWhiteSpace(_instanceContext.InstanceOwner.Username)
+                ? "selfIdentified"
+                : "unknown"
+            ),
             _ => throw new ExpressionEvaluatorTypeErrorException($"Unknown Instance context property {key}"),
         };
     }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/ExpressionTestCaseRoot.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/ExpressionTestCaseRoot.cs
@@ -51,52 +51,12 @@ public class ExpressionTestCaseRoot
     [JsonPropertyName("frontendSettings")]
     public FrontEndSettings? FrontEndSettings { get; set; }
 
-    [JsonPropertyName("instanceContext")]
-    [JsonConverter(typeof(InstanceConverter))]
-    public Instance? InstanceContext { get; set; }
+    [JsonPropertyName("instance")]
+    public Instance? Instance { get; set; }
 
     public override string ToString()
     {
         return $"{Filename}: {Name}";
-    }
-}
-
-public class InstanceConverter : JsonConverter<Instance>
-{
-    public override Instance? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-        var testInstance = JsonSerializer.Deserialize<InstanceForTestSpec>(ref reader, options);
-        if (testInstance is null)
-        {
-            return null;
-        }
-
-        return new Instance
-        {
-            AppId = testInstance.AppId,
-            Id = testInstance.InstanceId,
-            InstanceOwner = new()
-            {
-                PartyId = testInstance.InstanceOwnerPartyId,
-            }
-        };
-    }
-
-    public override void Write(Utf8JsonWriter writer, Instance value, JsonSerializerOptions options)
-    {
-        throw new NotImplementedException();
-    }
-
-    public class InstanceForTestSpec
-    {
-        [JsonPropertyName("instanceId")]
-        public string InstanceId { get; set; } = default!;
-
-        [JsonPropertyName("appId")]
-        public string AppId { get; set; } = default!;
-
-        [JsonPropertyName("instanceOwnerPartyId")]
-        public string InstanceOwnerPartyId { get; set; } = default!;
     }
 }
 

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
@@ -93,7 +93,7 @@ public class TestFunctions
             new JsonDataModel(test.DataModel),
             test.ComponentModel,
             test.FrontEndSettings ?? new(),
-            test.InstanceContext ?? new());
+            test.Instance ?? new());
 
         if (test.ExpectsFailure is not null)
         {
@@ -176,6 +176,7 @@ public class SharedTestAttribute : DataAttribute
                     new JsonSerializerOptions
                     {
                         ReadCommentHandling = JsonCommentHandling.Skip,
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                     })!;
             }
             catch (Exception e)

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
@@ -29,12 +29,18 @@ public class TestInvalid
         _output.WriteLine(testCase.FullPath);
         Action act = () =>
         {
-            var test = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(testCase.RawJson!)!;
+            var test = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(
+                testCase.RawJson!,
+                new JsonSerializerOptions
+                {
+                    ReadCommentHandling = JsonCommentHandling.Skip,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                })!;
             var state = new LayoutEvaluatorState(
                 new JsonDataModel(test.DataModel),
                 test.ComponentModel,
                 test.FrontEndSettings ?? new(),
-                test.InstanceContext ?? new());
+                test.Instance ?? new());
             ExpressionEvaluator.EvaluateExpression(state, test.Expression, test.Context?.ToContext(test.ComponentModel) ?? null!);
         };
         act.Should().Throw<Exception>().WithMessage(testCase.ExpectsFailure);

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/only-dict.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/only-dict.json
@@ -2,7 +2,7 @@
   "name": "Only works on one level (as a dictionary)",
   "expression": ["equals", ["instanceContext", "deep.key"], null],
   "expectsFailure": "Unknown Instance context property deep.key",
-  "instanceContext": {
+  "instance": {
     "deep": {
       "key": "should not be found"
     }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeOrg.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeOrg.json
@@ -1,0 +1,13 @@
+{
+  "name": "PartyType is Org",
+  "expression": ["instanceContext", "instanceOwnerPartyType"],
+  "expects": "org",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwner": {
+      "partyId": "12345",
+      "organisationNumber": "1234567"
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypePerson.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypePerson.json
@@ -1,0 +1,13 @@
+{
+  "name": "PartyType is Person",
+  "expression": ["instanceContext", "instanceOwnerPartyType"],
+  "expects": "person",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwner": {
+      "partyId": "12345",
+      "personNumber": "1234567"
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeSelfIdentified.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeSelfIdentified.json
@@ -1,0 +1,13 @@
+{
+  "name": "PartyType is Self Identified",
+  "expression": ["instanceContext", "instanceOwnerPartyType"],
+  "expects": "selfIdentified",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwner": {
+      "partyId": "12345",
+      "username": "1234567"
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeUnknown.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeUnknown.json
@@ -1,7 +1,7 @@
 {
-  "name": "Looking up null",
-  "expression": ["instanceContext", null],
-  "expectsFailure": "Unknown Instance context property ",
+  "name": "Party type unknown",
+  "expression": ["instanceContext", "instanceOwnerPartyType"],
+  "expects": "unknown",
   "instance": {
     "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
     "appId": "org/app-name",

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/simple-lookup-equals.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/simple-lookup-equals.json
@@ -6,9 +6,11 @@
     ["instanceContext", "appId"]
   ],
   "expects": false,
-  "instanceContext": {
-    "instanceId": "d00ce51c-800b-416a-a906-ccab55f597e9",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
     "appId": "org/app-name",
-    "instanceOwnerPartyId": "12345"
+    "instanceOwner": {
+      "partyId": "12345"
+    }
   }
 }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/simple-lookup-is-null.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/simple-lookup-is-null.json
@@ -2,9 +2,11 @@
   "name": "Simple lookup for non-existing key equals null",
   "expression": ["equals", ["instanceContext", "doesNotExist"], null],
   "expectsFailure": "Unknown Instance context property doesNotExist",
-  "instanceContext": {
-    "instanceId": "d00ce51c-800b-416a-a906-ccab55f597e9",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
     "appId": "org/app-name",
-    "instanceOwnerPartyId": "12345"
+    "instanceOwner": {
+      "partyId": "12345"
+    }
   }
 }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/simple-lookup.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/simple-lookup.json
@@ -2,9 +2,11 @@
   "name": "Simple lookup",
   "expression": ["instanceContext", "appId"],
   "expects": "org/app-name",
-  "instanceContext": {
-    "instanceId": "d00ce51c-800b-416a-a906-ccab55f597e9",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
     "appId": "org/app-name",
-    "instanceOwnerPartyId": "12345"
+    "instanceOwner": {
+      "partyId": "12345"
+    }
   }
 }


### PR DESCRIPTION
 so that dynamic expression can reference the type of instance owner.

see https://github.com/Altinn/app-frontend-react/pull/805

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/pull/805

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
