### PR TITLE
New field AltinnNugetVersion in applicationMetadata.cs

### DIFF
--- a/src/Altinn.App.Core/Models/ApplicationMetadata.cs
+++ b/src/Altinn.App.Core/Models/ApplicationMetadata.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Altinn.Platform.Storage.Interface.Models;
 using Newtonsoft.Json;
 
@@ -57,7 +58,13 @@ namespace Altinn.App.Core.Models
         /// </summary>
         [JsonProperty(PropertyName = "logo")]
         public Logo? Logo { get; set; }
-        
+
+        /// <summary>
+        /// Frontend sometimes need to have knowledge of the nuget package version for backwards compatibility
+        /// </summary>
+        [JsonProperty(PropertyName = "altinnNugetVersion")]
+        public string AltinnNugetVersion { get; set; } = typeof(ApplicationMetadata).Assembly!.GetName().Version!.ToString();
+
         /// <summary>
         /// Holds properties that are not mapped to other properties
         /// </summary>

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Internal.App;
@@ -482,8 +483,9 @@ namespace Altinn.App.Core.Tests.Internal.App
             AppSettings appSettings = GetAppSettings("AppMetadata", "unmapped-properties.applicationmetadata.json");
             IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
             var appMetadataObj = await appMetadata.GetApplicationMetadata();
-            string serialized = JsonSerializer.Serialize(appMetadataObj, new JsonSerializerOptions { WriteIndented = true });
+            string serialized = JsonSerializer.Serialize(appMetadataObj, new JsonSerializerOptions { WriteIndented = true, Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
             string expected = File.ReadAllText(Path.Join(appBasePath, "AppMetadata", "unmapped-properties.applicationmetadata.expected.json"));
+            expected = expected.Replace("--AltinnNugetVersion--", typeof(ApplicationMetadata).Assembly!.GetName().Version!.ToString());
             serialized.Should().Be(expected);
         }
 

--- a/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/unmapped-properties.applicationmetadata.expected.json
+++ b/test/Altinn.App.Core.Tests/Internal/App/TestData/AppMetadata/unmapped-properties.applicationmetadata.expected.json
@@ -10,6 +10,7 @@
     "Show": "select-instance"
   },
   "Logo": null,
+  "AltinnNugetVersion": "--AltinnNugetVersion--",
   "VersionId": null,
   "Org": "tdd",
   "Title": {


### PR DESCRIPTION
Rather simple implementation that makes it possible to override, but if the property isn't set, the version info will be read by from the assembly that contains `ApplicationMetadata`.

Should probably consider adding some error handling, but I don't know when it might trigger, so it's hard to know what to say. 

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/315

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
