### PR TITLE
Update microsoft dependencies for net8.0

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,11 +1,4 @@
 <Project>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="'$(IntegrationBuild)' != 'true'">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
     <PropertyGroup>
         <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
     </PropertyGroup>

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -14,8 +14,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.23" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.23" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 		<PackageReference Include="Moq" Version="4.20.69" />
 		<PackageReference Include="xunit" Version="2.5.2" />


### PR DESCRIPTION
 Source link is no longer required: https://github.com/dotnet/sourcelink/releases/tag/8.0.0
 
> Source Link is now included in .NET SDK 8 and enabled by default. Projects that migrate to .NET SDK 8 do not need to reference Source Link packages explicitly via PackageReference anymore.


## Related Issue(s)
I closed the following renovate PRs because the updates relate to net8 that is only used in v8
- #358 
- #359
- #360

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
