### PR TITLE
Fix: Use different source for custom validation

### DIFF
--- a/src/Altinn.App.Core/Models/Validation/ValidationIssueSource.cs
+++ b/src/Altinn.App.Core/Models/Validation/ValidationIssueSource.cs
@@ -20,5 +20,10 @@ namespace Altinn.App.Core.Models.Validation
         /// Required field validation
         /// </summary>
         public static readonly string Required = nameof(Required);
+
+        /// <summary>
+        /// Required field validation
+        /// </summary>
+        public static readonly string Custom = nameof(Custom);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It turns out that custom validation modifies the same ModelStateDictionary as the data model validation, meaning that custom validation would get mapped with the same `Source` as data model validation and would be filtered out in the frontend. This PR keeps the validations separate and gives them different `Source`-fields.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/287
- https://altinndevops.slack.com/archives/C045EB3JA9X/p1695629729345499

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
