### PR TITLE
Make language nullable in option lists and data lists

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataListsController.cs
+++ b/src/Altinn.App.Api/Controllers/DataListsController.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿#nullable enable
 using Altinn.App.Core.Features.DataLists;
 using Altinn.App.Core.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.App.Api.Controllers
@@ -30,15 +27,15 @@ namespace Altinn.App.Api.Controllers
         /// Api that exposes app related datalists
         /// </summary>
         /// <param name="id">The listId</param>
-        /// <param name="language">The language selected by the user.</param>
         /// <param name="queryParams">Query parameteres supplied</param>
+        /// <param name="language">The language selected by the user.</param>
         /// <returns>The data list</returns>
         [HttpGet]
         [Route("/{org}/{app}/api/datalists/{id}")]
         public async Task<IActionResult> Get(
             [FromRoute] string id,
-            [FromQuery] string language,
-            [FromQuery] Dictionary<string, string> queryParams)
+            [FromQuery] Dictionary<string, string> queryParams,
+            [FromQuery] string? language = null)
         {
             DataList dataLists = await _dataListsService.GetDataListAsync(id, language, queryParams);
             if (dataLists.ListItems == null)
@@ -55,8 +52,8 @@ namespace Altinn.App.Api.Controllers
         /// <param name="instanceOwnerPartyId">unique id of the party that is the owner of the instance</param>
         /// <param name="instanceGuid">unique id to identify the instance</param>
         /// <param name="id">The datalistId</param>
-        /// <param name="language">The language selected by the user.</param>
         /// <param name="queryParams">Query parameteres supplied</param>
+        /// <param name="language">The language selected by the user.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -67,8 +64,8 @@ namespace Altinn.App.Api.Controllers
             [FromRoute] int instanceOwnerPartyId,
             [FromRoute] Guid instanceGuid,
             [FromRoute] string id,
-            [FromQuery] string language,
-            [FromQuery] Dictionary<string, string> queryParams)
+            [FromQuery] Dictionary<string, string> queryParams,
+            [FromQuery] string? language = null)
         {
             var instanceIdentifier = new InstanceIdentifier(instanceOwnerPartyId, instanceGuid);
 

--- a/src/Altinn.App.Api/Controllers/OptionsController.cs
+++ b/src/Altinn.App.Api/Controllers/OptionsController.cs
@@ -34,16 +34,16 @@ namespace Altinn.App.Api.Controllers
         /// Api that exposes app related options
         /// </summary>
         /// <param name="optionsId">The optionsId</param>
+        /// <param name="queryParams">Query parameters supplied</param>
         /// <param name="language">The language selected by the user.</param>
-        /// <param name="queryParams">Query parameteres supplied</param>
         /// <returns>The options list</returns>
         [HttpGet("{optionsId}")]
         public async Task<IActionResult> Get(
             [FromRoute] string optionsId,
-            [FromQuery] string? language,
-            [FromQuery] Dictionary<string, string> queryParams)
+            [FromQuery] Dictionary<string, string> queryParams,
+            [FromQuery] string? language = null)
         {
-            AppOptions appOptions = await _appOptionsService.GetOptionsAsync(optionsId, language ?? "nb", queryParams);
+            AppOptions appOptions = await _appOptionsService.GetOptionsAsync(optionsId, language, queryParams);
             if (appOptions.Options == null)
             {
                 return NotFound();

--- a/src/Altinn.App.Core/Extensions/DictionaryExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/DictionaryExtensions.cs
@@ -11,7 +11,7 @@ namespace Altinn.App.Core.Extensions
         /// <summary>
         /// Converts a dictionary to a name value string on the form key1=value1,key2=value2 url encoding both key and value.
         /// </summary>
-        public static string ToUrlEncodedNameValueString(this Dictionary<string, string>? parameters, char separator)
+        public static string ToUrlEncodedNameValueString(this Dictionary<string, string?>? parameters, char separator)
         {
             if (parameters == null)
             {

--- a/src/Altinn.App.Core/Features/DataLists/DataListsService.cs
+++ b/src/Altinn.App.Core/Features/DataLists/DataListsService.cs
@@ -25,13 +25,13 @@ namespace Altinn.App.Core.Features.DataLists
         }
 
         /// <inheritdoc/>
-        public async Task<DataList> GetDataListAsync(string dataListId, string language, Dictionary<string, string> keyValuePairs)
+        public async Task<DataList> GetDataListAsync(string dataListId, string? language, Dictionary<string, string> keyValuePairs)
         {
             return await _dataListsFactory.GetDataListProvider(dataListId).GetDataListAsync(language, keyValuePairs);
         }
 
         /// <inheritdoc />
-        public async Task<DataList> GetDataListAsync(InstanceIdentifier instanceIdentifier, string dataListId, string language, Dictionary<string, string> keyValuePairs)
+        public async Task<DataList> GetDataListAsync(InstanceIdentifier instanceIdentifier, string dataListId, string? language, Dictionary<string, string> keyValuePairs)
         {
             return await _instanceDataListsFactory.GetDataListProvider(dataListId).GetInstanceDataListAsync(instanceIdentifier, language, keyValuePairs);
         }

--- a/src/Altinn.App.Core/Features/DataLists/IDataListsService.cs
+++ b/src/Altinn.App.Core/Features/DataLists/IDataListsService.cs
@@ -19,7 +19,7 @@ namespace Altinn.App.Core.Features.DataLists
         /// <param name="language">The language code requested.</param>
         /// <param name="keyValuePairs">Optional list of key/value pairs to use for filtering and further lookup.</param>
         /// <returns>The list of options</returns>
-        Task<DataList> GetDataListAsync(string dataListId, string language, Dictionary<string, string> keyValuePairs);
+        Task<DataList> GetDataListAsync(string dataListId, string? language, Dictionary<string, string> keyValuePairs);
 
         /// <summary>
         /// Get the list of instance specific datalist for a specific data list based on the <see cref="InstanceIdentifier"/>
@@ -31,6 +31,6 @@ namespace Altinn.App.Core.Features.DataLists
         /// <param name="language">The language code requested.</param>
         /// <param name="keyValuePairs">Optional list of key/value pairs to use for filtering and further lookup.</param>
         /// <returns>The list of options</returns>
-        Task<DataList> GetDataListAsync(InstanceIdentifier instanceIdentifier, string dataListId, string language, Dictionary<string, string> keyValuePairs);
+        Task<DataList> GetDataListAsync(InstanceIdentifier instanceIdentifier, string dataListId, string? language, Dictionary<string, string> keyValuePairs);
     }
 }

--- a/src/Altinn.App.Core/Features/DataLists/NullDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/DataLists/NullDataListProvider.cs
@@ -18,7 +18,7 @@ namespace Altinn.App.Core.Features.DataLists
         public string Id => string.Empty;
 
         /// <inheritdoc/>
-        public Task<DataList> GetDataListAsync(string language, Dictionary<string, string> keyValuePairs)
+        public Task<DataList> GetDataListAsync(string? language, Dictionary<string, string> keyValuePairs)
         {
             return Task.FromResult(new DataList() { ListItems = null });
         }

--- a/src/Altinn.App.Core/Features/DataLists/NullInstanceDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/DataLists/NullInstanceDataListProvider.cs
@@ -18,7 +18,7 @@ namespace Altinn.App.Core.Features.DataLists
         public string Id => string.Empty;
 
         /// <inheritdoc/>
-        public Task<DataList> GetInstanceDataListAsync(InstanceIdentifier instanceIdentifier, string language, Dictionary<string, string> keyValuePairs)
+        public Task<DataList> GetInstanceDataListAsync(InstanceIdentifier instanceIdentifier, string? language, Dictionary<string, string> keyValuePairs)
         {
             return Task.FromResult(new DataList() { ListItems = null });
         }

--- a/src/Altinn.App.Core/Features/IAppOptionsProvider.cs
+++ b/src/Altinn.App.Core/Features/IAppOptionsProvider.cs
@@ -20,6 +20,6 @@ namespace Altinn.App.Core.Features
         /// <param name="keyValuePairs">Key/value pairs to control what options to get.
         /// When called from the options controller this will be the querystring key/value pairs.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<AppOptions> GetAppOptionsAsync(string language, Dictionary<string, string> keyValuePairs);
+        Task<AppOptions> GetAppOptionsAsync(string? language, Dictionary<string, string> keyValuePairs);
     }
 }

--- a/src/Altinn.App.Core/Features/IDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/IDataListProvider.cs
@@ -25,6 +25,6 @@ namespace Altinn.App.Core.Features
         /// <param name="keyValuePairs">Key/value pairs to control what options to get.
         /// When called from the data lists controller this will be the querystring key/value pairs.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<DataList> GetDataListAsync(string language, Dictionary<string, string> keyValuePairs);
+        Task<DataList> GetDataListAsync(string? language, Dictionary<string, string> keyValuePairs);
     }
 }

--- a/src/Altinn.App.Core/Features/IInstanceAppOptionsProvider.cs
+++ b/src/Altinn.App.Core/Features/IInstanceAppOptionsProvider.cs
@@ -21,6 +21,6 @@ namespace Altinn.App.Core.Features
         /// <param name="keyValuePairs">Key/value pairs to control what options to get.
         /// When called from the options controller this will be the querystring key/value pairs.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<AppOptions> GetInstanceAppOptionsAsync(InstanceIdentifier instanceIdentifier, string language, Dictionary<string, string> keyValuePairs);
+        Task<AppOptions> GetInstanceAppOptionsAsync(InstanceIdentifier instanceIdentifier, string? language, Dictionary<string, string> keyValuePairs);
     }
 }

--- a/src/Altinn.App.Core/Features/IInstanceDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataListProvider.cs
@@ -26,6 +26,6 @@ namespace Altinn.App.Core.Features
         /// <param name="keyValuePairs">Key/value pairs to control what options to get.
         /// When called from the data lists controller this will be the querystring key/value pairs.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<DataList> GetInstanceDataListAsync(InstanceIdentifier instanceIdentifier, string language, Dictionary<string, string> keyValuePairs);
+        Task<DataList> GetInstanceDataListAsync(InstanceIdentifier instanceIdentifier, string? language, Dictionary<string, string> keyValuePairs);
     }
 }

--- a/src/Altinn.App.Core/Features/Options/Altinn2Provider/Altinn2CodeListProvider.cs
+++ b/src/Altinn.App.Core/Features/Options/Altinn2Provider/Altinn2CodeListProvider.cs
@@ -60,7 +60,7 @@ namespace Altinn.App.Core.Features.Options.Altinn2Provider
         /// <summary>
         /// Utility method if you need the raw codelist for dataprocessinghandler
         /// </summary>
-        public async Task<MetadataCodelistResponse> GetRawAltinn2CodelistAsync(string language)
+        public async Task<MetadataCodelistResponse> GetRawAltinn2CodelistAsync(string? language)
         {
             var langCode = language switch
             {
@@ -79,7 +79,7 @@ namespace Altinn.App.Core.Features.Options.Altinn2Provider
         }
 
         /// <inheritdoc/>
-        public async Task<AppOptions> GetAppOptionsAsync(string language, Dictionary<string, string> keyValuePairs)
+        public async Task<AppOptions> GetAppOptionsAsync(string? language, Dictionary<string, string> keyValuePairs)
         {
             var codelist = await GetRawAltinn2CodelistAsync(language);
 

--- a/src/Altinn.App.Core/Features/Options/AppOptionsService.cs
+++ b/src/Altinn.App.Core/Features/Options/AppOptionsService.cs
@@ -20,13 +20,13 @@ namespace Altinn.App.Core.Features.Options
         }
 
         /// <inheritdoc/>
-        public async Task<AppOptions> GetOptionsAsync(string optionId, string language, Dictionary<string, string> keyValuePairs)
+        public async Task<AppOptions> GetOptionsAsync(string optionId, string? language, Dictionary<string, string> keyValuePairs)
         {
             return await _appOpptionsFactory.GetOptionsProvider(optionId).GetAppOptionsAsync(language, keyValuePairs);
         }
 
         /// <inheritdoc/>
-        public async Task<AppOptions> GetOptionsAsync(InstanceIdentifier instanceIdentifier, string optionId, string language, Dictionary<string, string> keyValuePairs)
+        public async Task<AppOptions> GetOptionsAsync(InstanceIdentifier instanceIdentifier, string optionId, string? language, Dictionary<string, string> keyValuePairs)
         {
             return await _instanceAppOptionsFactory.GetOptionsProvider(optionId).GetInstanceAppOptionsAsync(instanceIdentifier, language, keyValuePairs);
         }

--- a/src/Altinn.App.Core/Features/Options/DefaultAppOptionsProvider.cs
+++ b/src/Altinn.App.Core/Features/Options/DefaultAppOptionsProvider.cs
@@ -24,7 +24,7 @@ namespace Altinn.App.Core.Features.Options
         public string Id { get; internal set; } = "default";
 
         /// <inheritdoc/>
-        public async Task<AppOptions> GetAppOptionsAsync(string language, Dictionary<string, string> keyValuePairs)
+        public async Task<AppOptions> GetAppOptionsAsync(string? language, Dictionary<string, string> keyValuePairs)
         {
             // This will get static options if it exists
             var appOptions = new AppOptions

--- a/src/Altinn.App.Core/Features/Options/IAppOptionsService.cs
+++ b/src/Altinn.App.Core/Features/Options/IAppOptionsService.cs
@@ -14,7 +14,7 @@ namespace Altinn.App.Core.Features.Options
         /// <param name="language">The language code requested.</param>
         /// <param name="keyValuePairs">Optional list of key/value pairs to use for filtering and further lookup.</param>
         /// <returns>The list of options</returns>
-        Task<AppOptions> GetOptionsAsync(string optionId, string language, Dictionary<string, string> keyValuePairs);
+        Task<AppOptions> GetOptionsAsync(string optionId, string? language, Dictionary<string, string> keyValuePairs);
 
         /// <summary>
         /// Get the list of instance specific options for a specific options list based on the <see cref="InstanceIdentifier"/>
@@ -26,6 +26,6 @@ namespace Altinn.App.Core.Features.Options
         /// <param name="language">The language code requested.</param>
         /// <param name="keyValuePairs">Optional list of key/value pairs to use for filtering and further lookup.</param>
         /// <returns>The list of options</returns>
-        Task<AppOptions> GetOptionsAsync(InstanceIdentifier instanceIdentifier, string optionId, string language, Dictionary<string, string> keyValuePairs);
+        Task<AppOptions> GetOptionsAsync(InstanceIdentifier instanceIdentifier, string optionId, string? language, Dictionary<string, string> keyValuePairs);
     }
 }

--- a/src/Altinn.App.Core/Features/Options/NullInstanceAppOptionsProvider.cs
+++ b/src/Altinn.App.Core/Features/Options/NullInstanceAppOptionsProvider.cs
@@ -13,7 +13,7 @@ namespace Altinn.App.Core.Features.Options
         public string Id => string.Empty;
 
         /// <inheritdoc/>
-        public Task<AppOptions> GetInstanceAppOptionsAsync(InstanceIdentifier instanceIdentifier, string language, Dictionary<string, string> keyValuePairs)
+        public Task<AppOptions> GetInstanceAppOptionsAsync(InstanceIdentifier instanceIdentifier, string? language, Dictionary<string, string> keyValuePairs)
         {
             return Task.FromResult<AppOptions>(new AppOptions() { IsCacheable = false, Options = null });
         }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfOptionsMapping.cs
@@ -71,7 +71,7 @@ public class PdfOptionsMapping : IPdfOptionsMapping
         }
     }
 
-    private async Task<AppOptions> GetOptions(bool isSecure, InstanceIdentifier instanceIdentifier, string optionsId, string language, Dictionary<string, string> mappings)
+    private async Task<AppOptions> GetOptions(bool isSecure, InstanceIdentifier instanceIdentifier, string optionsId, string? language, Dictionary<string, string> mappings)
     {
         if (isSecure)
         {

--- a/src/Altinn.App.Core/Models/AppOptions.cs
+++ b/src/Altinn.App.Core/Models/AppOptions.cs
@@ -17,7 +17,7 @@ namespace Altinn.App.Core.Models
         /// The dictionary key is the name of the parameter and the value is the value of the parameter.
         /// This can be used to document the parameters used to generate the options.
         /// </summary>
-        public Dictionary<string, string> Parameters{ get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, string?> Parameters { get; set; } = new Dictionary<string, string?>();
 
         /// <summary>
         /// Gets or sets a value indicating whether the options can be cached.

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -38,7 +38,7 @@ namespace Altinn.App.Api.Tests.Controllers
         }
 
         [Fact]
-        public async Task Get_ShouldDefaultToNbLanguage()
+        public async Task Get_ShouldNotDefaultToNbLanguage()
         {
             OverrideServicesForThisTest = (services) =>
             {
@@ -56,7 +56,7 @@ namespace Altinn.App.Api.Tests.Controllers
 
             var headerValue = response.Headers.GetValues("Altinn-DownstreamParameters");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
-            headerValue.Should().Contain("lang=nb");
+            headerValue.Should().NotContain("nb");
         }
     }
 

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -64,11 +64,11 @@ namespace Altinn.App.Api.Tests.Controllers
     {
         public string Id => "test";
 
-        public Task<AppOptions> GetAppOptionsAsync(string language, Dictionary<string, string> keyValuePairs)
+        public Task<AppOptions> GetAppOptionsAsync(string? language, Dictionary<string, string> keyValuePairs)
         {
             AppOptions appOptions = new AppOptions()
             {
-                Parameters = new Dictionary<string, string>()
+                Parameters = new()
                 {
                     { "lang", language }
                 }


### PR DESCRIPTION
Make language parameter nullable to match dataProcessWrite in #405 
Now that we can rewrite interfaces to nullable in all apps on upgrade, it makes much more sense to make language nullable than to have `"nb"` as a default language.

Note that functionally this is a revert of some changes in #328, so should be good.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
