### PR TITLE
Remove static feature flags

### DIFF
--- a/src/Altinn.App.Core/Internal/App/FrontendFeatures.cs
+++ b/src/Altinn.App.Core/Internal/App/FrontendFeatures.cs
@@ -15,9 +15,6 @@ namespace Altinn.App.Core.Internal.App
         /// </summary>
         public FrontendFeatures(IFeatureManager featureManager)
         {
-            features.Add("footer", true);
-            features.Add("processActions", true);
-
             if (featureManager.IsEnabledAsync(FeatureFlags.JsonObjectInDataResponse).Result)
             {
                 features.Add("jsonObjectInDataResponse", true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The `footer` and `processActions` feature flags are static and only exist to make app-frontend backwards compatible with older versions of app-lib. app-frontend v4 will assume that these features are available and will no longer check for these flags since: https://github.com/Altinn/app-frontend-react/pull/1450 and https://github.com/Altinn/app-frontend-react/pull/1516.

Assuming that v8 app-lib will require v4 app-frontend these flags can be removed.