### PR TITLE
Improve handling of non existing source instance

### DIFF
--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
@@ -2,6 +2,7 @@ using Altinn.App.Api.Controllers;
 using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Interface;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
@@ -183,6 +184,41 @@ public class InstancesController_CopyInstanceTests
             .ReturnsAsync(CreateXacmlResponse("Permit"));
         _instanceClient.Setup(i => i.GetInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Guid>()))
             .ReturnsAsync(instance);
+
+        // Act
+        ActionResult actual = await SUT.CopyInstance("ttd", "copy-instance", instanceOwnerPartyId, instanceGuid);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(actual);
+        BadRequestObjectResult badRequest = (BadRequestObjectResult)actual;
+        Assert.Contains("instance being copied must be archived", badRequest!.Value!.ToString());
+
+        _appMetadata.VerifyAll();
+        _pdp.VerifyAll();
+        _instanceClient.VerifyAll();
+        VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CopyInstance_InstanceDoesNotExists_ReturnsBadRequest()
+    {
+        // Arrange
+        const string Org = "ttd";
+        const string AppName = "copy-instance";
+        int instanceOwnerPartyId = 343234;
+        Guid instanceGuid = Guid.NewGuid();
+
+        // Storage returns Forbidden if the given instance id is wrong.
+        PlatformHttpException platformHttpException = 
+            await PlatformHttpException.CreateAsync(new HttpResponseMessage(System.Net.HttpStatusCode.Forbidden));
+
+        _httpContextMock.Setup(httpContext => httpContext.User).Returns(PrincipalUtil.GetUserPrincipal(1337));
+        _appMetadata.Setup(a => a.GetApplicationMetadata())
+            .ReturnsAsync(CreateApplicationMetadata($"{Org}/{AppName}", true));
+        _pdp.Setup<Task<XacmlJsonResponse>>(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+            .ReturnsAsync(CreateXacmlResponse("Permit"));
+        _instanceClient.Setup(i => i.GetInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Guid>()))
+            .ThrowsAsync(platformHttpException);
 
         // Act
         ActionResult actual = await SUT.CopyInstance("ttd", "copy-instance", instanceOwnerPartyId, instanceGuid);


### PR DESCRIPTION
## Description
Turns out that Storage returns 403 if the given instance id results in a 404 from Cosmos DB. I've added slightly better handling of this specific case in the new Copy instance logic, but I'm not confident it's the best solution.

## Related Issue(s)
- https://github.com/Altinn/altinn-platform/issues/355

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
