### PR TITLE
feat(AppLogo): extend settings for appowner logo in applactionMetadata

### DIFF
--- a/src/Altinn.App.Core/Models/ApplicationMetadata.cs
+++ b/src/Altinn.App.Core/Models/ApplicationMetadata.cs
@@ -54,9 +54,9 @@ namespace Altinn.App.Core.Models
         public AppIdentifier AppIdentifier { get; private set; }
 
         /// <summary>
-        /// A flag to specify that the form should use a custom logo
+        /// Configure options for setting organisation logo
         /// </summary>
-        [JsonProperty(PropertyName = "useCustomLogo")]
-        public bool UseCustomLogo { get; set; }
+        [JsonProperty(PropertyName = "logo")]
+        public Logo? Logo { get; set; }
     }
 }

--- a/src/Altinn.App.Core/Models/Logo.cs
+++ b/src/Altinn.App.Core/Models/Logo.cs
@@ -12,8 +12,8 @@ namespace Altinn.App.Core.Models
         /// <summary>
         /// A flag to specify that the form should display appOwner in header
         /// </summary>
-        [JsonProperty(PropertyName = "showAppOwnerInHeader")]
-        public bool ShowAppOwnerInHeader { get; set; }
+        [JsonProperty(PropertyName = "displayAppOwnerNameInHeader")]
+        public bool DisplayAppOwnerNameInHeader { get; set; }
 
         /// <summary>
         /// Specifies from where the logo url should be fetched

--- a/src/Altinn.App.Core/Models/Logo.cs
+++ b/src/Altinn.App.Core/Models/Logo.cs
@@ -1,0 +1,25 @@
+using Altinn.Platform.Storage.Interface.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Altinn.App.Core.Models
+{
+    /// <summary>
+    /// The Logo configuration
+    /// </summary>
+    public class Logo
+    {
+        /// <summary>
+        /// A flag to specify that the form should display appOwner in header
+        /// </summary>
+        [JsonProperty(PropertyName = "showAppOwnerInHeader")]
+        public bool ShowAppOwnerInHeader { get; set; }
+
+        /// <summary>
+        /// Specifies from where the logo url should be fetched
+        /// </summary>
+        [JsonProperty(PropertyName = "source")]
+        public string? Source { get; set; }
+
+    }
+}

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -392,6 +392,75 @@ namespace Altinn.App.Core.Tests.Internal.App
         }
 
         [Fact]
+        public async Task GetApplicationMetadata_logo_can_intstantiate_with_source_and_DisplayAppOwnerNameInHeader()
+        {
+            var featureManagerMock = new Mock<IFeatureManager>();
+            IFrontendFeatures frontendFeatures = new FrontendFeatures(featureManagerMock.Object);
+            Dictionary<string, bool> enabledFrontendFeatures = await frontendFeatures.GetFrontendFeatures();
+
+            AppSettings appSettings = GetAppSettings("AppMetadata", "logo-org-source.applicationmetadata.json");
+            IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
+            ApplicationMetadata expected = new ApplicationMetadata("tdd/bestilling")
+            {
+                Id = "tdd/bestilling",
+                Org = "tdd",
+                Created = DateTime.Parse("2019-09-16T22:22:22"),
+                CreatedBy = "username",
+                Title = new Dictionary<string, string>()
+                {
+                    { "nb", "Bestillingseksempelapp" }
+                },
+                DataTypes = new List<DataType>()
+                {
+                    new()
+                    {
+                        Id = "vedlegg",
+                        AllowedContentTypes = new List<string>() { "application/pdf", "image/png", "image/jpeg" },
+                        MinCount = 0,
+                        TaskId = "Task_1"
+                    },
+                    new()
+                    {
+                        Id = "ref-data-as-pdf",
+                        AllowedContentTypes = new List<string>() { "application/pdf" },
+                        MinCount = 1,
+                        TaskId = "Task_1"
+                    }
+                },
+                PartyTypesAllowed = new PartyTypesAllowed()
+                {
+                    BankruptcyEstate = true,
+                    Organisation = true,
+                    Person = true,
+                    SubUnit = true
+                },
+                OnEntry = new OnEntry()
+                {
+                    Show = "select-instance",
+                    InstanceSelection = new()
+                    {
+                        SortDirection = "desc",
+                        RowsPerPageOptions = new List<int>()
+                        {
+                            5, 3, 10, 25, 50, 100
+                        },
+                        DefaultRowsPerPage = 1,
+                        DefaultSelectedOption = 3
+                    }
+                },
+                Logo = new Logo
+                {
+                    Source = "org",
+                    DisplayAppOwnerNameInHeader = true
+                },
+                Features = enabledFrontendFeatures
+            };
+            var actual = await appMetadata.GetApplicationMetadata();
+            actual.Should().NotBeNull();
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
         public async void GetApplicationMetadata_throws_ApplicationConfigException_if_file_not_found()
         {
             AppSettings appSettings = GetAppSettings("AppMetadata", "notfound.applicationmetadata.json");

--- a/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/logo-org-source.applicationmetadata.json
+++ b/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/logo-org-source.applicationmetadata.json
@@ -1,0 +1,40 @@
+{
+  "id": "tdd/bestilling",
+  "org": "tdd",
+  "created": "2019-09-16T22:22:22",
+  "createdBy": "username",
+  "title": { "nb": "Bestillingseksempelapp" },
+  "dataTypes": [
+    {
+      "id": "vedlegg",
+      "allowedContentTypes": [ "application/pdf", "image/png", "image/jpeg" ],
+      "minCount": 0,
+      "taskId":  "Task_1",
+    },
+    {
+      "id": "ref-data-as-pdf",
+      "allowedContentTypes": [ "application/pdf" ],
+      "minCount":  1,
+      "taskId":  "Task_1",
+    }
+  ],
+  "partyTypesAllowed": {
+    "bankruptcyEstate": true,
+    "organisation": true,
+    "person": true,
+    "subUnit": true
+  },
+  "onEntry": {
+    "show": "select-instance",
+    "instanceSelection": {
+      "sortDirection": "desc",
+      "rowsPerPageOptions": [5, 3, 10, 25, 50, 100],
+      "defaultRowsPerPage": 1,
+      "defaultSelectedOption": 3
+    }
+  },
+  "logo": {
+    "displayAppOwnerNameInHeader": true,
+    "source": "org"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the settings for showing app organisation logo. App developers can now decide from which source the logo should be fetched, `altinn-orgs.json` or `resource` files. App developers can also explicitly set whether or not `appOwner` should be displayed alongside the logo in the header. This is so that organisations with organisation name in the logo should not get the organisation name displayed multiple times. 

## Related Issue(s)
- Altinn/app-frontend-react#138

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
