### PR TITLE
Use more relaxed Json parsing in AppResourcesSi.cs

### DIFF
--- a/src/Altinn.App.Core/Features/PageOrder/DefaultPageOrder.cs
+++ b/src/Altinn.App.Core/Features/PageOrder/DefaultPageOrder.cs
@@ -22,7 +22,7 @@ namespace Altinn.App.Core.Features.PageOrder
         /// <inheritdoc />
         public async Task<List<string>> GetPageOrder(AppIdentifier appIdentifier, InstanceIdentifier instanceIdentifier, string layoutSetId, string currentPage, string dataTypeId, object formData)
         {
-            LayoutSettings layoutSettings;
+            LayoutSettings? layoutSettings;
 
             if (string.IsNullOrEmpty(layoutSetId))
             {

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -23,6 +23,12 @@ namespace Altinn.App.Core.Implementation
         private readonly IWebHostEnvironment _hostingEnvironment;
         private readonly ILogger _logger;
         private Application? _application;
+        private static readonly JsonSerializerOptions DESERIALIZER_OPTIONS = new()
+        {
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            PropertyNameCaseInsensitive = true,
+        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AppResourcesSI"/> class.
@@ -91,8 +97,7 @@ namespace Altinn.App.Core.Implementation
 
             using (FileStream fileStream = new(fullFileName, FileMode.Open, FileAccess.Read))
             {
-                JsonSerializerOptions options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-                TextResource textResource = (await System.Text.Json.JsonSerializer.DeserializeAsync<TextResource>(fileStream, options))!;
+                TextResource textResource = (await System.Text.Json.JsonSerializer.DeserializeAsync<TextResource>(fileStream, DESERIALIZER_OPTIONS))!;
                 textResource.Id = $"{org}-{app}-{language}";
                 textResource.Org = org;
                 textResource.Language = language;
@@ -331,7 +336,7 @@ namespace Altinn.App.Core.Implementation
             string? layoutSetsString = GetLayoutSets();
             if (layoutSetsString is not null)
             {
-                return System.Text.Json.JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+                return System.Text.Json.JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, DESERIALIZER_OPTIONS);
             }
             return null;
         }
@@ -378,7 +383,7 @@ namespace Altinn.App.Core.Implementation
                 var pageBytes = File.ReadAllBytes(Path.Join(folder, page + ".json"));
                 // Set the PageName using AsyncLocal before deserializing.
                 PageComponentConverter.SetAsyncLocalPageName(page);
-                layoutModel.Pages[page] = System.Text.Json.JsonSerializer.Deserialize<PageComponent>(pageBytes.RemoveBom(), new JsonSerializerOptions(JsonSerializerDefaults.Web)) ?? throw new InvalidDataException(page + ".json is \"null\"");
+                layoutModel.Pages[page] = System.Text.Json.JsonSerializer.Deserialize<PageComponent>(pageBytes.RemoveBom(), DESERIALIZER_OPTIONS) ?? throw new InvalidDataException(page + ".json is \"null\"");
             }
 
             return layoutModel;


### PR DESCRIPTION
Sometimes people want to use trailing commas or comments in their json files, and I can't really see why that should be a failiure that requires fixing. This fix is also part of https://github.com/Altinn/app-lib-dotnet/pull/173, but seems like it is worth a standalone review.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
