### PR TITLE
v7: Fix issue with non-ascii characters in code list parameters not being correctly encoded in parameter header.

### DIFF
--- a/src/Altinn.App.Api/Controllers/OptionsController.cs
+++ b/src/Altinn.App.Api/Controllers/OptionsController.cs
@@ -47,7 +47,7 @@ namespace Altinn.App.Api.Controllers
                 return NotFound();
             }
 
-            HttpContext.Response.Headers.Add("Altinn-DownstreamParameters", appOptions.Parameters.ToNameValueString(','));
+            HttpContext.Response.Headers.Append("Altinn-DownstreamParameters", appOptions.Parameters.ToUrlEncodedNameValueString(','));
 
             return Ok(appOptions.Options);
         }
@@ -88,7 +88,7 @@ namespace Altinn.App.Api.Controllers
                 return NotFound();
             }
 
-            HttpContext.Response.Headers.Add("Altinn-DownstreamParameters", appOptions.Parameters.ToNameValueString(','));
+            HttpContext.Response.Headers.Append("Altinn-DownstreamParameters", appOptions.Parameters.ToUrlEncodedNameValueString(','));
 
             return Ok(appOptions.Options);
         }

--- a/src/Altinn.App.Core/Extensions/DictionaryExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/DictionaryExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Net;
+using System.Text;
 
 namespace Altinn.App.Core.Extensions
 {
@@ -8,9 +9,9 @@ namespace Altinn.App.Core.Extensions
     public static class DictionaryExtensions
     {
         /// <summary>
-        /// Converts a dictionary to a name value string on the form key1=value1,key2=value2
+        /// Converts a dictionary to a name value string on the form key1=value1,key2=value2 url encoding both key and value.
         /// </summary>
-        public static string ToNameValueString(this Dictionary<string, string> parameters, char separator)
+        public static string ToUrlEncodedNameValueString(this Dictionary<string, string>? parameters, char separator)
         {
             if (parameters == null)
             {
@@ -24,8 +25,12 @@ namespace Altinn.App.Core.Extensions
                 {
                     builder.Append(separator);
                 }
-                builder.Append(param.Key + "=" + param.Value);
+
+                builder.Append(WebUtility.UrlEncode(param.Key));
+                builder.Append('=');
+                builder.Append(WebUtility.UrlEncode(param.Value));
             }
+
             return builder.ToString();
         }
     }

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 using FluentAssertions;
+using Moq;
 
 namespace Altinn.App.Api.Tests.Controllers
 {
@@ -16,6 +17,28 @@ namespace Altinn.App.Api.Tests.Controllers
 
         [Fact]
         public async Task Get_ShouldReturnParametersInHeader()
+        {
+            OverrideServicesForThisTest = (services) =>
+            {
+                services.AddTransient<IAppOptionsProvider, DummyProvider>();
+            };
+
+            string org = "tdd";
+            string app = "contributer-restriction";
+            HttpClient client = GetRootedClient(org, app);
+
+            string url = $"/{org}/{app}/api/options/test?language=esperanto";
+            HttpResponseMessage response = await client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+            response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+            var headerValue = response.Headers.GetValues("Altinn-DownstreamParameters");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            headerValue.Should().Contain("lang=esperanto");
+        }
+
+        [Fact]
+        public async Task Get_ShouldDefaultToNbLanguage()
         {
             OverrideServicesForThisTest = (services) =>
             {
@@ -45,7 +68,7 @@ namespace Altinn.App.Api.Tests.Controllers
             {
                 Parameters = new Dictionary<string, string>()
                 {
-                    { "lang", "nb" }
+                    { "lang", language ?? "nb" }
                 }
             };
 

--- a/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
@@ -21,7 +21,7 @@ namespace Altinn.App.Core.Tests.Extensions
 
             IHeaderDictionary headers = new HeaderDictionary
             {
-                { "Altinn-DownstreamParameters", options.Parameters.ToNameValueString(',') }
+                { "Altinn-DownstreamParameters", options.Parameters.ToUrlEncodedNameValueString(',') }
             };
 
             Assert.Equal("lang=nb,level=1", headers["Altinn-DownstreamParameters"]);
@@ -37,7 +37,7 @@ namespace Altinn.App.Core.Tests.Extensions
 
             IHeaderDictionary headers = new HeaderDictionary
             {
-                { "Altinn-DownstreamParameters", options.Parameters.ToNameValueString(',') }
+                { "Altinn-DownstreamParameters", options.Parameters.ToUrlEncodedNameValueString(',') }
             };
 
             Assert.Equal(string.Empty, headers["Altinn-DownstreamParameters"]);
@@ -48,15 +48,35 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Parameters = null
+                Parameters = null!
             };
 
             IHeaderDictionary headers = new HeaderDictionary
             {
-                { "Altinn-DownstreamParameters", options.Parameters.ToNameValueString(',') }
+                { "Altinn-DownstreamParameters", options.Parameters.ToUrlEncodedNameValueString(',') }
             };
 
             Assert.Equal(string.Empty, headers["Altinn-DownstreamParameters"]);
+        }
+
+        [Fact]
+        public void ToNameValueString_OptionParametersWithSpecialCharaters_IsValidAsHeaders()
+        {
+            var options = new AppOptions
+            {
+                Parameters = new Dictionary<string, string>
+                {
+                    { "lang", "nb" },
+                    { "level", "1" },
+                    { "name", "ÆØÅ" },
+                    { "variant", "Småvilt1" }
+                },
+            };
+
+            IHeaderDictionary headers = new HeaderDictionary();
+            headers.Add("Altinn-DownstreamParameters", options.Parameters.ToUrlEncodedNameValueString(','));
+
+            Assert.Equal("lang=nb,level=1,name=%C3%86%C3%98%C3%85,variant=Sm%C3%A5vilt1", headers["Altinn-DownstreamParameters"]);
         }
     }
 }


### PR DESCRIPTION
I tried adding some tests, but the ascii validation from the stack trace in https://github.com/Altinn/codelists-lib-dotnet/issues/23, does not seem to trigger with WebApplicationFactory. Thus this requires a manual test with an app.

## Related Issue(s)
- Likely fix https://github.com/Altinn/codelists-lib-dotnet/issues/23

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
