### PR TITLE
Upgradetool upgrades apps to dotnet 8

### DIFF
--- a/cli-tools/altinn-app-cli/altinn-app-cli.csproj
+++ b/cli-tools/altinn-app-cli/altinn-app-cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>altinn_app_cli</RootNamespace>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -31,7 +31,7 @@
     <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
     <MinVerTagPrefix>altinn-app-cli</MinVerTagPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!=''">

--- a/cli-tools/altinn-app-cli/v7Tov8/DockerfileRewriters/DockerfileRewriter.cs
+++ b/cli-tools/altinn-app-cli/v7Tov8/DockerfileRewriters/DockerfileRewriter.cs
@@ -1,0 +1,50 @@
+using System.Text.RegularExpressions;
+using altinn_app_cli.v7Tov8.DockerfileRewriters.Extensions;
+
+namespace altinn_app_cli.v7Tov8.DockerfileRewriters;
+
+/// <summary>
+/// Rewrites the dockerfile
+/// </summary>
+public class DockerfileRewriter
+{
+    private readonly string dockerFilePath;
+    private readonly string targetFramework;
+    
+    /// <summary>
+    /// Creates a new instance of the <see cref="DockerfileRewriter"/> class
+    /// </summary>
+    /// <param name="dockerFilePath"></param>
+    /// <param name="targetFramework"></param>
+    public DockerfileRewriter(string dockerFilePath, string targetFramework = "net8.0")
+    {
+        this.dockerFilePath = dockerFilePath;
+        this.targetFramework = targetFramework;
+    }
+    
+    /// <summary>
+    /// Upgrades the dockerfile
+    /// </summary>
+    public async Task Upgrade()
+    {
+        var dockerFile = await File.ReadAllLinesAsync(dockerFilePath);
+        var newDockerFile = new List<string>();
+        foreach (var line in dockerFile)
+        {
+            var imageTag = GetImageTagFromFrameworkVersion(targetFramework);
+            newDockerFile.Add(line.ReplaceSdkVersion(imageTag).ReplaceAspNetVersion(imageTag));
+        }
+
+        await File.WriteAllLinesAsync(dockerFilePath, newDockerFile);
+    }
+    
+    private static string GetImageTagFromFrameworkVersion(string targetFramework)
+    {
+        return targetFramework switch
+        {
+            "net6.0" => "6.0-alpine",
+            "net7.0" => "7.0-alpine",
+            _ => "8.0-alpine"
+        };
+    }
+}

--- a/cli-tools/altinn-app-cli/v7Tov8/DockerfileRewriters/Extensions/StringDockerTagExtensions.cs
+++ b/cli-tools/altinn-app-cli/v7Tov8/DockerfileRewriters/Extensions/StringDockerTagExtensions.cs
@@ -1,0 +1,33 @@
+using System.Text.RegularExpressions;
+
+namespace altinn_app_cli.v7Tov8.DockerfileRewriters.Extensions;
+
+/// <summary>
+/// Extensions for string replacing tags in dockerfiles
+/// </summary>
+public static class DockerfileStringExtensions
+{
+    /// <summary>
+    /// Replaces the dotnet sdk image tag version in a dockerfile
+    /// </summary>
+    /// <param name="line">a line in the dockerfile</param>
+    /// <param name="imageTag">the new image tag</param>
+    /// <returns></returns>
+    public static string ReplaceSdkVersion(this string line, string imageTag)
+    {
+        const string pattern = @"(^FROM mcr.microsoft.com/dotnet/sdk):(.+?)( AS .*)?$";
+        return Regex.Replace(line, pattern, $"$1:{imageTag}$3");
+    }
+    
+    /// <summary>
+    /// Replaces the aspnet image tag version in a dockerfile
+    /// </summary>
+    /// <param name="line">a line in the dockerfile</param>
+    /// <param name="imageTag">the new image tag</param>
+    /// <returns></returns>
+    public static string ReplaceAspNetVersion(this string line, string imageTag)
+    {
+        const string pattern = @"(^FROM mcr.microsoft.com/dotnet/aspnet):(.+?)( AS .*)?$";
+        return Regex.Replace(line, pattern, $"$1:{imageTag}$3");
+    }
+}


### PR DESCRIPTION
Upgraded tool to dotnet 8
Upgrade TargetFramework to net8 and dockerfile when running upgrade
Make code rewrite more reliable by moving it before the csproj rewrite

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
