### PR TITLE
Fix: Sender not displayed in PDF when representing an org

### DIFF
--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -53,7 +53,7 @@ public class PdfGeneratorClient : IPdfGeneratorClient
     }
 
     /// <inheritdoc/>
-    public async Task<Stream> GeneratePdf(Uri uri, CancellationToken ct, string partyId)
+    public async Task<Stream> GeneratePdf(Uri uri, CancellationToken ct, string? partyId)
     {
         bool hasWaitForSelector = !string.IsNullOrWhiteSpace(_pdfGeneratorSettings.WaitForSelector);
         PdfGeneratorRequest generatorRequest = new()
@@ -68,12 +68,15 @@ public class PdfGeneratorClient : IPdfGeneratorClient
             Domain = uri.Host
         });
 
-        generatorRequest.Cookies.Add(new PdfGeneratorCookieOptions
+        if (partyId != null)
         {
-            Name = _generalSettings.AltinnPartyCookieName,
-            Value = partyId,
-            Domain = uri.Host,
-        });
+            generatorRequest.Cookies.Add(new PdfGeneratorCookieOptions
+            {
+                Name = _generalSettings.AltinnPartyCookieName,
+                Value = partyId,
+                Domain = uri.Host,
+            });
+        }
 
         string requestContent = JsonSerializer.Serialize(generatorRequest, _jsonSerializerOptions);
         using StringContent stringContent = new(requestContent, Encoding.UTF8, "application/json");

--- a/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
@@ -11,5 +11,5 @@ public interface IPdfGeneratorClient
     /// Generates a PDF.
     /// </summary>
     /// <returns>A stream with the binary content of the generated PDF</returns>
-    Task<Stream> GeneratePdf(Uri uri, CancellationToken ct, string partyId);
+    Task<Stream> GeneratePdf(Uri uri, CancellationToken ct, string? partyId);
 }

--- a/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
@@ -11,5 +11,5 @@ public interface IPdfGeneratorClient
     /// Generates a PDF.
     /// </summary>
     /// <returns>A stream with the binary content of the generated PDF</returns>
-    Task<Stream> GeneratePdf(Uri uri, CancellationToken ct);
+    Task<Stream> GeneratePdf(Uri uri, CancellationToken ct, string partyId);
 }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -94,7 +94,7 @@ public class PdfService : IPdfService
 
         Uri uri = BuildUri(baseUrl, pagePath, language);
 
-        Stream pdfContent = await _pdfGeneratorClient.GeneratePdf(uri, ct);
+        Stream pdfContent = await _pdfGeneratorClient.GeneratePdf(uri, ct, instance.InstanceOwner.PartyId); 
 
         var appIdentifier = new AppIdentifier(instance);
 

--- a/src/Altinn.App.Core/Models/Pdf/PdfGeneratorCookieOptions.cs
+++ b/src/Altinn.App.Core/Models/Pdf/PdfGeneratorCookieOptions.cs
@@ -8,7 +8,7 @@ internal class PdfGeneratorCookieOptions
     /// <summary>
     /// The name of the cookie.
     /// </summary>
-    public string Name { get; } = "AltinnStudioRuntime";
+    public string Name { get; set; } = "AltinnStudioRuntime";
 
     /// <summary>
     /// The cookie content.
@@ -23,5 +23,5 @@ internal class PdfGeneratorCookieOptions
     /// <summary>
     /// The cookie sameSite settings.
     /// </summary>
-    public string SameSite { get; } = "Lax";
+    public string SameSite { get; set; } = "Lax";
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The frontend relies on the `AltinnPartyId` cookie to get the party information (org.nr., org name...), since this was not available to the PDF service, it could not display the "Sender" in the PDF when you submitted on behalf of an organization. It would only get its personal party information, which did not match with the instanceOwnerParty. This change sets this cookie in the PDF service request.

Fixing this in app-frontend would be more complicated and would likely have unintended consequences by changing the selected party.

## Related Issue(s)
- #244 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- ~~[ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
