### PR TITLE
Documentation of parameteres used when generating codelists

### DIFF
--- a/src/Altinn.App.Core/Models/AppOptions.cs
+++ b/src/Altinn.App.Core/Models/AppOptions.cs
@@ -1,3 +1,5 @@
+using System.Reflection.Metadata.Ecma335;
+
 namespace Altinn.App.Core.Models
 {
     /// <summary>
@@ -8,7 +10,14 @@ namespace Altinn.App.Core.Models
         /// <summary>
         /// Gets or sets the list of options.
         /// </summary>
-        public List<AppOption> Options { get; set; }
+        public List<AppOption> Options { get; set; } = new List<AppOption>();
+
+        /// <summary>
+        /// Gets or sets the parameters used to generate the options.
+        /// The dictionary key is the name of the parameter and the value is the value of the parameter.
+        /// This can be used to document the parameters used to generate the options.
+        /// </summary>
+        public Dictionary<string, string> Parameters{ get; set; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Gets or sets a value indicating whether the options can be cached.

--- a/test/Altinn.App.Core.Tests/Options/AppOptionsFactoryTests.cs
+++ b/test/Altinn.App.Core.Tests/Options/AppOptionsFactoryTests.cs
@@ -60,7 +60,7 @@ namespace Altinn.App.PlatformServices.Tests.Options
         }
 
         [Fact]
-        public async Task GetOptionsProvider_CustomOptionsProviderWithUpperCase_ShouldReturnCustomType()
+        public void GetOptionsProvider_CustomOptionsProviderWithUpperCase_ShouldReturnCustomType()
         {
             var appOptionsFileHandler = new Mock<IAppOptionsFileHandler>();
             var factory = new AppOptionsFactory(new List<IAppOptionsProvider>() { new DefaultAppOptionsProvider(appOptionsFileHandler.Object), new CountryAppOptionsProvider() });
@@ -73,14 +73,14 @@ namespace Altinn.App.PlatformServices.Tests.Options
 
         [Fact]
         public async Task GetParameters_CustomOptionsProviderWithUpperCase_ShouldReturnCustomType()
-            {
-                var appOptionsFileHandler = new Mock<IAppOptionsFileHandler>();
-                var factory = new AppOptionsFactory(new List<IAppOptionsProvider>() { new DefaultAppOptionsProvider(appOptionsFileHandler.Object), new CountryAppOptionsProvider() });
+        {
+            var appOptionsFileHandler = new Mock<IAppOptionsFileHandler>();
+            var factory = new AppOptionsFactory(new List<IAppOptionsProvider>() { new DefaultAppOptionsProvider(appOptionsFileHandler.Object), new CountryAppOptionsProvider() });
 
-                IAppOptionsProvider optionsProvider = factory.GetOptionsProvider("Country");
+            IAppOptionsProvider optionsProvider = factory.GetOptionsProvider("Country");
 
-                AppOptions options = await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>() { { "key", "value" } });
-                options.Parameters.First(x => x.Key == "key").Value.Should().Be("value");
+            AppOptions options = await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>() { { "key", "value" } });
+            options.Parameters.First(x => x.Key == "key").Value.Should().Be("value");
         }
 
         internal class CountryAppOptionsProvider : IAppOptionsProvider

--- a/test/Altinn.App.Core.Tests/Options/AppOptionsFactoryTests.cs
+++ b/test/Altinn.App.Core.Tests/Options/AppOptionsFactoryTests.cs
@@ -60,7 +60,7 @@ namespace Altinn.App.PlatformServices.Tests.Options
         }
 
         [Fact]
-        public void GetOptionsProvider_CustomOptionsProviderWithUpperCase_ShouldReturnCustomType()
+        public async Task GetOptionsProvider_CustomOptionsProviderWithUpperCase_ShouldReturnCustomType()
         {
             var appOptionsFileHandler = new Mock<IAppOptionsFileHandler>();
             var factory = new AppOptionsFactory(new List<IAppOptionsProvider>() { new DefaultAppOptionsProvider(appOptionsFileHandler.Object), new CountryAppOptionsProvider() });
@@ -69,6 +69,18 @@ namespace Altinn.App.PlatformServices.Tests.Options
 
             optionsProvider.Should().BeOfType<CountryAppOptionsProvider>();
             optionsProvider.Id.Should().Be("country");
+        }
+
+        [Fact]
+        public async Task GetParameters_CustomOptionsProviderWithUpperCase_ShouldReturnCustomType()
+            {
+                var appOptionsFileHandler = new Mock<IAppOptionsFileHandler>();
+                var factory = new AppOptionsFactory(new List<IAppOptionsProvider>() { new DefaultAppOptionsProvider(appOptionsFileHandler.Object), new CountryAppOptionsProvider() });
+
+                IAppOptionsProvider optionsProvider = factory.GetOptionsProvider("Country");
+
+                AppOptions options = await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>() { { "key", "value" } });
+                options.Parameters.First(x => x.Key == "key").Value.Should().Be("value");
         }
 
         internal class CountryAppOptionsProvider : IAppOptionsProvider
@@ -91,7 +103,9 @@ namespace Altinn.App.PlatformServices.Tests.Options
                             Label = "Sverige",
                             Value = "46"
                         }
-                    }
+                    },
+
+                    Parameters = keyValuePairs
                 };
 
                 return Task.FromResult(options);


### PR DESCRIPTION
## Description
Add parameter list to AppOptions to allow parameters used when getting the codelist to be returned for documenting which parameters where used when the option list was generated.

## Related Issue(s)
- #256 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
