### PR TITLE
Get rid of Microsoft.AspNet.WebApi.Client that uses Newtonsoft

### DIFF
--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.11.53" />
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Scrutor" Version="4.2.2" />

--- a/src/Altinn.App.Core/Features/Options/Altinn2Provider/Altinn2MetadataApiClient.cs
+++ b/src/Altinn.App.Core/Features/Options/Altinn2Provider/Altinn2MetadataApiClient.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using Altinn.App.Core.Helpers;
+
 namespace Altinn.App.Core.Features.Options.Altinn2Provider
 {
     /// <summary>
@@ -33,7 +35,7 @@ namespace Altinn.App.Core.Features.Options.Altinn2Provider
                 response = await _client.GetAsync($"https://www.altinn.no/api/metadata/codelists/{id}/{version?.ToString() ?? string.Empty}");
             }
             response.EnsureSuccessStatusCode();
-            var codelist = await response.Content.ReadAsAsync<MetadataCodelistResponse>();
+            var codelist = await JsonSerializerPermissive.DeserializeAsync<MetadataCodelistResponse>(response.Content);
             return codelist;
         }
     }

--- a/src/Altinn.App.Core/Helpers/JsonSerializerPermissive.cs
+++ b/src/Altinn.App.Core/Helpers/JsonSerializerPermissive.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Altinn.Platform.Register.Models;
+
+namespace Altinn.App.Core.Helpers;
+
+/// <summary>
+/// Wrapper of <see cref="JsonSerializer"/> with permissive settings parsing settings.
+/// </summary>
+public static class JsonSerializerPermissive
+{
+    /// <summary>
+    /// <see cref="JsonSerializerOptions"/> for the most permissive parsing of JSON.
+    /// </summary>
+    public static readonly JsonSerializerOptions JsonSerializerOptionsDefaults = new(JsonSerializerDefaults.Web)
+    {
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        Converters =
+        {
+            new JsonStringEnumConverter(),
+        },
+    };
+
+    /// <summary>
+    /// Simple wrapper of <see cref="JsonSerializer.Deserialize{TValue}(string, JsonSerializerOptions?)"/> with permissive defaults.
+    /// </summary>
+    public static T Deserialize<T>(string content)
+    {
+        return JsonSerializer.Deserialize<T>(content, JsonSerializerOptionsDefaults) ?? throw new JsonException("Could not deserialize json value \"null\" to type " + typeof(T).FullName);
+    }
+
+    /// <summary>
+    /// Simple wrapper of <see cref="JsonSerializer.DeserializeAsync{TValue}(Stream, JsonSerializerOptions, CancellationToken)"/> with permissive defaults.
+    /// </summary>
+    public static async Task<T> DeserializeAsync<T>(HttpContent content, CancellationToken cancellationToken = default)
+    {
+        await using var stream = await content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<T>(stream, JsonSerializerOptionsDefaults, cancellationToken) ?? throw new JsonException("Could not deserialize json value \"null\" to type " + typeof(T).FullName);
+    }
+
+    /// <summary>
+    /// Simple wrapper of <see cref="JsonSerializer.Serialize{TValue}(TValue, JsonSerializerOptions?)"/> with permissive defaults.
+    /// </summary>
+    public static string Serialize(PartyLookup partyLookup)
+    {
+        return JsonSerializer.Serialize(partyLookup, JsonSerializerOptionsDefaults);
+    }
+}

--- a/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Extensions;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Profile;
 using Altinn.App.Core.Models;
@@ -57,9 +58,9 @@ namespace Altinn.App.Core.Infrastructure.Clients.Profile
         }
 
         /// <inheritdoc />
-        public async Task<UserProfile> GetUserProfile(int userId)
+        public async Task<UserProfile?> GetUserProfile(int userId)
         {
-            UserProfile userProfile = null;
+            UserProfile? userProfile = null;
 
             string endpointUrl = $"users/{userId}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
@@ -68,7 +69,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Profile
             HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, _accessTokenGenerator.GenerateAccessToken(applicationMetadata.Org, applicationMetadata.AppIdentifier.App));
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                userProfile = await response.Content.ReadAsAsync<UserProfile>();
+                userProfile = await JsonSerializerPermissive.DeserializeAsync<UserProfile>(response.Content);
             }
             else
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -13,7 +13,6 @@ using AltinnCore.Authentication.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 
 namespace Altinn.App.Core.Infrastructure.Clients.Register
 {
@@ -70,7 +69,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
             HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App));
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                party = await response.Content.ReadAsAsync<Party>();
+                party = await JsonSerializerPermissive.DeserializeAsync<Party>(response.Content);
             }
             else if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
@@ -92,7 +91,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
             string endpointUrl = "parties/lookup";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            StringContent content = new StringContent(JsonConvert.SerializeObject(partyLookup));
+            StringContent content = new StringContent(JsonSerializerPermissive.Serialize(partyLookup));
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
             HttpRequestMessage request = new HttpRequestMessage
             {
@@ -108,7 +107,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
             HttpResponseMessage response = await _client.SendAsync(request);
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                party = await response.Content.ReadAsAsync<Party>();
+                party = await JsonSerializerPermissive.DeserializeAsync<Party>(response.Content);
             }
             else
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/RegisterERClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/RegisterERClient.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Extensions;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Registers;
 using Altinn.App.Core.Models;
@@ -69,7 +70,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
-                organization = await response.Content.ReadAsAsync<Organization>();
+                organization = await JsonSerializerPermissive.DeserializeAsync<Organization>(response.Content);
             }
             else
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/TextClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/TextClient.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Extensions;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.Texts;
 using Altinn.Platform.Storage.Interface.Models;
 using AltinnCore.Authentication.Utils;
@@ -73,7 +74,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
                 HttpResponseMessage response = await _client.GetAsync(token, url);
                 if (response.StatusCode == System.Net.HttpStatusCode.OK)
                 {
-                    textResource = await response.Content.ReadAsAsync<TextResource>();
+                    textResource = await JsonSerializerPermissive.DeserializeAsync<TextResource>(response.Content);
                     _memoryCache.Set(cacheKey, textResource, cacheEntryOptions);
                 }
                 else

--- a/src/Altinn.App.Core/Internal/Profile/IProfileClient.cs
+++ b/src/Altinn.App.Core/Internal/Profile/IProfileClient.cs
@@ -12,6 +12,6 @@ namespace Altinn.App.Core.Internal.Profile
         /// </summary>
         /// <param name="userId">the user id</param>
         /// <returns>The userprofile for the given user id</returns>
-        Task<UserProfile> GetUserProfile(int userId);
+        Task<UserProfile?> GetUserProfile(int userId);
     }
 }

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/SignClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/SignClientTests.cs
@@ -89,7 +89,7 @@ public class SignClientTests
         platformRequest.Should().NotBeNull();
         platformRequest!.Method.Should().Be(HttpMethod.Post);
         platformRequest!.RequestUri!.ToString().Should().Be($"{apiStorageEndpoint}instances/{instanceIdentifier.InstanceOwnerPartyId}/{instanceIdentifier.InstanceGuid}/sign");
-        SignRequest actual = await platformRequest.Content.ReadAsAsync<SignRequest>();
+        SignRequest actual = await JsonSerializerPermissive.DeserializeAsync<SignRequest>(platformRequest!.Content!);
         actual.Should().BeEquivalentTo(expectedRequest);
     }
     


### PR DESCRIPTION
Microsoft.AspNet.WebApi.Client is an old utility that uses `Newtonsoft`.

System.Text.Json includes some bolilerplate and in my opinion wrong defaults.

I added JsonSerializerPremissive witch provides dropp inn replacements with more sensible defaults.

I also considered adding
```
#if DEBUG
        WriteIndented = true,
#else
        WriteIndented = false,
#endif
```
but fear this will cause issues for unit tests, so I dropped it. Would be great for debugging.

* Fixes https://github.com/Altinn/app-lib-dotnet/pull/332

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
