### PR TITLE
feat(OrganisationLogo): Add a size option for OrganisationLogo in app…

### DIFF
--- a/src/Altinn.App.Core/Models/Logo.cs
+++ b/src/Altinn.App.Core/Models/Logo.cs
@@ -21,5 +21,11 @@ namespace Altinn.App.Core.Models
         [JsonProperty(PropertyName = "source")]
         public string? Source { get; set; }
 
+        /// <summary>
+        /// Specifies the size of the logo. Can have the values
+        /// 'small', 'medium', or 'large'
+        /// </summary>
+        [JsonProperty(PropertyName = "size")]
+        public string Size { get; set; } = "small";
     }
 }

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -451,7 +451,8 @@ namespace Altinn.App.Core.Tests.Internal.App
                 Logo = new Logo
                 {
                     Source = "org",
-                    DisplayAppOwnerNameInHeader = true
+                    DisplayAppOwnerNameInHeader = true,
+                    Size = "medium"
                 },
                 Features = enabledFrontendFeatures
             };

--- a/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/logo-org-source.applicationmetadata.json
+++ b/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/logo-org-source.applicationmetadata.json
@@ -35,6 +35,7 @@
   },
   "logo": {
     "displayAppOwnerNameInHeader": true,
-    "source": "org"
+    "source": "org",
+    "size": "medium"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds a size option for organisation logo in `ApplicationMetadata`. 


## Related Issue(s)
- Altinn/app-frontend-react#1452

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.] https://github.com/Altinn/altinn-studio-docs/pull/1154
