### PR TITLE
PDF should not override pageOrder

### DIFF
--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -104,7 +104,6 @@ namespace Altinn.App.Api.Controllers
             layoutSettings ??= new();
             layoutSettings.Pages ??= new();
             layoutSettings.Pages.ExcludeFromPdf ??= new();
-            layoutSettings.Pages.Order ??= new();
             layoutSettings.Components ??= new();
             layoutSettings.Components.ExcludeFromPdf ??= new();
 
@@ -116,7 +115,6 @@ namespace Altinn.App.Api.Controllers
             {
                 ExcludedPages = layoutSettings.Pages.ExcludeFromPdf,
                 ExcludedComponents = layoutSettings.Components.ExcludeFromPdf,
-                PageOrder = layoutSettings.Pages.Order,
             };
             return Ok(result);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Quick fix. Realized that if I actually let the developer override the page order in `IPdfFormatter` it will override any custom logic defined using `IPageOrder`. And if they do not set it in `IPdfFormatter`, it will be reset to whatever is in the static `Settings.json`. So only `excludeFromPdf` should be set with `IPdfFormatter`.
