### PR TITLE
Add header with parameters used when fetching options

### DIFF
--- a/src/Altinn.App.Api/Controllers/OptionsController.cs
+++ b/src/Altinn.App.Api/Controllers/OptionsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -46,6 +47,8 @@ namespace Altinn.App.Api.Controllers
                 return NotFound();
             }
 
+            HttpContext.Response.Headers.Add("Altinn-DownstreamParameters", appOptions.Parameters.ToNameValueString(','));
+
             return Ok(appOptions.Options);
         }
 
@@ -84,6 +87,8 @@ namespace Altinn.App.Api.Controllers
             {
                 return NotFound();
             }
+
+            HttpContext.Response.Headers.Add("Altinn-DownstreamParameters", appOptions.Parameters.ToNameValueString(','));
 
             return Ok(appOptions.Options);
         }

--- a/src/Altinn.App.Core/Extensions/DictionaryExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Text;
+
+namespace Altinn.App.Core.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="Dictionary{TKey, TValue}"/>
+    /// </summary>
+    public static class DictionaryExtensions
+    {
+        /// <summary>
+        /// Converts a dictionary to a name value string on the form key1=value1,key2=value2
+        /// </summary>
+        public static string ToNameValueString(this Dictionary<string, string> parameters, char separator)
+        {
+            if (parameters == null)
+            {
+                return string.Empty;
+            }
+
+            StringBuilder builder = new();
+            foreach (var param in parameters)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(separator);
+                }
+                builder.Append(param.Key + "=" + param.Value);
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using Xunit;
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Models;
+using FluentAssertions;
+
+namespace Altinn.App.Api.Tests.Controllers
+{
+    public class OptionsControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
+    {
+        public OptionsControllerTests(WebApplicationFactory<Program> factory) : base(factory)
+        {
+        }
+
+        [Fact]
+        public async Task Get_ShouldReturnParametersInHeader()
+        {
+            OverrideServicesForThisTest = (services) =>
+            {
+                services.AddTransient<IAppOptionsProvider, DummyProvider>();
+            };
+
+            string org = "tdd";
+            string app = "contributer-restriction";
+            HttpClient client = GetRootedClient(org, app);
+
+            string url = $"/{org}/{app}/api/options/test";
+            HttpResponseMessage response = await client.GetAsync(url);
+
+            var headerValue = response.Headers.GetValues("Altinn-DownstreamParameters");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            headerValue.Should().Contain("lang=nb");
+        }
+    }
+
+    public class DummyProvider : IAppOptionsProvider
+    {
+        public string Id => "test";
+
+        public Task<AppOptions> GetAppOptionsAsync(string language, Dictionary<string, string> keyValuePairs)
+        {
+            AppOptions appOptions = new AppOptions()
+            {
+                Parameters = new Dictionary<string, string>()
+                {
+                    { "lang", "nb" }
+                }
+            };
+
+            return Task.FromResult(appOptions);
+        }
+    }
+}

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Watch Remove="Extensions\DictionaryExtensionsTests.cs" />
     <Watch Remove="Internal\Pdf\PdfServiceTests.cs" />
     <Watch Remove="Mocks\RequestInterceptor.cs" />
   </ItemGroup>

--- a/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
@@ -1,0 +1,62 @@
+﻿using Altinn.App.Core.Extensions;
+using Altinn.App.Core.Models;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Altinn.App.Core.Tests.Extensions
+{
+    public class DictionaryExtensionsTests
+    {
+        [Fact]
+        public void ToNameValueString_OptionParameters_ShouldConvertToHttpHeaderFormat()
+        {
+            var options = new AppOptions
+            {
+                Parameters = new Dictionary<string, string>
+                {
+                    { "lang", "nb" },
+                    { "level", "1" }
+                },
+            };
+
+            IHeaderDictionary headers = new HeaderDictionary
+            {
+                { "Altinn-DownstreamParameters", options.Parameters.ToNameValueString(',') }
+            };
+
+            Assert.Equal("lang=nb,level=1", headers["Altinn-DownstreamParameters"]);
+        }
+
+        [Fact]
+        public void ToNameValueString_OptionParametersWithEmptyValue_ShouldConvertToHttpHeaderFormat()
+        {
+            var options = new AppOptions
+            {
+                Parameters = new Dictionary<string, string>()
+            };
+
+            IHeaderDictionary headers = new HeaderDictionary
+            {
+                { "Altinn-DownstreamParameters", options.Parameters.ToNameValueString(',') }
+            };
+
+            Assert.Equal(string.Empty, headers["Altinn-DownstreamParameters"]);
+        }
+
+        [Fact]
+        public void ToNameValueString_OptionParametersWithNullValue_ShouldConvertToHttpHeaderFormat()
+        {
+            var options = new AppOptions
+            {
+                Parameters = null
+            };
+
+            IHeaderDictionary headers = new HeaderDictionary
+            {
+                { "Altinn-DownstreamParameters", options.Parameters.ToNameValueString(',') }
+            };
+
+            Assert.Equal(string.Empty, headers["Altinn-DownstreamParameters"]);
+        }
+    }
+}

--- a/test/Altinn.App.Core.Tests/Features/Validators/ValidationAppSITests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/ValidationAppSITests.cs
@@ -100,10 +100,10 @@ public class ValidationAppSITests
         var appResourcesMock = new Mock<IAppResources>();
         var appMetadataMock = new Mock<IAppMetadata>();
         var objectModelValidatorMock = new Mock<IObjectModelValidator>();
-        var layoutEvaluatorStateInitializer = new LayoutEvaluatorStateInitializer(appResourcesMock.Object, Options.Create(new Configuration.FrontEndSettings()));
+        var layoutEvaluatorStateInitializer = new LayoutEvaluatorStateInitializer(appResourcesMock.Object, Microsoft.Extensions.Options.Options.Create(new Configuration.FrontEndSettings()));
         var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-        var generalSettings = Options.Create(new Configuration.GeneralSettings());
-        var appSettings = Options.Create(new Configuration.AppSettings());
+        var generalSettings = Microsoft.Extensions.Options.Options.Create(new Configuration.GeneralSettings());
+        var appSettings = Microsoft.Extensions.Options.Options.Create(new Configuration.AppSettings());
 
         var validationAppSI = new ValidationAppSI(
             loggerMock.Object,

--- a/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
@@ -21,8 +21,8 @@ public class AppResourcesSITests
     public void GetApplication_desrializes_file_from_disk()
     {
         AppSettings appSettings = GetAppSettings("AppMetadata", "default.applicationmetadata.json");
-        var settings = Options.Create<AppSettings>(appSettings);
-        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+        var settings = Microsoft.Extensions.Options.Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
         IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
         Application expected = new Application()
         {
@@ -72,8 +72,8 @@ public class AppResourcesSITests
     public void GetApplication_handles_onEntry_null()
     {
         AppSettings appSettings = GetAppSettings("AppMetadata", "no-on-entry.applicationmetadata.json");
-        var settings = Options.Create<AppSettings>(appSettings);
-        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+        var settings = Microsoft.Extensions.Options.Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
         IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
         Application expected = new Application()
         {
@@ -121,8 +121,8 @@ public class AppResourcesSITests
         AppSettings appSettings = GetAppSettings("AppMetadata", "default.applicationmetadata.json");
         Mock<IFrontendFeatures> appFeaturesMock = new Mock<IFrontendFeatures>();
         appFeaturesMock.Setup(af => af.GetFrontendFeatures()).ReturnsAsync(new Dictionary<string, bool>() { { "footer", true } });
-        var settings = Options.Create<AppSettings>(appSettings);
-        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings), appFeaturesMock.Object);
+        var settings = Microsoft.Extensions.Options.Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings), appFeaturesMock.Object);
         IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
         Application expected = new Application()
         {
@@ -176,8 +176,8 @@ public class AppResourcesSITests
     public void GetApplicationMetadata_throws_ApplicationConfigException_if_file_not_found()
     {
         AppSettings appSettings = GetAppSettings("AppMetadata", "notfound.applicationmetadata.json");
-        var settings = Options.Create<AppSettings>(appSettings);
-        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+        var settings = Microsoft.Extensions.Options.Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
         IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
         Assert.Throws<ApplicationConfigException>(() => appResources.GetApplication());
     }
@@ -186,8 +186,8 @@ public class AppResourcesSITests
     public void GetApplicationMetadata_throws_ApplicationConfigException_if_deserialization_fails()
     {
         AppSettings appSettings = GetAppSettings("AppMetadata", "invalid.applicationmetadata.json");
-        var settings = Options.Create<AppSettings>(appSettings);
-        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+        var settings = Microsoft.Extensions.Options.Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
         IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
         Assert.Throws<ApplicationConfigException>(() => appResources.GetApplication());
     }
@@ -196,8 +196,8 @@ public class AppResourcesSITests
     public void GetApplicationXACMLPolicy_return_policyfile_as_string()
     {
         AppSettings appSettings = GetAppSettings(subfolder: "AppPolicy", policyFilename: "policy.xml");
-        var settings = Options.Create<AppSettings>(appSettings);
-        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+        var settings = Microsoft.Extensions.Options.Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
         IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
         string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine + "<root>policy</root>";
         var actual = appResources.GetApplicationXACMLPolicy();
@@ -208,8 +208,8 @@ public class AppResourcesSITests
     public void GetApplicationXACMLPolicy_return_null_if_file_not_found()
     {
         AppSettings appSettings = GetAppSettings(subfolder: "AppPolicy", policyFilename: "notfound.xml");
-        var settings = Options.Create<AppSettings>(appSettings);
-        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+        var settings = Microsoft.Extensions.Options.Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
         IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
         var actual = appResources.GetApplicationXACMLPolicy();
         actual.Should().BeNull();
@@ -219,8 +219,8 @@ public class AppResourcesSITests
     public void GetApplicationBPMNProcess_return_process_as_string()
     {
         AppSettings appSettings = GetAppSettings(subfolder: "AppProcess", bpmnFilename: "process.bpmn");
-        var settings = Options.Create<AppSettings>(appSettings);
-        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+        var settings = Microsoft.Extensions.Options.Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
         IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
         string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine + "<root>process</root>";
         var actual = appResources.GetApplicationBPMNProcess();
@@ -231,8 +231,8 @@ public class AppResourcesSITests
     public void GetApplicationBPMNProcess_return_null_if_file_not_found()
     {
         AppSettings appSettings = GetAppSettings(subfolder: "AppProcess", policyFilename: "notfound.xml");
-        var settings = Options.Create<AppSettings>(appSettings);
-        IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+        var settings = Microsoft.Extensions.Options.Options.Create<AppSettings>(appSettings);
+        IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
         IAppResources appResources = new AppResourcesSI(settings, appMetadata, null, new NullLogger<AppResourcesSI>());
         var actual = appResources.GetApplicationBPMNProcess();
         actual.Should().BeNull();

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -22,7 +22,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             Dictionary<string, bool> enabledFrontendFeatures = await frontendFeatures.GetFrontendFeatures();
 
             AppSettings appSettings = GetAppSettings("AppMetadata", "default.applicationmetadata.json");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
             {
                 Id = "tdd/bestilling",
@@ -76,7 +76,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             Dictionary<string, bool> enabledFrontendFeatures = await frontendFeatures.GetFrontendFeatures();
 
             AppSettings appSettings = GetAppSettings("AppMetadata", "eformid.applicationmetadata.json");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
             {
                 Id = "tdd/bestilling",
@@ -144,7 +144,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             AppSettings appSettings = GetAppSettings("AppMetadata", "default.applicationmetadata.json");
             Mock<IFrontendFeatures> appFeaturesMock = new Mock<IFrontendFeatures>();
             appFeaturesMock.Setup(af => af.GetFrontendFeatures()).ReturnsAsync(new Dictionary<string, bool>() { { "footer", true } });
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings), appFeaturesMock.Object);
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings), appFeaturesMock.Object);
             ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
             {
                 Id = "tdd/bestilling",
@@ -205,7 +205,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             Dictionary<string, bool> enabledFrontendFeatures = await frontendFeatures.GetFrontendFeatures();
 
             AppSettings appSettings = GetAppSettings("AppMetadata", "onentry-legacy-selectoptions.applicationmetadata.json");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
             {
                 Id = "tdd/bestilling",
@@ -270,7 +270,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             Dictionary<string, bool> enabledFrontendFeatures = await frontendFeatures.GetFrontendFeatures();
 
             AppSettings appSettings = GetAppSettings("AppMetadata", "onentry-new-selectoptions.applicationmetadata.json");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
             {
                 Id = "tdd/bestilling",
@@ -334,7 +334,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             Dictionary<string, bool> enabledFrontendFeatures = await frontendFeatures.GetFrontendFeatures();
 
             AppSettings appSettings = GetAppSettings("AppMetadata", "onentry-prefer-new-selectoptions.applicationmetadata.json");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
             {
                 Id = "tdd/bestilling",
@@ -395,7 +395,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         public async void GetApplicationMetadata_throws_ApplicationConfigException_if_file_not_found()
         {
             AppSettings appSettings = GetAppSettings("AppMetadata", "notfound.applicationmetadata.json");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             await Assert.ThrowsAsync<ApplicationConfigException>(async () => await appMetadata.GetApplicationMetadata());
         }
 
@@ -403,7 +403,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         public async void GetApplicationMetadata_throw_ApplicationConfigException_if_deserialization_fails()
         {
             AppSettings appSettings = GetAppSettings("AppMetadata", "invalid.applicationmetadata.json");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             await Assert.ThrowsAsync<ApplicationConfigException>(async () => await appMetadata.GetApplicationMetadata());
         }
 
@@ -411,7 +411,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         public async void GetApplicationMetadata_throws_ApplicationConfigException_if_deserialization_fails_due_to_string_in_int()
         {
             AppSettings appSettings = GetAppSettings("AppMetadata", "invalid-int.applicationmetadata.json");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             await Assert.ThrowsAsync<ApplicationConfigException>(async () => await appMetadata.GetApplicationMetadata());
         }
 
@@ -419,7 +419,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         public async void GetApplicationXACMLPolicy_return_policyfile_as_string()
         {
             AppSettings appSettings = GetAppSettings(subfolder: "AppPolicy", policyFilename: "policy.xml");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine + "<root>policy</root>";
             var actual = await appMetadata.GetApplicationXACMLPolicy();
             actual.Should().BeEquivalentTo(expected);
@@ -429,7 +429,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         public async void GetApplicationXACMLPolicy_throws_FileNotFoundException_if_file_not_found()
         {
             AppSettings appSettings = GetAppSettings(subfolder: "AppPolicy", policyFilename: "notfound.xml");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             await Assert.ThrowsAsync<FileNotFoundException>(async () => await appMetadata.GetApplicationXACMLPolicy());
         }
 
@@ -437,7 +437,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         public async void GetApplicationBPMNProcess_return_process_as_string()
         {
             AppSettings appSettings = GetAppSettings(subfolder: "AppProcess", bpmnFilename: "process.bpmn");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine + "<root>process</root>";
             var actual = await appMetadata.GetApplicationBPMNProcess();
             actual.Should().BeEquivalentTo(expected);
@@ -447,7 +447,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         public async void GetApplicationBPMNProcess_throws_ApplicationConfigException_if_file_not_found()
         {
             AppSettings appSettings = GetAppSettings(subfolder: "AppProcess", policyFilename: "notfound.xml");
-            IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
             await Assert.ThrowsAsync<ApplicationConfigException>(async () => await appMetadata.GetApplicationBPMNProcess());
         }
 

--- a/test/Altinn.App.Core.Tests/Options/AppOptionsFactoryTests.cs
+++ b/test/Altinn.App.Core.Tests/Options/AppOptionsFactoryTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Models;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This feature adds the parameters used when getting options to the response as a http header named Altinn-DownstreamParameters, and can be used for documenting the parameters used when getting a list of options.

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/256

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
