### PR TITLE
Add PresentationTexts to {org}/{app}/instances/{instanceOwnerPartyId}/active endpoint

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -13,6 +13,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Altinn/app-lib-dotnet</RepositoryUrl>
     <IsPackable>true</IsPackable>
+    <ImplicitUsings>true</ImplicitUsings>
 
     <!-- SonarCloud requires a ProjectGuid to separate projects. -->
     <ProjectGuid>{E8F29FE8-6B62-41F1-A08C-2A318DD08BB4}</ProjectGuid>

--- a/src/Altinn.App.Api/Mappers/SimpleInstanceMapper.cs
+++ b/src/Altinn.App.Api/Mappers/SimpleInstanceMapper.cs
@@ -1,6 +1,4 @@
 #nullable enable
-using System.Collections.Generic;
-using System.Linq;
 
 using Altinn.App.Api.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -22,6 +20,7 @@ namespace Altinn.App.Api.Mappers
             return new SimpleInstance
             {
                 Id = instance.Id,
+                PresentationTexts = instance.PresentationTexts,
                 LastChanged = instance.LastChanged,
                 LastChangedBy = lastChangedByName
             };

--- a/src/Altinn.App.Api/Models/SimpleInstance.cs
+++ b/src/Altinn.App.Api/Models/SimpleInstance.cs
@@ -1,25 +1,28 @@
-using System;
+#nullable enable
+namespace Altinn.App.Api.Models;
 
-namespace Altinn.App.Api.Models
+/// <summary>
+/// A simplified instance model used for presentation of key instance information.
+/// </summary>
+public class SimpleInstance
 {
     /// <summary>
-    /// A simplified instance model used for presentation of key instance information.
+    /// The instance identifier formated as {instanceOwner.partyId}/{instanceGuid}.
     /// </summary>
-    public class SimpleInstance
-    {
-        /// <summary>
-        /// The instance identifier formated as {instanceOwner.partyId}/{instanceGuid}.
-        /// </summary>
-        public string Id { get; set; }
+    public string Id { get; set; } = default!;
 
-        /// <summary>
-        /// Last changed date time in UTC format.
-        /// </summary>
-        public DateTime? LastChanged { get; set; }
+    /// <summary>
+    /// Presentation texts from the instance
+    /// </summary>
+    public Dictionary<string, string>? PresentationTexts { get; set; }
 
-        /// <summary>
-        /// Full name of user to last change the instance.
-        /// </summary>
-        public string LastChangedBy { get; set; }
-    }
+    /// <summary>
+    /// Last changed date time in UTC format.
+    /// </summary>
+    public DateTime? LastChanged { get; set; }
+
+    /// <summary>
+    /// Full name of user to last change the instance.
+    /// </summary>
+    public string LastChangedBy { get; set; } = default!;
 }

--- a/src/Altinn.App.Core/Features/DataProcessing/NullInstantiationProcessor.cs
+++ b/src/Altinn.App.Core/Features/DataProcessing/NullInstantiationProcessor.cs
@@ -9,7 +9,7 @@ namespace Altinn.App.Core.Features.DataProcessing;
 public class NullInstantiationProcessor: IInstantiationProcessor
 {
     /// <inheritdoc />
-    public async Task DataCreation(Instance instance, object data, Dictionary<string, string> prefill)
+    public async Task DataCreation(Instance instance, object data, Dictionary<string, string>? prefill)
     {
         await Task.CompletedTask;
     }

--- a/src/Altinn.App.Core/Features/IInstantiationProcessor.cs
+++ b/src/Altinn.App.Core/Features/IInstantiationProcessor.cs
@@ -16,5 +16,5 @@ public interface IInstantiationProcessor
     /// <param name="instance">Instance information</param>
     /// <param name="data">The data object created</param>
     /// <param name="prefill">External prefill available under instansiation if supplied</param>
-    public Task DataCreation(Instance instance, object data, Dictionary<string, string> prefill);
+    public Task DataCreation(Instance instance, object data, Dictionary<string, string>? prefill);
 }

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_ActiveInstancesTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_ActiveInstancesTests.cs
@@ -108,11 +108,16 @@ public class InstancesController_ActiveInstancesTest
                 Id = $"{1234}/{Guid.NewGuid()}",
                 LastChanged = DateTime.Now,
                 LastChangedBy = "12345",
+                PresentationTexts = new()
+                {
+                    {"periode","1. halvår 2023"}
+                }
             }
         };
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch
             {
@@ -154,11 +159,17 @@ public class InstancesController_ActiveInstancesTest
                 Id = $"{1234}/{Guid.NewGuid()}",
                 LastChanged = DateTime.Now,
                 LastChangedBy = "12345",
+                PresentationTexts = new()
+                {
+                    {"periode","1. halvår 2023"},
+                    {"kontaktperson","Eirk Blodøks"}
+                }
             }
         };
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch
             {
@@ -205,6 +216,7 @@ public class InstancesController_ActiveInstancesTest
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch
             {
@@ -256,6 +268,7 @@ public class InstancesController_ActiveInstancesTest
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch
             {
@@ -266,7 +279,7 @@ public class InstancesController_ActiveInstancesTest
         });
 
         _instanceClient.Setup(c => c.GetInstances(It.IsAny<Dictionary<string, StringValues>>())).ReturnsAsync(instances);
-        _registrer.Setup(r=>r.ER.GetOrganization("123456789")).ReturnsAsync(default(Organization));
+        _registrer.Setup(r => r.ER.GetOrganization("123456789")).ReturnsAsync(default(Organization));
 
         // Act
         var controller = SUT;
@@ -302,6 +315,7 @@ public class InstancesController_ActiveInstancesTest
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch
             {
@@ -311,7 +325,7 @@ public class InstancesController_ActiveInstancesTest
         });
 
         _instanceClient.Setup(c => c.GetInstances(It.IsAny<Dictionary<string, StringValues>>())).ReturnsAsync(instances);
-        _registrer.Setup(r=>r.ER.GetOrganization("123456789")).ReturnsAsync(new Organization
+        _registrer.Setup(r => r.ER.GetOrganization("123456789")).ReturnsAsync(new Organization
         {
             Name = "Testdepartementet"
         });


### PR DESCRIPTION
This is in preparation for showing presentation texts in the onEntry.Show = "select-instance" instance picker to help users and emulate the inbox in localtest, like requested in https://github.com/Altinn/app-localtest/issues/3

## Description
Backend support needs to come before frontend support. The goal is to add a new column if any of the instances has presentationTexts.

![image](https://user-images.githubusercontent.com/131616/215861172-928c848c-b6e9-4884-a9a4-e6a5524da53f.png)


I'm sorry for including a few unrelated changes in this commit.
* Added `<ImplicitUsings>true` to the Api project (same as in core)
* Add nullable dictionary to `IInstantiationProcessor`. (The parameter is usually null, so this should be safe but causes a warning in apps)

## Related Issue(s)
- https://github.com/Altinn/app-localtest/issues/3

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
