### PR TITLE
Introduce new option for default selected pages per row

### DIFF
--- a/src/Altinn.App.Core/Models/InstanceSelection.cs
+++ b/src/Altinn.App.Core/Models/InstanceSelection.cs
@@ -7,6 +7,8 @@ namespace Altinn.App.Core.Models
     /// </summary>
     public class InstanceSelection
     {
+        private int? _defaultSelectedOption;
+
         /// <summary>
         /// A list of selectable options for amount of rows per page to show for pagination
         /// </summary>
@@ -18,6 +20,16 @@ namespace Altinn.App.Core.Models
         /// </summary>
         [JsonProperty(PropertyName = "defaultRowsPerPage")]
         public int? DefaultRowsPerPage { get; set; }
+
+        /// <summary>
+        /// The default selected option for rows per page to show for pagination
+        /// </summary>
+        [JsonProperty(PropertyName = "defaultSelectedOption")]
+        public int? DefaultSelectedOption
+        {
+            get { return _defaultSelectedOption ?? DefaultRowsPerPage; }
+            set { _defaultSelectedOption = value; }
+        }
 
         /// <summary>
         /// The direction of sorting the list of instances, asc or desc

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -196,6 +196,200 @@ namespace Altinn.App.Core.Tests.Internal.App
             actual.Should().BeEquivalentTo(expected);
             actual2.Should().BeEquivalentTo(expected);
         }
+        
+        [Fact]
+        public async Task GetApplicationMetadata_onEntry_InstanceSelection_DefaultSelectedOption_read_legacy_value_if_new_not_set()
+        {
+            var featureManagerMock = new Mock<IFeatureManager>();
+            IFrontendFeatures frontendFeatures = new FrontendFeatures(featureManagerMock.Object);
+            Dictionary<string, bool> enabledFrontendFeatures = await frontendFeatures.GetFrontendFeatures();
+
+            AppSettings appSettings = GetAppSettings("AppMetadata", "onentry-legacy-selectoptions.applicationmetadata.json");
+            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
+            {
+                Id = "tdd/bestilling",
+                Org = "tdd",
+                Created = DateTime.Parse("2019-09-16T22:22:22"),
+                CreatedBy = "username",
+                Title = new Dictionary<string, string>()
+                {
+                    { "nb", "Bestillingseksempelapp" }
+                },
+                DataTypes = new List<DataType>()
+                {
+                    new()
+                    {
+                        Id = "vedlegg",
+                        AllowedContentTypes = new List<string>() { "application/pdf", "image/png", "image/jpeg" },
+                        MinCount = 0,
+                        TaskId = "Task_1"
+                    },
+                    new()
+                    {
+                        Id = "ref-data-as-pdf",
+                        AllowedContentTypes = new List<string>() { "application/pdf" },
+                        MinCount = 1,
+                        TaskId = "Task_1"
+                    }
+                },
+                PartyTypesAllowed = new PartyTypesAllowed()
+                {
+                    BankruptcyEstate = true,
+                    Organisation = true,
+                    Person = true,
+                    SubUnit = true
+                },
+                OnEntry = new OnEntry()
+                {
+                    Show = "select-instance",
+                    InstanceSelection = new ()
+                    {
+                        SortDirection = "desc",
+                        RowsPerPageOptions = new List<int>()
+                        {
+                            5, 3, 10, 25, 50, 100
+                        },
+                        DefaultRowsPerPage = 1,
+                        DefaultSelectedOption = 1
+                    }
+                },
+                Features = enabledFrontendFeatures
+            };
+            var actual = await appMetadata.GetApplicationMetadata();
+            actual.Should().NotBeNull();
+            actual.Should().BeEquivalentTo(expected);
+            actual.OnEntry?.InstanceSelection?.DefaultSelectedOption.Should().Be(1);
+        }
+        
+        [Fact]
+        public async Task GetApplicationMetadata_onEntry_supports_new_option()
+        {
+            var featureManagerMock = new Mock<IFeatureManager>();
+            IFrontendFeatures frontendFeatures = new FrontendFeatures(featureManagerMock.Object);
+            Dictionary<string, bool> enabledFrontendFeatures = await frontendFeatures.GetFrontendFeatures();
+
+            AppSettings appSettings = GetAppSettings("AppMetadata", "onentry-new-selectoptions.applicationmetadata.json");
+            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
+            {
+                Id = "tdd/bestilling",
+                Org = "tdd",
+                Created = DateTime.Parse("2019-09-16T22:22:22"),
+                CreatedBy = "username",
+                Title = new Dictionary<string, string>()
+                {
+                    { "nb", "Bestillingseksempelapp" }
+                },
+                DataTypes = new List<DataType>()
+                {
+                    new()
+                    {
+                        Id = "vedlegg",
+                        AllowedContentTypes = new List<string>() { "application/pdf", "image/png", "image/jpeg" },
+                        MinCount = 0,
+                        TaskId = "Task_1"
+                    },
+                    new()
+                    {
+                        Id = "ref-data-as-pdf",
+                        AllowedContentTypes = new List<string>() { "application/pdf" },
+                        MinCount = 1,
+                        TaskId = "Task_1"
+                    }
+                },
+                PartyTypesAllowed = new PartyTypesAllowed()
+                {
+                    BankruptcyEstate = true,
+                    Organisation = true,
+                    Person = true,
+                    SubUnit = true
+                },
+                OnEntry = new OnEntry()
+                {
+                    Show = "select-instance",
+                    InstanceSelection = new ()
+                    {
+                        SortDirection = "desc",
+                        RowsPerPageOptions = new List<int>()
+                        {
+                            5, 3, 10, 25, 50, 100
+                        },
+                        DefaultSelectedOption = 2
+                    }
+                },
+                Features = enabledFrontendFeatures
+            };
+            var actual = await appMetadata.GetApplicationMetadata();
+            actual.Should().NotBeNull();
+            actual.Should().BeEquivalentTo(expected);
+            actual.OnEntry?.InstanceSelection?.DefaultSelectedOption.Should().Be(2);
+        }
+        
+        [Fact]
+        public async Task GetApplicationMetadata_onEntry_prefer_new_option()
+        {
+            var featureManagerMock = new Mock<IFeatureManager>();
+            IFrontendFeatures frontendFeatures = new FrontendFeatures(featureManagerMock.Object);
+            Dictionary<string, bool> enabledFrontendFeatures = await frontendFeatures.GetFrontendFeatures();
+
+            AppSettings appSettings = GetAppSettings("AppMetadata", "onentry-prefer-new-selectoptions.applicationmetadata.json");
+            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
+            {
+                Id = "tdd/bestilling",
+                Org = "tdd",
+                Created = DateTime.Parse("2019-09-16T22:22:22"),
+                CreatedBy = "username",
+                Title = new Dictionary<string, string>()
+                {
+                    { "nb", "Bestillingseksempelapp" }
+                },
+                DataTypes = new List<DataType>()
+                {
+                    new()
+                    {
+                        Id = "vedlegg",
+                        AllowedContentTypes = new List<string>() { "application/pdf", "image/png", "image/jpeg" },
+                        MinCount = 0,
+                        TaskId = "Task_1"
+                    },
+                    new()
+                    {
+                        Id = "ref-data-as-pdf",
+                        AllowedContentTypes = new List<string>() { "application/pdf" },
+                        MinCount = 1,
+                        TaskId = "Task_1"
+                    }
+                },
+                PartyTypesAllowed = new PartyTypesAllowed()
+                {
+                    BankruptcyEstate = true,
+                    Organisation = true,
+                    Person = true,
+                    SubUnit = true
+                },
+                OnEntry = new OnEntry()
+                {
+                    Show = "select-instance",
+                    InstanceSelection = new ()
+                    {
+                        SortDirection = "desc",
+                        RowsPerPageOptions = new List<int>()
+                        {
+                            5, 3, 10, 25, 50, 100
+                        },
+                        DefaultRowsPerPage = 1,
+                        DefaultSelectedOption = 3
+                    }
+                },
+                Features = enabledFrontendFeatures
+            };
+            var actual = await appMetadata.GetApplicationMetadata();
+            actual.Should().NotBeNull();
+            actual.Should().BeEquivalentTo(expected);
+            actual.OnEntry?.InstanceSelection?.DefaultSelectedOption.Should().Be(3);
+        }
 
         [Fact]
         public async void GetApplicationMetadata_throws_ApplicationConfigException_if_file_not_found()

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -196,7 +196,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             actual.Should().BeEquivalentTo(expected);
             actual2.Should().BeEquivalentTo(expected);
         }
-        
+
         [Fact]
         public async Task GetApplicationMetadata_onEntry_InstanceSelection_DefaultSelectedOption_read_legacy_value_if_new_not_set()
         {
@@ -243,7 +243,7 @@ namespace Altinn.App.Core.Tests.Internal.App
                 OnEntry = new OnEntry()
                 {
                     Show = "select-instance",
-                    InstanceSelection = new ()
+                    InstanceSelection = new()
                     {
                         SortDirection = "desc",
                         RowsPerPageOptions = new List<int>()
@@ -261,7 +261,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             actual.Should().BeEquivalentTo(expected);
             actual.OnEntry?.InstanceSelection?.DefaultSelectedOption.Should().Be(1);
         }
-        
+
         [Fact]
         public async Task GetApplicationMetadata_onEntry_supports_new_option()
         {
@@ -308,7 +308,7 @@ namespace Altinn.App.Core.Tests.Internal.App
                 OnEntry = new OnEntry()
                 {
                     Show = "select-instance",
-                    InstanceSelection = new ()
+                    InstanceSelection = new()
                     {
                         SortDirection = "desc",
                         RowsPerPageOptions = new List<int>()
@@ -325,7 +325,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             actual.Should().BeEquivalentTo(expected);
             actual.OnEntry?.InstanceSelection?.DefaultSelectedOption.Should().Be(2);
         }
-        
+
         [Fact]
         public async Task GetApplicationMetadata_onEntry_prefer_new_option()
         {
@@ -372,7 +372,7 @@ namespace Altinn.App.Core.Tests.Internal.App
                 OnEntry = new OnEntry()
                 {
                     Show = "select-instance",
-                    InstanceSelection = new ()
+                    InstanceSelection = new()
                     {
                         SortDirection = "desc",
                         RowsPerPageOptions = new List<int>()
@@ -474,7 +474,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             {
                 return new AppMetadata(appsettings, new FrontendFeatures(featureManagerMock.Object));
             }
-            
+
             return new AppMetadata(appsettings, frontendFeatures);
         }
     }

--- a/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/onentry-legacy-selectoptions.applicationmetadata.json
+++ b/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/onentry-legacy-selectoptions.applicationmetadata.json
@@ -1,0 +1,35 @@
+{
+  "id": "tdd/bestilling",
+  "org": "tdd",
+  "created": "2019-09-16T22:22:22",
+  "createdBy": "username",
+  "title": { "nb": "Bestillingseksempelapp" },
+  "dataTypes": [
+    {
+      "id": "vedlegg",
+      "allowedContentTypes": [ "application/pdf", "image/png", "image/jpeg" ],
+      "minCount": 0,
+      "taskId":  "Task_1",
+    },
+    {
+      "id": "ref-data-as-pdf",
+      "allowedContentTypes": [ "application/pdf" ],
+      "minCount":  1,
+      "taskId":  "Task_1",
+    }
+  ],
+  "partyTypesAllowed": {
+    "bankruptcyEstate": true,
+    "organisation": true,
+    "person": true,
+    "subUnit": true
+  },
+  "onEntry": {
+    "show": "select-instance",
+    "instanceSelection": {
+      "sortDirection": "desc",
+      "rowsPerPageOptions": [5, 3, 10, 25, 50, 100],
+      "defaultRowsPerPage": 1
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/onentry-new-selectoptions.applicationmetadata.json
+++ b/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/onentry-new-selectoptions.applicationmetadata.json
@@ -1,0 +1,35 @@
+{
+  "id": "tdd/bestilling",
+  "org": "tdd",
+  "created": "2019-09-16T22:22:22",
+  "createdBy": "username",
+  "title": { "nb": "Bestillingseksempelapp" },
+  "dataTypes": [
+    {
+      "id": "vedlegg",
+      "allowedContentTypes": [ "application/pdf", "image/png", "image/jpeg" ],
+      "minCount": 0,
+      "taskId":  "Task_1",
+    },
+    {
+      "id": "ref-data-as-pdf",
+      "allowedContentTypes": [ "application/pdf" ],
+      "minCount":  1,
+      "taskId":  "Task_1",
+    }
+  ],
+  "partyTypesAllowed": {
+    "bankruptcyEstate": true,
+    "organisation": true,
+    "person": true,
+    "subUnit": true
+  },
+  "onEntry": {
+    "show": "select-instance",
+    "instanceSelection": {
+      "sortDirection": "desc",
+      "rowsPerPageOptions": [5, 3, 10, 25, 50, 100],
+      "defaultSelectedOption": 2
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/onentry-prefer-new-selectoptions.applicationmetadata.json
+++ b/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/onentry-prefer-new-selectoptions.applicationmetadata.json
@@ -1,0 +1,36 @@
+{
+  "id": "tdd/bestilling",
+  "org": "tdd",
+  "created": "2019-09-16T22:22:22",
+  "createdBy": "username",
+  "title": { "nb": "Bestillingseksempelapp" },
+  "dataTypes": [
+    {
+      "id": "vedlegg",
+      "allowedContentTypes": [ "application/pdf", "image/png", "image/jpeg" ],
+      "minCount": 0,
+      "taskId":  "Task_1",
+    },
+    {
+      "id": "ref-data-as-pdf",
+      "allowedContentTypes": [ "application/pdf" ],
+      "minCount":  1,
+      "taskId":  "Task_1",
+    }
+  ],
+  "partyTypesAllowed": {
+    "bankruptcyEstate": true,
+    "organisation": true,
+    "person": true,
+    "subUnit": true
+  },
+  "onEntry": {
+    "show": "select-instance",
+    "instanceSelection": {
+      "sortDirection": "desc",
+      "rowsPerPageOptions": [5, 3, 10, 25, 50, 100],
+      "defaultRowsPerPage": 1,
+      "defaultSelectedOption": 3
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
During testing name of the property defaultRowsPerPage felt misleading as it selects an index from the rowsPerPageOptions list.
Added new config element with the name defaultSelectedOption, this will read the old config if the old is configured and the new is null. Otherwise it will always return the value of the new configoption.

## Related Issue(s)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
