### PR TITLE
Expose prometheus endpoint and som default metrics

### DIFF
--- a/src/Altinn.App.Api/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/WebApplicationBuilderExtensions.cs
@@ -24,11 +24,11 @@ public static class WebApplicationBuilderExtensions
         app.UseHttpMetrics();
         app.UseMetricServer();
         var appId = StartupHelper.GetApplicationId();
-        var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString();
         Metrics.DefaultRegistry.SetStaticLabels(new Dictionary<string, string>()
         {
-            {"application_id", appId},
-            {"nuget_package_version", version}
+            { "application_id", appId },
+            { "nuget_package_version", version }
         });
         app.UseDefaultSecurityHeaders();
         app.UseRouting();

--- a/src/Altinn.App.Api/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Altinn.App.Api.Helpers;
+using Prometheus;
+
+namespace Altinn.App.Api.Extensions;
+
+/// <summary>
+/// Altinn specific extensions for <see cref="WebApplication"/>.
+/// </summary>
+public static class WebApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Add default Altinn configuration for an app.
+    /// </summary>
+    /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
+    /// <returns></returns>
+    public static IApplicationBuilder UseAltinnAppCommonConfiguration(this IApplicationBuilder app)
+    {
+        if (app is WebApplication webApp && webApp.Environment.IsDevelopment())
+        {
+            app.UseDeveloperExceptionPage();
+        }
+        
+        app.UseHttpMetrics();
+        app.UseMetricServer();
+        var appId = StartupHelper.GetApplicationId();
+        var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        Metrics.DefaultRegistry.SetStaticLabels(new Dictionary<string, string>()
+        {
+            {"application_id", appId},
+            {"nuget_package_version", version}
+        });
+        app.UseDefaultSecurityHeaders();
+        app.UseRouting();
+        app.UseStaticFiles('/' + appId);
+        app.UseAuthentication();
+        app.UseAuthorization();
+
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapControllers();
+        });
+        app.UseHealthChecks("/health");
+        return app;
+    }
+}

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Scrutor" Version="4.2.2" />
+    <PackageReference Include="prometheus-net" Version="8.0.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -45,6 +45,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Linq;
+using Prometheus;
 using IProcessEngine = Altinn.App.Core.Internal.Process.IProcessEngine;
 using IProcessReader = Altinn.App.Core.Internal.Process.IProcessReader;
 using ProcessEngine = Altinn.App.Core.Internal.Process.ProcessEngine;
@@ -78,6 +79,7 @@ namespace Altinn.App.Core.Extensions
             services.AddHttpClient<IDataClient, DataClient>();
             services.AddHttpClient<IOrganizationClient, RegisterERClient>();
             services.AddHttpClient<IInstanceClient, InstanceClient>();
+            services.Decorate<IInstanceClient, InstanceClientMetricsDecorator>();
             services.AddHttpClient<IInstanceEventClient, InstanceEventClient>();
             services.AddHttpClient<IEventsClient, EventsClient>();
             services.AddHttpClient<IPDF, PDFClient>();
@@ -231,6 +233,7 @@ namespace Altinn.App.Core.Extensions
         private static void AddProcessServices(IServiceCollection services)
         {
             services.TryAddTransient<IProcessEngine, ProcessEngine>();
+            services.Decorate<IProcessEngine, ProcessEngineMetricsDecorator>();
             services.TryAddTransient<IProcessNavigator, ProcessNavigator>();
             services.TryAddSingleton<IProcessReader, ProcessReader>();
             services.TryAddTransient<IProcessEventDispatcher, ProcessEventDispatcher>();

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClientMetricsDecorator.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClientMetricsDecorator.cs
@@ -6,38 +6,50 @@ using Prometheus;
 
 namespace Altinn.App.Core.Infrastructure.Clients.Storage;
 
+/// <summary>
+/// Decorator for the instance client that adds metrics for the number of instances created, completed and deleted.
+/// </summary>
 public class InstanceClientMetricsDecorator : IInstanceClient
 {
     private readonly IInstanceClient _instanceClient;
-    private static readonly Counter InstancesCreatedCounter = Metrics.CreateCounter("altinn_app_instances_created", "Number of instances created", labelNames: new[] { "result" });
-    private static readonly Counter InstancesCompletedCounter = Metrics.CreateCounter("altinn_app_instances_completed", "Number of instances completed", labelNames: new[] { "result" });
-    private static readonly Counter InstancesDeletedCounter = Metrics.CreateCounter("altinn_app_instances_deleted", "Number of instances completed", labelNames: new[] { "result", "mode" });
+    private static readonly Counter InstancesCreatedCounter = Metrics.CreateCounter("altinn_app_instances_created", "Number of instances created", "result");
+    private static readonly Counter InstancesCompletedCounter = Metrics.CreateCounter("altinn_app_instances_completed", "Number of instances completed", "result");
+    private static readonly Counter InstancesDeletedCounter = Metrics.CreateCounter("altinn_app_instances_deleted", "Number of instances completed", "result", "mode" );
 
+    /// <summary>
+    /// Create a new instance of the <see cref="InstanceClientMetricsDecorator"/> class.
+    /// </summary>
+    /// <param name="instanceClient">The instance client to decorate.</param>
     public InstanceClientMetricsDecorator(IInstanceClient instanceClient)
     {
         _instanceClient = instanceClient;
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> GetInstance(string app, string org, int instanceOwnerPartyId, Guid instanceId)
     {
         return await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceId);
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> GetInstance(Instance instance)
     {
         return await _instanceClient.GetInstance(instance);
     }
 
+    /// <inheritdoc/>
     public async Task<List<Instance>> GetInstances(Dictionary<string, StringValues> queryParams)
     {
         return await _instanceClient.GetInstances(queryParams);
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> UpdateProcess(Instance instance)
     {
         return await _instanceClient.UpdateProcess(instance);
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> CreateInstance(string org, string app, Instance instanceTemplate)
     {
         var success = false;
@@ -53,6 +65,7 @@ public class InstanceClientMetricsDecorator : IInstanceClient
         }
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> AddCompleteConfirmation(int instanceOwnerPartyId, Guid instanceGuid)
     {
         var success = false;
@@ -68,26 +81,31 @@ public class InstanceClientMetricsDecorator : IInstanceClient
         }
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> UpdateReadStatus(int instanceOwnerPartyId, Guid instanceGuid, string readStatus)
     {
         return await _instanceClient.UpdateReadStatus(instanceOwnerPartyId, instanceGuid, readStatus);
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> UpdateSubstatus(int instanceOwnerPartyId, Guid instanceGuid, Substatus substatus)
     {
         return await _instanceClient.UpdateSubstatus(instanceOwnerPartyId, instanceGuid, substatus);
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> UpdatePresentationTexts(int instanceOwnerPartyId, Guid instanceGuid, PresentationTexts presentationTexts)
     {
         return await _instanceClient.UpdatePresentationTexts(instanceOwnerPartyId, instanceGuid, presentationTexts);
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> UpdateDataValues(int instanceOwnerPartyId, Guid instanceGuid, DataValues dataValues)
     {
         return await _instanceClient.UpdateDataValues(instanceOwnerPartyId, instanceGuid, dataValues);
     }
 
+    /// <inheritdoc/>
     public async Task<Instance> DeleteInstance(int instanceOwnerPartyId, Guid instanceGuid, bool hard)
     {
         var success = false;

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClientMetricsDecorator.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClientMetricsDecorator.cs
@@ -1,0 +1,105 @@
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Internal.Instances;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Primitives;
+using Prometheus;
+
+namespace Altinn.App.Core.Infrastructure.Clients.Storage;
+
+public class InstanceClientMetricsDecorator : IInstanceClient
+{
+    private readonly IInstanceClient _instanceClient;
+    private static readonly Counter InstancesCreatedCounter = Metrics.CreateCounter("altinn_app_instances_created", "Number of instances created", labelNames: new[] { "result" });
+    private static readonly Counter InstancesCompletedCounter = Metrics.CreateCounter("altinn_app_instances_completed", "Number of instances completed", labelNames: new[] { "result" });
+    private static readonly Counter InstancesDeletedCounter = Metrics.CreateCounter("altinn_app_instances_deleted", "Number of instances completed", labelNames: new[] { "result", "mode" });
+
+    public InstanceClientMetricsDecorator(IInstanceClient instanceClient)
+    {
+        _instanceClient = instanceClient;
+    }
+
+    public async Task<Instance> GetInstance(string app, string org, int instanceOwnerPartyId, Guid instanceId)
+    {
+        return await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceId);
+    }
+
+    public async Task<Instance> GetInstance(Instance instance)
+    {
+        return await _instanceClient.GetInstance(instance);
+    }
+
+    public async Task<List<Instance>> GetInstances(Dictionary<string, StringValues> queryParams)
+    {
+        return await _instanceClient.GetInstances(queryParams);
+    }
+
+    public async Task<Instance> UpdateProcess(Instance instance)
+    {
+        return await _instanceClient.UpdateProcess(instance);
+    }
+
+    public async Task<Instance> CreateInstance(string org, string app, Instance instanceTemplate)
+    {
+        var success = false;
+        try
+        {
+            var instance = await _instanceClient.CreateInstance(org, app, instanceTemplate);
+            success = true;
+            return instance;
+        }
+        finally
+        {
+            InstancesCreatedCounter.WithLabels(success ? "success" : "failure").Inc();
+        }
+    }
+
+    public async Task<Instance> AddCompleteConfirmation(int instanceOwnerPartyId, Guid instanceGuid)
+    {
+        var success = false;
+        try
+        {
+            var instance = await _instanceClient.AddCompleteConfirmation(instanceOwnerPartyId, instanceGuid);
+            success = true;
+            return instance;
+        }
+        finally
+        {
+            InstancesCompletedCounter.WithLabels(success ? "success" : "failure").Inc();
+        }
+    }
+
+    public async Task<Instance> UpdateReadStatus(int instanceOwnerPartyId, Guid instanceGuid, string readStatus)
+    {
+        return await _instanceClient.UpdateReadStatus(instanceOwnerPartyId, instanceGuid, readStatus);
+    }
+
+    public async Task<Instance> UpdateSubstatus(int instanceOwnerPartyId, Guid instanceGuid, Substatus substatus)
+    {
+        return await _instanceClient.UpdateSubstatus(instanceOwnerPartyId, instanceGuid, substatus);
+    }
+
+    public async Task<Instance> UpdatePresentationTexts(int instanceOwnerPartyId, Guid instanceGuid, PresentationTexts presentationTexts)
+    {
+        return await _instanceClient.UpdatePresentationTexts(instanceOwnerPartyId, instanceGuid, presentationTexts);
+    }
+
+    public async Task<Instance> UpdateDataValues(int instanceOwnerPartyId, Guid instanceGuid, DataValues dataValues)
+    {
+        return await _instanceClient.UpdateDataValues(instanceOwnerPartyId, instanceGuid, dataValues);
+    }
+
+    public async Task<Instance> DeleteInstance(int instanceOwnerPartyId, Guid instanceGuid, bool hard)
+    {
+        var success = false;
+        try
+        {
+            var deleteInstance = await _instanceClient.DeleteInstance(instanceOwnerPartyId, instanceGuid, hard);
+            success = true;
+            return deleteInstance;
+        }
+        finally
+        {
+            InstancesDeletedCounter.WithLabels(success ? "success" : "failure", hard ? "hard" : "soft").Inc();
+        }
+    }
+}

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineMetricsDecorator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineMetricsDecorator.cs
@@ -2,47 +2,55 @@ using Altinn.App.Core.Models.Process;
 using Altinn.Platform.Storage.Interface.Models;
 using Prometheus;
 
-namespace Altinn.App.Core.Internal.Process
+namespace Altinn.App.Core.Internal.Process;
+
+/// <summary>
+/// Decorator for the process engine that adds metrics for the number of processes started, ended and moved to next.
+/// </summary>
+public class ProcessEngineMetricsDecorator : IProcessEngine
 {
-    public class ProcessEngineMetricsDecorator : IProcessEngine
+    private readonly IProcessEngine _processEngine;
+    private static readonly Counter ProcessTaskStartCounter = Metrics.CreateCounter("altinn_app_process_start_count", "Number of tasks started", labelNames: "result" );
+    private static readonly Counter ProcessTaskNextCounter = Metrics.CreateCounter("altinn_app_process_task_next_count", "Number of tasks moved to next", "result", "action", "task");
+    private static readonly Counter ProcessTaskEndCounter = Metrics.CreateCounter("altinn_app_process_end_count", "Number of tasks ended", labelNames: "result");
+    private static readonly Counter ProcessTimeCounter = Metrics.CreateCounter("altinn_app_process_end_time_total", "Number of seconds used to complete instances", labelNames: "result");
+
+    /// <summary>
+    /// Create a new instance of the <see cref="ProcessEngineMetricsDecorator"/> class.
+    /// </summary>
+    /// <param name="processEngine">The process engine to decorate.</param>
+    public ProcessEngineMetricsDecorator(IProcessEngine processEngine)
     {
-        private readonly IProcessEngine _processEngine;
-        private static readonly Counter ProcessTaskStartCounter = Metrics.CreateCounter("altinn_app_process_start_count", "Number of tasks started", labelNames: new []{ "result" });
-        private static readonly Counter ProcessTaskNextCounter = Metrics.CreateCounter("altinn_app_process_task_next_count", "Number of tasks moved to next", labelNames: new []{ "result", "action", "task" });
-        private static readonly Counter ProcessTaskEndCounter = Metrics.CreateCounter("altinn_app_process_end_count", "Number of tasks ended", labelNames: new []{ "result" });
-        private static readonly Counter ProcessTimeCounter = Metrics.CreateCounter("altinn_app_process_end_time_total", "Number of seconds used to complete instances", labelNames: new []{ "result" });
+        _processEngine = processEngine;
+    }
 
-        public ProcessEngineMetricsDecorator(IProcessEngine processEngine)
+    /// <inheritdoc/>
+    public async Task<ProcessChangeResult> StartProcess(ProcessStartRequest processStartRequest)
+    {
+        var result = await _processEngine.StartProcess(processStartRequest);
+        ProcessTaskStartCounter.WithLabels(result.Success ? "success" : "failure").Inc();
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ProcessChangeResult> Next(ProcessNextRequest request)
+    {
+        var result = await _processEngine.Next(request);
+        ProcessTaskNextCounter.WithLabels(result.Success ? "success" : "failure", request.Action?? "", request.Instance.Process?.CurrentTask?.ElementId ?? "").Inc();
+        if(result.ProcessStateChange?.NewProcessState?.Ended != null)
         {
-            _processEngine = processEngine;
-        }
-
-
-        public async Task<ProcessChangeResult> StartProcess(ProcessStartRequest processStartRequest)
-        {
-            var result = await _processEngine.StartProcess(processStartRequest);
-            ProcessTaskStartCounter.WithLabels(result.Success ? "success" : "failure").Inc();
-            return result;
-        }
-
-        public async Task<ProcessChangeResult> Next(ProcessNextRequest request)
-        {
-            var result = await _processEngine.Next(request);
-            ProcessTaskNextCounter.WithLabels(result.Success ? "success" : "failure", request.Action?? "", request.Instance.Process?.CurrentTask?.ElementId ?? "").Inc();
-            if(result.ProcessStateChange?.NewProcessState?.Ended != null)
+            ProcessTaskEndCounter.WithLabels(result.Success ? "success" : "failure").Inc();
+            if (result.ProcessStateChange?.NewProcessState?.Started != null)
             {
-                ProcessTaskEndCounter.WithLabels(result.Success ? "success" : "failure").Inc();
-                if (result.ProcessStateChange?.NewProcessState?.Started != null)
-                {
-                    ProcessTimeCounter.WithLabels(result.Success ? "success" : "failure").Inc(result.ProcessStateChange.NewProcessState.Ended.Value.Subtract(result.ProcessStateChange.NewProcessState.Started.Value).TotalSeconds);
-                }
+                ProcessTimeCounter.WithLabels(result.Success ? "success" : "failure").Inc(result.ProcessStateChange.NewProcessState.Ended.Value.Subtract(result.ProcessStateChange.NewProcessState.Started.Value).TotalSeconds);
             }
-            return result;
         }
+        return result;
+    }
 
-        public async Task<Instance> UpdateInstanceAndRerunEvents(ProcessStartRequest startRequest, List<InstanceEvent>? events)
-        {
-            return await _processEngine.UpdateInstanceAndRerunEvents(startRequest, events);
-        }
+    /// <inheritdoc/>
+    public async Task<Instance> UpdateInstanceAndRerunEvents(ProcessStartRequest startRequest, List<InstanceEvent>? events)
+    {
+        return await _processEngine.UpdateInstanceAndRerunEvents(startRequest, events);
     }
 }

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineMetricsDecorator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineMetricsDecorator.cs
@@ -1,0 +1,48 @@
+using Altinn.App.Core.Models.Process;
+using Altinn.Platform.Storage.Interface.Models;
+using Prometheus;
+
+namespace Altinn.App.Core.Internal.Process
+{
+    public class ProcessEngineMetricsDecorator : IProcessEngine
+    {
+        private readonly IProcessEngine _processEngine;
+        private static readonly Counter ProcessTaskStartCounter = Metrics.CreateCounter("altinn_app_process_start_count", "Number of tasks started", labelNames: new []{ "result" });
+        private static readonly Counter ProcessTaskNextCounter = Metrics.CreateCounter("altinn_app_process_task_next_count", "Number of tasks moved to next", labelNames: new []{ "result", "action", "task" });
+        private static readonly Counter ProcessTaskEndCounter = Metrics.CreateCounter("altinn_app_process_end_count", "Number of tasks ended", labelNames: new []{ "result" });
+        private static readonly Counter ProcessTimeCounter = Metrics.CreateCounter("altinn_app_process_end_time_total", "Number of seconds used to complete instances", labelNames: new []{ "result" });
+
+        public ProcessEngineMetricsDecorator(IProcessEngine processEngine)
+        {
+            _processEngine = processEngine;
+        }
+
+
+        public async Task<ProcessChangeResult> StartProcess(ProcessStartRequest processStartRequest)
+        {
+            var result = await _processEngine.StartProcess(processStartRequest);
+            ProcessTaskStartCounter.WithLabels(result.Success ? "success" : "failure").Inc();
+            return result;
+        }
+
+        public async Task<ProcessChangeResult> Next(ProcessNextRequest request)
+        {
+            var result = await _processEngine.Next(request);
+            ProcessTaskNextCounter.WithLabels(result.Success ? "success" : "failure", request.Action?? "", request.Instance.Process?.CurrentTask?.ElementId ?? "").Inc();
+            if(result.ProcessStateChange?.NewProcessState?.Ended != null)
+            {
+                ProcessTaskEndCounter.WithLabels(result.Success ? "success" : "failure").Inc();
+                if (result.ProcessStateChange?.NewProcessState?.Started != null)
+                {
+                    ProcessTimeCounter.WithLabels(result.Success ? "success" : "failure").Inc(result.ProcessStateChange.NewProcessState.Ended.Value.Subtract(result.ProcessStateChange.NewProcessState.Started.Value).TotalSeconds);
+                }
+            }
+            return result;
+        }
+
+        public async Task<Instance> UpdateInstanceAndRerunEvents(ProcessStartRequest startRequest, List<InstanceEvent>? events)
+        {
+            return await _processEngine.UpdateInstanceAndRerunEvents(startRequest, events);
+        }
+    }
+}

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
@@ -18,7 +18,7 @@ public class InstanceClientMetricsDecoratorTests
     {
         Metrics.SuppressDefaultMetrics();
     }
-    
+
     [Fact]
     public async Task CreateInstance_calls_decorated_service_and_update_on_success()
     {
@@ -31,7 +31,7 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.CreateInstance("org", "app", instanceTemplate);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().HaveCount(1);
@@ -39,7 +39,7 @@ public class InstanceClientMetricsDecoratorTests
         instanceClient.Verify(i => i.CreateInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Instance>()));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task CreateInstance_calls_decorated_service_and_update_on_failure()
     {
@@ -55,7 +55,7 @@ public class InstanceClientMetricsDecoratorTests
         var ex = await Assert.ThrowsAsync<PlatformHttpException>(async () => await instanceClientMetricsDecorator.CreateInstance("org", "app", instanceTemplate));
         ex.Should().BeSameAs(platformHttpException);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().HaveCount(1);
@@ -63,7 +63,7 @@ public class InstanceClientMetricsDecoratorTests
         instanceClient.Verify(i => i.CreateInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Instance>()));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task AddCompleteConfirmation_calls_decorated_service_and_update_on_success()
     {
@@ -75,7 +75,7 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.AddCompleteConfirmation(1337, Guid.NewGuid());
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().HaveCount(1);
@@ -83,7 +83,7 @@ public class InstanceClientMetricsDecoratorTests
         instanceClient.Verify(i => i.AddCompleteConfirmation(It.IsAny<int>(), It.IsAny<Guid>()));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task AddCompleteConfirmation_calls_decorated_service_and_update_on_failure()
     {
@@ -98,7 +98,7 @@ public class InstanceClientMetricsDecoratorTests
         var ex = await Assert.ThrowsAsync<PlatformHttpException>(async () => await instanceClientMetricsDecorator.AddCompleteConfirmation(1337, Guid.NewGuid()));
         ex.Should().BeSameAs(platformHttpException);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().HaveCount(1);
@@ -106,7 +106,7 @@ public class InstanceClientMetricsDecoratorTests
         instanceClient.Verify(i => i.AddCompleteConfirmation(It.IsAny<int>(), It.IsAny<Guid>()));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task DeleteInstance_calls_decorated_service_and_update_on_success_soft_delete()
     {
@@ -118,7 +118,7 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.DeleteInstance(1337, Guid.NewGuid(), false);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().HaveCount(1);
@@ -126,7 +126,7 @@ public class InstanceClientMetricsDecoratorTests
         instanceClient.Verify(i => i.DeleteInstance(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<bool>()));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task DeleteInstance_calls_decorated_service_and_update_on_success_soft_hard()
     {
@@ -138,7 +138,7 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.DeleteInstance(1337, Guid.NewGuid(), true);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().HaveCount(1);
@@ -161,7 +161,7 @@ public class InstanceClientMetricsDecoratorTests
         var ex = await Assert.ThrowsAsync<PlatformHttpException>(async () => await instanceClientMetricsDecorator.DeleteInstance(1337, Guid.NewGuid(), false));
         ex.Should().BeSameAs(platformHttpException);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().HaveCount(1);
@@ -180,16 +180,16 @@ public class InstanceClientMetricsDecoratorTests
 
         // Act
         var instanceId = Guid.NewGuid();
-        await instanceClientMetricsDecorator.GetInstance("test-app", "ttd",1337, instanceId);
+        await instanceClientMetricsDecorator.GetInstance("test-app", "ttd", 1337, instanceId);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().BeEmpty();
-        instanceClient.Verify(i => i.GetInstance("test-app", "ttd",1337, instanceId));
+        instanceClient.Verify(i => i.GetInstance("test-app", "ttd", 1337, instanceId));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task GetInstance_instance_calls_decorated_service()
     {
@@ -202,14 +202,14 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.GetInstance(instance);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().BeEmpty();
         instanceClient.Verify(i => i.GetInstance(instance));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task GetInstances_calls_decorated_service()
     {
@@ -221,14 +221,14 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.GetInstances(new Dictionary<string, StringValues>());
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().BeEmpty();
         instanceClient.Verify(i => i.GetInstances(new Dictionary<string, StringValues>()));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task UpdateProcess_of_instance_owner_calls_decorated_service()
     {
@@ -241,7 +241,7 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.UpdateProcess(instance);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().BeEmpty();
@@ -261,14 +261,14 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.UpdateReadStatus(1337, instanceGuid, "read");
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().BeEmpty();
         instanceClient.Verify(i => i.UpdateReadStatus(1337, instanceGuid, "read"));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task UpdateSubstatus_of_instance_owner_calls_decorated_service()
     {
@@ -282,14 +282,14 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.UpdateSubstatus(1337, instanceGuid, substatus);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().BeEmpty();
         instanceClient.Verify(i => i.UpdateSubstatus(1337, instanceGuid, substatus));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task UpdatePresentationTexts_of_instance_owner_calls_decorated_service()
     {
@@ -303,14 +303,14 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.UpdatePresentationTexts(1337, instanceGuid, presentationTexts);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().BeEmpty();
         instanceClient.Verify(i => i.UpdatePresentationTexts(1337, instanceGuid, presentationTexts));
         instanceClient.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task UpdateDataValues_of_instance_owner_calls_decorated_service()
     {
@@ -324,7 +324,7 @@ public class InstanceClientMetricsDecoratorTests
         // Act
         await instanceClientMetricsDecorator.UpdateDataValues(1337, instanceGuid, dataValues);
         var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
-        
+
         // Assert
         var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
         diff.Should().BeEmpty();

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
@@ -338,14 +338,7 @@ public class InstanceClientMetricsDecoratorTests
         IEnumerable<string> set1 = s1.Split('\n').Distinct().Where(s => !s.StartsWith("#"));
         IEnumerable<string> set2 = s2.Split('\n').Distinct().Where(s => !s.StartsWith("#"));
 
-        if (set2.Count() > set1.Count())
-        {
-            diff = set2.Except(set1).ToList();
-        }
-        else
-        {
-            diff = set1.Except(set2).ToList();
-        }
+        diff = set2.Count() > set1.Count() ? set2.Except(set1).ToList() : set1.Except(set2).ToList();
 
         return diff;
     }

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
@@ -1,0 +1,352 @@
+using System.Net;
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Infrastructure.Clients.Storage;
+using Altinn.App.Core.Internal.Instances;
+using Altinn.App.Core.Tests.TestHelpers;
+using Altinn.Platform.Storage.Interface.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Prometheus;
+using Xunit;
+
+namespace Altinn.App.Core.Tests.InfrastrucZture.Clients.Storage;
+
+public class InstanceClientMetricsDecoratorTests
+{
+    public InstanceClientMetricsDecoratorTests()
+    {
+        Metrics.SuppressDefaultMetrics();
+    }
+    
+    [Fact]
+    public async Task CreateInstance_calls_decorated_service_and_update_on_success()
+    {
+        // Arrange
+        Mock<IInstanceClient> instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        var instanceTemplate = new Instance();
+
+        // Act
+        await instanceClientMetricsDecorator.CreateInstance("org", "app", instanceTemplate);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().HaveCount(1);
+        diff.Should().Contain("altinn_app_instances_created{result=\"success\"} 1");
+        instanceClient.Verify(i => i.CreateInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Instance>()));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task CreateInstance_calls_decorated_service_and_update_on_failure()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var platformHttpException = new PlatformHttpException(new HttpResponseMessage(HttpStatusCode.BadRequest), "test");
+        instanceClient.Setup(i => i.CreateInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Instance>())).ThrowsAsync(platformHttpException);
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        var instanceTemplate = new Instance();
+
+        // Act
+        var ex = await Assert.ThrowsAsync<PlatformHttpException>(async () => await instanceClientMetricsDecorator.CreateInstance("org", "app", instanceTemplate));
+        ex.Should().BeSameAs(platformHttpException);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().HaveCount(1);
+        diff.Should().Contain("altinn_app_instances_created{result=\"failure\"} 1");
+        instanceClient.Verify(i => i.CreateInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Instance>()));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task AddCompleteConfirmation_calls_decorated_service_and_update_on_success()
+    {
+        // Arrange
+        Mock<IInstanceClient> instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+
+        // Act
+        await instanceClientMetricsDecorator.AddCompleteConfirmation(1337, Guid.NewGuid());
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().HaveCount(1);
+        diff.Should().Contain("altinn_app_instances_completed{result=\"success\"} 1");
+        instanceClient.Verify(i => i.AddCompleteConfirmation(It.IsAny<int>(), It.IsAny<Guid>()));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task AddCompleteConfirmation_calls_decorated_service_and_update_on_failure()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var platformHttpException = new PlatformHttpException(new HttpResponseMessage(HttpStatusCode.BadRequest), "test");
+        instanceClient.Setup(i => i.AddCompleteConfirmation(It.IsAny<int>(), It.IsAny<Guid>())).ThrowsAsync(platformHttpException);
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+
+        // Act
+        var ex = await Assert.ThrowsAsync<PlatformHttpException>(async () => await instanceClientMetricsDecorator.AddCompleteConfirmation(1337, Guid.NewGuid()));
+        ex.Should().BeSameAs(platformHttpException);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().HaveCount(1);
+        diff.Should().Contain("altinn_app_instances_completed{result=\"failure\"} 1");
+        instanceClient.Verify(i => i.AddCompleteConfirmation(It.IsAny<int>(), It.IsAny<Guid>()));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task DeleteInstance_calls_decorated_service_and_update_on_success_soft_delete()
+    {
+        // Arrange
+        Mock<IInstanceClient> instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+
+        // Act
+        await instanceClientMetricsDecorator.DeleteInstance(1337, Guid.NewGuid(), false);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().HaveCount(1);
+        diff.Should().Contain("altinn_app_instances_deleted{result=\"success\",mode=\"soft\"} 1");
+        instanceClient.Verify(i => i.DeleteInstance(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<bool>()));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task DeleteInstance_calls_decorated_service_and_update_on_success_soft_hard()
+    {
+        // Arrange
+        Mock<IInstanceClient> instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+
+        // Act
+        await instanceClientMetricsDecorator.DeleteInstance(1337, Guid.NewGuid(), true);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().HaveCount(1);
+        diff.Should().Contain("altinn_app_instances_deleted{result=\"success\",mode=\"hard\"} 1");
+        instanceClient.Verify(i => i.DeleteInstance(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<bool>()));
+        instanceClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task DeleteInstance_calls_decorated_service_and_update_on_failure()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var platformHttpException = new PlatformHttpException(new HttpResponseMessage(HttpStatusCode.BadRequest), "test");
+        instanceClient.Setup(i => i.DeleteInstance(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<bool>())).ThrowsAsync(platformHttpException);
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+
+        // Act
+        var ex = await Assert.ThrowsAsync<PlatformHttpException>(async () => await instanceClientMetricsDecorator.DeleteInstance(1337, Guid.NewGuid(), false));
+        ex.Should().BeSameAs(platformHttpException);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().HaveCount(1);
+        diff.Should().Contain("altinn_app_instances_deleted{result=\"failure\",mode=\"soft\"} 1");
+        instanceClient.Verify(i => i.DeleteInstance(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<bool>()));
+        instanceClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task GetInstance_calls_decorated_service()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+
+        // Act
+        var instanceId = Guid.NewGuid();
+        await instanceClientMetricsDecorator.GetInstance("test-app", "ttd",1337, instanceId);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().BeEmpty();
+        instanceClient.Verify(i => i.GetInstance("test-app", "ttd",1337, instanceId));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task GetInstance_instance_calls_decorated_service()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        var instance = new Instance();
+
+        // Act
+        await instanceClientMetricsDecorator.GetInstance(instance);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().BeEmpty();
+        instanceClient.Verify(i => i.GetInstance(instance));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task GetInstances_calls_decorated_service()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+
+        // Act
+        await instanceClientMetricsDecorator.GetInstances(new Dictionary<string, StringValues>());
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().BeEmpty();
+        instanceClient.Verify(i => i.GetInstances(new Dictionary<string, StringValues>()));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task UpdateProcess_of_instance_owner_calls_decorated_service()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        var instance = new Instance();
+
+        // Act
+        await instanceClientMetricsDecorator.UpdateProcess(instance);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().BeEmpty();
+        instanceClient.Verify(i => i.UpdateProcess(instance));
+        instanceClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task UpdateReadStatus_of_instance_owner_calls_decorated_service()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        var instanceGuid = Guid.NewGuid();
+
+        // Act
+        await instanceClientMetricsDecorator.UpdateReadStatus(1337, instanceGuid, "read");
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().BeEmpty();
+        instanceClient.Verify(i => i.UpdateReadStatus(1337, instanceGuid, "read"));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task UpdateSubstatus_of_instance_owner_calls_decorated_service()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        var instanceGuid = Guid.NewGuid();
+        var substatus = new Substatus();
+
+        // Act
+        await instanceClientMetricsDecorator.UpdateSubstatus(1337, instanceGuid, substatus);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().BeEmpty();
+        instanceClient.Verify(i => i.UpdateSubstatus(1337, instanceGuid, substatus));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task UpdatePresentationTexts_of_instance_owner_calls_decorated_service()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        var instanceGuid = Guid.NewGuid();
+        var presentationTexts = new PresentationTexts();
+
+        // Act
+        await instanceClientMetricsDecorator.UpdatePresentationTexts(1337, instanceGuid, presentationTexts);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().BeEmpty();
+        instanceClient.Verify(i => i.UpdatePresentationTexts(1337, instanceGuid, presentationTexts));
+        instanceClient.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task UpdateDataValues_of_instance_owner_calls_decorated_service()
+    {
+        // Arrange
+        var instanceClient = new Mock<IInstanceClient>();
+        var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
+        var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        var instanceGuid = Guid.NewGuid();
+        var dataValues = new DataValues();
+
+        // Act
+        await instanceClientMetricsDecorator.UpdateDataValues(1337, instanceGuid, dataValues);
+        var postUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
+        
+        // Assert
+        var diff = GetDiff(preUpdateMetrics, postUpdateMetrics);
+        diff.Should().BeEmpty();
+        instanceClient.Verify(i => i.UpdateDataValues(1337, instanceGuid, dataValues));
+        instanceClient.VerifyNoOtherCalls();
+    }
+
+    private static List<string> GetDiff(string s1, string s2)
+    {
+        List<string> diff;
+        IEnumerable<string> set1 = s1.Split('\n').Distinct().Where(s => !s.StartsWith("#"));
+        IEnumerable<string> set2 = s2.Split('\n').Distinct().Where(s => !s.StartsWith("#"));
+
+        if (set2.Count() > set1.Count())
+        {
+            diff = set2.Except(set1).ToList();
+        }
+        else
+        {
+            diff = set1.Except(set2).ToList();
+        }
+
+        return diff;
+    }
+}

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineMetricsDecoratorTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineMetricsDecoratorTests.cs
@@ -1,0 +1,305 @@
+using Altinn.App.Core.Internal.Process;
+using Altinn.App.Core.Models.Process;
+using Altinn.App.Core.Tests.TestHelpers;
+using Altinn.Platform.Storage.Interface.Models;
+using FluentAssertions;
+using Moq;
+using Prometheus;
+using Xunit;
+
+namespace Altinn.App.Core.Tests.Internal.Process;
+
+public class ProcessEngineMetricsDecoratorTests
+{
+    public ProcessEngineMetricsDecoratorTests()
+    {
+        Metrics.SuppressDefaultMetrics();
+    }
+    
+    [Fact]
+    public async Task StartProcess_calls_decorated_service_and_increments_success_counter_when_successful()
+    {
+        // Arrange
+        var processEngine = new Mock<IProcessEngine>();
+        processEngine.Setup(p => p.StartProcess(It.IsAny<ProcessStartRequest>())).ReturnsAsync(new ProcessChangeResult { Success = true });
+        var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
+        (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_start_count{result=\"success\"}");
+        
+        var result = decorator.StartProcess(new ProcessStartRequest());
+
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_start_count{result=\"success\"} 1");
+        result.Result.Success.Should().BeTrue();
+        result = decorator.StartProcess(new ProcessStartRequest());
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_start_count{result=\"success\"} 2");
+        result.Result.Success.Should().BeTrue();
+        processEngine.Verify(p => p.StartProcess(It.IsAny<ProcessStartRequest>()), Times.Exactly(2));
+        processEngine.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task StartProcess_calls_decorated_service_and_increments_failure_counter_when_unsuccessful()
+    {
+        // Arrange
+        var processEngine = new Mock<IProcessEngine>();
+        processEngine.Setup(p => p.StartProcess(It.IsAny<ProcessStartRequest>())).ReturnsAsync(new ProcessChangeResult { Success = false });
+        var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
+        (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_start_count{result=\"failure\"}");
+        
+        var result = decorator.StartProcess(new ProcessStartRequest());
+
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_start_count{result=\"failure\"} 1");
+        result.Result.Success.Should().BeFalse();
+        result = decorator.StartProcess(new ProcessStartRequest());
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_start_count{result=\"failure\"} 2");
+        result.Result.Success.Should().BeFalse();
+        processEngine.Verify(p => p.StartProcess(It.IsAny<ProcessStartRequest>()), Times.Exactly(2));
+        processEngine.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task Next_calls_decorated_service_and_increments_success_counter_when_successful()
+    {
+        // Arrange
+        var processEngine = new Mock<IProcessEngine>();
+        processEngine.Setup(p => p.Next(It.IsAny<ProcessNextRequest>())).ReturnsAsync(new ProcessChangeResult { Success = true });
+        var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
+        (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_task_next_count{result=\"success\",action=\"write\",task=\"Task_1\"}");
+        
+        var result = decorator.Next(new ProcessNextRequest()
+        {
+            Instance = new ()
+            {
+                Process = new ()
+                {
+                    CurrentTask = new ()
+                    {
+                        ElementId = "Task_1"
+                    }
+                }
+            },
+            Action = "write"
+        });
+
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_task_next_count{result=\"success\",action=\"write\",task=\"Task_1\"} 1");
+        result.Result.Success.Should().BeTrue();
+        result = decorator.Next(new ProcessNextRequest()
+        {
+            Instance = new ()
+            {
+                Process = new ()
+                {
+                    CurrentTask = new ()
+                    {
+                        ElementId = "Task_1"
+                    }
+                }
+            },
+            Action = "write"
+        });
+        var prometheusMetricsToString = await ReadPrometheusMetricsToString();
+        prometheusMetricsToString.Should().Contain("altinn_app_process_task_next_count{result=\"success\",action=\"write\",task=\"Task_1\"} 2");
+        result.Result.Success.Should().BeTrue();
+        processEngine.Verify(p => p.Next(It.IsAny<ProcessNextRequest>()), Times.Exactly(2));
+        processEngine.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task Next_calls_decorated_service_and_increments_failure_counter_when_unsuccessful()
+    {
+        // Arrange
+        var processEngine = new Mock<IProcessEngine>();
+        processEngine.Setup(p => p.Next(It.IsAny<ProcessNextRequest>())).ReturnsAsync(new ProcessChangeResult { Success = false });
+        var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
+        (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_task_next_count{result=\"failure\",action=\"write\",task=\"Task_1\"}");
+        
+        var result = decorator.Next(new ProcessNextRequest()
+        {
+            Instance = new ()
+            {
+                Process = new ()
+                {
+                    CurrentTask = new ()
+                    {
+                        ElementId = "Task_1"
+                    }
+                }
+            },
+            Action = "write"
+        });
+
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_task_next_count{result=\"failure\",action=\"write\",task=\"Task_1\"} 1");
+        result.Result.Success.Should().BeFalse();
+        result = decorator.Next(new ProcessNextRequest()
+        {
+            Instance = new ()
+            {
+                Process = new ()
+                {
+                    CurrentTask = new ()
+                    {
+                        ElementId = "Task_1"
+                    }
+                }
+            },
+            Action = "write"
+        });
+        var prometheusMetricsToString = await ReadPrometheusMetricsToString();
+        prometheusMetricsToString.Should().Contain("altinn_app_process_task_next_count{result=\"failure\",action=\"write\",task=\"Task_1\"} 2");
+        result.Result.Success.Should().BeFalse();
+        processEngine.Verify(p => p.Next(It.IsAny<ProcessNextRequest>()), Times.Exactly(2));
+        processEngine.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task Next_calls_decorated_service_and_increments_success_and_end_counters_when_successful_and_process_ended()
+    {
+        // Arrange
+        var processEngine = new Mock<IProcessEngine>();
+        var ended = DateTime.Now;
+        var started = ended.AddSeconds(-20);
+        processEngine.Setup(p => p.Next(It.IsAny<ProcessNextRequest>())).ReturnsAsync(new ProcessChangeResult
+        {
+            Success = true,
+            ProcessStateChange = new ()
+            {
+                NewProcessState = new ()
+                {
+                    Ended = ended,
+                    Started = started
+                }
+            }
+        });
+        var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
+        (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_task_next_count{result=\"success\",action=\"confirm\",task=\"Task_2\"}");
+        (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_end_count{result=\"success\"}");
+        (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_end_time_total{result=\"success\"}");
+        
+        var result = decorator.Next(new ProcessNextRequest()
+        {
+            Instance = new ()
+            {
+                Process = new ()
+                {
+                    CurrentTask = new ()
+                    {
+                        ElementId = "Task_2"
+                    }
+                }
+            },
+            Action = "confirm"
+        });
+
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_task_next_count{result=\"success\",action=\"confirm\",task=\"Task_2\"} 1");
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_end_count{result=\"success\"} 1");
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_end_time_total{result=\"success\"} 20");
+        result.Result.Success.Should().BeTrue();
+        result = decorator.Next(new ProcessNextRequest()
+        {
+            Instance = new ()
+            {
+                Process = new ()
+                {
+                    CurrentTask = new ()
+                    {
+                        ElementId = "Task_2"
+                    }
+                }
+            },
+            Action = "confirm"
+        });
+        var prometheusMetricsToString = await ReadPrometheusMetricsToString();
+        prometheusMetricsToString.Should().Contain("altinn_app_process_task_next_count{result=\"success\",action=\"confirm\",task=\"Task_2\"} 2");
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_end_count{result=\"success\"} 2");
+        (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_end_time_total{result=\"success\"} 40");
+        result.Result.Success.Should().BeTrue();
+        processEngine.Verify(p => p.Next(It.IsAny<ProcessNextRequest>()), Times.Exactly(2));
+        processEngine.VerifyNoOtherCalls();
+    }
+    
+    [Fact]
+    public async Task Next_calls_decorated_service_and_increments_failure_and_end_counters_when_unsuccessful_and_process_ended_no_time_added_if_started_null()
+    {
+        // Arrange
+        var processEngine = new Mock<IProcessEngine>();
+        var ended = DateTime.Now;
+        var started = ended.AddSeconds(-20);
+        processEngine.Setup(p => p.Next(It.IsAny<ProcessNextRequest>())).ReturnsAsync(new ProcessChangeResult
+        {
+            Success = false,
+            ProcessStateChange = new ()
+            {
+                NewProcessState = new ()
+                {
+                    Ended = ended
+                }
+            }
+        });
+        var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
+        var prometheusMetricsToString = await ReadPrometheusMetricsToString();
+        prometheusMetricsToString.Should().NotContain("altinn_app_process_task_next_count{result=\"failure\",action=\"confirm\",task=\"Task_3\"}");
+        prometheusMetricsToString.Should().NotContain("altinn_app_process_end_count{result=\"failure\"}");
+        prometheusMetricsToString.Should().NotContain("altinn_app_process_end_time_total{result=\"failure\"}");
+        
+        var result = decorator.Next(new ProcessNextRequest()
+        {
+            Instance = new ()
+            {
+                Process = new ()
+                {
+                    CurrentTask = new ()
+                    {
+                        ElementId = "Task_3"
+                    }
+                }
+            },
+            Action = "confirm"
+        });
+        
+        prometheusMetricsToString = await ReadPrometheusMetricsToString();
+        prometheusMetricsToString.Should().Contain("altinn_app_process_task_next_count{result=\"failure\",action=\"confirm\",task=\"Task_3\"} 1");
+        prometheusMetricsToString.Should().Contain("altinn_app_process_end_count{result=\"failure\"} 1");
+        prometheusMetricsToString.Should().NotContain("altinn_app_process_end_time_total{result=\"failure\"}");
+        result.Result.Success.Should().BeFalse();
+        result = decorator.Next(new ProcessNextRequest()
+        {
+            Instance = new ()
+            {
+                Process = new ()
+                {
+                    CurrentTask = new ()
+                    {
+                        ElementId = "Task_3"
+                    }
+                }
+            },
+            Action = "confirm"
+        });
+        prometheusMetricsToString = await ReadPrometheusMetricsToString();
+        prometheusMetricsToString.Should().Contain("altinn_app_process_task_next_count{result=\"failure\",action=\"confirm\",task=\"Task_3\"} 2");
+        prometheusMetricsToString.Should().Contain("altinn_app_process_end_count{result=\"failure\"} 2");
+        prometheusMetricsToString.Should().NotContain("altinn_app_process_end_time_total{result=\"failure\"}");
+        result.Result.Success.Should().BeFalse();
+        processEngine.Verify(p => p.Next(It.IsAny<ProcessNextRequest>()), Times.Exactly(2));
+        processEngine.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task UpdateInstanceAndRerunEvents_calls_decorated_service()
+    {
+        // Arrange
+        var processEngine = new Mock<IProcessEngine>();
+        processEngine.Setup(p => p.UpdateInstanceAndRerunEvents(It.IsAny<ProcessStartRequest>(), It.IsAny<List<InstanceEvent>?>())).ReturnsAsync(new Instance { });
+        var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
+        (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_start_count{result=\"success\"}");
+        
+        var result = decorator.UpdateInstanceAndRerunEvents(new ProcessStartRequest(), new List<InstanceEvent>());
+        
+        processEngine.Verify(p => p.UpdateInstanceAndRerunEvents(It.IsAny<ProcessStartRequest>(), It.IsAny<List<InstanceEvent>>()), Times.Once);
+        processEngine.VerifyNoOtherCalls();
+    }
+
+    private static async Task<string> ReadPrometheusMetricsToString()
+    {
+        return await PrometheusTestHelper.ReadPrometheusMetricsToString();
+    }
+}

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineMetricsDecoratorTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineMetricsDecoratorTests.cs
@@ -222,7 +222,6 @@ public class ProcessEngineMetricsDecoratorTests
         // Arrange
         var processEngine = new Mock<IProcessEngine>();
         var ended = DateTime.Now;
-        var started = ended.AddSeconds(-20);
         processEngine.Setup(p => p.Next(It.IsAny<ProcessNextRequest>())).ReturnsAsync(new ProcessChangeResult
         {
             Success = false,
@@ -292,7 +291,7 @@ public class ProcessEngineMetricsDecoratorTests
         var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
         (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_start_count{result=\"success\"}");
         
-        var result = decorator.UpdateInstanceAndRerunEvents(new ProcessStartRequest(), new List<InstanceEvent>());
+        await decorator.UpdateInstanceAndRerunEvents(new ProcessStartRequest(), new List<InstanceEvent>());
         
         processEngine.Verify(p => p.UpdateInstanceAndRerunEvents(It.IsAny<ProcessStartRequest>(), It.IsAny<List<InstanceEvent>>()), Times.Once);
         processEngine.VerifyNoOtherCalls();

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineMetricsDecoratorTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineMetricsDecoratorTests.cs
@@ -15,7 +15,7 @@ public class ProcessEngineMetricsDecoratorTests
     {
         Metrics.SuppressDefaultMetrics();
     }
-    
+
     [Fact]
     public async Task StartProcess_calls_decorated_service_and_increments_success_counter_when_successful()
     {
@@ -24,7 +24,7 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Setup(p => p.StartProcess(It.IsAny<ProcessStartRequest>())).ReturnsAsync(new ProcessChangeResult { Success = true });
         var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
         (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_start_count{result=\"success\"}");
-        
+
         var result = decorator.StartProcess(new ProcessStartRequest());
 
         (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_start_count{result=\"success\"} 1");
@@ -35,7 +35,7 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Verify(p => p.StartProcess(It.IsAny<ProcessStartRequest>()), Times.Exactly(2));
         processEngine.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task StartProcess_calls_decorated_service_and_increments_failure_counter_when_unsuccessful()
     {
@@ -44,7 +44,7 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Setup(p => p.StartProcess(It.IsAny<ProcessStartRequest>())).ReturnsAsync(new ProcessChangeResult { Success = false });
         var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
         (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_start_count{result=\"failure\"}");
-        
+
         var result = decorator.StartProcess(new ProcessStartRequest());
 
         (await ReadPrometheusMetricsToString()).Should().Contain("altinn_app_process_start_count{result=\"failure\"} 1");
@@ -55,7 +55,7 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Verify(p => p.StartProcess(It.IsAny<ProcessStartRequest>()), Times.Exactly(2));
         processEngine.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task Next_calls_decorated_service_and_increments_success_counter_when_successful()
     {
@@ -64,14 +64,14 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Setup(p => p.Next(It.IsAny<ProcessNextRequest>())).ReturnsAsync(new ProcessChangeResult { Success = true });
         var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
         (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_task_next_count{result=\"success\",action=\"write\",task=\"Task_1\"}");
-        
+
         var result = decorator.Next(new ProcessNextRequest()
         {
-            Instance = new ()
+            Instance = new()
             {
-                Process = new ()
+                Process = new()
                 {
-                    CurrentTask = new ()
+                    CurrentTask = new()
                     {
                         ElementId = "Task_1"
                     }
@@ -84,11 +84,11 @@ public class ProcessEngineMetricsDecoratorTests
         result.Result.Success.Should().BeTrue();
         result = decorator.Next(new ProcessNextRequest()
         {
-            Instance = new ()
+            Instance = new()
             {
-                Process = new ()
+                Process = new()
                 {
-                    CurrentTask = new ()
+                    CurrentTask = new()
                     {
                         ElementId = "Task_1"
                     }
@@ -102,7 +102,7 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Verify(p => p.Next(It.IsAny<ProcessNextRequest>()), Times.Exactly(2));
         processEngine.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task Next_calls_decorated_service_and_increments_failure_counter_when_unsuccessful()
     {
@@ -111,14 +111,14 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Setup(p => p.Next(It.IsAny<ProcessNextRequest>())).ReturnsAsync(new ProcessChangeResult { Success = false });
         var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
         (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_task_next_count{result=\"failure\",action=\"write\",task=\"Task_1\"}");
-        
+
         var result = decorator.Next(new ProcessNextRequest()
         {
-            Instance = new ()
+            Instance = new()
             {
-                Process = new ()
+                Process = new()
                 {
-                    CurrentTask = new ()
+                    CurrentTask = new()
                     {
                         ElementId = "Task_1"
                     }
@@ -131,11 +131,11 @@ public class ProcessEngineMetricsDecoratorTests
         result.Result.Success.Should().BeFalse();
         result = decorator.Next(new ProcessNextRequest()
         {
-            Instance = new ()
+            Instance = new()
             {
-                Process = new ()
+                Process = new()
                 {
-                    CurrentTask = new ()
+                    CurrentTask = new()
                     {
                         ElementId = "Task_1"
                     }
@@ -149,7 +149,7 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Verify(p => p.Next(It.IsAny<ProcessNextRequest>()), Times.Exactly(2));
         processEngine.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task Next_calls_decorated_service_and_increments_success_and_end_counters_when_successful_and_process_ended()
     {
@@ -160,9 +160,9 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Setup(p => p.Next(It.IsAny<ProcessNextRequest>())).ReturnsAsync(new ProcessChangeResult
         {
             Success = true,
-            ProcessStateChange = new ()
+            ProcessStateChange = new()
             {
-                NewProcessState = new ()
+                NewProcessState = new()
                 {
                     Ended = ended,
                     Started = started
@@ -173,14 +173,14 @@ public class ProcessEngineMetricsDecoratorTests
         (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_task_next_count{result=\"success\",action=\"confirm\",task=\"Task_2\"}");
         (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_end_count{result=\"success\"}");
         (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_end_time_total{result=\"success\"}");
-        
+
         var result = decorator.Next(new ProcessNextRequest()
         {
-            Instance = new ()
+            Instance = new()
             {
-                Process = new ()
+                Process = new()
                 {
-                    CurrentTask = new ()
+                    CurrentTask = new()
                     {
                         ElementId = "Task_2"
                     }
@@ -195,11 +195,11 @@ public class ProcessEngineMetricsDecoratorTests
         result.Result.Success.Should().BeTrue();
         result = decorator.Next(new ProcessNextRequest()
         {
-            Instance = new ()
+            Instance = new()
             {
-                Process = new ()
+                Process = new()
                 {
-                    CurrentTask = new ()
+                    CurrentTask = new()
                     {
                         ElementId = "Task_2"
                     }
@@ -215,7 +215,7 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Verify(p => p.Next(It.IsAny<ProcessNextRequest>()), Times.Exactly(2));
         processEngine.VerifyNoOtherCalls();
     }
-    
+
     [Fact]
     public async Task Next_calls_decorated_service_and_increments_failure_and_end_counters_when_unsuccessful_and_process_ended_no_time_added_if_started_null()
     {
@@ -225,9 +225,9 @@ public class ProcessEngineMetricsDecoratorTests
         processEngine.Setup(p => p.Next(It.IsAny<ProcessNextRequest>())).ReturnsAsync(new ProcessChangeResult
         {
             Success = false,
-            ProcessStateChange = new ()
+            ProcessStateChange = new()
             {
-                NewProcessState = new ()
+                NewProcessState = new()
                 {
                     Ended = ended
                 }
@@ -238,14 +238,14 @@ public class ProcessEngineMetricsDecoratorTests
         prometheusMetricsToString.Should().NotContain("altinn_app_process_task_next_count{result=\"failure\",action=\"confirm\",task=\"Task_3\"}");
         prometheusMetricsToString.Should().NotContain("altinn_app_process_end_count{result=\"failure\"}");
         prometheusMetricsToString.Should().NotContain("altinn_app_process_end_time_total{result=\"failure\"}");
-        
+
         var result = decorator.Next(new ProcessNextRequest()
         {
-            Instance = new ()
+            Instance = new()
             {
-                Process = new ()
+                Process = new()
                 {
-                    CurrentTask = new ()
+                    CurrentTask = new()
                     {
                         ElementId = "Task_3"
                     }
@@ -253,7 +253,7 @@ public class ProcessEngineMetricsDecoratorTests
             },
             Action = "confirm"
         });
-        
+
         prometheusMetricsToString = await ReadPrometheusMetricsToString();
         prometheusMetricsToString.Should().Contain("altinn_app_process_task_next_count{result=\"failure\",action=\"confirm\",task=\"Task_3\"} 1");
         prometheusMetricsToString.Should().Contain("altinn_app_process_end_count{result=\"failure\"} 1");
@@ -261,11 +261,11 @@ public class ProcessEngineMetricsDecoratorTests
         result.Result.Success.Should().BeFalse();
         result = decorator.Next(new ProcessNextRequest()
         {
-            Instance = new ()
+            Instance = new()
             {
-                Process = new ()
+                Process = new()
                 {
-                    CurrentTask = new ()
+                    CurrentTask = new()
                     {
                         ElementId = "Task_3"
                     }
@@ -287,12 +287,12 @@ public class ProcessEngineMetricsDecoratorTests
     {
         // Arrange
         var processEngine = new Mock<IProcessEngine>();
-        processEngine.Setup(p => p.UpdateInstanceAndRerunEvents(It.IsAny<ProcessStartRequest>(), It.IsAny<List<InstanceEvent>?>())).ReturnsAsync(new Instance { });
+        processEngine.Setup(p => p.UpdateInstanceAndRerunEvents(It.IsAny<ProcessStartRequest>(), It.IsAny<List<InstanceEvent>>())).ReturnsAsync(new Instance { });
         var decorator = new ProcessEngineMetricsDecorator(processEngine.Object);
         (await ReadPrometheusMetricsToString()).Should().NotContain("altinn_app_process_start_count{result=\"success\"}");
-        
+
         await decorator.UpdateInstanceAndRerunEvents(new ProcessStartRequest(), new List<InstanceEvent>());
-        
+
         processEngine.Verify(p => p.UpdateInstanceAndRerunEvents(It.IsAny<ProcessStartRequest>(), It.IsAny<List<InstanceEvent>>()), Times.Once);
         processEngine.VerifyNoOtherCalls();
     }

--- a/test/Altinn.App.Core.Tests/TestHelpers/PrometheusTestHelper.cs
+++ b/test/Altinn.App.Core.Tests/TestHelpers/PrometheusTestHelper.cs
@@ -1,0 +1,15 @@
+using Prometheus;
+
+namespace Altinn.App.Core.Tests.TestHelpers;
+
+public class PrometheusTestHelper
+{
+    public static async Task<string> ReadPrometheusMetricsToString()
+    {
+        MemoryStream memoryStream = new MemoryStream();
+        await Metrics.DefaultRegistry.CollectAndExportAsTextAsync(memoryStream);
+        using StreamReader reader = new StreamReader(memoryStream);
+        memoryStream.Position = 0;
+        return reader.ReadToEnd();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Expose a prometheus metrics endpoint with the use of [prometheus-net](https://github.com/prometheus-net/prometheus-net) nuget

Altinn specific metrics exposed:
* number instances (skjemaer) created of an application
* number of instances completed of an application
* number of process next calls
* duration in seconds from created to ended
* number of instances deleted

Default ASP.NET and System.Runtim metrics are also exposed.

Quick test dashboard in Grafana:
![image](https://github.com/Altinn/app-lib-dotnet/assets/1145298/ba6322ab-a4a1-43f6-a7aa-0f07c726c13a)


## Related Issue(s)
Fixes #269 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
