### PR TITLE
Added API for fetching footer layout

### DIFF
--- a/src/Altinn.App.Api/Controllers/ResourceController.cs
+++ b/src/Altinn.App.Api/Controllers/ResourceController.cs
@@ -258,10 +258,15 @@ namespace Altinn.App.Api.Controllers
         /// <param name="app">The application name</param>
         /// <returns>The footer layout in the form of a string.</returns>
         [HttpGet]
-        [Route("{org}/{app}/api/footer")]
+        [Route("{org}/{app}/api/v1/footer")]
         public ActionResult GetFooterLayout(string org, string app)
         {
             string layout = _appResourceService.GetFooter();
+            if (layout is null)
+            {
+                return NoContent();
+            }
+            
             return Ok(layout);
         }
     }

--- a/src/Altinn.App.Api/Controllers/ResourceController.cs
+++ b/src/Altinn.App.Api/Controllers/ResourceController.cs
@@ -250,5 +250,19 @@ namespace Altinn.App.Api.Controllers
 
             return new FileContentResult(fileContent, MimeTypeMap.GetMimeType(".json"));
         }
+
+        /// <summary>
+        /// Get the footer layout
+        /// </summary>
+        /// <param name="org">The application owner short name</param>
+        /// <param name="app">The application name</param>
+        /// <returns>The footer layout in the form of a string.</returns>
+        [HttpGet]
+        [Route("{org}/{app}/api/footer")]
+        public ActionResult GetFooterLayout(string org, string app)
+        {
+            string layout = _appResourceService.GetFooter();
+            return Ok(layout);
+        }
     }
 }

--- a/src/Altinn.App.Api/Controllers/ResourceController.cs
+++ b/src/Altinn.App.Api/Controllers/ResourceController.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Globalization;
 using System.IO;
@@ -70,7 +71,7 @@ namespace Altinn.App.Api.Controllers
         [HttpGet]
         public IActionResult GetRuntimeResource(string id)
         {
-            byte[] fileContent = _appResourceService.GetRuntimeResource(id);
+            byte[]? fileContent = _appResourceService.GetRuntimeResource(id);
 
             if (fileContent != null)
             {
@@ -178,7 +179,7 @@ namespace Altinn.App.Api.Controllers
         [Route("{org}/{app}/api/layoutsettings")]
         public ActionResult GetLayoutSettings(string org, string app)
         {
-            string settings = _appResourceService.GetLayoutSettingsString();
+            string? settings = _appResourceService.GetLayoutSettingsString();
             return Ok(settings);
         }
 
@@ -193,7 +194,7 @@ namespace Altinn.App.Api.Controllers
         [Route("{org}/{app}/api/layoutsettings/{id}")]
         public ActionResult GetLayoutSettings(string org, string app, string id)
         {
-            string settings = _appResourceService.GetLayoutSettingsStringForSet(id);
+            string? settings = _appResourceService.GetLayoutSettingsStringForSet(id);
             return Ok(settings);
         }
 
@@ -259,9 +260,9 @@ namespace Altinn.App.Api.Controllers
         /// <returns>The footer layout in the form of a string.</returns>
         [HttpGet]
         [Route("{org}/{app}/api/v1/footer")]
-        public ActionResult GetFooterLayout(string org, string app)
+        public async Task<ActionResult> GetFooterLayout(string org, string app)
         {
-            string layout = _appResourceService.GetFooter();
+            string? layout = await _appResourceService.GetFooter();
             if (layout is null)
             {
                 return NoContent();

--- a/src/Altinn.App.Core/Configuration/AppSettings.cs
+++ b/src/Altinn.App.Core/Configuration/AppSettings.cs
@@ -83,6 +83,11 @@ namespace Altinn.App.Core.Configuration
         /// </summary>
         public string LayoutSetsFileName { get; set; } = "layout-sets.json";
 
+                /// <summary>
+        /// Gets or sets the name of the layout setting file name
+        /// </summary>
+        public string FooterFileName { get; set; } = "footer.json";
+
         /// <summary>
         /// Gets or sets The name of the rule configuration json file Name
         /// </summary>

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -462,13 +462,13 @@ namespace Altinn.App.Core.Implementation
         }
 
         /// <inheritdoc />
-        public string? GetFooter()
+        public async Task<string?> GetFooter()
         {
             string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, _settings.FooterFileName);
-            string filedata = null;
+            string? filedata = null;
             if (File.Exists(filename))
             {
-                filedata = File.ReadAllText(filename, Encoding.UTF8);
+                filedata = await File.ReadAllTextAsync(filename, Encoding.UTF8);
             }
 
             return filedata;

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -460,5 +460,18 @@ namespace Altinn.App.Core.Implementation
 
             return null;
         }
+
+        /// <inheritdoc />
+        public string GetFooter()
+        {
+            string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, _settings.FooterFileName);
+            string filedata = null;
+            if (File.Exists(filename))
+            {
+                filedata = File.ReadAllText(filename, Encoding.UTF8);
+            }
+
+            return filedata;
+        }
     }
 }

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -462,7 +462,7 @@ namespace Altinn.App.Core.Implementation
         }
 
         /// <inheritdoc />
-        public string GetFooter()
+        public string? GetFooter()
         {
             string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, _settings.FooterFileName);
             string filedata = null;

--- a/src/Altinn.App.Core/Interface/IAppResources.cs
+++ b/src/Altinn.App.Core/Interface/IAppResources.cs
@@ -119,7 +119,7 @@ namespace Altinn.App.Core.Interface
         /// Gets the footer layout
         /// </summary>
         /// <returns>The footer layout</returns>
-        string? GetFooter();
+        Task<string?> GetFooter();
 
         /// <summary>
         /// Get the layout set definition. Return null if no layoutsets exists

--- a/src/Altinn.App.Core/Interface/IAppResources.cs
+++ b/src/Altinn.App.Core/Interface/IAppResources.cs
@@ -116,6 +116,12 @@ namespace Altinn.App.Core.Interface
         string GetLayoutSets();
 
         /// <summary>
+        /// Gets the footer layout
+        /// </summary>
+        /// <returns>The footer layout</returns>
+        string GetFooter();
+
+        /// <summary>
         /// Get the layout set definition. Return null if no layoutsets exists
         /// </summary>
         LayoutSets? GetLayoutSet();

--- a/src/Altinn.App.Core/Interface/IAppResources.cs
+++ b/src/Altinn.App.Core/Interface/IAppResources.cs
@@ -119,7 +119,7 @@ namespace Altinn.App.Core.Interface
         /// Gets the footer layout
         /// </summary>
         /// <returns>The footer layout</returns>
-        string GetFooter();
+        string? GetFooter();
 
         /// <summary>
         /// Get the layout set definition. Return null if no layoutsets exists


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added API for fetching footer layout file. Currently a static file, could be defined in layout-sets when that becomes standard. Is it necessary with tests for something as simple as serving one static file?

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/110
- https://github.com/Altinn/app-frontend-react/issues/538

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
