### PR TITLE
Add new DynamicsPdfFormatter

### DIFF
--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -1,7 +1,6 @@
-using System;
-using System.Linq;
+#nullable enable
+
 using System.Text.Json;
-using System.Threading.Tasks;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Interface;
 using Altinn.App.Core.Internal.AppModel;
@@ -66,13 +65,13 @@ namespace Altinn.App.Api.Controllers
                 return NotFound("Did not find instance");
             }
 
-            string taskId = instance.Process?.CurrentTask?.ElementId;
+            string? taskId = instance.Process?.CurrentTask?.ElementId;
             if (taskId == null)
             {
                 return Conflict("Instance does not have a valid currentTask");
             }
 
-            DataElement dataElement = instance.Data.FirstOrDefault(d => d.Id == dataGuid.ToString());
+            DataElement? dataElement = instance.Data.FirstOrDefault(d => d.Id == dataGuid.ToString());
             if (dataElement == null)
             {
                 return NotFound("Did not find data element");
@@ -84,20 +83,20 @@ namespace Altinn.App.Api.Controllers
             JsonSerializerOptions options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
             string layoutSetsString = _resources.GetLayoutSets();
-            LayoutSets layoutSets = null;
-            LayoutSet layoutSet = null;
+            LayoutSets? layoutSets = null;
+            LayoutSet? layoutSet = null;
             if (!string.IsNullOrEmpty(layoutSetsString))
             {
-                layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, options);
+                layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, options)!;
                 layoutSet = layoutSets.Sets?.FirstOrDefault(t => t.DataType.Equals(dataElement.DataType) && t.Tasks.Contains(taskId));
             }
 
-            string layoutSettingsFileContent = layoutSet == null ? _resources.GetLayoutSettingsString() : _resources.GetLayoutSettingsStringForSet(layoutSet.Id);
+            string? layoutSettingsFileContent = layoutSet == null ? _resources.GetLayoutSettingsString() : _resources.GetLayoutSettingsStringForSet(layoutSet.Id);
 
-            LayoutSettings layoutSettings = null;
+            LayoutSettings? layoutSettings = null;
             if (!string.IsNullOrEmpty(layoutSettingsFileContent))
             {
-                layoutSettings = JsonSerializer.Deserialize<LayoutSettings>(layoutSettingsFileContent, options);
+                layoutSettings = JsonSerializer.Deserialize<LayoutSettings>(layoutSettingsFileContent, options)!;
             }
 
             // Ensure layoutsettings are initialized in FormatPdf
@@ -113,8 +112,8 @@ namespace Altinn.App.Api.Controllers
 
             var result = new
             {
-                ExcludedPages = layoutSettings.Pages.ExcludeFromPdf,
-                ExcludedComponents = layoutSettings.Components.ExcludeFromPdf,
+                ExcludedPages = layoutSettings?.Pages?.ExcludeFromPdf ?? new List<string>(),
+                ExcludedComponents = layoutSettings?.Components?.ExcludeFromPdf ?? new List<string>(),
             };
             return Ok(result);
         }

--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -108,7 +108,7 @@ namespace Altinn.App.Api.Controllers
 
             object data = await _dataClient.GetFormData(instanceGuid, dataType, org, app, instanceOwnerPartyId, new Guid(dataElement.Id));
 
-            layoutSettings = await _pdfFormatter.FormatPdf(layoutSettings, data, instance);
+            layoutSettings = await _pdfFormatter.FormatPdf(layoutSettings, data, instance, layoutSet);
 
             var result = new
             {

--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -109,7 +109,7 @@ namespace Altinn.App.Api.Controllers
 
             object data = await _dataClient.GetFormData(instanceGuid, dataType, org, app, instanceOwnerPartyId, new Guid(dataElement.Id));
 
-            layoutSettings = await _pdfFormatter.FormatPdf(layoutSettings, data);
+            layoutSettings = await _pdfFormatter.FormatPdf(layoutSettings, data, instance);
 
             var result = new
             {

--- a/src/Altinn.App.Core/Features/IPdfFormatter.cs
+++ b/src/Altinn.App.Core/Features/IPdfFormatter.cs
@@ -1,15 +1,30 @@
 ﻿using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Models;
 
-namespace Altinn.App.Core.Features
+namespace Altinn.App.Core.Features;
+
+/// <summary>
+/// Interface to customize PDF formatting.
+/// </summary>
+/// <remarks>
+/// This interface has been changed and both methods now has default implementation for backwards compatibility.
+/// All users will call the method with the Instance parameter, and a user only needs to implement one
+/// </remarks>
+public interface IPdfFormatter
 {
     /// <summary>
-    /// Interface to customize PDF formatting.
+    /// Old method to format the PDF dynamically (without Instance)
     /// </summary>
-    public interface IPdfFormatter
+    Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data)
     {
-        /// <summary>
-        /// Method to format the PDF dynamically
-        /// </summary>        
-        Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data);
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Method to format the PDF dynamically (new version with the instance)
+    /// </summary>
+    async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data, Instance instance)
+    {
+        return await FormatPdf(layoutSettings, data);
     }
 }

--- a/src/Altinn.App.Core/Features/IPdfFormatter.cs
+++ b/src/Altinn.App.Core/Features/IPdfFormatter.cs
@@ -23,7 +23,7 @@ public interface IPdfFormatter
     /// <summary>
     /// Method to format the PDF dynamically (new version with the instance)
     /// </summary>
-    async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data, Instance instance)
+    async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data, Instance instance, LayoutSet? layoutSet)
     {
         return await FormatPdf(layoutSettings, data);
     }

--- a/src/Altinn.App.Core/Features/Pdf/DynamicsPdfFormatter.cs
+++ b/src/Altinn.App.Core/Features/Pdf/DynamicsPdfFormatter.cs
@@ -27,28 +27,28 @@ public class DynamicsPdfFormatter : IPdfFormatter
     }
 
     /// <inheritdoc />
-    public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data, Instance instance)
+    public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data, Instance instance, LayoutSet? layoutSet)
     {
         layoutSettings.Pages ??= new();
         layoutSettings.Pages.ExcludeFromPdf ??= new();
         layoutSettings.Components ??= new();
         layoutSettings.Components.ExcludeFromPdf ??= new();
 
-        var state = await _layoutStateInit.Init(instance, data, layoutSetId:null);
-        foreach(var pageContext in state.GetComponentContexts())
+        var state = await _layoutStateInit.Init(instance, data, layoutSetId: layoutSet?.Id);
+        foreach (var pageContext in state.GetComponentContexts())
         {
             var pageHidden = ExpressionEvaluator.EvaluateBooleanExpression(state, pageContext, "hidden", false);
-            if(pageHidden)
+            if (pageHidden)
             {
                 layoutSettings.Pages.ExcludeFromPdf.Add(pageContext.Component.Id);
             }
             else
             {
                 //TODO: figure out how pdf reacts to groups one level down.
-                foreach(var componentContext in pageContext.ChildContexts)
+                foreach (var componentContext in pageContext.ChildContexts)
                 {
                     var componentHidden = ExpressionEvaluator.EvaluateBooleanExpression(state, componentContext, "hidden", false);
-                    if(componentHidden)
+                    if (componentHidden)
                     {
                         layoutSettings.Components.ExcludeFromPdf.Add(componentContext.Component.Id);
                     }

--- a/src/Altinn.App.Core/Features/Pdf/DynamicsPdfFormatter.cs
+++ b/src/Altinn.App.Core/Features/Pdf/DynamicsPdfFormatter.cs
@@ -1,0 +1,60 @@
+using Altinn.App.Core.Internal.Expressions;
+using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.Core.Features.Pdf;
+
+/// <summary>
+/// Custom formatter that reads the `hidden` properties of components and pages
+/// to determine if they should be hidden in PDF as well.
+/// </summary>
+/// <remarks>
+/// Add this to dependency injection in order to run dynamics for hiding pages and comonents.
+/// <code>
+/// services.AddTrancient&lt;IPdfFormatter, DynamicsPdfFormatter&gt;();
+/// </code>
+/// </remarks>
+public class DynamicsPdfFormatter : IPdfFormatter
+{
+    private readonly LayoutEvaluatorStateInitializer _layoutStateInit;
+
+    /// <summary>
+    /// Constructor for <see cref="DynamicsPdfFormatter" />
+    /// </summary>
+    public DynamicsPdfFormatter(LayoutEvaluatorStateInitializer layoutStateInit)
+    {
+        _layoutStateInit = layoutStateInit;
+    }
+
+    /// <inheritdoc />
+    public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, object data, Instance instance)
+    {
+        layoutSettings.Pages ??= new();
+        layoutSettings.Pages.ExcludeFromPdf ??= new();
+        layoutSettings.Components ??= new();
+        layoutSettings.Components.ExcludeFromPdf ??= new();
+
+        var state = await _layoutStateInit.Init(instance, data, layoutSetId:null);
+        foreach(var pageContext in state.GetComponentContexts())
+        {
+            var pageHidden = ExpressionEvaluator.EvaluateBooleanExpression(state, pageContext, "hidden", false);
+            if(pageHidden)
+            {
+                layoutSettings.Pages.ExcludeFromPdf.Add(pageContext.Component.Id);
+            }
+            else
+            {
+                //TODO: figure out how pdf reacts to groups one level down.
+                foreach(var componentContext in pageContext.ChildContexts)
+                {
+                    var componentHidden = ExpressionEvaluator.EvaluateBooleanExpression(state, componentContext, "hidden", false);
+                    if(componentHidden)
+                    {
+                        layoutSettings.Components.ExcludeFromPdf.Add(componentContext.Component.Id);
+                    }
+                }
+            }
+        }
+        return layoutSettings;
+    }
+}

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -72,7 +72,7 @@ public class PdfService : IPdfService
         _dataClient = dataClient;
         _httpContextAccessor = httpContextAccessor;
         _profileClient = profileClient;
-        _registerClient= registerClient;
+        _registerClient = registerClient;
         _pdfFormatter = pdfFormatter;
         _pdfGeneratorClient = pdfGeneratorClient;
         _pdfGeneratorSettings = pdfGeneratorSettings.Value;
@@ -140,7 +140,7 @@ public class PdfService : IPdfService
 
         object data = await _dataClient.GetFormData(instanceGuid, dataElementModelType, org, app, instanceOwnerId, new Guid(dataElement.Id));
 
-        layoutSettings = await _pdfFormatter.FormatPdf(layoutSettings, data, instance);
+        layoutSettings = await _pdfFormatter.FormatPdf(layoutSettings, data, instance, layoutSet);
         XmlSerializer serializer = new XmlSerializer(dataElementModelType);
         using MemoryStream stream = new MemoryStream();
 
@@ -216,7 +216,7 @@ public class PdfService : IPdfService
             textResource.Resources.Find(textResourceElement => textResourceElement.Id.Equals("ServiceName"));
 
         fileName = (titleText != null && !string.IsNullOrEmpty(titleText.Value)) ? $"{titleText.Value}.pdf" : $"{app}.pdf";
-        
+
         fileName = GetValidFileName(fileName);
 
         return await _dataClient.InsertBinaryData(
@@ -280,7 +280,7 @@ public class PdfService : IPdfService
         {
             fileName = titleText.Value + ".pdf";
         }
-        
+
         return GetValidFileName(fileName);
     }
 

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -140,7 +140,7 @@ public class PdfService : IPdfService
 
         object data = await _dataClient.GetFormData(instanceGuid, dataElementModelType, org, app, instanceOwnerId, new Guid(dataElement.Id));
 
-        layoutSettings = await _pdfFormatter.FormatPdf(layoutSettings, data);
+        layoutSettings = await _pdfFormatter.FormatPdf(layoutSettings, data, instance);
         XmlSerializer serializer = new XmlSerializer(dataElementModelType);
         using MemoryStream stream = new MemoryStream();
 


### PR DESCRIPTION
Read the layout files and hide the relevant pages/components.
We needed this for a big app with lots of dynamics and thought it would be nice to share.

Activation is simple as it is just another service to registrer in `Program.cs`.
```C#
using Altinn.App.Core.Features.Pdf;
...
    services.AddTransient<IPdfFormatterInstance, DynamicsPdfFormatter>();
```

## Description
This ~is~ (was intended to be) a simple `IPdfFormatter` implementation that uses the dynamics infrastructure to figure out what the page/component ids that would be `hidden` in using dynamic `hidden` expressions. Because expressions has `instanceContext` that requires the instance to be available, it required a new interface (`IPdfFormatterInstance`) and some cleanup of the code that calls the pdf formatter.

## Changes
1. New interface `IPdfFormatterInstance` that is a copy of `IPdfFormatter`, but includes the instance, so it can be used for determining what to hide.
2. New `IPdfFormatterInstance` implementation, `DynamicsPdfFormatter` that reads dynamic expressions and hide `hidden` pages and components.
3. Use the shared json deserialization functionality from `AppResourcesSI`, instead of deserializing json in `PdfController` and `PdfService`.
4. Improve `AppResourcesSI` to use a shared `JsonSerializerOptions` instance that accepts comments and trailing commas.
5. Remove `NullPdfFormatter` and make the constructor injection inject optional services instead `IPdfFormatter? pdfFormatter = default,`

If this is somewhat hard to write sensible tests for this functionality (we really need an app and pdf generation to see), so I'll wait for feedback before writing tests.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (will be provided if this is approved)
