### PR TITLE
Support number, boolean and null as AppOption values

### DIFF
--- a/src/Altinn.App.Core/Models/AppOption.cs
+++ b/src/Altinn.App.Core/Models/AppOption.cs
@@ -99,7 +99,7 @@ namespace Altinn.App.Core.Models
                         case "description":
                             description = reader.GetString();
                             break;
-                        case "helpText":
+                        case "helptext":
                             helpText = reader.GetString();
                             break;
                         default:

--- a/src/Altinn.App.Core/Models/AppOption.cs
+++ b/src/Altinn.App.Core/Models/AppOption.cs
@@ -1,19 +1,29 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace Altinn.App.Core.Models
 {
     /// <summary>
     /// Represents a key value pair to be used as options in dropdown selectors.
     /// </summary>
+    [JsonConverter(typeof(AppOptionConverter))]
     public class AppOption
     {
         /// <summary>
         /// The value of a given option
         /// </summary>
-        public string Value { get; set; }
+        public required string? Value { get; set; }
+
+        /// <summary>
+        /// The type of the value for Json serialization
+        /// </summary>
+        public AppOptionValueType ValueType { get; set; }
 
         /// <summary>
         /// The label of a given option
         /// </summary>
-        public string Label { get; set; }
+        public required string Label { get; set; }
 
         /// <summary>
         /// The description of a given option
@@ -24,5 +34,141 @@ namespace Altinn.App.Core.Models
         /// The help text of a given option
         /// </summary>
         public string? HelpText { get; set; }
+    }
+
+    /// <summary>
+    /// The type of the value for Json serialization
+    /// Application developers must set this, if they want options that isn't strings.
+    /// </summary>
+    public enum AppOptionValueType
+    {
+        /// <summary>
+        /// Default value, will be serialized as a string if not specified
+        /// </summary>
+        String,
+        /// <summary>
+        /// The app option value is a number and can be bound to a numeric field
+        /// </summary>
+        Number,
+        /// <summary>
+        /// The app option value is a boolean and can be bound to a boolean field
+        /// </summary>
+        Boolean,
+        /// <summary>
+        /// The app option value is null and can be used to signal that the option is not set
+        /// </summary>
+        Null,
+    }
+
+    internal class AppOptionConverter : JsonConverter<AppOption>
+    {
+        public override AppOption Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string? value = null;
+            string? label = null;
+            string? description = null;
+            string? helpText = null;
+            AppOptionValueType valueType = AppOptionValueType.Null;
+
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = reader.GetString();
+                    reader.Read();
+                    switch (propertyName)
+                    {
+                        case "value":
+                            switch (reader.TokenType)
+                            {
+                                case JsonTokenType.String:
+                                    value = reader.GetString();
+                                    valueType = AppOptionValueType.String;
+                                    break;
+                                case JsonTokenType.Number:
+                                    value = reader.GetDouble().ToString(CultureInfo.InvariantCulture);
+                                    valueType = AppOptionValueType.Number;
+                                    break;
+                                case JsonTokenType.True:
+                                case JsonTokenType.False:
+                                    value = reader.GetBoolean() ? "true" : "false";
+                                    valueType = AppOptionValueType.Boolean;
+                                    break;
+                                case JsonTokenType.Null:
+                                    value = null;
+                                    valueType = AppOptionValueType.Null;
+                                    break;
+                                default:
+                                    throw new JsonException($"Unexpected token type {reader.TokenType} for property 'value' on AppOption");
+                            }
+                            break;
+                        case "label":
+                            label = reader.GetString();
+                            break;
+                        case "description":
+                            description = reader.GetString();
+                            break;
+                        case "helpText":
+                            helpText = reader.GetString();
+                            break;
+                        default:
+                            throw new JsonException($"Unknown property {propertyName ?? "'NULL'"} on AppOption");
+                    }
+                }
+            }
+
+            return new AppOption
+            {
+                Value = value,
+                ValueType = valueType,
+                Label = label ?? throw new JsonException("Missing required property 'label' on AppOption"),
+                Description = description,
+                HelpText = helpText,
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, AppOption value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            switch (value.ValueType)
+            {
+                case AppOptionValueType.String:
+                    writer.WriteString("value", value.Value);
+                    break;
+                case AppOptionValueType.Boolean:
+                    writer.WriteBoolean("value", value.Value switch
+                    {
+                        "true" => true,
+                        "false" => false,
+                        _ => throw new JsonException($"Unable to parse value {value.Value} as a boolean on AppOption")
+                    });
+                    break;
+                case AppOptionValueType.Number:
+                    if (double.TryParse(value.Value, out double doubleValue))
+                    {
+                        writer.WriteNumber("value", doubleValue);
+                    }
+                    else
+                    {
+                        throw new JsonException($"Unable to parse value {value.Value} as a number on AppOption");
+                    }
+
+                    break;
+                case AppOptionValueType.Null:
+                    writer.WriteNull("value");
+                    break;
+                default:
+                    throw new JsonException($"Unknown value type {value.ValueType} on AppOption");
+            }
+            if (!string.IsNullOrEmpty(value.Description))
+            {
+                writer.WriteString("description", value.Description);
+            }
+            if (!string.IsNullOrEmpty(value.HelpText))
+            {
+                writer.WriteString("helpText", value.HelpText);
+            }
+            writer.WriteEndObject();
+        }
     }
 }

--- a/src/Altinn.App.Core/Models/AppOption.cs
+++ b/src/Altinn.App.Core/Models/AppOption.cs
@@ -13,26 +13,34 @@ namespace Altinn.App.Core.Models
         /// <summary>
         /// The value of a given option
         /// </summary>
+        [JsonPropertyName("value")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         public required string? Value { get; set; }
 
         /// <summary>
         /// The type of the value for Json serialization
         /// </summary>
+        [JsonIgnore]
         public AppOptionValueType ValueType { get; set; }
 
         /// <summary>
         /// The label of a given option
         /// </summary>
+        [JsonPropertyName("label")]
         public required string Label { get; set; }
 
         /// <summary>
         /// The description of a given option
         /// </summary>
+        [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? Description { get; set; }
 
         /// <summary>
         /// The help text of a given option
         /// </summary>
+        [JsonPropertyName("helpText")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? HelpText { get; set; }
     }
 
@@ -60,6 +68,10 @@ namespace Altinn.App.Core.Models
         Null,
     }
 
+    /// <summary>
+    /// A converter for AppOption that can handle the different value types
+    /// This will override [JsonPropertyName] annotatinos, but I keep them for documentation purposes
+    /// </summary>
     internal class AppOptionConverter : JsonConverter<AppOption>
     {
         public override AppOption Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -76,7 +88,7 @@ namespace Altinn.App.Core.Models
                 {
                     var propertyName = reader.GetString();
                     reader.Read();
-                    switch (propertyName)
+                    switch (propertyName.ToLowerInvariant())
                     {
                         case "value":
                             switch (reader.TokenType)
@@ -160,6 +172,9 @@ namespace Altinn.App.Core.Models
                 default:
                     throw new JsonException($"Unknown value type {value.ValueType} on AppOption");
             }
+
+            writer.WriteString("label", value.Label);
+
             if (!string.IsNullOrEmpty(value.Description))
             {
                 writer.WriteString("description", value.Description);

--- a/src/Altinn.App.Core/Models/AppOption.cs
+++ b/src/Altinn.App.Core/Models/AppOption.cs
@@ -88,31 +88,10 @@ namespace Altinn.App.Core.Models
                 {
                     var propertyName = reader.GetString();
                     reader.Read();
-                    switch (propertyName.ToLowerInvariant())
+                    switch (propertyName?.ToLowerInvariant())
                     {
                         case "value":
-                            switch (reader.TokenType)
-                            {
-                                case JsonTokenType.String:
-                                    value = reader.GetString();
-                                    valueType = AppOptionValueType.String;
-                                    break;
-                                case JsonTokenType.Number:
-                                    value = reader.GetDouble().ToString(CultureInfo.InvariantCulture);
-                                    valueType = AppOptionValueType.Number;
-                                    break;
-                                case JsonTokenType.True:
-                                case JsonTokenType.False:
-                                    value = reader.GetBoolean() ? "true" : "false";
-                                    valueType = AppOptionValueType.Boolean;
-                                    break;
-                                case JsonTokenType.Null:
-                                    value = null;
-                                    valueType = AppOptionValueType.Null;
-                                    break;
-                                default:
-                                    throw new JsonException($"Unexpected token type {reader.TokenType} for property 'value' on AppOption");
-                            }
+                            ReadValue(ref reader, out value, out valueType);
                             break;
                         case "label":
                             label = reader.GetString();
@@ -137,6 +116,32 @@ namespace Altinn.App.Core.Models
                 Description = description,
                 HelpText = helpText,
             };
+        }
+
+        private static void ReadValue(ref Utf8JsonReader reader, out string? value, out AppOptionValueType valueType)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.String:
+                    value = reader.GetString();
+                    valueType = AppOptionValueType.String;
+                    break;
+                case JsonTokenType.Number:
+                    value = reader.GetDouble().ToString(CultureInfo.InvariantCulture);
+                    valueType = AppOptionValueType.Number;
+                    break;
+                case JsonTokenType.True:
+                case JsonTokenType.False:
+                    value = reader.GetBoolean() ? "true" : "false";
+                    valueType = AppOptionValueType.Boolean;
+                    break;
+                case JsonTokenType.Null:
+                    value = null;
+                    valueType = AppOptionValueType.Null;
+                    break;
+                default:
+                    throw new JsonException($"Unexpected token type {reader.TokenType} for property 'value' on AppOption");
+            }
         }
 
         public override void Write(Utf8JsonWriter writer, AppOption value, JsonSerializerOptions options)

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -58,6 +58,28 @@ namespace Altinn.App.Api.Tests.Controllers
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             headerValue.Should().NotContain("nb");
         }
+
+        [Fact]
+        public async Task Get_ShouldSerializeToCorrectTypes()
+        {
+            OverrideServicesForThisTest = (services) =>
+            {
+                services.AddTransient<IAppOptionsProvider, DummyProvider>();
+            };
+
+            string org = "tdd";
+            string app = "contributer-restriction";
+            HttpClient client = GetRootedClient(org, app);
+
+            string url = $"/{org}/{app}/api/options/test";
+            HttpResponseMessage response = await client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+            response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var options = await response.Content.ReadAsStringAsync();
+            options.Should().Be("[{\"value\":null,\"label\":\"\"},{\"value\":\"SomeString\",\"label\":\"False\"},{\"value\":true,\"label\":\"True\"},{\"value\":0,\"label\":\"Zero\"},{\"value\":1,\"label\":\"One\",\"description\":\"This is a description\",\"helpText\":\"This is a help text\"}]");
+        }
     }
 
     public class DummyProvider : IAppOptionsProvider
@@ -71,6 +93,39 @@ namespace Altinn.App.Api.Tests.Controllers
                 Parameters = new()
                 {
                     { "lang", language }
+                },
+                Options = new List<AppOption>()
+                {
+                    new()
+                    {
+                        Value  = null,
+                        Label = "",
+                    },
+                    new ()
+                    {
+                        Value = "SomeString",
+                        Label = "False",
+                    },
+                    new ()
+                    {
+                        Value = "true",
+                        ValueType = AppOptionValueType.Boolean,
+                        Label = "True",
+                    },
+                    new ()
+                    {
+                        Value = "0",
+                        ValueType = AppOptionValueType.Number,
+                        Label = "Zero",
+                    },
+                    new ()
+                    {
+                        Value = "1",
+                        ValueType = AppOptionValueType.Number,
+                        Label = "One",
+                        Description = "This is a description",
+                        HelpText = "This is a help text"
+                    },
                 }
             };
 

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/FirstPage.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/FirstPage.json
@@ -27,7 +27,9 @@
           },
           {
             "label": "boolean",
-            "value": true
+            "value": true,
+            "description": "boolean description",
+            "helpText": "boolean help text"
           }
         ]
       },

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/FirstPage.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/FirstPage.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4.0.0-rc1/schemas/json/layout/layout.schema.v1.json",
   "data": {
     "layout": [
       {
@@ -9,7 +9,26 @@
           "simpleBinding": "some.notRepeating"
         },
         "options": [
-          { "label": "Vis gruppe", "value": "showGroup" }
+          {
+            "label": "",
+            "value": null
+          },
+          {
+            "label": "Vis gruppe",
+            "value": "showGroup"
+          },
+          {
+            "label": "Skjul gruppe",
+            "value": "hideGroup"
+          },
+          {
+            "label": "tall",
+            "value": 12
+          },
+          {
+            "label": "boolean",
+            "value": true
+          }
         ]
       },
       {

--- a/test/Altinn.App.Core.Tests/Models/page-component-converter-tests/grid.json
+++ b/test/Altinn.App.Core.Tests/Models/page-component-converter-tests/grid.json
@@ -131,11 +131,11 @@
           "options": [
             {
               "label": "Ja",
-              "value": "ja"
+              "value": true
             },
             {
               "label": "Nei",
-              "value": "nei"
+              "value": false
             }
           ],
           "grid": {


### PR DESCRIPTION
Add support for multiple types as AppOptionValues. The internal representation is still string for simplicity for app developers and backwards compatibility, but you can specify a type for json serialisation.


## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/413

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
