### PR TITLE
Add support for "source" parameter on option based components

### DIFF
--- a/src/Altinn.App.Core/Models/Layout/Components/OptionsComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/Components/OptionsComponent.cs
@@ -22,6 +22,11 @@ public class OptionsComponent : BaseComponent
     public List<AppOption>? Options { get; }
 
     /// <summary>
+    /// Alternaltive to <see cref="OptionId" /> where the options are sourced from a repeating group in the datamodel
+    /// </summary>
+    public OptionsSource? OptionsSource { get; }
+
+    /// <summary>
     /// Is the component referencing a secure code list (uses security context of the instance)
     /// </summary>
     public bool Secure { get; }
@@ -29,12 +34,70 @@ public class OptionsComponent : BaseComponent
     /// <summary>
     /// Constructor
     /// </summary>
-    public OptionsComponent(string id, string type, IReadOnlyDictionary<string, string>? dataModelBindings, Expression? hidden, Expression? required, Expression? readOnly, string? optionId, List<AppOption>? options, bool secure, IReadOnlyDictionary<string, string>? additionalProperties) :
+    public OptionsComponent(string id, string type, IReadOnlyDictionary<string, string>? dataModelBindings, Expression? hidden, Expression? required, Expression? readOnly, string? optionId, List<AppOption>? options, OptionsSource? optionsSource, bool secure, IReadOnlyDictionary<string, string>? additionalProperties) :
         base(id, type, dataModelBindings, hidden, required, readOnly, additionalProperties)
     {
         OptionId = optionId;
         Options = options;
+        OptionsSource = optionsSource;
         Secure = secure;
     }
 }
 
+/// <summary>
+/// This is an optional child element of <see cref="OptionsComponent" /> that specifies that  
+/// </summary>
+public class OptionsSource
+{
+    /// <summary>
+    /// Constructor for <see cref="OptionsSource" />
+    /// </summary>
+    public OptionsSource(string group, string label, string value)
+    {
+        Group = group;
+        Label = label;
+        Value = value;
+    }
+    /// <summary>
+    /// the group field in the data model to base the options on
+    /// </summary>
+    public string Group { get; }
+    /// <summary>
+    /// a reference to a text id to be used as the label for each iteration of the group
+    /// </summary>
+    /// <remarks>
+    /// As for the label property, we have to define a text resource that can be used as a label for each repetition of the group.
+    /// This follows similar syntax as the value, and will also be familiar if you have used variables in text.
+    /// </remarks>
+    /// <example>
+    /// The referenced text resource must use variables to read text from individual fields
+    /// {
+    ///     "language": "nb",
+    ///     "resources": [
+    ///         {
+    ///         "id": "dropdown.label",
+    ///         "value": "Person: {0}, Age: {1}",
+    ///         "variables": [
+    ///             {
+    ///             "key": "some.group[{0}].name",
+    ///             "dataSource": "dataModel.default"
+    ///             },
+    ///             {
+    ///             "key": "some.group[{0}].age",
+    ///             "dataSource": "dataModel.default"
+    ///             }
+    ///         ]
+    ///         }
+    ///     ]
+    /// }
+    /// </example>
+    public string Label { get; }
+    /// <summary>
+    /// a reference to a field in the group that should be used as the option value. Notice that we set up this [{0}] syntax. Here the {0} will be replaced by each index of the group.
+    /// </summary>
+    /// <remarks>
+    /// Notice that the value field must be unique for each element. If the repeating group does not contain a field which is unique for each item
+    /// it is recommended to add a field to the data model that can be used as identificator, for instance a GUID.
+    /// </remarks>
+    public string Value { get; }
+}

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/FirstPage.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/FirstPage.json
@@ -13,6 +13,20 @@
         ]
       },
       {
+        "id": "options-with-source",
+        "type": "RadioButtons",
+        "source": {
+          "group": "some.data",
+          "label": "some.text.key",
+          "value": "some.data[{0}].binding"
+        }
+      },
+      {
+        "id": "options-with-id",
+        "type": "RadioButtons",
+        "optionsId": "ASF_Land"
+      },
+      {
         "id": "gruppe1",
         "type": "Group",
         "children": ["comp","comp1", "comp2"],
@@ -29,6 +43,7 @@
           "simpleBinding": "some.data.binding"
         }
       },
+      
       {
         "id": "comp1",
         "type": "Input",


### PR DESCRIPTION
Not sure if these validations of the json content to ensure that nullability annotations in C# are correct really makes sense to have, now that https://github.com/Altinn/app-lib-dotnet/pull/98 was abandoned, but I kind of like them.

## Related Issue(s)
- Fixes https://github.com/Altinn/app-lib-dotnet/issues/234

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
