### PR TITLE
Avoid Task.Run when calling methods from IAppMetadata

### DIFF
--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -111,9 +111,7 @@ namespace Altinn.App.Core.Implementation
         {
             try
             {
-                var task = Task.Run(async () => await _appMetadata.GetApplicationMetadata());
-                task.Wait();
-                return task.Result;
+                return _appMetadata.GetApplicationMetadata().Result;
             }
             catch (AggregateException ex)
             {
@@ -126,13 +124,7 @@ namespace Altinn.App.Core.Implementation
         {
             try
             {
-                var task = Task.Run(async () => await _appMetadata.GetApplicationXACMLPolicy());
-                task.Wait();
-                if (task.IsCompletedSuccessfully)
-                {
-                    return task.Result;
-                }
-                return null;
+                return _appMetadata.GetApplicationXACMLPolicy().Result;
             }
             catch (AggregateException ex)
             {
@@ -146,15 +138,7 @@ namespace Altinn.App.Core.Implementation
         {
             try
             {
-                var task = Task.Run<string?>(async () => await _appMetadata.GetApplicationBPMNProcess());
-                task.Wait();
-                if (task.IsCompletedSuccessfully || task.Exception != null)
-                {
-                    return task.Result;
-                }
-
-                _logger.LogError(task.Exception, "Something went wrong fetching application policy");
-                return null;
+                return _appMetadata.GetApplicationBPMNProcess().Result;
             }
             catch (AggregateException ex)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This changes the way we call async methods from IAppMetadata within synchronous methods in AppResourcesSi. The newly introduced way was based on Task.Run which performance test showed to be a critical bottleneck.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
