### PR TITLE
Removing / for health endpoint filter

### DIFF
--- a/src/Altinn.App.Api/Infrastructure/Telemetry/HealthTelemetryFilter.cs
+++ b/src/Altinn.App.Api/Infrastructure/Telemetry/HealthTelemetryFilter.cs
@@ -37,7 +37,7 @@ namespace Altinn.App.Api.Infrastructure.Telemetry
         {
             RequestTelemetry request = item as RequestTelemetry;
 
-            if (request != null && request.Url.ToString().EndsWith("/health/"))
+            if (request != null && request.Url.ToString().EndsWith("/health"))
             {
                 return true;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Health requests not filtered out before telemetry is sent to AI due to error in config. 
endpoint is not completed with a `/` at the end

![image](https://user-images.githubusercontent.com/47737608/229467786-51e9bfe3-46a2-4f4d-92ad-1a2f4506d5b8.png)


we need this result set to be empty. 

## Related Issue(s)
- #226 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
~~- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green
