### PR TITLE
Fixed FindDiff not going deep enough

### DIFF
--- a/src/Altinn.App.Core/Helpers/JsonHelper.cs
+++ b/src/Altinn.App.Core/Helpers/JsonHelper.cs
@@ -161,18 +161,18 @@ namespace Altinn.App.Core.Helpers
                     break;
 
                 case JTokenType.Null:
-                    if (oldObj != null)
+                    if (old?.Type == JTokenType.Object)
                     {
-                        foreach (string key in oldObj.Properties().Select(c => c.Name))
+                        foreach (string key in oldObj!.Properties().Select(c => c.Name))
                         {
                             FindDiff(dict, oldObj[key], JValue.CreateNull(), Join(prefix, key));
                         }
                     }
                     else if (old?.Type == JTokenType.Array)
                     {
-                        for (index = 0; index < oldArray?.Count; index++)
+                        for (index = 0; index < oldArray!.Count; index++)
                         {
-                            dict.Add($"{prefix}[{index}]", null);
+                            FindDiff(dict, oldArray[index], JValue.CreateNull(), $"{prefix}[{index}]");
                         }
                     }
                     else

--- a/src/Altinn.App.Core/Helpers/JsonHelper.cs
+++ b/src/Altinn.App.Core/Helpers/JsonHelper.cs
@@ -161,16 +161,16 @@ namespace Altinn.App.Core.Helpers
                     break;
 
                 case JTokenType.Null:
-                    if (old?.Type == JTokenType.Object)
+                    if (oldObj != null && old?.Type == JTokenType.Object)
                     {
-                        foreach (string key in oldObj!.Properties().Select(c => c.Name))
+                        foreach (string key in oldObj.Properties().Select(c => c.Name))
                         {
                             FindDiff(dict, oldObj[key], JValue.CreateNull(), Join(prefix, key));
                         }
                     }
-                    else if (old?.Type == JTokenType.Array)
+                    else if (oldArray != null && old?.Type == JTokenType.Array)
                     {
-                        for (index = 0; index < oldArray!.Count; index++)
+                        for (index = 0; index < oldArray.Count; index++)
                         {
                             FindDiff(dict, oldArray[index], JValue.CreateNull(), $"{prefix}[{index}]");
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was a problem where finding the changed fields was not checking deep enough in nested arrays when the new value was null.

The following is a result of adding and removing the same data, but FindDiff did not return as many when removed as when added. This caused some data to linger (specifically nested arrays) in the redux state which caused the linked issue.

Adding a row (repeated group prefill from ProcessDataWrite):

![image](https://user-images.githubusercontent.com/47412359/212303065-abdefc8c-c5fb-4c95-990b-6e2a5f2f2577.png)

Removing the same row:

![image](https://user-images.githubusercontent.com/47412359/212303099-bd255c09-811d-4b78-b312-a48de347f7c4.png)

Tested the fix on `stian.vestli/ra0244-01`

## Related Issue(s)
- closes https://github.com/Altinn/app-frontend-react/issues/836

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
