### PR TITLE
Only set hard and soft delete flags when process is ended for autoDeleteOnProcessEnd

### DIFF
--- a/src/Altinn.App.Core/Implementation/DefaultTaskEvents.cs
+++ b/src/Altinn.App.Core/Implementation/DefaultTaskEvents.cs
@@ -204,7 +204,7 @@ public class DefaultTaskEvents : ITaskEvents
 
     private async Task RunAutoDeleteOnProcessEnd(Instance instance, Guid instanceGuid)
     {
-        if (_appMetadata.AutoDeleteOnProcessEnd)
+        if (_appMetadata.AutoDeleteOnProcessEnd && instance.Process?.Ended != null)
         {
             int instanceOwnerPartyId = int.Parse(instance.InstanceOwner.PartyId);
             await _instanceClient.DeleteInstance(instanceOwnerPartyId, instanceGuid, true);

--- a/test/Altinn.App.Core.Tests/Implementation/DefaultTaskEventsTests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/DefaultTaskEventsTests.cs
@@ -173,6 +173,143 @@ public class DefaultTaskEventsTests: IDisposable
         startTwo.VerifyNoOtherCalls();
     }
 
+    [Fact]
+    public async void OnEndProcessTask_does_not_sets_hard_soft_delete_if_process_ended_and_autoDeleteOnProcessEnd_false()
+    {
+        _application.DataTypes = new List<DataType>();
+        _application.AutoDeleteOnProcessEnd = false;
+        _resMock.Setup(r => r.GetApplication()).Returns(_application);
+        DefaultTaskEvents te = new DefaultTaskEvents(
+            _logger,
+            _resMock.Object,
+            _dataMock.Object,
+            _prefillMock.Object,
+            _appModel,
+            _instantiationMock.Object,
+            _instanceMock.Object,
+            _taskStarts,
+            _taskEnds,
+            _taskAbandons,
+            _pdfMock.Object,
+            _featureManagerMock.Object,
+            _layoutStateInitializer);
+        var instance = new Instance()
+        {
+            Id = "1337/fa0678ad-960d-4307-aba2-ba29c9804c9d",
+            InstanceOwner = new()
+            {
+                PartyId = "1000"
+            },
+            Process = new()
+            {
+                Ended = DateTime.Now
+            }
+        };
+        await te.OnEndProcessTask("EndEvent_1", instance);
+        _instanceMock.Verify(i => i.DeleteInstance(1000, Guid.Parse("fa0678ad-960d-4307-aba2-ba29c9804c9d"), true), Times.Never);
+    }
+    
+    [Fact]
+    public async void OnEndProcessTask_sets_hard_soft_delete_if_process_ended_and_autoDeleteOnProcessEnd_true()
+    {
+        _application.DataTypes = new List<DataType>();
+        _application.AutoDeleteOnProcessEnd = true;
+        _resMock.Setup(r => r.GetApplication()).Returns(_application);
+        DefaultTaskEvents te = new DefaultTaskEvents(
+            _logger,
+            _resMock.Object,
+            _dataMock.Object,
+            _prefillMock.Object,
+            _appModel,
+            _instantiationMock.Object,
+            _instanceMock.Object,
+            _taskStarts,
+            _taskEnds,
+            _taskAbandons,
+            _pdfMock.Object,
+            _featureManagerMock.Object,
+            _layoutStateInitializer);
+        var instance = new Instance()
+        {
+            Id = "1337/fa0678ad-960d-4307-aba2-ba29c9804c9d",
+            InstanceOwner = new()
+            {
+                PartyId = "1000"
+            },
+            Process = new()
+            {
+                Ended = DateTime.Now
+            }
+        };
+        await te.OnEndProcessTask("EndEvent_1", instance);
+        _instanceMock.Verify(i => i.DeleteInstance(1000, Guid.Parse("fa0678ad-960d-4307-aba2-ba29c9804c9d"), true), Times.Once);
+    }
+    
+    [Fact]
+    public async void OnEndProcessTask_does_not_sets_hard_soft_delete_if_process_not_ended_and_autoDeleteOnProcessEnd_true()
+    {
+        _application.DataTypes = new List<DataType>();
+        _application.AutoDeleteOnProcessEnd = true;
+        _resMock.Setup(r => r.GetApplication()).Returns(_application);
+        DefaultTaskEvents te = new DefaultTaskEvents(
+            _logger,
+            _resMock.Object,
+            _dataMock.Object,
+            _prefillMock.Object,
+            _appModel,
+            _instantiationMock.Object,
+            _instanceMock.Object,
+            _taskStarts,
+            _taskEnds,
+            _taskAbandons,
+            _pdfMock.Object,
+            _featureManagerMock.Object,
+            _layoutStateInitializer);
+        var instance = new Instance()
+        {
+            Id = "1337/fa0678ad-960d-4307-aba2-ba29c9804c9d",
+            InstanceOwner = new()
+            {
+                PartyId = "1000"
+            },
+            Process = new()
+        };
+        await te.OnEndProcessTask("EndEvent_1", instance);
+        _instanceMock.Verify(i => i.DeleteInstance(1000, Guid.Parse("fa0678ad-960d-4307-aba2-ba29c9804c9d"), true), Times.Never);
+    }
+    
+    [Fact]
+    public async void OnEndProcessTask_does_not_sets_hard_soft_delete_if_process_null_and_autoDeleteOnProcessEnd_true()
+    {
+        _application.DataTypes = new List<DataType>();
+        _application.AutoDeleteOnProcessEnd = true;
+        _resMock.Setup(r => r.GetApplication()).Returns(_application);
+        DefaultTaskEvents te = new DefaultTaskEvents(
+            _logger,
+            _resMock.Object,
+            _dataMock.Object,
+            _prefillMock.Object,
+            _appModel,
+            _instantiationMock.Object,
+            _instanceMock.Object,
+            _taskStarts,
+            _taskEnds,
+            _taskAbandons,
+            _pdfMock.Object,
+            _featureManagerMock.Object,
+            _layoutStateInitializer);
+        var instance = new Instance()
+        {
+            Id = "1337/fa0678ad-960d-4307-aba2-ba29c9804c9d",
+            InstanceOwner = new()
+            {
+                PartyId = "1000"
+            }
+        };
+        await te.OnEndProcessTask("EndEvent_1", instance);
+        _instanceMock.Verify(i => i.DeleteInstance(1000, Guid.Parse("fa0678ad-960d-4307-aba2-ba29c9804c9d"), true), Times.Never);
+    }
+
     public void Dispose()
     {
         _resMock.Verify(r => r.GetApplication());


### PR DESCRIPTION
## Description
If autoDeleteOnProcessEnd is set to true for an instance the instance metadata is updated with softDelete and hardDelete values when the first process task is ended.
If an application has more than one data tasks in its process the application will crash when trying to update data on the second task due to an 409 Cannot update data element of archived or deleted instance {instanceOwnerPartyId}/{instanceGuid}

The application should not set hard/soft-delete values before the process is ended

## Related Issue(s)
Fixes #189

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
