### PR TITLE
Fix bugs with new Validation and PATCH endpoint

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -507,9 +507,7 @@ namespace Altinn.App.Api.Controllers
             // Ensure that all lists are changed from null to empty list.
             ObjectUtils.InitializeListsAndNullEmptyStrings(model);
 
-            var changedFields = dataPatchRequest.Patch.Operations.Select(o => o.Path.ToString()).ToList();
-
-            var validationIssues = await _validationService.ValidateFormData(instance, dataElement, dataType, model, changedFields, dataPatchRequest.IgnoredValidators);
+            var validationIssues = await _validationService.ValidateFormData(instance, dataElement, dataType, model, oldModel, dataPatchRequest.IgnoredValidators);
             var response = new DataPatchResponse
             {
                 NewDataModel = model,

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -181,18 +181,18 @@ namespace Altinn.App.Core.Extensions
             services.TryAddTransient<IValidationService, ValidationService>();
             if (configuration.GetSection("AppSettings").Get<AppSettings>()?.RequiredValidation == true)
             {
-                services.TryAddTransient<IFormDataValidator, RequiredLayoutValidator>();
+                services.AddTransient<IFormDataValidator, RequiredLayoutValidator>();
             }
 
             if (configuration.GetSection("AppSettings").Get<AppSettings>()?.ExpressionValidation == true)
             {
-                services.TryAddTransient<IFormDataValidator, ExpressionValidator>();
+                services.AddTransient<IFormDataValidator, ExpressionValidator>();
             }
-            services.TryAddTransient<IFormDataValidator, DataAnnotationValidator>();
-            services.TryAddTransient<IFormDataValidator, LegacyIInstanceValidatorFormDataValidator>();
-            services.TryAddTransient<IDataElementValidator, DefaultDataElementValidator>();
-            services.TryAddTransient<ITaskValidator, LegacyIInstanceValidatorTaskValidator>();
-            services.TryAddTransient<ITaskValidator, DefaultTaskValidator>();
+            services.AddTransient<IFormDataValidator, DataAnnotationValidator>();
+            services.AddTransient<IFormDataValidator, LegacyIInstanceValidatorFormDataValidator>();
+            services.AddTransient<IDataElementValidator, DefaultDataElementValidator>();
+            services.AddTransient<ITaskValidator, LegacyIInstanceValidatorTaskValidator>();
+            services.AddTransient<ITaskValidator, DefaultTaskValidator>();
         }
 
         /// <summary>

--- a/src/Altinn.App.Core/Features/Validation/Default/LegacyIInstanceValidatorFormDataValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/LegacyIInstanceValidatorFormDataValidator.cs
@@ -19,7 +19,7 @@ public class LegacyIInstanceValidatorFormDataValidator : IFormDataValidator
     /// <summary>
     /// constructor
     /// </summary>
-    public LegacyIInstanceValidatorFormDataValidator(IInstanceValidator? instanceValidator, IOptions<GeneralSettings> generalSettings)
+    public LegacyIInstanceValidatorFormDataValidator(IOptions<GeneralSettings> generalSettings, IInstanceValidator? instanceValidator = null)
     {
         _instanceValidator = instanceValidator;
         _generalSettings = generalSettings.Value;
@@ -28,7 +28,10 @@ public class LegacyIInstanceValidatorFormDataValidator : IFormDataValidator
     /// <summary>
     /// The legacy validator should run for all data types
     /// </summary>
-    public string DataType => "*";
+    public string DataType => _instanceValidator is null ? "" : "*";
+
+    /// <inheritdoc />>
+    public string ValidationSource => _instanceValidator?.GetType().FullName ?? GetType().FullName!;
 
     /// <summary>
     /// Always run for incremental validation (if it exists)

--- a/src/Altinn.App.Core/Features/Validation/Default/LegacyIInstanceValidatorTaskValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/LegacyIInstanceValidatorTaskValidator.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Options;
 namespace Altinn.App.Core.Features.Validation.Default;
 
 /// <summary>
-/// Ensures that the old <see cref="IInstanceValidator.ValidateTask(Instance, string, ModelStateDictionary)"/> extention hook is still supported.
+/// Ensures that the old <see cref="IInstanceValidator.ValidateTask(Instance, string, ModelStateDictionary)"/> extension hook is still supported.
 /// </summary>
 public class LegacyIInstanceValidatorTaskValidator : ITaskValidator
 {

--- a/src/Altinn.App.Core/Features/Validation/ValidationService.cs
+++ b/src/Altinn.App.Core/Features/Validation/ValidationService.cs
@@ -140,7 +140,7 @@ public class ValidationService : IValidationService
             {
                 _logger.LogDebug("Start running validator {validatorName} on {dataType} for data element {dataElementId} in instance {instanceId}", v.GetType().Name, dataElement.DataType, dataElement.Id, instance.Id);
                 var issues = await v.ValidateFormData(instance, dataElement, data);
-                issues.ForEach(i => i.Source = v.ValidationSource);// Ensure that the code is set to the validator code
+                issues.ForEach(i => i.Source = v.ValidationSource); // Ensure that the Source is set to the ValidatorSource
                 return issues;
             }
             catch (Exception e)

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
@@ -72,7 +72,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         var readDataElementResponseContent = await readDataElementResponse.Content.ReadAsStringAsync();
         var readDataElementResponseParsed =
             JsonSerializer.Deserialize<Skjema>(readDataElementResponseContent)!;
-        readDataElementResponseParsed.Melding.Name.Should().Be("Ola Olsen");
+        readDataElementResponseParsed.Melding!.Name.Should().Be("Ola Olsen");
 
         _dataProcessor.Verify(p => p.ProcessDataRead(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>(), null), Times.Exactly(1));
         _dataProcessor.Verify(p => p.ProcessDataWrite(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>(), It.IsAny<Skjema?>(), null), Times.Exactly(1)); // TODO: Shouldn't this be 2 because of the first write?
@@ -88,7 +88,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
             {
                 if (data is Skjema skjema)
                 {
-                    skjema.Melding.Toggle = true;
+                    skjema.Melding!.Toggle = true;
                 }
 
                 return Task.CompletedTask;
@@ -128,7 +128,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         var firstReadDataElementResponseContent = await firstReadDataElementResponse.Content.ReadAsStringAsync();
         var firstReadDataElementResponseParsed =
             JsonSerializer.Deserialize<Skjema>(firstReadDataElementResponseContent)!;
-        firstReadDataElementResponseParsed.Melding.Name.Should().Be("Ivar");
+        firstReadDataElementResponseParsed.Melding!.Name.Should().Be("Ivar");
         firstReadDataElementResponseParsed.Melding.Toggle.Should().BeFalse();
 
         // Update data element
@@ -143,7 +143,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         var readDataElementResponseContent = await readDataElementResponse.Content.ReadAsStringAsync();
         var readDataElementResponseParsed =
             JsonSerializer.Deserialize<Skjema>(readDataElementResponseContent)!;
-        readDataElementResponseParsed.Melding.Name.Should().Be("Ola Olsen");
+        readDataElementResponseParsed.Melding!.Name.Should().Be("Ola Olsen");
         readDataElementResponseParsed.Melding.Toggle.Should().BeTrue();
 
         _dataProcessor.Verify(p=>p.ProcessDataRead(It.IsAny<Instance>(), It.Is<Guid>(dataId => dataId == Guid.Parse(dataGuid)), It.IsAny<Skjema>(), null), Times.Exactly(2));

--- a/test/Altinn.App.Api.Tests/Data/Instances/tdd/contributer-restriction/500600/3102f61d-1446-4ca5-9fed-3c7c7d67249c/blob/5240d834-dca6-44d3-b99a-1b7ca9b862af.pretest
+++ b/test/Altinn.App.Api.Tests/Data/Instances/tdd/contributer-restriction/500600/3102f61d-1446-4ca5-9fed-3c7c7d67249c/blob/5240d834-dca6-44d3-b99a-1b7ca9b862af.pretest
@@ -2,6 +2,8 @@
 <Skjema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <melding>
     <name>Per Olsen</name>
+    <random>afdetsd</random>
+    <tags>ddd</tags>
     <toggle>false</toggle>
   </melding>
 </Skjema>

--- a/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/models/Skjema.cs
+++ b/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/models/Skjema.cs
@@ -11,7 +11,7 @@ public class Skjema
     [XmlElement("melding", Order = 1)]
     [JsonProperty("melding")]
     [JsonPropertyName("melding")]
-    public Dummy Melding { get; set; } = default!;
+    public Dummy? Melding { get; set; }
 }
 
 public class Dummy
@@ -19,37 +19,37 @@ public class Dummy
     [XmlElement("name", Order = 1)]
     [JsonProperty("name")]
     [JsonPropertyName("name")]
-    public string Name { get; set; } = default!;
+    public string? Name { get; set; }
 
     [XmlElement("random", Order = 2)]
     [JsonProperty("random")]
     [JsonPropertyName("random")]
-    public string Random { get; set; } = default!;
+    public string? Random { get; set; }
 
     [XmlElement("tags", Order = 3)]
     [JsonProperty("tags")]
     [JsonPropertyName("tags")]
-    public string Tags { get; set; } = default!;
+    public string? Tags { get; set; }
 
     [XmlElement("simple_list", Order = 4)]
     [JsonProperty("simple_list")]
     [JsonPropertyName("simple_list")]
-    public ValuesList SimpleList { get; set; } = default!;
+    public ValuesList? SimpleList { get; set; }
 
     [XmlElement("nested_list", Order = 5)]
     [JsonProperty("nested_list")]
     [JsonPropertyName("nested_list")]
-    public List<Nested> NestedList { get; set; } = default!;
+    public List<Nested>? NestedList { get; set; }
 
     [XmlElement("toggle", Order = 6)]
     [JsonProperty("toggle")]
     [JsonPropertyName("toggle")]
-    public bool Toggle { get; set; } = default!;
+    public bool Toggle { get; set; }
 
     [XmlElement("tag-with-attribute", IsNullable = true, Order = 7)]
     [JsonProperty("tag-with-attribute")]
     [JsonPropertyName("tag-with-attribute")]
-    public TagWithAttribute TagWithAttribute { get; set; } = default!;
+    public TagWithAttribute? TagWithAttribute { get; set; }
 }
 
 public class TagWithAttribute
@@ -70,7 +70,7 @@ public class ValuesList
     [XmlElement("simple_keyvalues", Order = 1)]
     [JsonProperty("simple_keyvalues")]
     [JsonPropertyName("simple_keyvalues")]
-    public List<SimpleKeyvalues> SimpleKeyvalues { get; set; } = default!;
+    public List<SimpleKeyvalues>? SimpleKeyvalues { get; set; }
 }
 
 public class SimpleKeyvalues
@@ -78,18 +78,18 @@ public class SimpleKeyvalues
     [XmlElement("key", Order = 1)]
     [JsonProperty("key")]
     [JsonPropertyName("key")]
-    public string Key { get; set; } = default!;
+    public string? Key { get; set; }
 
     [XmlElement("doubleValue", Order = 2)]
     [JsonProperty("doubleValue")]
     [JsonPropertyName("doubleValue")]
-    public decimal DoubleValue { get; set; } = default!;
+    public decimal? DoubleValue { get; set; }
 
     [Range(int.MinValue, int.MaxValue)]
     [XmlElement("intValue", Order = 3)]
     [JsonProperty("intValue")]
     [JsonPropertyName("intValue")]
-    public decimal IntValue { get; set; } = default!;
+    public decimal? IntValue { get; set; }
 }
 
 public class Nested
@@ -97,10 +97,10 @@ public class Nested
     [XmlElement("key", Order = 1)]
     [JsonProperty("key")]
     [JsonPropertyName("key")]
-    public string Key { get; set; } = default!;
+    public string? Key { get; set; }
 
     [XmlElement("values", Order = 2)]
     [JsonProperty("values")]
     [JsonPropertyName("values")]
-    public List<SimpleKeyvalues> Values { get; set; } = default!;
+    public List<SimpleKeyvalues>? Values { get; set; }
 }

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/LegacyIValidationFormDataTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/LegacyIValidationFormDataTests.cs
@@ -22,7 +22,7 @@ namespace Altinn.App.Core.Tests.Features.Validators.Default
         {
             var generalSettings = new GeneralSettings();
             _validator =
-                new LegacyIInstanceValidatorFormDataValidator(_instanceValidator.Object, Options.Create(generalSettings));
+                new LegacyIInstanceValidatorFormDataValidator(Options.Create(generalSettings), _instanceValidator.Object);
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace Altinn.App.Core.Tests.Features.Validators.Default
             // Arrange
             var data = new object();
 
-            var validator = new LegacyIInstanceValidatorFormDataValidator(null, Options.Create(new GeneralSettings()));
+            var validator = new LegacyIInstanceValidatorFormDataValidator(Options.Create(new GeneralSettings()), null);
             validator.HasRelevantChanges(data, data).Should().BeFalse();
 
             // Act


### PR DESCRIPTION
Tempted to just merge this, as it is a few clean bug fixes for validation in v8 that hits apps that attempt to upgrade.

* Ensure that validators are not registrered with `TryAddTrancient` (as this only registrers the first one)
* Ensure that Patch sends the old model to validation instead of the change list
* Run LegacyIInstanceValidatorFormDataValidator only when a IInstanceValidator is present
* Update and improve tests

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
