### PR TITLE
Bugfix for missing taskId in UserActionAuthorizer

### DIFF
--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -276,7 +276,7 @@ namespace Altinn.App.Api.Controllers
 
                 bool authorized;
                 string checkedAction = EnsureActionNotTaskType(processNext?.Action ?? altinnTaskType);
-                authorized = await AuthorizeAction(checkedAction, org, app, instanceOwnerPartyId, instanceGuid);
+                authorized = await AuthorizeAction(checkedAction, org, app, instanceOwnerPartyId, instanceGuid, instance.Process.CurrentTask?.ElementId);
 
                 if (!authorized)
                 {
@@ -372,7 +372,7 @@ namespace Altinn.App.Api.Controllers
             {
                 string altinnTaskType = EnsureActionNotTaskType(instance.Process.CurrentTask?.AltinnTaskType);
 
-                bool authorized = await AuthorizeAction(altinnTaskType, org, app, instanceOwnerPartyId, instanceGuid);
+                bool authorized = await AuthorizeAction(altinnTaskType, org, app, instanceOwnerPartyId, instanceGuid, instance.Process.CurrentTask?.ElementId);
                 if (!authorized)
                 {
                     return Forbid();

--- a/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
+++ b/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
@@ -38,6 +38,10 @@ public class UniqueSignatureAuthorizer : IUserActionAuthorizer
     /// <inheritdoc />
     public async Task<bool> AuthorizeAction(UserActionAuthorizerContext context)
     {
+        if (context.TaskId == null)
+        {
+            return true;
+        }
         var flowElement = _processReader.GetFlowElement(context.TaskId) as ProcessTask;
         if (flowElement?.ExtensionElements?.TaskExtension?.SignatureConfiguration?.UniqueFromSignaturesInDataTypes.Count > 0)
         {

--- a/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
@@ -173,6 +173,37 @@ public class UniqueSignatureAuthorizerTests : IDisposable
     }
     
     [Fact]
+    public async Task AuthorizeAction_returns_true_if_taskID_is_null()
+    {
+        ProcessElement processTask = new ProcessTask()
+        {
+            ExtensionElements = new()
+            {
+                TaskExtension = new()
+                {
+                    SignatureConfiguration = new()
+                    {
+                        UniqueFromSignaturesInDataTypes = new()
+                        {
+                            "signature"
+                        }
+                    }
+                }
+            }
+        };
+        UniqueSignatureAuthorizer authorizer = CreateUniqueSignatureAuthorizer(processTask);
+        var user = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>()
+        {
+            new(AltinnCoreClaimTypes.UserId, "1337"),
+            new(AltinnCoreClaimTypes.AuthenticationLevel, "2"),
+            new(AltinnCoreClaimTypes.Org, "tdd")
+        }));
+
+        bool result = await authorizer.AuthorizeAction(new UserActionAuthorizerContext(user, new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"), null, "sign"));
+        result.Should().BeTrue();
+    }
+    
+    [Fact]
     public async Task AuthorizeAction_returns_true_if_dataelement_not_of_type_SignDocument()
     {
         ProcessElement processTask = new ProcessTask()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When performing a action the current taskId was not passed along. Added taskId to context for all calls in ProcessController and added a failsafe in the UniqueSignatureAuthorizer class

## Related Issue(s)
- #265 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
