### PR TITLE
Skip InstanceClientMetricsDecoratorTests

### DIFF
--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
@@ -14,6 +14,16 @@ namespace Altinn.App.Core.Tests.InfrastrucZture.Clients.Storage;
 
 public class InstanceClientMetricsDecoratorTests
 {
+    // Xunit does not have a class level Skip setting, so using this hack instead
+    // Redefine the [Fact] attribute for this class in a way that sets Skip
+    private class FactAttribute : Xunit.FactAttribute
+    {
+        public FactAttribute()
+        {
+            Skip = "Skip metric tests due to flakyness when run in paralell with other test classes";
+        }
+    }
+
     public InstanceClientMetricsDecoratorTests()
     {
         Metrics.SuppressDefaultMetrics();


### PR DESCRIPTION
They are flaky due to global state

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
