### PR TITLE
Ensure app options gets parsed with System.Text.Json (and let API return 404)

### DIFF
--- a/src/Altinn.App.Api/Controllers/OptionsController.cs
+++ b/src/Altinn.App.Api/Controllers/OptionsController.cs
@@ -44,7 +44,7 @@ namespace Altinn.App.Api.Controllers
             [FromQuery] string? language = null)
         {
             AppOptions appOptions = await _appOptionsService.GetOptionsAsync(optionsId, language, queryParams);
-            if (appOptions.Options == null)
+            if (appOptions?.Options == null)
             {
                 return NotFound();
             }

--- a/src/Altinn.App.Core/Features/Options/AppOptionsFileHandler.cs
+++ b/src/Altinn.App.Core/Features/Options/AppOptionsFileHandler.cs
@@ -1,9 +1,9 @@
 using System.Text;
+using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Models;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 
 namespace Altinn.App.Core.Features.Options
 {
@@ -11,6 +11,11 @@ namespace Altinn.App.Core.Features.Options
     public class AppOptionsFileHandler : IAppOptionsFileHandler
     {
         private readonly AppSettings _settings;
+        private static readonly JsonSerializerOptions JSON_SERIALIZER_SETTINGS = new(JsonSerializerDefaults.Web)
+        {
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AppOptionsFileHandler"/> class.
@@ -21,20 +26,20 @@ namespace Altinn.App.Core.Features.Options
         }
 
         /// <inheritdoc/>
-        public async Task<List<AppOption>> ReadOptionsFromFileAsync(string optionId)
+        public async Task<List<AppOption>?> ReadOptionsFromFileAsync(string optionId)
         {
-            string legalPath = _settings.AppBasePath + _settings.OptionsFolder;
+            string legalPath = Path.Join(_settings.AppBasePath, _settings.OptionsFolder);
             string filename = legalPath + optionId + ".json";
             PathHelper.EnsureLegalPath(legalPath, filename);
 
             if (File.Exists(filename))
             {
                 string fileData = await File.ReadAllTextAsync(filename, Encoding.UTF8);
-                List<AppOption> options = JsonConvert.DeserializeObject<List<AppOption>>(fileData)!;
+                List<AppOption> options = JsonSerializer.Deserialize<List<AppOption>>(fileData, JSON_SERIALIZER_SETTINGS)!;
                 return options;
             }
 
-            return new List<AppOption>();
+            return null;
         }
     }
 }

--- a/src/Altinn.App.Core/Features/Options/IAppOptionsFileHandler.cs
+++ b/src/Altinn.App.Core/Features/Options/IAppOptionsFileHandler.cs
@@ -11,7 +11,7 @@ namespace Altinn.App.Core.Features.Options
         /// Reads the app options from file
         /// </summary>
         /// <param name="optionId">The option id that should be loaded. Should equal the filename without the .json extension.</param>
-        /// <returns>A <see cref="List{AppOption}"/> containing the option from the json file on disk. If no file is found an empty list is returned.</returns>
-        Task<List<AppOption>> ReadOptionsFromFileAsync(string optionId);
+        /// <returns>A <see cref="List{AppOption}"/> containing the option from the json file on disk. If no file is found null is returned.</returns>
+        Task<List<AppOption>?> ReadOptionsFromFileAsync(string optionId);
     }
 }

--- a/src/Altinn.App.Core/Models/AppOptions.cs
+++ b/src/Altinn.App.Core/Models/AppOptions.cs
@@ -1,5 +1,3 @@
-using System.Reflection.Metadata.Ecma335;
-
 namespace Altinn.App.Core.Models
 {
     /// <summary>
@@ -8,9 +6,9 @@ namespace Altinn.App.Core.Models
     public class AppOptions
     {
         /// <summary>
-        /// Gets or sets the list of options.
+        /// Gets or sets the list of options. Null indicates that no options are found
         /// </summary>
-        public List<AppOption> Options { get; set; } = new List<AppOption>();
+        public List<AppOption>? Options { get; set; }
 
         /// <summary>
         /// Gets or sets the parameters used to generate the options.

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -1,18 +1,21 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
-using Xunit;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 using FluentAssertions;
-using Moq;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Altinn.App.Api.Tests.Controllers
 {
     public class OptionsControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
     {
-        public OptionsControllerTests(WebApplicationFactory<Program> factory) : base(factory)
+        private readonly ITestOutputHelper _testOutput;
+
+        public OptionsControllerTests(ITestOutputHelper testOutput, WebApplicationFactory<Program> factory) : base(factory)
         {
+            _testOutput = testOutput;
         }
 
         [Fact]
@@ -30,7 +33,8 @@ namespace Altinn.App.Api.Tests.Controllers
             string url = $"/{org}/{app}/api/options/test?language=esperanto";
             HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
-            response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+            _testOutput.WriteLine(content);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var headerValue = response.Headers.GetValues("Altinn-DownstreamParameters");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -52,11 +56,44 @@ namespace Altinn.App.Api.Tests.Controllers
             string url = $"/{org}/{app}/api/options/test";
             HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
-            response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+            _testOutput.WriteLine(content);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var headerValue = response.Headers.GetValues("Altinn-DownstreamParameters");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             headerValue.Should().NotContain("nb");
+        }
+
+        [Fact]
+        public async Task Get_ShouldWorkWithFileSource()
+        {
+            string org = "tdd";
+            string app = "contributer-restriction";
+            HttpClient client = GetRootedClient(org, app);
+
+            string url = $"/{org}/{app}/api/options/fileSourceOptions";
+            HttpResponseMessage response = await client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+            _testOutput.WriteLine(content);
+            response.Should().HaveStatusCode(HttpStatusCode.OK);
+            content.Should()
+                .Be(
+                    """[{"value":null,"label":""},{"value":"string-value","label":"string-label"},{"value":3,"label":"number"},{"value":true,"label":"boolean-true"},{"value":false,"label":"boolean-false"}]""");
+
+        }
+
+        [Fact]
+        public async Task GetNonExistentList_Return404()
+        {
+            string org = "tdd";
+            string app = "contributer-restriction";
+            HttpClient client = GetRootedClient(org, app);
+
+            string url = $"/{org}/{app}/api/options/non-existent-option-list";
+            HttpResponseMessage response = await client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+            _testOutput.WriteLine(content);
+            response.Should().HaveStatusCode(HttpStatusCode.NotFound);
         }
 
         [Fact]
@@ -74,11 +111,10 @@ namespace Altinn.App.Api.Tests.Controllers
             string url = $"/{org}/{app}/api/options/test";
             HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
-            response.StatusCode.Should().Be(HttpStatusCode.OK, content);
-
+            _testOutput.WriteLine(content);
             response.StatusCode.Should().Be(HttpStatusCode.OK);
-            var options = await response.Content.ReadAsStringAsync();
-            options.Should().Be("[{\"value\":null,\"label\":\"\"},{\"value\":\"SomeString\",\"label\":\"False\"},{\"value\":true,\"label\":\"True\"},{\"value\":0,\"label\":\"Zero\"},{\"value\":1,\"label\":\"One\",\"description\":\"This is a description\",\"helpText\":\"This is a help text\"}]");
+
+            content.Should().Be("[{\"value\":null,\"label\":\"\"},{\"value\":\"SomeString\",\"label\":\"False\"},{\"value\":true,\"label\":\"True\"},{\"value\":0,\"label\":\"Zero\"},{\"value\":1,\"label\":\"One\",\"description\":\"This is a description\",\"helpText\":\"This is a help text\"}]");
         }
     }
 

--- a/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/options/fileSourceOptions.json
+++ b/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/options/fileSourceOptions.json
@@ -1,0 +1,24 @@
+[
+  // Comment is valid
+  {
+    "value": null,
+    "label": ""
+  },
+  {
+    "value": "string-value",
+    "label": "string-label"
+  },
+  {
+    "value": 3,
+    "label": "number"
+  },
+  {
+    "value": true,
+    "label": "boolean-true"
+  },
+  {
+    "value": false,
+    "label": "boolean-false",
+    // Trailing comma should be valid
+  },
+]


### PR DESCRIPTION
In https://github.com/Altinn/app-lib-dotnet/pull/417 I assumed that System.Text.Json would be used for parsing as well as serialization. While removing newtonsoft I discovered that it was not the case for app options in files, and while writing tests, I discovered that the endpoint never returns 404 and fixed that issue aswell.

## Related Issue(s)
- #417

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
