### PR TITLE
Add language to IDataProcessor and as an optional query param to apis

### DIFF
--- a/cli-tools/altinn-app-cli/v7Tov8/CodeRewriters/IDataProcessorRewriter.cs
+++ b/cli-tools/altinn-app-cli/v7Tov8/CodeRewriters/IDataProcessorRewriter.cs
@@ -52,20 +52,26 @@ namespace altinn_app_cli.v7Tov8.CodeRewriters
             if (processDataWrite.ParameterList.Parameters.Count == 3 &&
                 processDataWrite.ReturnType.ToString() == "Task<bool>")
             {
-                processDataWrite = AddParameter_ChangedFields(processDataWrite);
+                processDataWrite = AddParameterToProcessDataWrite(processDataWrite);
                 processDataWrite = ChangeReturnType_FromTaskBool_ToTask(processDataWrite);
             }
 
             return processDataWrite;
         }
 
-        private MethodDeclarationSyntax AddParameter_ChangedFields(MethodDeclarationSyntax method)
+        private MethodDeclarationSyntax AddParameterToProcessDataWrite(MethodDeclarationSyntax method)
         {
             return method.ReplaceNode(method.ParameterList,
-                method.ParameterList.AddParameters(SyntaxFactory.Parameter(SyntaxFactory.Identifier("previousData"))
-                    .WithLeadingTrivia(SyntaxFactory.Space)
-                    .WithType(SyntaxFactory.ParseTypeName("object?"))
-                    .WithLeadingTrivia(SyntaxFactory.Space)));
+                method.ParameterList.AddParameters(
+                    SyntaxFactory.Parameter(SyntaxFactory.Identifier("previousData"))
+                        .WithLeadingTrivia(SyntaxFactory.Space)
+                        .WithType(SyntaxFactory.ParseTypeName("object?"))
+                        .WithLeadingTrivia(SyntaxFactory.Space),
+                    SyntaxFactory.Parameter(SyntaxFactory.Identifier("language"))
+                        .WithLeadingTrivia(SyntaxFactory.Space)
+                        .WithType(SyntaxFactory.ParseTypeName("string?"))
+                        .WithLeadingTrivia(SyntaxFactory.Space)
+                    ));
         }
 
         private MethodDeclarationSyntax ChangeReturnType_FromTaskBool_ToTask(MethodDeclarationSyntax method)

--- a/src/Altinn.App.Api/Controllers/StatelessDataController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessDataController.cs
@@ -231,11 +231,7 @@ namespace Altinn.App.Api.Controllers
             await _prefillService.PrefillDataModel(owner.PartyId, dataType, appModel);
 
             Instance virtualInstance = new Instance() { InstanceOwner = owner };
-            foreach (var dataProcessor in _dataProcessors)
-            {
-                _logger.LogInformation("ProcessDataRead for {modelType} using {dataProcesor}", appModel.GetType().Name, dataProcessor.GetType().Name);
-                await dataProcessor.ProcessDataRead(virtualInstance, null, appModel, language);
-            }
+            await ProcessAllDataRead(virtualInstance, appModel, language);
 
             return Ok(appModel);
         }
@@ -278,11 +274,7 @@ namespace Altinn.App.Api.Controllers
             }
 
             Instance virtualInstance = new Instance();
-            foreach (var dataProcessor in _dataProcessors)
-            {
-                _logger.LogInformation("ProcessDataRead for {modelType} using {dataProcesor}", appModel.GetType().Name, dataProcessor.GetType().Name);
-                await dataProcessor.ProcessDataRead(virtualInstance, null, appModel, language);
-            }
+            await ProcessAllDataRead(virtualInstance, appModel, language);
 
             return Ok(appModel);
         }

--- a/src/Altinn.App.Api/Controllers/StatelessDataController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessDataController.cs
@@ -72,6 +72,7 @@ namespace Altinn.App.Api.Controllers
         /// <param name="app">application identifier which is unique within an organisation</param>
         /// <param name="dataType">The data type id</param>
         /// <param name="partyFromHeader">The party that should be represented with  prefix "partyId:", "person:" or "org:" (eg: "partyId:123")</param>
+        /// <param name="language">Currently selected language by the user (if available)</param>
         /// <returns>Return a new instance of the data object including prefill and initial calculations</returns>
         [Authorize]
         [HttpGet]
@@ -83,7 +84,8 @@ namespace Altinn.App.Api.Controllers
             [FromRoute] string org,
             [FromRoute] string app,
             [FromQuery] string dataType,
-            [FromHeader(Name = "party")] string partyFromHeader)
+            [FromHeader(Name = "party")] string partyFromHeader,
+            [FromQuery] string? language = null)
         {
             if (string.IsNullOrEmpty(dataType))
             {
@@ -116,12 +118,12 @@ namespace Altinn.App.Api.Controllers
             await _prefillService.PrefillDataModel(owner.PartyId, dataType, appModel);
 
             Instance virtualInstance = new Instance() { InstanceOwner = owner };
-            await ProcessAllDataRead(virtualInstance, appModel);
+            await ProcessAllDataRead(virtualInstance, appModel, language);
 
             return Ok(appModel);
         }
 
-        private async Task ProcessAllDataRead(Instance virtualInstance, object appModel)
+        private async Task ProcessAllDataRead(Instance virtualInstance, object appModel, string? language)
         {
             foreach (var dataProcessor in _dataProcessors)
             {
@@ -129,7 +131,7 @@ namespace Altinn.App.Api.Controllers
                     "ProcessDataRead for {modelType} using {dataProcesor}", 
                     appModel.GetType().Name,
                     dataProcessor.GetType().Name);
-                await dataProcessor.ProcessDataRead(virtualInstance, null, appModel);
+                await dataProcessor.ProcessDataRead(virtualInstance, null, appModel, language);
             }
         }
 
@@ -137,6 +139,7 @@ namespace Altinn.App.Api.Controllers
         /// Create a new data object of the defined data type
         /// </summary>
         /// <param name="dataType">The data type id</param>
+        /// <param name="language">The language selected by the user.</param>
         /// <returns>Return a new instance of the data object including prefill and initial calculations</returns>
         [AllowAnonymous]
         [HttpGet]
@@ -145,7 +148,9 @@ namespace Altinn.App.Api.Controllers
         [ProducesResponseType(typeof(DataElement), 200)]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         [Route("anonymous")]
-        public async Task<ActionResult> GetAnonymous([FromQuery] string dataType)
+        public async Task<ActionResult> GetAnonymous(
+            [FromQuery] string dataType,
+            [FromQuery] string? language = null)
         {
             if (string.IsNullOrEmpty(dataType))
             {
@@ -161,7 +166,7 @@ namespace Altinn.App.Api.Controllers
 
             object appModel = _appModel.Create(classRef);
             var virtualInstance = new Instance();
-            await ProcessAllDataRead(virtualInstance, appModel);
+            await ProcessAllDataRead(virtualInstance, appModel, language);
 
             return Ok(appModel);
         }
@@ -169,10 +174,11 @@ namespace Altinn.App.Api.Controllers
         /// <summary>
         /// Create a new data object of the defined data type
         /// </summary>
-        /// <param name="org">unique identfier of the organisation responsible for the app</param>
+        /// <param name="org">unique identifier of the organisation responsible for the app</param>
         /// <param name="app">application identifier which is unique within an organisation</param>
         /// <param name="dataType">The data type id</param>
         /// <param name="partyFromHeader">The party that should be represented with  prefix "partyId:", "person:" or "org:" (eg: "partyId:123")</param>
+        /// <param name="language">The language selected by the user.</param>
         /// <returns>Return a new instance of the data object including prefill and initial calculations</returns>
         [Authorize]
         [HttpPost]
@@ -184,7 +190,8 @@ namespace Altinn.App.Api.Controllers
             [FromRoute] string org,
             [FromRoute] string app,
             [FromQuery] string dataType,
-            [FromHeader(Name = "party")] string partyFromHeader)
+            [FromHeader(Name = "party")] string partyFromHeader,
+            [FromQuery] string? language = null)
         {
             if (string.IsNullOrEmpty(dataType))
             {
@@ -227,7 +234,7 @@ namespace Altinn.App.Api.Controllers
             foreach (var dataProcessor in _dataProcessors)
             {
                 _logger.LogInformation("ProcessDataRead for {modelType} using {dataProcesor}", appModel.GetType().Name, dataProcessor.GetType().Name);
-                await dataProcessor.ProcessDataRead(virtualInstance, null, appModel);
+                await dataProcessor.ProcessDataRead(virtualInstance, null, appModel, language);
             }
 
             return Ok(appModel);
@@ -237,6 +244,7 @@ namespace Altinn.App.Api.Controllers
         /// Create a new data object of the defined data type
         /// </summary>
         /// <param name="dataType">The data type id</param>
+        /// <param name="language">The language selected by the user.</param>
         /// <returns>Return a new instance of the data object including prefill and initial calculations</returns>
         [AllowAnonymous]
         [HttpPost]
@@ -245,7 +253,9 @@ namespace Altinn.App.Api.Controllers
         [ProducesResponseType(typeof(DataElement), 200)]
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         [Route("anonymous")]
-        public async Task<ActionResult> PostAnonymous([FromQuery] string dataType)
+        public async Task<ActionResult> PostAnonymous(
+            [FromQuery] string dataType,
+            [FromQuery] string? language = null)
         {
             if (string.IsNullOrEmpty(dataType))
             {
@@ -271,7 +281,7 @@ namespace Altinn.App.Api.Controllers
             foreach (var dataProcessor in _dataProcessors)
             {
                 _logger.LogInformation("ProcessDataRead for {modelType} using {dataProcesor}", appModel.GetType().Name, dataProcessor.GetType().Name);
-                await dataProcessor.ProcessDataRead(virtualInstance, null, appModel);
+                await dataProcessor.ProcessDataRead(virtualInstance, null, appModel, language);
             }
 
             return Ok(appModel);

--- a/src/Altinn.App.Core/Features/DataProcessing/GenericDataProcessor.cs
+++ b/src/Altinn.App.Core/Features/DataProcessing/GenericDataProcessor.cs
@@ -11,29 +11,29 @@ public abstract class GenericDataProcessor<TModel> : IDataProcessor where TModel
     /// Do changes to the model after it has been read from storage, but before it is returned to the app.
     /// this only executes on page load and not for subsequent updates.
     /// </summary>
-    public abstract Task ProcessDataRead(Instance instance, Guid? dataId, TModel model);
+    public abstract Task ProcessDataRead(Instance instance, Guid? dataId, TModel model, string? langauge);
 
     /// <summary>
     /// Do changes to the model before it is written to storage, and report back to frontend.
     /// Tyipically used to add calculated values to the model.
     /// </summary>
-    public abstract Task ProcessDataWrite(Instance instance, Guid? dataId, TModel model, TModel? previousModel);
+    public abstract Task ProcessDataWrite(Instance instance, Guid? dataId, TModel model, TModel? previousModel, string? language);
 
     /// <inheritdoc />
-    public async Task ProcessDataRead(Instance instance, Guid? dataId, object data)
+    public async Task ProcessDataRead(Instance instance, Guid? dataId, object data, string? language)
     {
         if (data is TModel model)
         {
-            await ProcessDataRead(instance, dataId, model);
+            await ProcessDataRead(instance, dataId, model, language);
         }
     }
 
     /// <inheritdoc />
-    public async Task ProcessDataWrite(Instance instance, Guid? dataId, object data, object? previousData)
+    public async Task ProcessDataWrite(Instance instance, Guid? dataId, object data, object? previousData, string? language)
     {
         if (data is TModel model)
         {
-            await ProcessDataWrite(instance, dataId, model, previousData as TModel);
+            await ProcessDataWrite(instance, dataId, model, previousData as TModel, language);
         }
     }
 }

--- a/src/Altinn.App.Core/Features/IDataProcessor.cs
+++ b/src/Altinn.App.Core/Features/IDataProcessor.cs
@@ -13,7 +13,8 @@ public interface IDataProcessor
     /// <param name="instance">Instance that data belongs to</param>
     /// <param name="dataId">Data id for the  data (nullable if stateless)</param>
     /// <param name="data">The data to perform calculations on</param>
-    public Task ProcessDataRead(Instance instance, Guid? dataId, object data);
+    /// <param name="language">The currently selected language of the user (if available)</param>
+    public Task ProcessDataRead(Instance instance, Guid? dataId, object data, string? language);
 
     /// <summary>
     /// Is called to run custom calculation events defined by app developer when data is written to app
@@ -22,5 +23,6 @@ public interface IDataProcessor
     /// <param name="dataId">Data id for the  data (nullable if stateless)</param>
     /// <param name="data">The data to perform calculations on</param>
     /// <param name="previousData">The previous data model (for running comparisons)</param>
-    public Task ProcessDataWrite(Instance instance, Guid? dataId, object data, object? previousData);
+    /// <param name="language">The currently selected language of the user (if available)</param>
+    public Task ProcessDataWrite(Instance instance, Guid? dataId, object data, object? previousData, string? language);
 }

--- a/src/Altinn.App.Core/Helpers/JsonHelper.cs
+++ b/src/Altinn.App.Core/Helpers/JsonHelper.cs
@@ -16,7 +16,7 @@ namespace Altinn.App.Core.Helpers
         /// <summary>
         /// Run DataProcessWrite returning the dictionary of the changed fields.
         /// </summary>
-        public static async Task<Dictionary<string, object?>?> ProcessDataWriteWithDiff(Instance instance, Guid dataGuid, object serviceModel, IEnumerable<IDataProcessor> dataProcessors, ILogger logger)
+        public static async Task<Dictionary<string, object?>?> ProcessDataWriteWithDiff(Instance instance, Guid dataGuid, object serviceModel, string? language, IEnumerable<IDataProcessor> dataProcessors, ILogger logger)
         {
             if (!dataProcessors.Any())
             {
@@ -27,7 +27,7 @@ namespace Altinn.App.Core.Helpers
             foreach (var dataProcessor in dataProcessors)
             {
                 logger.LogInformation("ProcessDataRead for {modelType} using {dataProcesor}", serviceModel.GetType().Name, dataProcessor.GetType().Name);
-                await dataProcessor.ProcessDataWrite(instance, dataGuid, serviceModel, null);
+                await dataProcessor.ProcessDataWrite(instance, dataGuid, serviceModel, null, language);
             }
 
             string updatedServiceModelString = System.Text.Json.JsonSerializer.Serialize(serviceModel);

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchFormDataImplementation.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchFormDataImplementation.cs
@@ -129,7 +129,7 @@ public class DataController_PatchFormDataImplementation : IAsyncDisposable
             }
         };
 
-        _dataProcessorMock.Setup(d => d.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<MyModel>(), It.IsAny<MyModel?>())).Returns((Instance i, Guid j, MyModel data, MyModel? oldData) => Task.CompletedTask);
+        _dataProcessorMock.Setup(d => d.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<MyModel>(), It.IsAny<MyModel?>(), null)).Returns((Instance i, Guid j, MyModel data, MyModel? oldData, string? language) => Task.CompletedTask);
         _formDataValidator.Setup(fdv => fdv.ValidateFormData(
             It.Is<Instance>(i => i == _instance),
             It.Is<DataElement>(de=>de == _dataElement),
@@ -137,7 +137,7 @@ public class DataController_PatchFormDataImplementation : IAsyncDisposable
             .ReturnsAsync(validationIssues);
 
         // Act
-        var (response, _) = await _dataController.PatchFormDataImplementation(_dataType, _dataElement, request, oldModel, _instance);
+        var (response, _) = await _dataController.PatchFormDataImplementation(_dataType, _dataElement, request, oldModel, null, _instance);
 
         // Assert
         response.Should().NotBeNull();
@@ -146,7 +146,7 @@ public class DataController_PatchFormDataImplementation : IAsyncDisposable
         validator.Key.Should().Be("formDataValidator");
         var issue = validator.Value.Should().ContainSingle().Which;
         issue.Description.Should().Be("First error");
-        _dataProcessorMock.Verify(d => d.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<MyModel>(), It.IsAny<MyModel?>()));
+        _dataProcessorMock.Verify(d => d.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<MyModel>(), It.IsAny<MyModel?>(), null));
     }
 
     public async ValueTask DisposeAsync()

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
@@ -74,8 +74,8 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
             JsonSerializer.Deserialize<Skjema>(readDataElementResponseContent)!;
         readDataElementResponseParsed.Melding.Name.Should().Be("Ola Olsen");
 
-        _dataProcessor.Verify(p => p.ProcessDataRead(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>()), Times.Exactly(1));
-        _dataProcessor.Verify(p => p.ProcessDataWrite(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>(), It.IsAny<Skjema?>()), Times.Exactly(1)); // TODO: Shouldn't this be 2 because of the first write?
+        _dataProcessor.Verify(p => p.ProcessDataRead(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>(), null), Times.Exactly(1));
+        _dataProcessor.Verify(p => p.ProcessDataWrite(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>(), It.IsAny<Skjema?>(), null), Times.Exactly(1)); // TODO: Shouldn't this be 2 because of the first write?
         _dataProcessor.VerifyNoOtherCalls();
     }
 
@@ -83,8 +83,8 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
     public async Task PutDataElement_TestMultiPartUpdateWithCustomDataProcessor_ReturnsOk()
     {
         // Run the previous test with a custom data processor
-        _dataProcessor.Setup(d => d.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<object>(), It.IsAny<object?>()))
-            .Returns((Instance instance, Guid dataGuid, object data, object previousData) =>
+        _dataProcessor.Setup(d => d.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<object>(), It.IsAny<object?>(), null))
+            .Returns((Instance instance, Guid dataGuid, object data, object previousData, string? language) =>
             {
                 if (data is Skjema skjema)
                 {
@@ -146,8 +146,8 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         readDataElementResponseParsed.Melding.Name.Should().Be("Ola Olsen");
         readDataElementResponseParsed.Melding.Toggle.Should().BeTrue();
 
-        _dataProcessor.Verify(p=>p.ProcessDataRead(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>()), Times.Exactly(2));
-        _dataProcessor.Verify(p => p.ProcessDataWrite(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>(), It.IsAny<Skjema?>()), Times.Exactly(1)); // TODO: Shouldn't this be 2 because of the first write?
+        _dataProcessor.Verify(p=>p.ProcessDataRead(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>(), null), Times.Exactly(2));
+        _dataProcessor.Verify(p => p.ProcessDataWrite(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>(), It.IsAny<Skjema?>(), null), Times.Exactly(1)); // TODO: Shouldn't this be 2 because of the first write?
         _dataProcessor.VerifyNoOtherCalls();
         
     }

--- a/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
@@ -345,7 +345,7 @@ public class StatelessDataControllerTests
         pdpMock.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()));
         appModelMock.Verify(a => a.Create(classRef), Times.Once);
         prefillMock.Verify(p => p.PrefillDataModel("12345", dataType, It.IsAny<DummyModel>(), null));
-        dataProcessorMock.Verify(a => a.ProcessDataRead(It.IsAny<Instance>(), null, It.IsAny<DummyModel>()));
+        dataProcessorMock.Verify(a => a.ProcessDataRead(It.IsAny<Instance>(), null, It.IsAny<DummyModel>(), null));
         registerMock.Verify(r=>r.GetParty(12345));
         appResourcesMock.VerifyNoOtherCalls();
         pdpMock.VerifyNoOtherCalls();

--- a/test/Altinn.App.Core.Tests/Features/DataProcessing/GenericDataProcessorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/DataProcessing/GenericDataProcessorTests.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using Altinn.App.Core.Features.DataProcessing;
+using Altinn.Platform.Storage.Interface.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Altinn.App.Core.Tests.Features.DataProcessing;
+
+public class GenericDataProcessorTests
+{
+    private class DummyModel
+    {
+    }
+
+    private class WrongModel
+    {
+    }
+
+    private class DummyProcessor : GenericDataProcessor<DummyModel>
+    {
+        public bool ReadCalled { get; set; } = false;
+
+        public bool WriteCalled { get; set; } = false;
+
+        public override Task ProcessDataRead(Instance instance, Guid? dataId, DummyModel model, string? langauge)
+        {
+            ReadCalled = true;
+            return Task.CompletedTask;
+        }
+
+        public override Task ProcessDataWrite(Instance instance, Guid? dataId, DummyModel model, DummyModel? previousModel, string? language)
+        {
+            WriteCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ShouldRunForCorrectType()
+    {
+        var processor = new DummyProcessor();
+        var data = new DummyModel();
+        await processor.ProcessDataRead(new Instance(), dataId: null, (object)data, language:null);
+        processor.ReadCalled.Should().BeTrue();
+        processor.WriteCalled.Should().BeFalse();
+        await processor.ProcessDataWrite(new Instance(), null, (object)data, null, null);
+        processor.ReadCalled.Should().BeTrue();
+        processor.WriteCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ShouldNotRunForIncorrectType()
+    {
+        var processor = new DummyProcessor();
+        var data = new WrongModel();
+        await processor.ProcessDataRead(new Instance(), dataId: null, (object)data, language:null);
+        processor.ReadCalled.Should().BeFalse();
+        processor.WriteCalled.Should().BeFalse();
+        await processor.ProcessDataWrite(new Instance(), null, (object)data, null, null);
+        processor.ReadCalled.Should().BeFalse();
+        processor.WriteCalled.Should().BeFalse();
+    }
+}

--- a/test/Altinn.App.Core.Tests/Helpers/JsonHelperTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/JsonHelperTests.cs
@@ -23,12 +23,12 @@ public class JsonHelperTests
         var logger = new Mock<ILogger>().Object;
         var guid = Guid.Empty;
         var dataProcessorMock = new Mock<IDataProcessor>();
-        Func<Instance, Guid, object, object?, Task<bool>> dataProcessWrite = (instance, guid, model, previousModel) => Task.FromResult(processDataWriteImpl((TModel)model));
+        Func<Instance, Guid, object, object?, string?, Task<bool>> dataProcessWrite = (instance, guid, model, previousModel, language) => Task.FromResult(processDataWriteImpl((TModel)model));
         dataProcessorMock
-            .Setup((d) => d.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<object>(), It.IsAny<object?>()))
+            .Setup((d) => d.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<object>(), It.IsAny<object?>(), null))
             .Returns(dataProcessWrite);
 
-        return await JsonHelper.ProcessDataWriteWithDiff(instance, guid, model, new IDataProcessor[] { dataProcessorMock.Object }, logger);
+        return await JsonHelper.ProcessDataWriteWithDiff(instance, guid, model, language:null, new IDataProcessor[] { dataProcessorMock.Object }, logger);
     }
 
     public class TestModel


### PR DESCRIPTION
In data processing it is sometimes valuable to know the language the user currently is showing in the schema. 

At least two cases comes to mind:
1. Saving the language to the data model for knowing the language to use for potential follow up with the reportee
2. Updating presentation values with correct language (`Uke 2 2023` vs `Week 2 2023`).

This PR also adds a Roslyn rewrite to fix the interface.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/16
- (Alternative solution for) https://github.com/Altinn/app-frontend-react/issues/1661

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
