### PR TITLE
Remove trailing slash from source filter in event subscription.

### DIFF
--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
@@ -57,7 +57,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Events
             {
                 TypeFilter = eventType,
                 EndPoint = new Uri($"{appBaseUrl}api/v1/eventsreceiver?code={await _secretCodeProvider.GetSecretCode()}"),
-                SourceFilter = new Uri(appBaseUrl)
+                SourceFilter = new Uri(appBaseUrl.TrimEnd('/')) // The event system is requireing the source filter to be without trailing slash
             };
 
             string serializedSubscriptionRequest = JsonSerializer.Serialize(subscriptionRequest);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a issue where a trailing slash was added as part of the source filter when subscribing to events from the event system.

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
