### PR TITLE
feat(CustomLogo): Add field in for custom logo in applicationmetadata

### DIFF
--- a/src/Altinn.App.Core/Models/ApplicationMetadata.cs
+++ b/src/Altinn.App.Core/Models/ApplicationMetadata.cs
@@ -52,5 +52,11 @@ namespace Altinn.App.Core.Models
         [System.Text.Json.Serialization.JsonIgnore]
         [Newtonsoft.Json.JsonIgnore]
         public AppIdentifier AppIdentifier { get; private set; }
+
+        /// <summary>
+        /// A flag to specify that the form should use a custom logo
+        /// </summary>
+        [JsonProperty(PropertyName = "useCustomLogo")]
+        public bool UseCustomLogo { get; set; }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new field to `ApplicationMetadata` which can be used to specify that an app should use a custom Logo.

## Related Issue(s)
- Altinn/app-frontend-react#138

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
