### PR TITLE
Add DueBefore to /active instances endpoint

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -698,7 +698,7 @@ namespace Altinn.App.Api.Controllers
                 if (lastChangedBy?.Length == 9)
                 {
                     Organization? organization = await _registerClient.ER.GetOrganization(lastChangedBy);
-                    if(organization is not null && !string.IsNullOrEmpty(organization.Name))
+                    if (organization is not null && !string.IsNullOrEmpty(organization.Name))
                     {
                         userAndOrgLookup.Add(lastChangedBy, organization.Name);
                     }
@@ -706,7 +706,7 @@ namespace Altinn.App.Api.Controllers
                 else if (int.TryParse(lastChangedBy, out int lastChangedByInt))
                 {
                     UserProfile? user = await _profileClientClient.GetUserProfile(lastChangedByInt);
-                    if(user is not null && user.Party is not null && !string.IsNullOrEmpty(user.Party.Name))
+                    if (user is not null && user.Party is not null && !string.IsNullOrEmpty(user.Party.Name))
                     {
                         userAndOrgLookup.Add(lastChangedBy, user.Party.Name);
                     }

--- a/src/Altinn.App.Api/Mappers/SimpleInstanceMapper.cs
+++ b/src/Altinn.App.Api/Mappers/SimpleInstanceMapper.cs
@@ -20,6 +20,7 @@ namespace Altinn.App.Api.Mappers
             return new SimpleInstance
             {
                 Id = instance.Id,
+                DueBefore = instance.DueBefore,
                 PresentationTexts = instance.PresentationTexts,
                 LastChanged = instance.LastChanged,
                 LastChangedBy = lastChangedByName

--- a/src/Altinn.App.Api/Models/SimpleInstance.cs
+++ b/src/Altinn.App.Api/Models/SimpleInstance.cs
@@ -17,6 +17,11 @@ public class SimpleInstance
     public Dictionary<string, string>? PresentationTexts { get; set; }
 
     /// <summary>
+    /// Gets or sets the due date to submit the instance to application owner.
+    /// </summary>
+    public DateTime? DueBefore { get; set; }
+
+    /// <summary>
     /// Last changed date time in UTC format.
     /// </summary>
     public DateTime? LastChanged { get; set; }

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_ActiveInstancesTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_ActiveInstancesTests.cs
@@ -117,6 +117,7 @@ public class InstancesController_ActiveInstancesTest
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            DueBefore = i.DueBefore,
             PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch
@@ -169,6 +170,7 @@ public class InstancesController_ActiveInstancesTest
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            DueBefore = i.DueBefore,
             PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch
@@ -216,6 +218,7 @@ public class InstancesController_ActiveInstancesTest
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            DueBefore = i.DueBefore,
             PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch
@@ -268,6 +271,7 @@ public class InstancesController_ActiveInstancesTest
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            DueBefore = i.DueBefore,
             PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch
@@ -315,6 +319,7 @@ public class InstancesController_ActiveInstancesTest
         var expected = instances.Select(i => new SimpleInstance()
         {
             Id = i.Id,
+            DueBefore = i.DueBefore,
             PresentationTexts = i.PresentationTexts,
             LastChanged = i.LastChanged,
             LastChangedBy = i.LastChangedBy switch

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_ActiveInstancesTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_ActiveInstancesTests.cs
@@ -106,6 +106,7 @@ public class InstancesController_ActiveInstancesTest
             new()
             {
                 Id = $"{1234}/{Guid.NewGuid()}",
+                DueBefore = DateTime.Today.AddDays(20),
                 LastChanged = DateTime.Now,
                 LastChangedBy = "12345",
                 PresentationTexts = new()


### PR DESCRIPTION
This is the same as https://github.com/Altinn/app-lib-dotnet/pull/177, but to add DueBefore in addition to PresentationValues

It seems obvious that due date is just as relevant as PresentationValues in this view.

CC: @tjololo 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
