### PR TITLE
File scan validation and scan results

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.1.0" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.13.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.14.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.1.0" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.12.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.13.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.1.0" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.11.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.12.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.App.Api/Controllers/FileScanController.cs
+++ b/src/Altinn.App.Api/Controllers/FileScanController.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading.Tasks;
+using Altinn.App.Api.Models;
+using Altinn.App.Core.Interface;
+using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.App.Api.Controllers
+{
+    /// <summary>
+    /// Contains actions for checking status on file scans.
+    /// </summary>
+    [Authorize]
+    [ApiController]
+    public class FileScanController : ControllerBase
+    {
+        private readonly IInstance _instanceClient;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="FileScanController"/> class
+        /// </summary>
+        public FileScanController(IInstance instanceClient)
+        {
+            _instanceClient = instanceClient;
+        }
+
+        /// <summary>
+        /// Checks that file scan result for an instance and it's data elements.
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation</param>
+        /// <param name="instanceOwnerPartyId">Unique id of the party that is the owner of the instance.</param>
+        /// <param name="instanceGuid">Unique id to identify the instance</param>
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [Route("{org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/filescanresult")]
+        public async Task<ActionResult<InstanceFileScanResult>> GetFileScanResults(
+            [FromRoute] string org,
+            [FromRoute] string app,
+            [FromRoute] int instanceOwnerPartyId,
+            [FromRoute] Guid instanceGuid)
+        {
+            Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            if (instance == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(MapFromInstance(instance));
+        }
+
+        private static InstanceFileScanResult MapFromInstance(Instance instance)
+        {
+            var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(instance));
+
+            if (instance.Data != null)
+            {
+                foreach (var dataElement in instance.Data)
+                {
+                    instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = dataElement.Id, FileScanResult = dataElement.FileScanResult });
+                }
+            }
+
+            return instanceFileScanResult;
+        }
+    }
+}

--- a/src/Altinn.App.Api/Models/DataElementFileScanResult.cs
+++ b/src/Altinn.App.Api/Models/DataElementFileScanResult.cs
@@ -18,6 +18,7 @@ namespace Altinn.App.Api.Models
         /// Gets or sets the file scan result for the data element.        
         /// </summary>
         [JsonPropertyName("fileScanResult")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public FileScanResult FileScanResult { get; set; }
     }
 }

--- a/src/Altinn.App.Api/Models/DataElementFileScanResult.cs
+++ b/src/Altinn.App.Api/Models/DataElementFileScanResult.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json.Serialization;
+using Altinn.Platform.Storage.Interface.Enums;
+
+namespace Altinn.App.Api.Models
+{
+    /// <summary>
+    /// File scan result for an individual data element.
+    /// </summary>
+    public class DataElementFileScanResult
+    {
+        /// <summary>
+        /// Gets or sets the data element id
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the file scan result for the data element.        
+        /// </summary>
+        [JsonPropertyName("fileScanResult")]
+        public FileScanResult FileScanResult { get; set; }
+    }
+}

--- a/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
+++ b/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
@@ -48,9 +48,12 @@ namespace Altinn.App.Api.Models
         /// </summary>        
         public void AddFileScanResult(DataElementFileScanResult dataElementFileScanResult)
         {
-            _dataElements.Add(dataElementFileScanResult);
+            if (dataElementFileScanResult.FileScanResult != FileScanResult.NotApplicable)
+            {
+                _dataElements.Add(dataElementFileScanResult);
 
-            RecalculateAggregatedStatus();
+                RecalculateAggregatedStatus();
+            }            
         }
 
         private void RecalculateAggregatedStatus()

--- a/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
+++ b/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
@@ -11,6 +11,7 @@ namespace Altinn.App.Api.Models
     /// </summary>
     public class InstanceFileScanResult
     {
+        private readonly InstanceIdentifier _instanceIdentifier;
         private readonly List<DataElementFileScanResult> _dataElements;
 
         /// <summary>
@@ -18,7 +19,7 @@ namespace Altinn.App.Api.Models
         /// </summary>
         public InstanceFileScanResult(InstanceIdentifier instanceIdentifier)
         {
-            Id = instanceIdentifier;
+            _instanceIdentifier = instanceIdentifier;
             _dataElements = new List<DataElementFileScanResult>();
         }
 
@@ -26,7 +27,10 @@ namespace Altinn.App.Api.Models
         /// Instance id
         /// </summary>
         [JsonPropertyName("id")]
-        public InstanceIdentifier Id { get; set; }
+        public string Id
+        {
+            get { return _instanceIdentifier.ToString(); }
+        }
 
         /// <summary>
         /// Contains the aggregated file scan result for an instance.

--- a/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
+++ b/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
@@ -63,14 +63,16 @@ namespace Altinn.App.Api.Models
 
         private void RecalculateAggregatedStatus()
         {
-            if (_dataElements.TrueForAll(dataElement => dataElement.FileScanResult == FileScanResult.Clean))
-            {
-                FileScanResult = FileScanResult.Clean;
-            }
-            else if (_dataElements.Any(dataElement => dataElement.FileScanResult == FileScanResult.Infected))
+            FileScanResult = FileScanResult.Clean;
+
+            if (_dataElements.Any(dataElement => dataElement.FileScanResult == FileScanResult.Infected))
             {
                 FileScanResult = FileScanResult.Infected;
             }
+
+            // This implicitly states that there are no infected files and that they
+            // either have to be clean or pending - so any pending would result in Pending status
+            // and if there are no Pending and no Infected they are all Clean.
             else if (_dataElements.Any(dataElement => dataElement.FileScanResult == FileScanResult.Pending))
             {
                 FileScanResult = FileScanResult.Pending;

--- a/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
+++ b/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Enums;
+
+namespace Altinn.App.Api.Models
+{
+    /// <summary>
+    /// Light weight model representing an instance and it's file scan result status.
+    /// </summary>
+    public class InstanceFileScanResult
+    {
+        private readonly List<DataElementFileScanResult> _dataElements;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstanceFileScanResult"/> class.
+        /// </summary>
+        public InstanceFileScanResult(InstanceIdentifier instanceIdentifier)
+        {
+            Id = instanceIdentifier;
+            _dataElements = new List<DataElementFileScanResult>();
+        }
+
+        /// <summary>
+        /// Instance id
+        /// </summary>
+        [JsonPropertyName("id")]
+        public InstanceIdentifier Id { get; set; }
+
+        /// <summary>
+        /// Contains the aggregated file scan result for an instance.
+        /// Infected = If any data elements has a status of Infected
+        /// Clean = If all data elements has status Clean
+        /// Pending = If all or some are Pending and the rest are Clean
+        /// </summary>
+        [JsonPropertyName("fileScanResult")]
+        public FileScanResult FileScanResult { get; private set; }
+
+        /// <summary>
+        /// File scan result for individual data elements.
+        /// </summary>
+        [JsonPropertyName("data")]
+        public IReadOnlyList<DataElementFileScanResult> DataElements => _dataElements.AsReadOnly();
+
+        /// <summary>
+        /// Adds a individual data element file scan result and updates the aggregated file scan result status
+        /// </summary>        
+        public void AddFileScanResult(DataElementFileScanResult dataElementFileScanResult)
+        {
+            _dataElements.Add(dataElementFileScanResult);
+
+            RecalculateAggregatedStatus();
+        }
+
+        private void RecalculateAggregatedStatus()
+        {
+            if (_dataElements.TrueForAll(dataElement => dataElement.FileScanResult == FileScanResult.Clean))
+            {
+                FileScanResult = FileScanResult.Clean;
+            }
+            else if (_dataElements.Any(dataElement => dataElement.FileScanResult == FileScanResult.Infected))
+            {
+                FileScanResult = FileScanResult.Infected;
+            }
+            else if (_dataElements.Any(dataElement => dataElement.FileScanResult == FileScanResult.Pending))
+            {
+                FileScanResult = FileScanResult.Pending;
+            }
+        }
+    }
+}

--- a/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
+++ b/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
@@ -35,6 +35,7 @@ namespace Altinn.App.Api.Models
         /// Pending = If all or some are Pending and the rest are Clean
         /// </summary>
         [JsonPropertyName("fileScanResult")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public FileScanResult FileScanResult { get; private set; }
 
         /// <summary>

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.3.3" />
     <PackageReference Include="Altinn.Common.PEP" Version="1.1.0" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.1.2" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.13.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.14.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.3.3" />
     <PackageReference Include="Altinn.Common.PEP" Version="1.1.0" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.1.2" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.12.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.13.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.3.3" />
     <PackageReference Include="Altinn.Common.PEP" Version="1.1.0" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.1.2" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.11.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.12.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />

--- a/src/Altinn.App.Core/Features/Validation/ValidationAppSI.cs
+++ b/src/Altinn.App.Core/Features/Validation/ValidationAppSI.cs
@@ -191,13 +191,28 @@ namespace Altinn.App.Core.Features.Validation
                 {
                     InstanceId = instance.Id,
                     DataElementId = dataElement.Id,
-                    Code = ValidationIssueCodes.DataElementCodes.DataElementFileScanPending,
+                    Code = ValidationIssueCodes.DataElementCodes.DataElementFileInfected,
                     Severity = ValidationIssueSeverity.Error,
-                    Description = ValidationIssueCodes.DataElementCodes.DataElementFileScanPending,
+                    Description = ValidationIssueCodes.DataElementCodes.DataElementFileInfected,
                     Field = dataType.Id
                 };
                 messages.Add(message);
             }
+
+            //TODO: Awaits new property on pending file scans
+            //if (dataType.EnableFileScan && dataElement.ValidationErrorOnPendingFileScan && dataElement.FileScanResult == FileScanResult.Pending)
+            //{
+            //    ValidationIssue message = new ValidationIssue()
+            //    {
+            //        InstanceId = instance.Id,
+            //        DataElementId = dataElement.Id,
+            //        Code = ValidationIssueCodes.DataElementCodes.DataElementFileScanPending,
+            //        Severity = ValidationIssueSeverity.Error,
+            //        Description = ValidationIssueCodes.DataElementCodes.DataElementFileScanPending,
+            //        Field = dataType.Id
+            //    };
+            //    messages.Add(message);
+            //}
 
             if (dataType.AppLogic?.ClassRef != null)
             {

--- a/src/Altinn.App.Core/Features/Validation/ValidationAppSI.cs
+++ b/src/Altinn.App.Core/Features/Validation/ValidationAppSI.cs
@@ -3,6 +3,7 @@ using Altinn.App.Core.Interface;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Models.Validation;
+using Altinn.Platform.Storage.Interface.Enums;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -179,6 +180,20 @@ namespace Altinn.App.Core.Features.Validation
                     Code = ValidationIssueCodes.DataElementCodes.DataElementTooLarge,
                     Severity = ValidationIssueSeverity.Error,
                     Description = ValidationIssueCodes.DataElementCodes.DataElementTooLarge,
+                    Field = dataType.Id
+                };
+                messages.Add(message);
+            }
+
+            if (dataType.EnableFileScan && dataElement.FileScanResult == FileScanResult.Infected)
+            {
+                ValidationIssue message = new ValidationIssue()
+                {
+                    InstanceId = instance.Id,
+                    DataElementId = dataElement.Id,
+                    Code = ValidationIssueCodes.DataElementCodes.DataElementFileScanPending,
+                    Severity = ValidationIssueSeverity.Error,
+                    Description = ValidationIssueCodes.DataElementCodes.DataElementFileScanPending,
                     Field = dataType.Id
                 };
                 messages.Add(message);

--- a/src/Altinn.App.Core/Models/Validation/ValidationIssueCodes.cs
+++ b/src/Altinn.App.Core/Models/Validation/ValidationIssueCodes.cs
@@ -45,6 +45,16 @@ namespace Altinn.App.Core.Models.Validation
             /// Gets a value that represents a validation issue where a data element has been validated at a process task different from expected.
             /// </summary>
             public static string DataElementValidatedAtWrongTask => nameof(DataElementValidatedAtWrongTask);
+
+            /// <summary>
+            /// Gets a value that represents a validation issue where the data element has a pending file virus scan.
+            /// </summary>
+            public static string DataElementFileScanPending => nameof(DataElementFileScanPending);
+
+            /// <summary>
+            /// Gets a value that represents a validation issue where the data element is infected with virus or malware of some form.
+            /// </summary>
+            public static string DataElementFileInfected => nameof(DataElementFileInfected);
         }
     }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
@@ -46,9 +46,9 @@ namespace Altinn.App.Api.Tests.Controllers
 
         private static Mock<IInstance> CreateInstanceClientMock(string org, string app, int instanceOwnerPartyId, Guid instanceId)
         {
-            Instance instance = new Instance
+            var instance = new Instance
             {
-                Id = instanceOwnerPartyId.ToString() + "/" + instanceId.ToString(),
+                Id = instanceOwnerPartyId.ToString() + "/" + instanceId,
                 Process = null,
                 Data = new List<DataElement>()
                 {
@@ -59,7 +59,7 @@ namespace Altinn.App.Api.Tests.Controllers
             var instanceClientMock = new Mock<IInstance>();
             instanceClientMock
                 .Setup(e => e.GetInstance(app, org, instanceOwnerPartyId, instanceId))
-                .Returns(Task.FromResult<Instance>(instance));
+                .Returns(Task.FromResult(instance));
 
             return instanceClientMock;
         }

--- a/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
@@ -2,11 +2,10 @@
 using Altinn.App.Core.Interface;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -15,34 +14,54 @@ namespace Altinn.App.Api.Tests.Controllers
     public class FileScanControllerTests
     {
         [Fact]
-        public async void AtLeasOneDataElementInfected()
+        public async Task InstanceAndDataExists_ShouldReturn200Ok()
         {
             const string org = "org";
             const string app = "app";
             const int instanceOwnerPartyId = 12345;
-            var instanceId = Guid.NewGuid();
+            Guid instanceId = Guid.NewGuid();
+            Mock<IInstance> instanceClientMock = CreateInstanceClientMock(org, app, instanceOwnerPartyId, instanceId);
 
+            var fileScanController = new FileScanController(instanceClientMock.Object);
+            var fileScanResults = await fileScanController.GetFileScanResults(org, app, instanceOwnerPartyId, instanceId);
+
+            fileScanResults.Result.Should().BeOfType<OkObjectResult>();
+            fileScanResults.Value?.FileScanResult.Should().Be(Platform.Storage.Interface.Enums.FileScanResult.Infected);
+        }
+
+        [Fact]
+        public async Task InstanceDoesNotExists_ShouldReturnNotFound()
+        {
+            const string org = "org";
+            const string app = "app";
+            const int instanceOwnerPartyId = 12345;
+            Guid instanceId = Guid.NewGuid();
+            Mock<IInstance> instanceClientMock = CreateInstanceClientMock(org, app, instanceOwnerPartyId, instanceId);
+
+            var fileScanController = new FileScanController(instanceClientMock.Object);
+            var fileScanResults = await fileScanController.GetFileScanResults(org, app, instanceOwnerPartyId, Guid.NewGuid());
+
+            fileScanResults.Result.Should().BeOfType<NotFoundResult>();
+        }
+
+        private static Mock<IInstance> CreateInstanceClientMock(string org, string app, int instanceOwnerPartyId, Guid instanceId)
+        {
             Instance instance = new Instance
             {
                 Id = instanceOwnerPartyId.ToString() + "/" + instanceId.ToString(),
                 Process = null,
-                Data = new List<DataElement>() 
+                Data = new List<DataElement>()
                 {
                     new() { Id = Guid.NewGuid().ToString(), FileScanResult = Platform.Storage.Interface.Enums.FileScanResult.Infected }
                 }
             };
-
 
             var instanceClientMock = new Mock<IInstance>();
             instanceClientMock
                 .Setup(e => e.GetInstance(app, org, instanceOwnerPartyId, instanceId))
                 .Returns(Task.FromResult<Instance>(instance));
 
-            FileScanController fileScanController = new FileScanController(instanceClientMock.Object);
-
-            var fileScanResults = await fileScanController.GetFileScanResults(org, app, instanceOwnerPartyId, instanceId);
-
-            fileScanResults.Value?.FileScanResult.Should().Be(Platform.Storage.Interface.Enums.FileScanResult.Infected);
+            return instanceClientMock;
         }
     }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
@@ -1,0 +1,48 @@
+﻿using Altinn.App.Api.Controllers;
+using Altinn.App.Core.Interface;
+using Altinn.Platform.Storage.Interface.Models;
+using FluentAssertions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Altinn.App.Api.Tests.Controllers
+{
+    public class FileScanControllerTests
+    {
+        [Fact]
+        public async void AtLeasOneDataElementInfected()
+        {
+            const string org = "org";
+            const string app = "app";
+            const int instanceOwnerPartyId = 12345;
+            var instanceId = Guid.NewGuid();
+
+            Instance instance = new Instance
+            {
+                Id = instanceOwnerPartyId.ToString() + "/" + instanceId.ToString(),
+                Process = null,
+                Data = new List<DataElement>() 
+                {
+                    new() { Id = Guid.NewGuid().ToString(), FileScanResult = Platform.Storage.Interface.Enums.FileScanResult.Infected }
+                }
+            };
+
+
+            var instanceClientMock = new Mock<IInstance>();
+            instanceClientMock
+                .Setup(e => e.GetInstance(app, org, instanceOwnerPartyId, instanceId))
+                .Returns(Task.FromResult<Instance>(instance));
+
+            FileScanController fileScanController = new FileScanController(instanceClientMock.Object);
+
+            var fileScanResults = await fileScanController.GetFileScanResults(org, app, instanceOwnerPartyId, instanceId);
+
+            fileScanResults.Value?.FileScanResult.Should().Be(Platform.Storage.Interface.Enums.FileScanResult.Infected);
+        }
+    }
+}

--- a/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
@@ -48,7 +48,7 @@ namespace Altinn.App.Api.Tests.Controllers
         {
             var instance = new Instance
             {
-                Id = instanceOwnerPartyId.ToString() + "/" + instanceId,
+                Id = $"{instanceOwnerPartyId}/{instanceId}",
                 Process = null,
                 Data = new List<DataElement>()
                 {

--- a/test/Altinn.App.Api.Tests/Models/InstanceFileScanResultTests.cs
+++ b/test/Altinn.App.Api.Tests/Models/InstanceFileScanResultTests.cs
@@ -10,11 +10,19 @@ namespace Altinn.App.Api.Tests.Models
     public class InstanceFileScanResultTests
     {
         //TODO: Add test for empty list and NotApplicable status
+        [Fact]
+        public void ZeroDataElement_AggregatedStatusShouldBeNotApplicable()
+        {
+            var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(12345, Guid.NewGuid()));
+
+            instanceFileScanResult.FileScanResult.Should().Be(FileScanResult.NotApplicable);
+        }
 
         [Theory]
         [InlineData(FileScanResult.Pending)]
         [InlineData(FileScanResult.Infected)]
         [InlineData(FileScanResult.Clean)]
+        [InlineData(FileScanResult.NotApplicable)]
         public void OneDataElement_AggregatedStatusShouldBeSame(FileScanResult fileScanResult)
         {
             var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(12345, Guid.NewGuid()));
@@ -28,6 +36,7 @@ namespace Altinn.App.Api.Tests.Models
         [InlineData(FileScanResult.Pending)]
         [InlineData(FileScanResult.Infected)]
         [InlineData(FileScanResult.Clean)]
+        [InlineData(FileScanResult.NotApplicable)]
         public void AtLeastOneDataElementInfected_AggregatedStatusShouldBeInfected(FileScanResult fileScanResult)
         {
             var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(12345, Guid.NewGuid()));
@@ -79,6 +88,7 @@ namespace Altinn.App.Api.Tests.Models
             instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Infected });
             instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Pending });
             instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Clean });
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.NotApplicable });
 
             instanceFileScanResult.FileScanResult.Should().Be(FileScanResult.Infected);
         }

--- a/test/Altinn.App.Api.Tests/Models/InstanceFileScanResultTests.cs
+++ b/test/Altinn.App.Api.Tests/Models/InstanceFileScanResultTests.cs
@@ -1,0 +1,86 @@
+﻿using Altinn.App.Api.Models;
+using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Enums;
+using FluentAssertions;
+using System;
+using Xunit;
+
+namespace Altinn.App.Api.Tests.Models
+{
+    public class InstanceFileScanResultTests
+    {
+        //TODO: Add test for empty list and NotApplicable status
+
+        [Theory]
+        [InlineData(FileScanResult.Pending)]
+        [InlineData(FileScanResult.Infected)]
+        [InlineData(FileScanResult.Clean)]
+        public void OneDataElement_AggregatedStatusShouldBeSame(FileScanResult fileScanResult)
+        {
+            var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(12345, Guid.NewGuid()));
+
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = fileScanResult });
+
+            instanceFileScanResult.FileScanResult.Should().Be(fileScanResult);
+        }
+
+        [Theory]
+        [InlineData(FileScanResult.Pending)]
+        [InlineData(FileScanResult.Infected)]
+        [InlineData(FileScanResult.Clean)]
+        public void AtLeastOneDataElementInfected_AggregatedStatusShouldBeInfected(FileScanResult fileScanResult)
+        {
+            var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(12345, Guid.NewGuid()));
+
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = fileScanResult });
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Infected });
+
+            instanceFileScanResult.FileScanResult.Should().Be(FileScanResult.Infected);
+        }
+
+        [Fact]
+        public void AllDataElemementsClean_AggregatedStatusShouldBeClean()
+        {
+            var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(12345, Guid.NewGuid()));
+
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Clean });
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Clean });
+
+            instanceFileScanResult.FileScanResult.Should().Be(FileScanResult.Clean);
+        }
+
+        [Fact]
+        public void OneCleanOnePending_AggregatedStatusShouldBePending()
+        {
+            var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(12345, Guid.NewGuid()));
+
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Clean });
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Pending });
+
+            instanceFileScanResult.FileScanResult.Should().Be(FileScanResult.Pending);
+        }
+
+        [Fact]
+        public void MultiplePending_AggregatedStatusShouldBePending()
+        {
+            var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(12345, Guid.NewGuid()));
+
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Pending });
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Pending });
+
+            instanceFileScanResult.FileScanResult.Should().Be(FileScanResult.Pending);
+        }
+
+        [Fact]
+        public void OneOfEach_AggregatedStatusShouldBeInfected()
+        {
+            var instanceFileScanResult = new InstanceFileScanResult(new InstanceIdentifier(12345, Guid.NewGuid()));
+
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Infected });
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Pending });
+            instanceFileScanResult.AddFileScanResult(new DataElementFileScanResult() { Id = Guid.NewGuid().ToString(), FileScanResult = FileScanResult.Clean });
+
+            instanceFileScanResult.FileScanResult.Should().Be(FileScanResult.Infected);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two things:
1. If an uploaded file is infected by virus/malware and the file scan has completed before the instance is submitted, it will produce a validation error.
2. A new endpoint for checking scan results for a instance and it's data elements.

## Related Issue(s)
- https://github.com/Altinn/altinn-file-scan/issues/30
- https://github.com/Altinn/altinn-file-scan/issues/11

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
