### PR TITLE
Enable description and helpText for options

### DIFF
--- a/src/Altinn.App.Core/Models/AppOption.cs
+++ b/src/Altinn.App.Core/Models/AppOption.cs
@@ -14,5 +14,10 @@ namespace Altinn.App.Core.Models
         /// The label of a given option
         /// </summary>
         public string Label { get; set; }
+
+        /// <summary>
+        /// The description of a given option
+        /// </summary>
+        public string? Description { get; set; }
     }
 }

--- a/src/Altinn.App.Core/Models/AppOption.cs
+++ b/src/Altinn.App.Core/Models/AppOption.cs
@@ -21,7 +21,7 @@ namespace Altinn.App.Core.Models
         public string? Description { get; set; }
 
         /// <summary>
-        /// The description of a given option
+        /// The help text of a given option
         /// </summary>
         public string? HelpText { get; set; }
     }

--- a/src/Altinn.App.Core/Models/AppOption.cs
+++ b/src/Altinn.App.Core/Models/AppOption.cs
@@ -19,5 +19,10 @@ namespace Altinn.App.Core.Models
         /// The description of a given option
         /// </summary>
         public string? Description { get; set; }
+
+        /// <summary>
+        /// The description of a given option
+        /// </summary>
+        public string? HelpText { get; set; }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the properties `Description` and `HelpText` to AppOption in order to support setting these attributes in code lists. These properties will per now only be used by Checkboxes and RadioButtons in frontend.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/615
- https://github.com/Altinn/app-frontend-react/issues/260

Frontend PR: https://github.com/Altinn/app-frontend-react/pull/1101
## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
