### PR TITLE
Add JsonEquivilentTo extension for FluentAssertions

### DIFF
--- a/AppLibDotnet.sln
+++ b/AppLibDotnet.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7AD5FADE-607
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Altinn.App.Core", "src\Altinn.App.Core\Altinn.App.Core.csproj", "{1745B251-BD5C-43B7-BA7D-9C4BFAB37535}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Altinn.App.TestUtils", "test\Altinn.App.TestUtils\Altinn.App.TestUtils.csproj", "{88930354-9AE0-4038-A9D5-70A3D3FF6404}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +42,10 @@ Global
 		{1745B251-BD5C-43B7-BA7D-9C4BFAB37535}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1745B251-BD5C-43B7-BA7D-9C4BFAB37535}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1745B251-BD5C-43B7-BA7D-9C4BFAB37535}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88930354-9AE0-4038-A9D5-70A3D3FF6404}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88930354-9AE0-4038-A9D5-70A3D3FF6404}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88930354-9AE0-4038-A9D5-70A3D3FF6404}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88930354-9AE0-4038-A9D5-70A3D3FF6404}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -49,6 +55,7 @@ Global
 		{17D7DCE9-7797-4BC1-B448-D0529FD6FB3D} = {6C8EB054-1747-4BAC-A637-754F304BCAFA}
 		{2FD56505-1DB2-4AE1-8911-E076E535EAC6} = {6C8EB054-1747-4BAC-A637-754F304BCAFA}
 		{1745B251-BD5C-43B7-BA7D-9C4BFAB37535} = {7AD5FADE-607F-4D5F-8511-6647D0C1AA1C}
+		{88930354-9AE0-4038-A9D5-70A3D3FF6404} = {6C8EB054-1747-4BAC-A637-754F304BCAFA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4584C6E1-D5B4-40B1-A8C4-CF4620EB0896}

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -31,6 +31,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Altinn.App.Api\Altinn.App.Api.csproj" />
+		<ProjectReference Include="..\Altinn.App.TestUtils\Altinn.App.TestUtils.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Altinn.App.Api.Models;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Utils;
+using Altinn.App.TestUtils.JsonCompare;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
@@ -82,15 +83,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
                                "endEvent": null
                              }
                              """;
-        CompareResult<AppProcessState>(expectedString, content);
+        content.Should().BeJsonEquivalentTo(expectedString);
     }
-    
-    
-    //TODO: replace this assertion with a proper one once fluentassertions has a json compare feature scheduled for v7 https://github.com/fluentassertions/fluentassertions/issues/2205
-    private static void CompareResult<T>(string expectedString, string actualString)
-    {
-        T? expected = JsonSerializer.Deserialize<T>(expectedString);
-        T? actual = JsonSerializer.Deserialize<T>(actualString);
-        actual.Should().BeEquivalentTo(expected);
-    }
+
 }

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -68,6 +68,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Altinn.App.Core\Altinn.App.Core.csproj" />
+    <ProjectReference Include="..\Altinn.App.TestUtils\Altinn.App.TestUtils.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Altinn.App.TestUtils/Altinn.App.TestUtils.csproj
+++ b/test/Altinn.App.TestUtils/Altinn.App.TestUtils.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    </ItemGroup>
+
+</Project>

--- a/test/Altinn.App.TestUtils/JsonCompare/FluentAssertionsExtentions.cs
+++ b/test/Altinn.App.TestUtils/JsonCompare/FluentAssertionsExtentions.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace Altinn.App.TestUtils.JsonCompare;
+
+public static class FluentAssertionsExtentions
+{
+    public static AndConstraint<StringAssertions> BeJsonEquivalentTo(this StringAssertions actual, string expected, JsonComparatorOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(actual, "Cannot assert string containment against <null>.");
+
+        string? result;
+        if (options?.LooseObjectOrderComparison != true)
+        {
+            result = JsonTokenStreamCompare.IsJsonTokenEquivalent(actual.Subject, expected, options);
+        }
+        else
+        {
+            throw new NotSupportedException(); // Not implemented yet
+        }
+
+        if (result is not null)
+        {
+            Execute.Assertion
+                .FailWith(() => new FailReason("Expected {context:string} to match expected json, but found diff\n{0}", result));
+        }
+
+        return new AndConstraint<StringAssertions>(actual);
+    }
+}

--- a/test/Altinn.App.TestUtils/JsonCompare/JsonComparatorOptions.cs
+++ b/test/Altinn.App.TestUtils/JsonCompare/JsonComparatorOptions.cs
@@ -1,0 +1,50 @@
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace Altinn.App.TestUtils.JsonCompare;
+
+[StructLayout(LayoutKind.Auto)]
+public readonly struct JsonComparatorOptions : IEquatable<JsonComparatorOptions>
+{
+    public JsonComparatorOptions()
+    {
+    }
+
+    public JsonCommentHandling CommentHandling { get; init; } = JsonCommentHandling.Skip;
+
+    public bool AllowTrailingCommas { get; init; } = true;
+
+    public int MaxDepth { get; init; } = 64;
+
+    public bool LooseObjectOrderComparison { get; init; }
+
+    public static implicit operator JsonReaderOptions(JsonComparatorOptions options) => new JsonReaderOptions()
+    {
+        CommentHandling = options.CommentHandling,
+        AllowTrailingCommas = options.AllowTrailingCommas,
+        MaxDepth = options.MaxDepth,
+    };
+
+// Analyzers require all structs to implement equality.
+    public override bool Equals(object? obj)
+    {
+        return obj is JsonComparatorOptions other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine((int)CommentHandling, AllowTrailingCommas, MaxDepth, LooseObjectOrderComparison);
+    }
+
+    public static bool operator ==(JsonComparatorOptions left, JsonComparatorOptions right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(JsonComparatorOptions left, JsonComparatorOptions right)
+    {
+        return !(left == right);
+    }
+
+    public bool Equals(JsonComparatorOptions other) => CommentHandling == other.CommentHandling && AllowTrailingCommas == other.AllowTrailingCommas && MaxDepth == other.MaxDepth && LooseObjectOrderComparison == other.LooseObjectOrderComparison;
+}

--- a/test/Altinn.App.TestUtils/JsonCompare/JsonTokenStreamCompare.cs
+++ b/test/Altinn.App.TestUtils/JsonCompare/JsonTokenStreamCompare.cs
@@ -1,0 +1,121 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Altinn.App.TestUtils.JsonCompare;
+internal static class JsonTokenStreamCompare
+{
+    private const int CharCountBeforeError = 14;
+    private const int CharCountAfterError = 150;
+    private static readonly JsonComparatorOptions DefaultOptions = new();
+
+    internal static string? IsJsonTokenEquivalent(string actual, string expected, JsonComparatorOptions? options = null)
+    {
+        var actualBytes = System.Text.Encoding.UTF8.GetBytes(actual);
+        var expectedBytes = System.Text.Encoding.UTF8.GetBytes(expected);
+        return IsJsonTokenEquivalent(actualBytes, expectedBytes, options);
+    }
+
+    internal static string? IsJsonTokenEquivalent(byte[] actualBytes, byte[] expectedBytes, JsonComparatorOptions? options = null)
+    {
+        options ??= DefaultOptions;
+        var actual = new Utf8JsonReader(actualBytes, options.Value);
+        var expected = new Utf8JsonReader(expectedBytes, options.Value);
+        var comparisonResult = CompareReaders(ref actual, actualBytes, ref expected, expectedBytes);
+        return comparisonResult;
+    }
+
+    private static string? CompareReaders(ref Utf8JsonReader actual, byte[] actualBytes,
+        ref Utf8JsonReader expected, byte[] expectedBytes)
+    {
+        while (actual.Read() && expected.Read())
+        {
+            if (actual.TokenType != expected.TokenType)
+            {
+                return CreateErrorMessage("JsonTokenType mismatch", ref actual, actualBytes, ref expected, expectedBytes);
+            }
+
+            switch (actual.TokenType)
+            {
+                // Ignore tokens without value
+                case JsonTokenType.StartObject:
+                case JsonTokenType.EndObject:
+                case JsonTokenType.None:
+                case JsonTokenType.StartArray:
+                case JsonTokenType.EndArray:
+                case JsonTokenType.True:
+                case JsonTokenType.False:
+                case JsonTokenType.Null:
+                    break;
+
+                // compare the value of tokens with value
+                case JsonTokenType.PropertyName:
+                    if (!actual.ValueTextEquals(expected.ValueSpan))
+                    {
+                        return CreateErrorMessage("PropertyName mismatch (validate strict order)", ref actual, actualBytes, ref expected,
+                            expectedBytes);
+                    }
+
+                    break;
+                case JsonTokenType.String:
+                    if (!actual.ValueTextEquals(expected.ValueSpan))
+                    {
+                        return CreateErrorMessage("string mismatch", ref actual, actualBytes, ref expected, expectedBytes);
+                    }
+
+                    break;
+                case JsonTokenType.Comment: // compare comments if they are not ignored
+                    if (actual.GetComment() != expected.GetComment())
+                    {
+                        return CreateErrorMessage("comment mismatch", ref actual, actualBytes, ref expected, expectedBytes);
+                    }
+
+                    break;
+                case JsonTokenType.Number:
+                    if (actual.GetDecimal() != expected.GetDecimal())
+                    {
+                        return CreateErrorMessage("number mismatch", ref actual, actualBytes, ref expected, expectedBytes);
+                    }
+
+                    break;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? CreateErrorMessage(string message, ref Utf8JsonReader actual, ReadOnlySpan<byte> actualBytes,
+        ref Utf8JsonReader expected, ReadOnlySpan<byte> expectedBytes)
+    {
+        var actualCharacterPositionError = Encoding.UTF8.GetCharCount(actualBytes.Slice(0, (int)actual.TokenStartIndex)); // might be less than pos if there are multi byte characters
+        var expectedCharacterPositionError = Encoding.UTF8.GetCharCount(expectedBytes.Slice(0, (int)expected.TokenStartIndex)); // might be less than pos if there are multi byte characters
+
+        return $"""
+
+                {message}
+                {GetRelevantErrorPart((int)actual.TokenStartIndex, actualBytes)} (diff at index {actualCharacterPositionError})
+                {GetRelevantErrorPart((int)expected.TokenStartIndex, expectedBytes)} (diff at index {expectedCharacterPositionError})
+                {"^", CharCountBeforeError + 1}
+
+                """;
+    }
+
+    private static readonly Regex RemoveNewlinesAndIndetionRegex = new Regex(@"\r?\n\s*", RegexOptions.Compiled);
+
+    private static string GetRelevantErrorPart(int pos, ReadOnlySpan<byte> bytes)
+    {
+        var startBeforePos = Math.Max(0, pos - (CharCountBeforeError * 3)); // take 3 times as many utf8 bytes than characters (might be multi byte characters, and we remove newlines and indentation)
+        var lengthAfterPos = Math.Min(CharCountAfterError * 3, bytes.Length - pos); // take 3 times as many utf8 bytes than characters
+
+        var beforeErrorString = Encoding.UTF8.GetString(bytes.Slice(startBeforePos, pos - startBeforePos));
+        beforeErrorString = RemoveNewlinesAndIndetionRegex.Replace(beforeErrorString, " ")
+            .PadLeft(CharCountBeforeError);
+        beforeErrorString = beforeErrorString.Substring(beforeErrorString.Length - CharCountBeforeError);
+
+        var afterErrorString = Encoding.UTF8.GetString(bytes.Slice(pos, lengthAfterPos));
+        afterErrorString = RemoveNewlinesAndIndetionRegex.Replace(afterErrorString, " ");
+        afterErrorString = afterErrorString.Substring(0, Math.Min(afterErrorString.Length, CharCountAfterError));
+
+        return beforeErrorString + afterErrorString;
+    }
+}


### PR DESCRIPTION
See https://github.com/fluentassertions/fluentassertions/pull/2493

This greatly simplifies writing tests that ensure that a json response is the same as another without carefully ensuring that spaces are the same.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
