### PR TITLE
Adding [Serializable] on custom exceptions in dotnet 8 causes warning

### DIFF
--- a/src/Altinn.App.Core/EFormidling/Implementation/EformidlingDeliveryException.cs
+++ b/src/Altinn.App.Core/EFormidling/Implementation/EformidlingDeliveryException.cs
@@ -4,7 +4,6 @@
     /// Exception thrown when Eformidling is unable to process the message delivered to
     /// the integration point.
     /// </summary>
-    [Serializable]
     public class EformidlingDeliveryException : Exception
     {
         ///<inheritDoc/>
@@ -21,12 +20,6 @@
         ///<inheritDoc/>
         public EformidlingDeliveryException(string message, Exception inner)
             : base(message, inner)
-        {
-        }
-
-        ///<inheritDoc/>
-        protected EformidlingDeliveryException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext)
-            : base(serializationInfo, streamingContext)
         {
         }
     }

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModelException.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModelException.cs
@@ -5,12 +5,8 @@ namespace Altinn.App.Core.Helpers.DataModel;
 /// <summary>
 /// Custom exception for errors when reading from a datamodel
 /// </summary>
-[Serializable]
 public class DataModelException : Exception
 {
     /// <inheritdoc />
     public DataModelException(string msg): base(msg) { }
-
-    /// <inheritdoc />
-    protected DataModelException(SerializationInfo info, StreamingContext ctxt) : base(info, ctxt) { }
 }

--- a/src/Altinn.App.Core/Helpers/PlatformHttpException.cs
+++ b/src/Altinn.App.Core/Helpers/PlatformHttpException.cs
@@ -5,7 +5,6 @@ namespace Altinn.App.Core.Helpers
     /// <summary>
     /// Exception class to hold exceptions when talking to the platform REST services
     /// </summary>
-    [Serializable]
     public class PlatformHttpException : Exception
     {
         /// <summary>
@@ -35,13 +34,6 @@ namespace Altinn.App.Core.Helpers
         public PlatformHttpException(HttpResponseMessage response, string message) : base(message)
         {
             this.Response = response;
-        }
-
-        /// <summary>
-        /// Add serialization info.
-        /// </summary>
-        protected PlatformHttpException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
         }
     }
 }

--- a/src/Altinn.App.Core/Helpers/ServiceException.cs
+++ b/src/Altinn.App.Core/Helpers/ServiceException.cs
@@ -6,7 +6,6 @@ namespace Altinn.App.Core.Helpers
     /// <summary>
     /// Exception that is thrown by service implementation. 
     /// </summary>
-    [Serializable]
     public class ServiceException : Exception
     {
         /// <summary>
@@ -33,13 +32,6 @@ namespace Altinn.App.Core.Helpers
         public ServiceException(HttpStatusCode statusCode, string message, Exception innerException) : base(message, innerException)
         {
             StatusCode = statusCode;
-        }
-
-        /// <summary>
-        /// Set serialization info.
-        /// </summary>
-        protected ServiceException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
         }
     }
 }

--- a/src/Altinn.App.Core/Internal/App/ApplicationConfigException.cs
+++ b/src/Altinn.App.Core/Internal/App/ApplicationConfigException.cs
@@ -5,7 +5,6 @@ namespace Altinn.App.Core.Internal.App
     /// <summary>
     /// Configuration is not valid for application
     /// </summary>
-    [Serializable]
     public class ApplicationConfigException: Exception
     {
 
@@ -13,15 +12,6 @@ namespace Altinn.App.Core.Internal.App
         /// Create ApplicationConfigException
         /// </summary>
         public ApplicationConfigException()
-        {
-        }
-
-        /// <summary>
-        /// Create ApplicationConfigException
-        /// </summary>
-        /// <param name="info">Exception information</param>
-        /// <param name="context">Exception context</param>
-        protected ApplicationConfigException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
 

--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluatorTypeErrorException.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluatorTypeErrorException.cs
@@ -5,14 +5,10 @@ namespace Altinn.App.Core.Internal.Expressions;
 /// <summary>
 /// Custom exception for <see cref="ExpressionEvaluator" /> to thow when expressions contains type errors.
 /// </summary>
-[Serializable]
 public class ExpressionEvaluatorTypeErrorException : Exception
 {
     /// <inheritdoc />
     public ExpressionEvaluatorTypeErrorException(string msg) : base(msg) {}
     /// <inheritdoc />
     public ExpressionEvaluatorTypeErrorException(string msg, Exception innerException) : base(msg, innerException) {}
-
-    /// <inheritdoc />
-    protected ExpressionEvaluatorTypeErrorException(SerializationInfo info, StreamingContext ctxt) : base(info, ctxt) { }
 }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfGenerationException.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfGenerationException.cs
@@ -5,7 +5,6 @@ namespace Altinn.App.Core.Internal.Pdf
     /// <summary>
     /// Class representing an exception throw when a PDF could not be created.
     /// </summary>
-    [Serializable]
     public class PdfGenerationException : Exception
     {
         /// <summary>
@@ -29,14 +28,6 @@ namespace Altinn.App.Core.Internal.Pdf
         /// Intended to be used when the generation of PDF fails.
         /// </summary>
         public PdfGenerationException(string? message, Exception? innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new Exception of <see cref="PdfGenerationException"/>
-        /// Intended to be used when the generation of PDF fails.
-        /// </summary>
-        protected PdfGenerationException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }


### PR DESCRIPTION
This code causes a warning in dotnet 8 and the explanation is that you should just remove it. I know I added this code because of a warning somewhere, but the docs are pretty clear that it is not used any more.

See: https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0051

If you created a custom type derived from System.Exception, consider whether you really need it to be serializable. It's likely that you don't need it to be serializable, as exception serialization is primarily intended to support remoting, and support for remoting was dropped in .NET Core 1.0.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
