### PR TITLE
[V7] Add [Authorize] attribute on AuthorizationController.GetCurrentParty

### DIFF
--- a/src/Altinn.App.Api/Controllers/AuthorizationController.cs
+++ b/src/Altinn.App.Api/Controllers/AuthorizationController.cs
@@ -37,6 +37,7 @@ namespace Altinn.App.Api.Controllers
         /// Gets current party by reading cookie value and validating.
         /// </summary>
         /// <returns>Party id for selected party. If invalid, partyId for logged in user is returned.</returns>
+        [Authorize]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         [HttpGet("{org}/{app}/api/authorization/parties/current")]
         public async Task<ActionResult> GetCurrentParty(bool returnPartyObject = false)


### PR DESCRIPTION
This means that the code won't crash with missing cookie when the cookie exipires

Opening this for `main` / `v7` in case we want to release a fixed nuget version, to reduce 500 errors caused by expired cookies.

## Related Issue(s)
- Likely to fix https://github.com/Altinn/app-lib-dotnet/issues/138

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
