### PR TITLE
Return NoContent for missing (optional) files

### DIFF
--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -56,11 +56,6 @@ namespace Altinn.App.Core.Implementation
             else if (resource == _settings.RuleConfigurationJSONFileName)
             {
                 fileContent = ReadFileContentsFromLegalPath(_settings.AppBasePath + _settings.UiFolder, resource);
-
-                if (fileContent == null)
-                {
-                    fileContent = new byte[0];
-                }
             }
             else
             {


### PR DESCRIPTION
`RuleConfiguration.js` and `RuleHandler.js` will soon be deprecated and removed from the app template. Frontend still needs to poll for the files for backwards compatibility, but showing permanent 404 in the browser console is a bad developer experience. 

This suggest to change the return code to `204` no content, ~but it should not be released in backend before a released version of frontend is tested and verified to support this new behaviour~. It seems to work fine as is.

## Related Issue(s)
- https://github.com/Altinn/app-template-dotnet/issues/169

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
