### PR TITLE
Fix default `AppPdfPageUriTemplate`

### DIFF
--- a/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
@@ -21,7 +21,7 @@ public class PdfGeneratorSettings
     /// instanceId - will be taken from current instance.Id.
     /// </remarks>
     public string AppPdfPageUriTemplate { get; set; } =
-        "https://{org}.apps.{hostName}/{appId}/#/instance/{instanceId}";
+        "https://{org}.apps.{hostName}/{appId}/#/instance/{instanceId}?pdf=1";
 
     /// <summary>
     /// The name of a DOM element to wait for before triggering PDF-generator.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I enabled the new PDF-generator in `frontend-test` and deployed to tt02. Then I noticed that the PDF did not use the PDF-view to generate, just the regular form. The default URL was missing `?pdf=1`.

I think the example in the docs is also incorrect, as the URL in the "default settings" was different from what is here.
See: https://github.com/Altinn/altinn-studio-docs/pull/847
