### PR TITLE
Mark IPageOrder [Obsolete] as it will be unused in frontend V4

### DIFF
--- a/src/Altinn.App.Api/Controllers/PagesController.cs
+++ b/src/Altinn.App.Api/Controllers/PagesController.cs
@@ -15,6 +15,7 @@ namespace Altinn.App.Api.Controllers
     [Authorize]
     [ApiController]
     [Route("{org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/pages")]
+    [Obsolete("IPageOrder does not work with frontend version 4")]
     public class PagesController : ControllerBase
     {
         private readonly IAppModel _appModel;

--- a/src/Altinn.App.Api/Controllers/StatelessPagesController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessPagesController.cs
@@ -15,6 +15,7 @@ namespace Altinn.App.Api.Controllers
     [ApiController]
     [Route("{org}/{app}/v1/pages")]
     [AllowAnonymous]
+    [Obsolete("IPageOrder does not work with frontend version 4")]
     public class StatelessPagesController : ControllerBase
     {
         private readonly IAppModel _appModel;

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -139,7 +139,9 @@ namespace Altinn.App.Core.Extensions
             services.TryAddSingleton<IFrontendFeatures, FrontendFeatures>();
             services.TryAddTransient<IAppEvents, DefaultAppEvents>();
             services.TryAddTransient<ITaskEvents, DefaultTaskEvents>();
+#pragma warning disable CS0618, CS0612 // Type or member is obsolete
             services.TryAddTransient<IPageOrder, DefaultPageOrder>();
+#pragma warning restore CS0618, CS0612 // Type or member is obsolete
             services.TryAddTransient<IInstantiationProcessor, NullInstantiationProcessor>();
             services.TryAddTransient<IInstantiationValidator, NullInstantiationValidator>();
             services.TryAddTransient<IInstanceValidator, NullInstanceValidator>();

--- a/src/Altinn.App.Core/Features/IPageOrder.cs
+++ b/src/Altinn.App.Core/Features/IPageOrder.cs
@@ -5,6 +5,7 @@ namespace Altinn.App.Core.Features
     /// <summary>
     /// Interface for page order handling in stateful apps
     /// </summary>
+    [Obsolete("IPageOrder does not work with frontend version 4")]
     public interface IPageOrder
     {
         /// <summary>

--- a/src/Altinn.App.Core/Features/PageOrder/DefaultPageOrder.cs
+++ b/src/Altinn.App.Core/Features/PageOrder/DefaultPageOrder.cs
@@ -6,6 +6,7 @@ namespace Altinn.App.Core.Features.PageOrder
     /// <summary>
     /// Interface for page order handling in stateless apps
     /// </summary>
+    [Obsolete("IPageOrder does not work with frontend version 4")]
     public class DefaultPageOrder : IPageOrder
     {
         private readonly IAppResources _resources;


### PR DESCRIPTION
Frontend v4 will remove support for tracks / calculatePageOrder / IPageOrder, and thus it should be removed in backend as well. Currently the thinking is that backend v8 should support frontend v3, but as IPageOrder isn't required for hiding pages anymore, I think it would be good to mark it `[Obsolete]`.

Thinking more about this. As we seem to agree that calculating page order in backend is wrong anyway, and we have an alternative, this should be accepted either way.

## Related Issue(s)
- One part of https://github.com/Altinn/app-frontend-react/issues/1491

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
