### PR TITLE
Update app-lib-dotnet to dotnet8 with c# 12

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,16 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
+    # The following step is required in order to use .NET 8 pre-release.
+    # We can remove if using an officially supported .NET version.
+    # See https://github.com/github/codeql-action/issues/757#issuecomment-977546999
+    - name: Setup .NET
+       uses: actions/setup-dotnet@v3
+       with:
+         dotnet-version: |
+           8.0.x
+         include-prerelease: true
+
     - name: Checkout repository
       uses: actions/checkout@v4
 

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -20,8 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
-            5.0.x
+            8.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
       - name: Install deps
         run: |
           dotnet restore
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
+            8.0.x
       - name: Build bundles
         run: |
           make bundles

--- a/.github/workflows/test-and-analyze-fork.yml
+++ b/.github/workflows/test-and-analyze-fork.yml
@@ -13,8 +13,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
-            5.0.x
+            8.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/test-and-analyze.yml
+++ b/.github/workflows/test-and-analyze.yml
@@ -19,8 +19,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            6.0.x
-            5.0.x
+            8.0.x
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.3.0" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.24.0" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0-preview" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -18,7 +18,7 @@
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0-preview" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Scrutor" Version="4.2.2" />
     <PackageReference Include="prometheus-net" Version="8.0.0" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
   
   <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!='' AND '$(BuildNumber)' != ''">

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>false</IsPackable>

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0-preview" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="xunit" Version="2.5.0" />

--- a/test/Altinn.App.Core.Tests/Internal/App/FrontendFeaturesTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/FrontendFeaturesTest.cs
@@ -36,7 +36,7 @@ namespace Altinn.App.Core.Tests.Internal.App
                 { "jsonObjectInDataResponse", true },
             };
             var featureManagerMock = new Mock<IFeatureManager>();
-            featureManagerMock.Setup(f => f.IsEnabledAsync(FeatureFlags.JsonObjectInDataResponse, default)).ReturnsAsync(true);
+            featureManagerMock.Setup(f => f.IsEnabledAsync(FeatureFlags.JsonObjectInDataResponse)).ReturnsAsync(true);
             IFrontendFeatures frontendFeatures = new FrontendFeatures(featureManagerMock.Object);
             var actual = await frontendFeatures.GetFrontendFeatures();
             actual.Should().BeEquivalentTo(expected);


### PR DESCRIPTION
We should ensure that v8 works with the newest dotnet version, which at the time of release of app-lib v8 will be `net8.0`.

If someone finds a compelling idea for why we would need multi-targeting `net6.0` (or `net7.0`), I'm not against it, but forcing users to have similar setup and not have to ask (Oh, you run `net6.0`, we didn't properly test that) is a huge time saver in my opinion.

This PR does not include the fix of the update tool to change dotnet version, as it would conflict with changes in https://github.com/Altinn/app-lib-dotnet/pull/329

## Related Issue(s)
- No separate issue

## Remarks
Something funny happened with FeatureManagment when updating, and I had to use the newest version to make the tests compile. Seems like a very sensible change.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
