### PR TITLE
Return 409 Conflict instead of 412 Precondition failed

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -382,7 +382,7 @@ namespace Altinn.App.Api.Controllers
         [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_WRITE)]
         [HttpPatch("{dataGuid:guid}")]
         [ProducesResponseType(typeof(DataPatchResponse), 200)]
-        [ProducesResponseType(typeof(ProblemDetails), 412)]
+        [ProducesResponseType(typeof(ProblemDetails), 409)]
         [ProducesResponseType(typeof(ProblemDetails), 422)]
         public async Task<ActionResult<DataPatchResponse>> PatchFormData(
             [FromRoute] string org,
@@ -475,10 +475,10 @@ namespace Altinn.App.Api.Controllers
                 bool testOperationFailed = patchResult.Error!.Contains("is not equal to the indicated value.");
                 return (null!, new ProblemDetails()
                 {
-                    Title = testOperationFailed ? "Precondition in patch failed" : "Patch Operation Failed",
+                    Title = testOperationFailed ? "Test operation in patch failed" : "Patch Operation Failed",
                     Detail = patchResult.Error,
                     Type = "https://datatracker.ietf.org/doc/html/rfc6902/",
-                    Status = testOperationFailed ? (int)HttpStatusCode.PreconditionFailed : (int)HttpStatusCode.UnprocessableContent,
+                    Status = testOperationFailed ? (int)HttpStatusCode.Conflict : (int)HttpStatusCode.UnprocessableContent,
                     Extensions = new Dictionary<string, object?>()
                     {
                         { "previousModel", oldModel },

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -140,14 +140,14 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
     }
 
     [Fact]
-    public async Task InvalidTestValue_ReturnsPreconditionFailed()
+    public async Task InvalidTestValue_ReturnsConflict()
     {
         // Update data element
         var patch = new JsonPatch(
             PatchOperation.Test(JsonPointer.Create("melding", "name"), JsonNode.Parse("\"Not correct previous value\"")),
             PatchOperation.Replace(JsonPointer.Create("melding", "name"), JsonNode.Parse("null")));
 
-        var (_, _, parsedResponse) = await CallPatchApi<ProblemDetails>(patch, null, HttpStatusCode.PreconditionFailed);
+        var (_, _, parsedResponse) = await CallPatchApi<ProblemDetails>(patch, null, HttpStatusCode.Conflict);
 
         parsedResponse.Detail.Should().Be("Path `/melding/name` is not equal to the indicated value.");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Return 409 Conflict instead of 412 Precondition failed when doing a patch operation.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/1714

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
