### PR TITLE
Always return 200 for success in PUT formdata api

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -317,7 +317,7 @@ namespace Altinn.App.Api.Controllers
         [DisableFormValueModelBinding]
         [RequestSizeLimit(REQUEST_SIZE_LIMIT)]
         [ProducesResponseType(typeof(DataElement), 201)]
-        [ProducesResponseType(typeof(CalculationResult), 303)]
+        [ProducesResponseType(typeof(CalculationResult), 200)]
         public async Task<ActionResult> Put(
             [FromRoute] string org,
             [FromRoute] string app,
@@ -835,7 +835,7 @@ namespace Altinn.App.Api.Controllers
                 {
                     ChangedFields = changedFields
                 };
-                return StatusCode((int)HttpStatusCode.SeeOther, calculationResult);
+                return Ok(calculationResult);
             }
 
             return Created(dataUrl, updatedDataElement);

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
@@ -135,7 +135,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         using var updateDataElementContent =
             new StringContent("""{"melding":{"name": "Ola Olsen"}}""", System.Text.Encoding.UTF8, "application/json");
         var response = await client.PutAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}", updateDataElementContent);
-        response.StatusCode.Should().Be(HttpStatusCode.SeeOther);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
 
         // Verify stored data


### PR DESCRIPTION
As requested in https://github.com/Altinn/app-lib-dotnet/issues/52

Not sure this change is worth it, but we should not keep simple issues open for so long and v8 is a great time to change this.

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/52

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
