### PR TITLE
Tweaked the PDF config

### DIFF
--- a/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequestOptions.cs
+++ b/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequestOptions.cs
@@ -8,12 +8,12 @@ internal class PdfGeneratorRequestOptions
     /// <summary>
     /// Indicate whether header and footer should be included.
     /// </summary>
-    public bool DisplayHeaderFooter { get; set; } = true;
+    public bool DisplayHeaderFooter { get; set; } = false;
 
     /// <summary>
     /// Indicate wheter the background should be included.
     /// </summary>
-    public bool PrintBackground { get; set; } = false;
+    public bool PrintBackground { get; set; } = true;
 
     /// <summary>
     /// Defines the page size. Default is A4.
@@ -34,20 +34,20 @@ internal class MarginOptions
     /// <summary>
     /// Top margin, accepts values labeled with units.
     /// </summary>
-    public string Top { get; set; } = "0.4in";
+    public string Top { get; set; } = "0.75in";
 
     /// <summary>
     /// Left margin, accepts values labeled with units
     /// </summary>
-    public string Left { get; set; } = "0.4in";
+    public string Left { get; set; } = "0.75in";
 
     /// <summary>
     /// Bottom margin, accepts values labeled with units
     /// </summary>
-    public string Bottom { get; set; } = "0.4in";
+    public string Bottom { get; set; } = "0.75in";
 
     /// <summary>
     /// Right margin, accepts values labeled with units
     /// </summary>
-    public string Right { get; set; } = "0.4in";
+    public string Right { get; set; } = "0.75in";
 }


### PR DESCRIPTION
I made some small modifications to the default pdf options.
1. PrintBackground needs to be true. If you have a panel component with a background color this is necessary, I have also made sure that printing with background will look good for this reason.
2. DisplayHeaderFooter I set to false, since we do not have anything in there anyway?
3. Increased the margins a bit. I have asked @Febakke what they should be, and there is not really any guidelines for now, but he agreed that larger margins were nicer.

![image](https://user-images.githubusercontent.com/47412359/218113107-2dd72a2f-49e7-42d0-b8ec-43a37137f05f.png)
