### PR TITLE
#294 Check if stream length is greater than 0 to avoid processing zero byte streams

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -165,13 +165,14 @@ namespace Altinn.App.Api.Controllers
                     await streamContent.CopyToAsync(fileStream);
                     if (fileStream.Length == 0)
                     {
+                        const string errorMessage = "Invalid data provided. Error: The file is zero bytes.";
                         var error = new ValidationIssue
                         {
                             Code = ValidationIssueCodes.DataElementCodes.ContentTypeNotAllowed,
                             Severity = ValidationIssueSeverity.Error,
-                            Description = $"Invalid data provided. Error: The file is zero bytes."
+                            Description = errorMessage
                         };
-                        _logger.LogError(error.Description);
+                        _logger.LogError(errorMessage);
                         return new BadRequestObjectResult(await GetErrorDetails(new List<ValidationIssue> { error }));
                     }
                     

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -163,7 +163,18 @@ namespace Altinn.App.Api.Controllers
 
                     using Stream fileStream = new MemoryStream();
                     await streamContent.CopyToAsync(fileStream);
-
+                    if (fileStream.Length == 0)
+                    {
+                        var error = new ValidationIssue
+                        {
+                            Code = ValidationIssueCodes.DataElementCodes.ContentTypeNotAllowed,
+                            Severity = ValidationIssueSeverity.Error,
+                            Description = $"Invalid data provided. Error: The file is zero bytes."
+                        };
+                        _logger.LogError(error.Description);
+                        return new BadRequestObjectResult(await GetErrorDetails(new List<ValidationIssue> { error }));
+                    }
+                    
                     bool parseSuccess = Request.Headers.TryGetValue("Content-Disposition", out StringValues headerValues);
                     string filename = parseSuccess ? DataRestrictionValidation.GetFileNameFromHeader(headerValues) : string.Empty;
 

--- a/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
@@ -54,6 +54,44 @@ namespace Altinn.App.Api.Tests.Controllers
 
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         }
+        
+        [Fact]
+        public async Task CreateDataElement_ZeroBytes_BinaryPdf_AnalyserShouldReturnBadRequest()
+        {
+            OverrideServicesForThisTest = (services) =>
+            {
+                services.AddTransient<IFileAnalyser, MimeTypeAnalyserSuccessStub>();
+                services.AddTransient<IFileValidator, MimeTypeValidatorStub>();
+            };
+
+            // Setup test data
+            string org = "tdd";
+            string app = "contributer-restriction";
+            HttpClient client = GetRootedClient(org, app);
+ 
+            Guid guid = new Guid("0fc98a23-fe31-4ef5-8fb9-dd3f479354cd");
+            TestData.DeleteInstance(org, app, 1337, guid);
+            TestData.PrepareInstance(org, app, 1337, guid);
+
+            // Setup the request
+            string token = PrincipalUtil.GetOrgToken("nav", "160694123");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            ByteArrayContent fileContent = await CreateBinaryContent(org, app, "zero.pdf", "application/pdf");
+            string url = $"/{org}/{app}/instances/1337/{guid}/data?dataType=specificFileType";
+            var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = fileContent
+            };
+
+            // This is where it happens
+            HttpResponseMessage response = await client.SendAsync(request);
+
+            // Cleanup testdata
+            TestData.DeleteInstanceAndData(org, app, 1337, guid);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal("Invalid data provided. Error: The file is zero bytes.",response.Content.ReadAsStringAsync().Result);
+        }
 
         [Fact]
         public async Task CreateDataElement_JpgFakedAsPdf_AnalyserShouldRunAndFail()


### PR DESCRIPTION

## Description
Altinn-storage checks that files are not zero bytes. If the application receives a stream of zero bytes we know it will fail and should return an error before further processing is done

## Related Issue(s)
Fixes #294 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
