### PR TITLE
Populate InstanceOwner the same way for statelss apps

### DIFF
--- a/src/Altinn.App.Api/Controllers/StatelessDataController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessDataController.cs
@@ -293,6 +293,7 @@ namespace Altinn.App.Api.Controllers
             var party = idPrefix switch
             {
                 PartyPrefix => await _registerClient.GetParty(int.TryParse(id, out var partyId) ? partyId : 0),
+
                 // Frontend seems to only use partyId, not orgnr or ssn.
                 PersonPrefix => await _registerClient.LookupParty(new PartyLookup { Ssn = id }),
                 OrgPrefix => await _registerClient.LookupParty(new PartyLookup { OrgNo = id }),

--- a/src/Altinn.App.Api/Controllers/StatelessDataController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessDataController.cs
@@ -1,10 +1,11 @@
-using System;
+#nullable enable
 using System.Net;
-using System.Threading.Tasks;
 
 using Altinn.App.Api.Infrastructure.Filters;
+using Altinn.App.Api.Mappers;
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Interface;
 using Altinn.App.Core.Internal.AppModel;
@@ -16,10 +17,7 @@ using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
 
 namespace Altinn.App.Api.Controllers
@@ -38,13 +36,12 @@ namespace Altinn.App.Api.Controllers
         private readonly IPrefill _prefillService;
         private readonly IRegister _registerClient;
         private readonly IPDP _pdp;
-   
+
         private const long REQUEST_SIZE_LIMIT = 2000 * 1024 * 1024;
 
-        private const string Partyheader = "party";
-        private const string PartyPrefix = "partyid:";
-        private const string PersonPrefix = "person:";
-        private const string OrgPrefix = "org:";
+        private const string PartyPrefix = "partyid";
+        private const string PersonPrefix = "person";
+        private const string OrgPrefix = "org";
 
         /// <summary>
         /// The stateless data controller is responsible for creating and updating stateles data elements.
@@ -73,6 +70,7 @@ namespace Altinn.App.Api.Controllers
         /// <param name="org">unique identfier of the organisation responsible for the app</param>
         /// <param name="app">application identifier which is unique within an organisation</param>
         /// <param name="dataType">The data type id</param>
+        /// <param name="partyFromHeader">The party that should be represented with  prefix "partyId:", "person:" or "org:" (eg: "partyId:123")</param>
         /// <returns>Return a new instance of the data object including prefill and initial calculations</returns>
         [Authorize]
         [HttpGet]
@@ -83,7 +81,8 @@ namespace Altinn.App.Api.Controllers
         public async Task<ActionResult> Get(
             [FromRoute] string org,
             [FromRoute] string app,
-            [FromQuery] string dataType)
+            [FromQuery] string dataType,
+            [FromHeader(Name = "party")] string partyFromHeader)
         {
             if (string.IsNullOrEmpty(dataType))
             {
@@ -97,16 +96,10 @@ namespace Altinn.App.Api.Controllers
                 return BadRequest($"Invalid dataType {dataType} provided. Please provide a valid dataType as query parameter.");
             }
 
-            if (GetPartyHeader(HttpContext).Count > 1)
+            InstanceOwner? owner = await GetInstanceOwner(partyFromHeader);
+            if (owner is null)
             {
-                return BadRequest($"Invalid party. Only one allowed");
-            }
-
-            InstanceOwner owner = await GetInstanceOwner(HttpContext);
-
-            if (string.IsNullOrEmpty(owner.PartyId))
-            {
-                return StatusCode((int)HttpStatusCode.Forbidden);
+                return BadRequest($"Invalid party header. Please provide a party header on the form partyid:123, org:[orgnr] or person:[ssn]");
             }
 
             EnforcementResult enforcementResult = await AuthorizeAction(org, app, Convert.ToInt32(owner.PartyId), "read");
@@ -115,7 +108,7 @@ namespace Altinn.App.Api.Controllers
             {
                 return Forbidden(enforcementResult);
             }
-        
+
             object appModel = _appModel.Create(classRef);
 
             // runs prefill from repo configuration if config exists
@@ -156,7 +149,7 @@ namespace Altinn.App.Api.Controllers
             object appModel = _appModel.Create(classRef);
 
             var virutalInstance = new Instance();
-            
+
             await _dataProcessor.ProcessDataRead(virutalInstance, null, appModel);
 
             return Ok(appModel);
@@ -168,6 +161,7 @@ namespace Altinn.App.Api.Controllers
         /// <param name="org">unique identfier of the organisation responsible for the app</param>
         /// <param name="app">application identifier which is unique within an organisation</param>
         /// <param name="dataType">The data type id</param>
+        /// <param name="partyFromHeader">The party that should be represented with  prefix "partyId:", "person:" or "org:" (eg: "partyId:123")</param>
         /// <returns>Return a new instance of the data object including prefill and initial calculations</returns>
         [Authorize]
         [HttpPost]
@@ -178,7 +172,8 @@ namespace Altinn.App.Api.Controllers
         public async Task<ActionResult> Post(
             [FromRoute] string org,
             [FromRoute] string app,
-            [FromQuery] string dataType)
+            [FromQuery] string dataType,
+            [FromHeader(Name = "party")] string partyFromHeader)
         {
             if (string.IsNullOrEmpty(dataType))
             {
@@ -192,16 +187,11 @@ namespace Altinn.App.Api.Controllers
                 return BadRequest($"Invalid dataType {dataType} provided. Please provide a valid dataType as query parameter.");
             }
 
-            if (GetPartyHeader(HttpContext).Count > 1)
-            {
-                return BadRequest($"Invalid party. Only one allowed");
-            }
+            InstanceOwner? owner = await GetInstanceOwner(partyFromHeader);
 
-            InstanceOwner owner = await GetInstanceOwner(HttpContext);
-
-            if (string.IsNullOrEmpty(owner.PartyId))
+            if (owner is null)
             {
-               return StatusCode((int)HttpStatusCode.Forbidden);
+                return BadRequest($"Invalid party header");
             }
 
             EnforcementResult enforcementResult = await AuthorizeAction(org, app, Convert.ToInt32(owner.PartyId), "read");
@@ -212,7 +202,7 @@ namespace Altinn.App.Api.Controllers
             }
 
             ModelDeserializer deserializer = new ModelDeserializer(_logger, _appModel.GetModelType(classRef));
-            object appModel = await deserializer.DeserializeAsync(Request.Body, Request.ContentType);
+            object? appModel = await deserializer.DeserializeAsync(Request.Body, Request.ContentType);
 
             if (!string.IsNullOrEmpty(deserializer.Error))
             {
@@ -255,7 +245,7 @@ namespace Altinn.App.Api.Controllers
             }
 
             ModelDeserializer deserializer = new ModelDeserializer(_logger, _appModel.GetModelType(classRef));
-            object appModel = await deserializer.DeserializeAsync(Request.Body, Request.ContentType);
+            object? appModel = await deserializer.DeserializeAsync(Request.Body, Request.ContentType);
 
             if (!string.IsNullOrEmpty(deserializer.Error))
             {
@@ -268,56 +258,53 @@ namespace Altinn.App.Api.Controllers
             return Ok(appModel);
         }
 
-        private static StringValues GetPartyHeader(HttpContext context)
+        private async Task<InstanceOwner?> GetInstanceOwner(string partyFromHeader)
         {
-            StringValues partyValues;
-            if (context.Request.Headers.TryGetValue(Partyheader, out partyValues))
+            // Use the party id of the logged in user, if no party id is given in the header
+            // Not sure if this is really used anywhere. It doesn't seem usefull, as you'd
+            // always want to create an instance based on the selected party, not the person
+            // you happend to log in as.
+            if (partyFromHeader is null)
             {
-                return partyValues;
+                var partyId = Request.HttpContext.User.GetPartyIdAsInt();
+                if (partyId is null)
+                {
+                    return null;
+                }
+
+                var partyFromUser = await _registerClient.GetParty(partyId.Value);
+                if (partyFromUser is null)
+                {
+                    return null;
+                }
+
+                return InstantiationHelper.PartyToInstanceOwner(partyFromUser);
             }
 
-            return partyValues;
-        }
-
-        private async Task<InstanceOwner> GetInstanceOwner(HttpContext context)
-        {
-            InstanceOwner owner = new InstanceOwner();
-            StringValues partyValues;
-            if (context.Request.Headers.TryGetValue(Partyheader, out partyValues))
+            // Get the party as read in from the header. Authorization happens later.
+            var headerParts = partyFromHeader.Split(':');
+            if (partyFromHeader.Contains(',') || headerParts.Length != 2)
             {
-                return await GetInstanceOwner(partyValues[0], owner);
-            }
-            else
-            {
-                owner.PartyId = context.User.GetPartyIdAsInt().ToString();
-                return owner;
-            }
-        }
-
-        private async Task<InstanceOwner> GetInstanceOwner(string partyValue, InstanceOwner owner)
-        {
-            Party party = null;
-            if (partyValue.StartsWith(PartyPrefix))
-            {
-                owner.PartyId = partyValue.Replace(PartyPrefix, string.Empty);
-                return owner;
-            }
-            else if (partyValue.StartsWith(PersonPrefix))
-            {
-                string ssn = partyValue.Replace(PersonPrefix, string.Empty);
-                party = await _registerClient.LookupParty(new PartyLookup { Ssn = ssn });
-                owner.PartyId = party.PartyId.ToString();
-                owner.PersonNumber = ssn;
-            }
-            else if (partyValue.StartsWith(OrgPrefix))
-            {
-                string orgno = partyValue.Replace(OrgPrefix, string.Empty);
-                party = await _registerClient.LookupParty(new PartyLookup { OrgNo = orgno });
-                owner.PartyId = party.PartyId.ToString();
-                owner.OrganisationNumber = orgno;
+                return null;
             }
 
-            return owner;
+            var id = headerParts[1];
+            var idPrefix = headerParts[0].ToLowerInvariant();
+            var party = idPrefix switch
+            {
+                PartyPrefix => await _registerClient.GetParty(int.TryParse(id, out var partyId) ? partyId : 0),
+                // Frontend seems to only use partyId, not orgnr or ssn.
+                PersonPrefix => await _registerClient.LookupParty(new PartyLookup { Ssn = id }),
+                OrgPrefix => await _registerClient.LookupParty(new PartyLookup { OrgNo = id }),
+                _ => null,
+            };
+
+            if (party is null || party.PartyId == 0)
+            {
+                return null;
+            }
+
+            return InstantiationHelper.PartyToInstanceOwner(party);
         }
 
         private async Task<EnforcementResult> AuthorizeAction(string org, string app, int partyId, string action)

--- a/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
+++ b/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
@@ -31,7 +31,7 @@ namespace Altinn.App.Core.Helpers
             {
                 bool canPartyInstantiate = IsPartyAllowedToInstantiate(party, partyTypesAllowed);
                 bool isChildPartyAllowed = false;
-                List<Party> allowedChildParties = null;
+                List<Party>? allowedChildParties = null;
                 if (party.ChildParties != null)
                 {
                     allowedChildParties = new List<Party>();
@@ -156,12 +156,48 @@ namespace Altinn.App.Core.Helpers
                     Party? validChildParty = party.ChildParties.Find(cp => cp.PartyId == partyId);
                     if (validChildParty != null)
                     {
-                      validParty = validChildParty;
+                        validParty = validChildParty;
                     }
                 }
             }
 
             return validParty;
+        }
+
+        /// <summary>
+        /// Get the correct <see cref="InstanceOwner" /> object from the <see cref="Party" /> object of the entity that should own the instance
+        /// </summary>
+        public static InstanceOwner PartyToInstanceOwner(Party party)
+        {
+            if (!string.IsNullOrEmpty(party.SSN))
+            {
+                return new()
+                {
+                    PartyId = party.PartyId.ToString(),
+                    PersonNumber = party.SSN,
+                };
+            }
+            else if (!string.IsNullOrEmpty(party.OrgNumber))
+            {
+                return new()
+                {
+                    PartyId = party.PartyId.ToString(),
+                    OrganisationNumber = party.OrgNumber,
+                };
+            }
+            else if (party.PartyTypeName.Equals(PartyType.SelfIdentified))
+            {
+                return new()
+                {
+                    PartyId = party.PartyId.ToString(),
+                    Username = party.Name,
+                };
+            }
+            return new()
+            {
+                PartyId = party.PartyId.ToString(),
+                // instanceOwnerPartyType == "unknown"
+            };
         }
     }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
@@ -118,7 +118,7 @@ public class StatelessDataControllerTests
         var client = factory.CreateClient();
         string token = PrincipalUtil.GetToken(1337);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        var request = new HttpRequestMessage(HttpMethod.Get, "/tdd/demo-app/v1/data?dataType=xml");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/tdd/demo-app/v1/data?dataType=xml");
         request.Headers.Add("party", new string[]{"partyid:234", "partyid:234"}); // Double header
 
         factory.AppResourcesMoq.Setup(ar=>ar.GetClassRefForLogicDataType(It.IsAny<string>())).Returns("Not.In.Valid.Namespace.ClassRef");
@@ -145,7 +145,7 @@ public class StatelessDataControllerTests
         var client = factory.CreateClient();
         string token = PrincipalUtil.GetToken(1337);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        var request = new HttpRequestMessage(HttpMethod.Get, "/tdd/demo-app/v1/data?dataType=xml");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/tdd/demo-app/v1/data?dataType=xml");
         request.Headers.Add("party", new string[]{"partyid:234"});
 
         factory.AppResourcesMoq.Setup(ar=>ar.GetClassRefForLogicDataType(It.IsAny<string>())).Returns("Not.In.Valid.Namespace.ClassRef");
@@ -157,7 +157,6 @@ public class StatelessDataControllerTests
 
         // Act
         var response = await client.SendAsync(request);
-        var responseText = await response.Content.ReadAsStringAsync();
 
         // Assert
         response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden);

--- a/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
@@ -1,9 +1,12 @@
 using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Security.Claims;
 using Altinn.App.Api.Controllers;
 using Altinn.App.Api.Tests.Controllers.TestResources;
+using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.DataProcessing;
+using Altinn.App.Core.Infrastructure.Clients.Profile;
 using Altinn.App.Core.Interface;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.Authorization.ABAC.Xacml;
@@ -11,11 +14,13 @@ using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
 
@@ -37,8 +42,10 @@ public class StatelessDataControllerTests
         var statelessDataController = new StatelessDataController(logger, altinnAppModelMock.Object, appResourcesMock.Object,
             dataProcessorMock.Object, prefillMock.Object, registerMock.Object, pdpMock.Object);
 
+        string dataType = null!; // this is what we're testing
+
         // Act
-        var result = await statelessDataController.Get("ttd", "demo-app", null);
+        var result = await statelessDataController.Get("ttd", "demo-app", dataType, "partyId:123");
 
         // Assert
         result.Should().BeOfType<BadRequestObjectResult>().Which.Value.Should().Be(
@@ -68,7 +75,7 @@ public class StatelessDataControllerTests
 
         // Act
         appResourcesMock.Setup(x => x.GetClassRefForLogicDataType(dataType)).Returns(string.Empty);
-        var result = await statelessDataController.Get("ttd", "demo-app", dataType);
+        var result = await statelessDataController.Get("ttd", "demo-app", dataType, "partyId:123");
 
         // Assert
         result.Should().BeOfType<BadRequestObjectResult>().Which.Value.Should().Be(
@@ -81,37 +88,79 @@ public class StatelessDataControllerTests
         pdpMock.VerifyNoOtherCalls();
     }
 
+    // WebApplicationFactory that allows testing how things work when the user has two
+    // party headers.
+    private class StatelessDataControllerWebApplicationFactory : WebApplicationFactory<Program>
+    {
+        public Mock<IProfile> ProfileClientMoq { get; set; } = new();
+        public Mock<IRegister> RegisterClientMoq { get; set; } = new();
+        public Mock<IAppResources> AppResourcesMoq { get; set; } = new();
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+
+            builder.ConfigureServices(services=>
+            {
+                services.AddTransient<IProfile>((sp)=>ProfileClientMoq.Object);
+                services.AddTransient<IRegister>((sp)=>RegisterClientMoq.Object);
+                services.AddTransient<IAppResources>((sp)=>AppResourcesMoq.Object);
+            });
+        }
+    }
+
     [Fact]
     public async void Get_Returns_BadRequest_when_party_header_count_greater_than_one()
     {
         // Arrange
-        var appModelMock = new Mock<IAppModel>();
-        var appResourcesMock = new Mock<IAppResources>();
-        var dataProcessorMock = new Mock<IDataProcessor>();
-        var prefillMock = new Mock<IPrefill>();
-        var registerMock = new Mock<IRegister>();
-        var pdpMock = new Mock<IPDP>();
-        var dataType = "some-value";
-        ILogger<DataController> logger = new NullLogger<DataController>();
-        var statelessDataController = new StatelessDataController(logger, appModelMock.Object, appResourcesMock.Object,
-            dataProcessorMock.Object, prefillMock.Object, registerMock.Object, pdpMock.Object);
-        statelessDataController.ControllerContext = new ControllerContext();
-        statelessDataController.ControllerContext.HttpContext = new DefaultHttpContext();
-        statelessDataController.ControllerContext.HttpContext.Request.Headers["party"] =
-            new StringValues((new[] { "12345", "67890" }));
+        var factory = new StatelessDataControllerWebApplicationFactory();
+        
+        var client = factory.CreateClient();
+        string token = PrincipalUtil.GetToken(1337);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var request = new HttpRequestMessage(HttpMethod.Get, "/tdd/demo-app/v1/data?dataType=xml");
+        request.Headers.Add("party", new string[]{"partyid:234", "partyid:234"}); // Double header
+
+        factory.AppResourcesMoq.Setup(ar=>ar.GetClassRefForLogicDataType(It.IsAny<string>())).Returns("Not.In.Valid.Namespace.ClassRef");
+        factory.RegisterClientMoq.Setup(p=>p.GetParty(234)).ReturnsAsync(new Platform.Register.Models.Party
+        {
+            PartyId = 234,
+        });
 
         // Act
-        appResourcesMock.Setup(x => x.GetClassRefForLogicDataType(dataType)).Returns(typeof(DummyModel).FullName!);
-        var result = await statelessDataController.Get("ttd", "demo-app", dataType);
+        var response = await client.SendAsync(request);
+        var responseText = await response.Content.ReadAsStringAsync();
 
         // Assert
-        result.Should().BeOfType<BadRequestObjectResult>().Which.Value.Should().Be("Invalid party. Only one allowed");
-        appResourcesMock.Verify(x => x.GetClassRefForLogicDataType(dataType), Times.Once);
-        appResourcesMock.VerifyNoOtherCalls();
-        dataProcessorMock.VerifyNoOtherCalls();
-        prefillMock.VerifyNoOtherCalls();
-        registerMock.VerifyNoOtherCalls();
-        pdpMock.VerifyNoOtherCalls();
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        responseText.Should().Contain("Invalid party header.");
+    }
+    
+    [Fact]
+    public async void Get_Returns_Forbidden_when_party_has_no_rights()
+    {
+        // Arrange
+        var factory = new StatelessDataControllerWebApplicationFactory();
+        
+        var client = factory.CreateClient();
+        string token = PrincipalUtil.GetToken(1337);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var request = new HttpRequestMessage(HttpMethod.Get, "/tdd/demo-app/v1/data?dataType=xml");
+        request.Headers.Add("party", new string[]{"partyid:234"});
+
+        factory.AppResourcesMoq.Setup(ar=>ar.GetClassRefForLogicDataType(It.IsAny<string>())).Returns("Not.In.Valid.Namespace.ClassRef");
+        factory.RegisterClientMoq.Setup(p=>p.GetParty(234)).ReturnsAsync(new Platform.Register.Models.Party
+        {
+            PartyId = 234,
+        });
+
+
+        // Act
+        var response = await client.SendAsync(request);
+        var responseText = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden);
     }
 
     [Fact]
@@ -128,17 +177,15 @@ public class StatelessDataControllerTests
         ILogger<DataController> logger = new NullLogger<DataController>();
         var statelessDataController = new StatelessDataController(logger, appModelMock.Object, appResourcesMock.Object,
             dataProcessorMock.Object, prefillMock.Object, registerMock.Object, pdpMock.Object);
-        statelessDataController.ControllerContext = new ControllerContext();
-        statelessDataController.ControllerContext.HttpContext = new DefaultHttpContext();
-        statelessDataController.ControllerContext.HttpContext.Request.Headers["party"] =
-            new StringValues((new[] { string.Empty }));
 
         // Act
         appResourcesMock.Setup(x => x.GetClassRefForLogicDataType(dataType)).Returns(typeof(DummyModel).FullName!);
-        var result = await statelessDataController.Get("ttd", "demo-app", dataType);
+        var result = await statelessDataController.Get("ttd", "demo-app", dataType, string.Empty);
 
         // Assert
-        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(403);
+        var response = result.Should().BeOfType<BadRequestObjectResult>().Which;
+        response.StatusCode.Should().Be(400);
+        response.Value.Should().BeOfType<string>().Which.Should().Contain("Invalid party header.");
         appResourcesMock.Verify(x => x.GetClassRefForLogicDataType(dataType), Times.Once);
         appResourcesMock.VerifyNoOtherCalls();
         dataProcessorMock.VerifyNoOtherCalls();
@@ -175,10 +222,10 @@ public class StatelessDataControllerTests
 
         // Act
         appResourcesMock.Setup(x => x.GetClassRefForLogicDataType(dataType)).Returns(typeof(DummyModel).FullName!);
-        var result = await statelessDataController.Get("ttd", "demo-app", dataType);
+        var result = await statelessDataController.Get("ttd", "demo-app", dataType, null!);
 
         // Assert
-        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(403);
+        result.Should().BeOfType<BadRequestObjectResult>().Which.StatusCode.Should().Be(400);
         appResourcesMock.Verify(x => x.GetClassRefForLogicDataType(dataType), Times.Once);
         appResourcesMock.VerifyNoOtherCalls();
         dataProcessorMock.VerifyNoOtherCalls();
@@ -223,15 +270,20 @@ public class StatelessDataControllerTests
                     }
                 }
             });
+        registerMock.Setup(r=>r.GetParty(12345)).ReturnsAsync(new Platform.Register.Models.Party
+        {
+            PartyId = 12345,
+        });
 
         // Act
         appResourcesMock.Setup(x => x.GetClassRefForLogicDataType(dataType)).Returns(typeof(DummyModel).FullName!);
-        var result = await statelessDataController.Get("ttd", "demo-app", dataType);
+        var result = await statelessDataController.Get("ttd", "demo-app", dataType, null!);
 
         // Assert
         result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(403);
         appResourcesMock.Verify(x => x.GetClassRefForLogicDataType(dataType), Times.Once);
         appResourcesMock.VerifyNoOtherCalls();
+        registerMock.Verify(r=>r.GetParty(12345));
         pdpMock.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()));
         pdpMock.VerifyNoOtherCalls();
         dataProcessorMock.VerifyNoOtherCalls();
@@ -278,10 +330,14 @@ public class StatelessDataControllerTests
             });
         appModelMock.Setup(a => a.Create(classRef))
             .Returns(new DummyModel());
+        registerMock.Setup(r=>r.GetParty(12345)).ReturnsAsync(new Platform.Register.Models.Party
+        {
+            PartyId = 12345,
+        });
 
         // Act
         appResourcesMock.Setup(x => x.GetClassRefForLogicDataType(dataType)).Returns(classRef);
-        var result = await statelessDataController.Get("ttd", "demo-app", dataType);
+        var result = await statelessDataController.Get("ttd", "demo-app", dataType, null!);
 
         // Assert
         result.Should().BeOfType<OkObjectResult>().Which.StatusCode.Should().Be(200);
@@ -291,6 +347,7 @@ public class StatelessDataControllerTests
         appModelMock.Verify(a => a.Create(classRef), Times.Once);
         prefillMock.Verify(p => p.PrefillDataModel("12345", dataType, It.IsAny<DummyModel>(), null));
         dataProcessorMock.Verify(a => a.ProcessDataRead(It.IsAny<Instance>(), null, It.IsAny<DummyModel>()));
+        registerMock.Verify(r=>r.GetParty(12345));
         appResourcesMock.VerifyNoOtherCalls();
         pdpMock.VerifyNoOtherCalls();
         dataProcessorMock.VerifyNoOtherCalls();


### PR DESCRIPTION
Currently stateless apps doesn't populate `instance.InstanceOwner` the same way as normal apps does. This means that logic like `["instanceContext","instanceOwnerType"]` and in `dataProcessRead` you can't use `instance.InstanceOwner.OrganisationNumber` for a lookup, as you would do with a normal instance.

## Description
Obviously I wanted to reuse the `InstancesController.SetInstanceOwnerProps` method in `StatelessDataController`, so I rewrote and moved it to `src/Altinn.App.Core/Helpers/InstantiationHelper.cs` as a common reference.

Next I disliked reading the `party` header value from the request object, instead of just as a parameter to the action with a `[FromHeader(Name = "party")] string partyFromHeader` annotation. The tests proved great to discover some edge cases, and I had to rewrite lots of them. One of the tests looked at what happens if a user adds multiple headers. To test that with my change, I had to use a `WebApplicationFactory`, because normal unit testing of controllers doesn't allow duplicate values to a string.

I also looked at the frontend code, and it seems like the backend supports much more than what is actually used. Fronend always specify `party: partyid:123` in a header, but backend also supports
* No header (use party id of the current user)
* `party: org:[orgnummer]`
* `party: person:[ssn]`
 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
