### PR TITLE
Improve exceptions for Expression Evaluation

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -17,24 +17,31 @@ public static class ExpressionEvaluator
     /// </summary>
     public static bool EvaluateBooleanExpression(LayoutEvaluatorState state, ComponentContext context, string property, bool defaultReturn)
     {
-        var expr = property switch
+        try
         {
-            "hidden" => context.Component.Hidden,
-            "required" => context.Component.Required,
-            _ => throw new ArgumentException($"unknown boolean expression property {property}")
-        };
-        if (expr is null)
-        {
-            return defaultReturn;
-        }
+            var expr = property switch
+            {
+                "hidden" => context.Component.Hidden,
+                "required" => context.Component.Required,
+                _ => throw new ExpressionEvaluatorTypeErrorException($"unknown boolean expression property {property}")
+            };
+            if (expr is null)
+            {
+                return defaultReturn;
+            }
 
-        return EvaluateExpression(state, expr, context) switch
+            return EvaluateExpression(state, expr, context) switch
+            {
+                true => true,
+                false => false,
+                null => defaultReturn,
+                _ => throw new ExpressionEvaluatorTypeErrorException($"Return was not boolean (value)")
+            };
+        }
+        catch(Exception e)
         {
-            true => true,
-            false => false,
-            null => defaultReturn,
-            _ => throw new ExpressionEvaluatorTypeErrorException($"Return from evaluating \"{property}\" on \"{context.Component.Id}\" was not boolean (value)")
-        };
+            throw new ExpressionEvaluatorTypeErrorException($"Error while evaluating \"{property}\" on \"{context.Component.PageId}.{context.Component.Id}\"", e);
+        }
     }
 
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluatorTypeErrorException.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluatorTypeErrorException.cs
@@ -10,6 +10,8 @@ public class ExpressionEvaluatorTypeErrorException : Exception
 {
     /// <inheritdoc />
     public ExpressionEvaluatorTypeErrorException(string msg) : base(msg) {}
+    /// <inheritdoc />
+    public ExpressionEvaluatorTypeErrorException(string msg, Exception innerException) : base(msg, innerException) {}
 
     /// <inheritdoc />
     protected ExpressionEvaluatorTypeErrorException(SerializationInfo info, StreamingContext ctxt) : base(info, ctxt) { }


### PR DESCRIPTION
Catch all exceptions when evaluating boolean expressions and rethrow a wrapped exception that includes page and component info.

## Description
Expressions that fails backend evaluation is hard to debug if you have many expressions in the layout, because it might not be obvious which one is failing. This adds debug info in a wrapper exception so that both exception messages will be available in logs and for debugging. 


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
