### PR TITLE
Reading out and passing on selected language to pdf generator

### DIFF
--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -237,6 +237,10 @@ namespace Altinn.App.Api.Controllers
         /// <param name="instanceGuid">unique id to identify the instance</param>
         /// <param name="elementId">the id of the next element to move to. Query parameter is optional,
         /// but must be specified if more than one element can be reached from the current process ellement.</param>
+        /// <param name="lang">Optional parameter to pass on the language used in the form if this differs from the profile language,
+        /// which otherwise is used automatically. The language is picked up when generating the PDF when leaving a step, 
+        /// and is not used for anything else.
+        /// </param>
         [HttpPut("next")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -246,7 +250,8 @@ namespace Altinn.App.Api.Controllers
             [FromRoute] string app,
             [FromRoute] int instanceOwnerPartyId,
             [FromRoute] Guid instanceGuid,
-            [FromQuery] string elementId = null)
+            [FromQuery] string elementId = null,
+            [FromQuery] string lang = null)
         {
             try
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If the user has selected another language than the one specified in the profile this language was not passed on to the pdf generator. This passes on the selected language if overridden or the profile language. If nothing is set the falls back to nb.

## Related Issue(s)
- [#1073](https://github.com/Altinn/app-frontend-react/issues/1073)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
