### PR TITLE
Update app-lib-dotnet to multi-target dotnet6 and dotnet8 with c# 12

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,17 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
+    # The following step is required in order to use .NET 8 pre-release.
+    # We can remove if using an officially supported .NET version.
+    # See https://github.com/github/codeql-action/issues/757#issuecomment-977546999
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          6.0.x
+          8.0.x
+        include-prerelease: true
+
     - name: Checkout repository
       uses: actions/checkout@v4
 

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            5.0.x
+            8.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
+            8.0.x
       - name: Install deps
         run: |
           dotnet restore
@@ -49,6 +50,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
+            8.0.x
       - name: Build bundles
         run: |
           make bundles

--- a/.github/workflows/test-and-analyze-fork.yml
+++ b/.github/workflows/test-and-analyze-fork.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            5.0.x
+            8.0.x
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis

--- a/.github/workflows/test-and-analyze.yml
+++ b/.github/workflows/test-and-analyze.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.x
-            5.0.x
+            8.0.x
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <PackageId>Altinn.App.Api</PackageId>
     <PackageTags>Altinn;Studio;App;Api;Controllers</PackageTags>
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="1.3.0" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.24.0" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0-preview" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
@@ -46,6 +46,9 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <NoWarn>$(NoWarn);8618</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -1,9 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <NoWarn>$(NoWarn);8618</NoWarn>
+  </PropertyGroup>
+  
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
@@ -18,7 +23,7 @@
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0-preview" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Scrutor" Version="4.2.2" />
     <PackageReference Include="prometheus-net" Version="8.0.0" />

--- a/src/Altinn.App.Core/Helpers/RequiredNet6Hacks.cs
+++ b/src/Altinn.App.Core/Helpers/RequiredNet6Hacks.cs
@@ -1,0 +1,18 @@
+// This file is a hack for required properties to work in net6.0
+// Should be removed when support for targeting net6.0 is removed
+
+#if NET6_0
+#pragma warning disable
+namespace System.Runtime.CompilerServices;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class RequiredMemberAttribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.All)]
+public class CompilerFeatureRequiredAttribute : Attribute
+{
+    public CompilerFeatureRequiredAttribute(string name) { }
+}
+[System.AttributeUsage(System.AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+public sealed class SetsRequiredMembersAttribute : Attribute { }
+#endif

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
   
   <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!='' AND '$(BuildNumber)' != ''">

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>false</IsPackable>

--- a/test/Altinn.App.Common.Tests/Altinn.App.Common.Tests.csproj
+++ b/test/Altinn.App.Common.Tests/Altinn.App.Common.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0-preview" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="xunit" Version="2.5.0" />

--- a/test/Altinn.App.Core.Tests/Internal/App/FrontendFeaturesTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/FrontendFeaturesTest.cs
@@ -36,7 +36,7 @@ namespace Altinn.App.Core.Tests.Internal.App
                 { "jsonObjectInDataResponse", true },
             };
             var featureManagerMock = new Mock<IFeatureManager>();
-            featureManagerMock.Setup(f => f.IsEnabledAsync(FeatureFlags.JsonObjectInDataResponse, default)).ReturnsAsync(true);
+            featureManagerMock.Setup(f => f.IsEnabledAsync(FeatureFlags.JsonObjectInDataResponse)).ReturnsAsync(true);
             IFrontendFeatures frontendFeatures = new FrontendFeatures(featureManagerMock.Object);
             var actual = await frontendFeatures.GetFrontendFeatures();
             actual.Should().BeEquivalentTo(expected);


### PR DESCRIPTION
Also include code that allows for unchecked use of `required` attributes in net6.0 (so we can start using `required` properties without dropping support for net6.0)

This is an alternative to https://github.com/Altinn/app-lib-dotnet/pull/340 that preserves support for apps that use net6.0. I think this adds much more complexity to app management than what it is worth.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
