### PR TITLE
Nullsafe active instances endpoint

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -135,7 +136,7 @@ namespace Altinn.App.Api.Controllers
                 Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
                 SelfLinkHelper.SetInstanceAppSelfLinks(instance, Request);
 
-                string userOrgClaim = User.GetOrg();
+                string? userOrgClaim = User.GetOrg();
 
                 if (userOrgClaim == null || !org.Equals(userOrgClaim, StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -195,7 +196,7 @@ namespace Altinn.App.Api.Controllers
                 return BadRequest($"Error when reading content: {JsonConvert.SerializeObject(parsedRequest.Errors)}");
             }
 
-            Instance instanceTemplate = await ExtractInstanceTemplate(parsedRequest);
+            Instance? instanceTemplate = await ExtractInstanceTemplate(parsedRequest);
 
             if (!instanceOwnerPartyId.HasValue && instanceTemplate == null)
             {
@@ -241,10 +242,8 @@ namespace Altinn.App.Api.Controllers
             }
             catch (Exception partyLookupException)
             {
-                if (partyLookupException is ServiceException)
+                if (partyLookupException is ServiceException sexp)
                 {
-                    ServiceException sexp = partyLookupException as ServiceException;
-
                     if (sexp.StatusCode.Equals(HttpStatusCode.Unauthorized))
                     {
                         return StatusCode((int)HttpStatusCode.Forbidden);
@@ -284,7 +283,7 @@ namespace Altinn.App.Api.Controllers
                 processChangeContext = await _processEngine.StartProcess(processChangeContext);
                 processResult = processChangeContext.ProcessStateChange;
 
-                string userOrgClaim = User.GetOrg();
+                string? userOrgClaim = User.GetOrg();
 
                 if (userOrgClaim == null || !org.Equals(userOrgClaim, StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -379,10 +378,8 @@ namespace Altinn.App.Api.Controllers
             }
             catch (Exception partyLookupException)
             {
-                if (partyLookupException is ServiceException)
+                if (partyLookupException is ServiceException sexp)
                 {
-                    ServiceException sexp = partyLookupException as ServiceException;
-
                     if (sexp.StatusCode.Equals(HttpStatusCode.Unauthorized))
                     {
                         return StatusCode((int)HttpStatusCode.Forbidden);
@@ -436,7 +433,7 @@ namespace Altinn.App.Api.Controllers
                 processChangeContext = await _processEngine.StartProcess(processChangeContext);
                 processResult = processChangeContext.ProcessStateChange;
 
-                string userOrgClaim = User.GetOrg();
+                string? userOrgClaim = User.GetOrg();
 
                 if (userOrgClaim == null || !org.Equals(userOrgClaim, StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -444,7 +441,7 @@ namespace Altinn.App.Api.Controllers
                     instanceTemplate.Status.ReadStatus = ReadStatus.Read;
                 }
 
-                Instance source = null;
+                Instance? source = null;
 
                 if (copySourceInstance)
                 {
@@ -536,7 +533,7 @@ namespace Altinn.App.Api.Controllers
                     }
 
                     await _prefillService.PrefillDataModel(instanceOwnerPartyId.ToString(), dt.Id, data);
-                    
+
                     await _instantiationProcessor.DataCreation(targetInstance, data, null);
 
                     await _dataClient.InsertFormData(
@@ -614,7 +611,7 @@ namespace Altinn.App.Api.Controllers
 
             Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
 
-            string orgClaim = User.GetOrg();
+            string? orgClaim = User.GetOrg();
             if (!instance.Org.Equals(orgClaim))
             {
                 return Forbid();
@@ -700,7 +697,7 @@ namespace Altinn.App.Api.Controllers
             {
                 if (lastChangedBy?.Length == 9)
                 {
-                    Organization organization = await _registerClient.ER.GetOrganization(lastChangedBy);
+                    Organization? organization = await _registerClient.ER.GetOrganization(lastChangedBy);
                     if(organization is not null && !string.IsNullOrEmpty(organization.Name))
                     {
                         userAndOrgLookup.Add(lastChangedBy, organization.Name);
@@ -708,7 +705,7 @@ namespace Altinn.App.Api.Controllers
                 }
                 else if (int.TryParse(lastChangedBy, out int lastChangedByInt))
                 {
-                    UserProfile user = await _profileClientClient.GetUserProfile(lastChangedByInt);
+                    UserProfile? user = await _profileClientClient.GetUserProfile(lastChangedByInt);
                     if(user is not null && user.Party is not null && !string.IsNullOrEmpty(user.Party.Name))
                     {
                         userAndOrgLookup.Add(lastChangedBy, user.Party.Name);
@@ -843,10 +840,10 @@ namespace Altinn.App.Api.Controllers
 
             foreach (RequestPart part in parts)
             {
-                DataType dataType = appInfo.DataTypes.Find(d => d.Id == part.Name);
+                DataType? dataType = appInfo.DataTypes.Find(d => d.Id == part.Name);
 
                 DataElement dataElement;
-                if (dataType.AppLogic?.ClassRef != null)
+                if (dataType?.AppLogic?.ClassRef != null)
                 {
                     _logger.LogInformation($"Storing part {part.Name}");
 
@@ -861,7 +858,7 @@ namespace Altinn.App.Api.Controllers
                     }
 
                     ModelDeserializer deserializer = new ModelDeserializer(_logger, type);
-                    object data = await deserializer.DeserializeAsync(part.Stream, part.ContentType);
+                    object? data = await deserializer.DeserializeAsync(part.Stream, part.ContentType);
 
                     if (!string.IsNullOrEmpty(deserializer.Error))
                     {
@@ -869,7 +866,7 @@ namespace Altinn.App.Api.Controllers
                     }
 
                     await _prefillService.PrefillDataModel(instance.InstanceOwner.PartyId, part.Name, data);
-                    
+
                     await _instantiationProcessor.DataCreation(instance, data, null);
 
                     dataElement = await _dataClient.InsertFormData(
@@ -901,11 +898,11 @@ namespace Altinn.App.Api.Controllers
         /// </summary>
         /// <param name="reader">multipart reader object</param>
         /// <returns>the instance template or null if none is found</returns>
-        private static async Task<Instance> ExtractInstanceTemplate(MultipartRequestReader reader)
+        private static async Task<Instance?> ExtractInstanceTemplate(MultipartRequestReader reader)
         {
-            Instance instanceTemplate = null;
+            Instance? instanceTemplate = null;
 
-            RequestPart instancePart = reader.Parts.Find(part => part.Name == "instance");
+            RequestPart? instancePart = reader.Parts.Find(part => part.Name == "instance");
 
             // assume that first part with no name is an instanceTemplate
             if (instancePart == null && reader.Parts.Count == 1 && reader.Parts[0].ContentType.Contains("application/json") && reader.Parts[0].Name == null)

--- a/src/Altinn.App.Api/Mappers/SimpleInstanceMapper.cs
+++ b/src/Altinn.App.Api/Mappers/SimpleInstanceMapper.cs
@@ -1,4 +1,6 @@
+#nullable enable
 using System.Collections.Generic;
+using System.Linq;
 
 using Altinn.App.Api.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -36,8 +38,8 @@ namespace Altinn.App.Api.Mappers
             List<SimpleInstance> simpleInstances = new List<SimpleInstance>();
             foreach (Instance instance in instances)
             {
-                string lastChangedByName = userDictionary.ContainsKey(instance.LastChangedBy ?? string.Empty) ? userDictionary[instance.LastChangedBy] : string.Empty;
-                simpleInstances.Add(MapInstanceToSimpleInstance(instance, lastChangedByName));
+                userDictionary.TryGetValue(instance.LastChangedBy ?? string.Empty, out string? lastChangedByName);
+                simpleInstances.Add(MapInstanceToSimpleInstance(instance, lastChangedByName ?? string.Empty));
             }
 
             return simpleInstances;

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
 
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_ActiveInstancesTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_ActiveInstancesTests.cs
@@ -1,0 +1,335 @@
+using Microsoft.Extensions.Primitives;
+using Altinn.App.Api.Controllers;
+using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Interface;
+using Altinn.App.Core.Internal.AppModel;
+using Altinn.Common.PEP.Interfaces;
+using Altinn.Platform.Storage.Interface.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+using Altinn.App.Api.Models;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Register.Models;
+
+namespace Altinn.App.Api.Tests.Controllers;
+
+public class InstancesController_ActiveInstancesTest
+{
+    private readonly Mock<ILogger<InstancesController>> _logger = new();
+    private readonly Mock<IRegister> _registrer = new();
+    private readonly Mock<IInstance> _instanceClient = new();
+    private readonly Mock<IData> _data = new();
+    private readonly Mock<IAppResources> _appResources = new();
+    private readonly Mock<IAppModel> _appModel = new();
+    private readonly Mock<IInstantiationProcessor> _instantiationProcessor = new();
+    private readonly Mock<IInstantiationValidator> _instantiationValidator = new();
+    private readonly Mock<IPDP> _pdp = new();
+    private readonly Mock<IEvents> _eventsService = new();
+    private readonly IOptions<AppSettings> _appSettings = Options.Create<AppSettings>(new());
+    private readonly Mock<IPrefill> _prefill = new();
+    private readonly Mock<IProfile> _profile = new();
+    private readonly Mock<IProcessEngine> _processEngine = new();
+
+    private InstancesController SUT => new InstancesController(
+        _logger.Object,
+        _registrer.Object,
+        _instanceClient.Object,
+        _data.Object,
+        _appResources.Object,
+        _appModel.Object,
+        _instantiationProcessor.Object,
+        _instantiationValidator.Object,
+        _pdp.Object,
+        _eventsService.Object,
+        _appSettings,
+        _prefill.Object,
+        _profile.Object,
+        _processEngine.Object);
+
+    private void VerifyNoOtherCalls()
+    {
+        // _logger.VerifyNoOtherCalls();
+        _registrer.VerifyNoOtherCalls();
+        _instanceClient.VerifyNoOtherCalls();
+        _data.VerifyNoOtherCalls();
+        _appResources.VerifyNoOtherCalls();
+        _appModel.VerifyNoOtherCalls();
+        _instantiationProcessor.VerifyNoOtherCalls();
+        _instantiationValidator.VerifyNoOtherCalls();
+        _pdp.VerifyNoOtherCalls();
+        _eventsService.VerifyNoOtherCalls();
+        // _appSettings,
+        _prefill.VerifyNoOtherCalls();
+        _profile.VerifyNoOtherCalls();
+        _processEngine.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task EmptySearchResult_ReturnsOkResult()
+    {
+        // Arrange
+        var org = "ttd";
+        var app = "unit-app";
+        var instances = new List<Instance>();
+        var expected = new List<SimpleInstance>();
+
+        _instanceClient.Setup(c => c.GetInstances(It.IsAny<Dictionary<string, StringValues>>())).ReturnsAsync(instances);
+
+        // Act
+        var controller = SUT;
+        var result = await controller.GetActiveInstances(org, app, 12345);
+
+        // Assert
+        var resultValue = result.Result.Should().BeOfType<OkObjectResult>().Which.Value;
+        resultValue.Should().NotBeNull();
+        resultValue.Should().BeEquivalentTo(expected);
+
+        _instanceClient.Verify(c => c.GetInstances(It.Is<Dictionary<string, StringValues>>(query =>
+            query.ContainsKey("appId")
+        )));
+        VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task UnknownUser_ReturnsEmptyString()
+    {
+        // Arrange
+        var org = "ttd";
+        var app = "unit-app";
+        var instances = new List<Instance>()
+        {
+            new()
+            {
+                Id = $"{1234}/{Guid.NewGuid()}",
+                LastChanged = DateTime.Now,
+                LastChangedBy = "12345",
+            }
+        };
+        var expected = instances.Select(i => new SimpleInstance()
+        {
+            Id = i.Id,
+            LastChanged = i.LastChanged,
+            LastChangedBy = i.LastChangedBy switch
+            {
+                "12345" => "",
+                // "12345" => "", // Would it be more sensible to return UserId as fallback?
+                _ => throw new Exception("Unknown user"),
+            }
+        });
+
+        _instanceClient.Setup(c => c.GetInstances(It.IsAny<Dictionary<string, StringValues>>())).ReturnsAsync(instances);
+        // _profile.Setup(p=>p.GetUserProfile(12345)).ReturnsAsync(default(UserProfile)!);
+
+        // Act
+        var controller = SUT;
+        var result = await controller.GetActiveInstances(org, app, 12345);
+
+        // Assert
+        var resultValue = result.Result.Should().BeOfType<OkObjectResult>().Which.Value;
+        resultValue.Should().NotBeNull();
+        resultValue.Should().BeEquivalentTo(expected);
+
+        _instanceClient.Verify(c => c.GetInstances(It.Is<Dictionary<string, StringValues>>(query =>
+            query.ContainsKey("appId")
+        )));
+        _profile.Verify(p => p.GetUserProfile(12345));
+        VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task UserProfilePartyIsNull_ReturnsEmptyString()
+    {
+        // Arrange
+        var org = "ttd";
+        var app = "unit-app";
+        var instances = new List<Instance>()
+        {
+            new()
+            {
+                Id = $"{1234}/{Guid.NewGuid()}",
+                LastChanged = DateTime.Now,
+                LastChangedBy = "12345",
+            }
+        };
+        var expected = instances.Select(i => new SimpleInstance()
+        {
+            Id = i.Id,
+            LastChanged = i.LastChanged,
+            LastChangedBy = i.LastChangedBy switch
+            {
+                "12345" => "",
+                // "12345" => "12345", // Would it be more sensible to return UserId as fallback?
+                _ => throw new Exception("Unknown user"),
+            }
+        });
+
+        _instanceClient.Setup(c => c.GetInstances(It.IsAny<Dictionary<string, StringValues>>())).ReturnsAsync(instances);
+        _profile.Setup(p => p.GetUserProfile(12345)).ReturnsAsync(new UserProfile());
+
+        // Act
+        var controller = SUT;
+        var result = await controller.GetActiveInstances(org, app, 12345);
+
+        // Assert
+        var resultValue = result.Result.Should().BeOfType<OkObjectResult>().Which.Value;
+        resultValue.Should().NotBeNull();
+        resultValue.Should().BeEquivalentTo(expected);
+
+        _instanceClient.Verify(c => c.GetInstances(It.Is<Dictionary<string, StringValues>>(query =>
+            query.ContainsKey("appId")
+        )));
+        _profile.Verify(p => p.GetUserProfile(12345));
+        VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task KnownUser_ReturnsUserName()
+    {
+        // Arrange
+        var org = "ttd";
+        var app = "unit-app";
+        var instances = new List<Instance>()
+        {
+            new()
+            {
+                Id = $"{1234}/{Guid.NewGuid()}",
+                LastChanged = DateTime.Now,
+                LastChangedBy = "12345",
+            }
+        };
+        var expected = instances.Select(i => new SimpleInstance()
+        {
+            Id = i.Id,
+            LastChanged = i.LastChanged,
+            LastChangedBy = i.LastChangedBy switch
+            {
+                "12345" => "Ola Nordmann",
+                _ => throw new Exception("Unknown user"),
+            }
+        });
+
+        _instanceClient.Setup(c => c.GetInstances(It.IsAny<Dictionary<string, StringValues>>())).ReturnsAsync(instances);
+        _profile.Setup(p => p.GetUserProfile(12345)).ReturnsAsync(new UserProfile()
+        {
+            Party = new()
+            {
+                Name = "Ola Nordmann"
+            }
+        });
+
+        // Act
+        var controller = SUT;
+        var result = await controller.GetActiveInstances(org, app, 12345);
+
+        // Assert
+        var resultValue = result.Result.Should().BeOfType<OkObjectResult>().Which.Value;
+        resultValue.Should().NotBeNull();
+        resultValue.Should().BeEquivalentTo(expected);
+
+        _instanceClient.Verify(c => c.GetInstances(It.Is<Dictionary<string, StringValues>>(query =>
+            query.ContainsKey("appId")
+        )));
+        _profile.Verify(p => p.GetUserProfile(12345));
+        VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task LastChangedBy9digits_LooksForOrg()
+    {
+        // Arrange
+        var org = "ttd";
+        var app = "unit-app";
+        var instances = new List<Instance>()
+        {
+            new()
+            {
+                Id = $"{1234}/{Guid.NewGuid()}",
+                LastChanged = DateTime.Now,
+                LastChangedBy = "123456789",
+            }
+        };
+        var expected = instances.Select(i => new SimpleInstance()
+        {
+            Id = i.Id,
+            LastChanged = i.LastChanged,
+            LastChangedBy = i.LastChangedBy switch
+            {
+                "123456789" => "",
+                // "123456789" => "123456789", // Would it be more sensible to return OrgNumber as fallback?
+                _ => throw new Exception("Unknown user"),
+            }
+        });
+
+        _instanceClient.Setup(c => c.GetInstances(It.IsAny<Dictionary<string, StringValues>>())).ReturnsAsync(instances);
+        _registrer.Setup(r=>r.ER.GetOrganization("123456789")).ReturnsAsync(default(Organization));
+
+        // Act
+        var controller = SUT;
+        var result = await controller.GetActiveInstances(org, app, 12345);
+
+        // Assert
+        var resultValue = result.Result.Should().BeOfType<OkObjectResult>().Which.Value;
+        resultValue.Should().NotBeNull();
+        resultValue.Should().BeEquivalentTo(expected);
+
+        _instanceClient.Verify(c => c.GetInstances(It.Is<Dictionary<string, StringValues>>(query =>
+            query.ContainsKey("appId")
+        )));
+        _registrer.Verify(r => r.ER.GetOrganization("123456789"));
+        VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task LastChangedBy9digits_FindsOrg()
+    {
+        // Arrange
+        var org = "ttd";
+        var app = "unit-app";
+        var instances = new List<Instance>()
+        {
+            new()
+            {
+                Id = $"{1234}/{Guid.NewGuid()}",
+                LastChanged = DateTime.Now,
+                LastChangedBy = "123456789",
+            }
+        };
+        var expected = instances.Select(i => new SimpleInstance()
+        {
+            Id = i.Id,
+            LastChanged = i.LastChanged,
+            LastChangedBy = i.LastChangedBy switch
+            {
+                "123456789" => "Testdepartementet",
+                _ => throw new Exception("Unknown user"),
+            }
+        });
+
+        _instanceClient.Setup(c => c.GetInstances(It.IsAny<Dictionary<string, StringValues>>())).ReturnsAsync(instances);
+        _registrer.Setup(r=>r.ER.GetOrganization("123456789")).ReturnsAsync(new Organization
+        {
+            Name = "Testdepartementet"
+        });
+
+        // Act
+        var controller = SUT;
+        var result = await controller.GetActiveInstances(org, app, 12345);
+
+        // Assert
+        var resultValue = result.Result.Should().BeOfType<OkObjectResult>().Which.Value;
+        resultValue.Should().NotBeNull();
+        resultValue.Should().BeEquivalentTo(expected);
+
+        _instanceClient.Verify(c => c.GetInstances(It.Is<Dictionary<string, StringValues>>(query =>
+            query.ContainsKey("appId")
+        )));
+        _registrer.Verify(r => r.ER.GetOrganization("123456789"));
+        VerifyNoOtherCalls();
+    }
+
+}


### PR DESCRIPTION
`{org}/{app}/instances/{id}/active` fails with a nullpointerexeption when the lookup for `instance.lastChangedBy` fails. This causes the frontend to crash and never load the app if one of the lookups for active instances fails.
```json
"onEntry": {
    "show": "select-instance"
}
```

## Question
Currently unknown values in `instance.lastChangedBy` results in an empty result.

![image](https://user-images.githubusercontent.com/131616/215410208-bb69a679-a3d2-44fa-ab1b-f0383256592b.png)


Would it look better to just show the raw value?

![image](https://user-images.githubusercontent.com/131616/215409788-3fa40b37-94c5-4667-b2f3-fed0c6c2f707.png)


**Note**: This PR has 2 commits, one significant and the other updating `InstancesController.cs` to `#nullable enable` in an effort to update the project when I touch files.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
