### PR TITLE
Mark onEntry as nullable and add check for null

### DIFF
--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -113,10 +113,14 @@ namespace Altinn.App.Core.Implementation
             {
                 ApplicationMetadata applicationMetadata = _appMetadata.GetApplicationMetadata().Result;
                 Application application = applicationMetadata;
-                application.OnEntry = new OnEntryConfig()
+                if (applicationMetadata.OnEntry != null)
                 {
-                    Show = applicationMetadata.OnEntry.Show
-                };
+                    application.OnEntry = new OnEntryConfig()
+                    {
+                        Show = applicationMetadata.OnEntry.Show
+                    };
+                }
+                
                 return application;
             }
             catch (AggregateException ex)

--- a/src/Altinn.App.Core/Models/ApplicationMetadata.cs
+++ b/src/Altinn.App.Core/Models/ApplicationMetadata.cs
@@ -43,7 +43,7 @@ namespace Altinn.App.Core.Models
         /// Configure options for handling what happens when entering the application
         /// </summary>
         [JsonProperty(PropertyName = "onEntry")]
-        public new OnEntry OnEntry { get; set; }
+        public new OnEntry? OnEntry { get; set; }
 
         /// <summary>
         /// Get AppIdentifier based on ApplicationMetadata.Id

--- a/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
@@ -67,6 +67,53 @@ public class AppResourcesSITests
         actual.Should().NotBeNull();
         actual.Should().BeEquivalentTo(expected);
     }
+    
+    [Fact]
+    public void GetApplication_handles_onEntry_null()
+    {
+        AppSettings appSettings = GetAppSettings("AppMetadata", "no-on-entry.applicationmetadata.json");
+        var settings = Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+        IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
+        Application expected = new Application()
+        {
+            Id = "tdd/bestilling",
+            Org = "tdd",
+            Created = DateTime.Parse("2019-09-16T22:22:22"),
+            CreatedBy = "username",
+            Title = new Dictionary<string, string>()
+            {
+                { "nb", "Bestillingseksempelapp" }
+            },
+            DataTypes = new List<DataType>()
+            {
+                new()
+                {
+                    Id = "vedlegg",
+                    AllowedContentTypes = new List<string>() { "application/pdf", "image/png", "image/jpeg" },
+                    MinCount = 0,
+                    TaskId = "Task_1"
+                },
+                new()
+                {
+                    Id = "ref-data-as-pdf",
+                    AllowedContentTypes = new List<string>() { "application/pdf" },
+                    MinCount = 1,
+                    TaskId = "Task_1"
+                }
+            },
+            PartyTypesAllowed = new PartyTypesAllowed()
+            {
+                BankruptcyEstate = true,
+                Organisation = true,
+                Person = true,
+                SubUnit = true
+            }
+        };
+        var actual = appResources.GetApplication();
+        actual.Should().NotBeNull();
+        actual.Should().BeEquivalentTo(expected);
+    }
 
     [Fact]
     public void GetApplication_second_read_from_cache()

--- a/test/Altinn.App.Core.Tests/Implementation/TestData/AppMetadata/no-on-entry.applicationmetadata.json
+++ b/test/Altinn.App.Core.Tests/Implementation/TestData/AppMetadata/no-on-entry.applicationmetadata.json
@@ -1,0 +1,27 @@
+{
+  "id": "tdd/bestilling",
+  "org": "tdd",
+  "created": "2019-09-16T22:22:22",
+  "createdBy": "username",
+  "title": { "nb": "Bestillingseksempelapp" },
+  "dataTypes": [
+    {
+      "id": "vedlegg",
+      "allowedContentTypes": [ "application/pdf", "image/png", "image/jpeg" ],
+      "minCount": 0,
+      "taskId":  "Task_1",
+    },
+    {
+      "id": "ref-data-as-pdf",
+      "allowedContentTypes": [ "application/pdf" ],
+      "minCount":  1,
+      "taskId":  "Task_1",
+    }
+  ],
+  "partyTypesAllowed": {
+    "bankruptcyEstate": true,
+    "organisation": true,
+    "person": true,
+    "subUnit": true
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
onEntry can be null. Using 7.12.0 without onEntry defined in `applicationmetadata.json` leads to NullReferenceException when starting the application.


## Related Issue(s)
Fixes #278 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
