### PR TITLE
Obsolete IText interface for getting texts from storage

### DIFF
--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -87,7 +87,9 @@ namespace Altinn.App.Core.Extensions
             services.AddHttpClient<IProfileClient, ProfileClient>();
             services.Decorate<IProfileClient, ProfileClientCachingDecorator>();
             services.AddHttpClient<IAltinnPartyClient, AltinnPartyClient>();
+#pragma warning disable CS0618 // Type or member is obsolete
             services.AddHttpClient<IText, TextClient>();
+#pragma warning restore CS0618 // Type or member is obsolete
             services.AddHttpClient<IProcessClient, ProcessClient>();
             services.AddHttpClient<IPersonClient, PersonClient>();
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/TextClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/TextClient.cs
@@ -16,6 +16,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
     /// <summary>
     /// A client forretrieving text resources from Altinn Platform.
     /// </summary>
+    [Obsolete("Use IAppResources.GetTexts() instead")]
     public class TextClient : IText
     {
         private readonly ILogger _logger;

--- a/src/Altinn.App.Core/Internal/Texts/IText.cs
+++ b/src/Altinn.App.Core/Internal/Texts/IText.cs
@@ -5,6 +5,7 @@ namespace Altinn.App.Core.Internal.Texts
     /// <summary>
     /// Describes the public methods of a text resources service
     /// </summary>
+    [Obsolete("Use IAppResources.GetTexts() instead")]
     public interface IText
     {
         /// <summary>


### PR DESCRIPTION
This interface is no longer used in apps, and when it is used it causes bugs where a newly deployed app used the old cached texts in storage.

See: https://github.com/Altinn/altinn-studio/pull/7900

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
