### PR TITLE
Don't run ProcessDataRead for locked data elements

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -750,6 +750,12 @@ namespace Altinn.App.Api.Controllers
                 return BadRequest($"Did not find form data for data element {dataGuid}");
             }
 
+            if (instance.Data.FirstOrDefault(d => d.Id == dataGuid.ToString())?.Locked == true)
+            {
+                // Skip further processing if the data element is locked
+                return Ok(appModel);
+            }
+
             // we need to save the changes if dataProcessRead changes the model
             byte[] beforeProcessDataRead = JsonSerializer.SerializeToUtf8Bytes(appModel);
 
@@ -761,7 +767,7 @@ namespace Altinn.App.Api.Controllers
 
             if (!beforeProcessDataRead.SequenceEqual(JsonSerializer.SerializeToUtf8Bytes(appModel)))
             {
-                // Save back teh changes if dataProcessRead has changed the model
+                // Save back the changes if dataProcessRead has changed the model
                 await _dataClient.UpdateData(appModel, instanceGuid, appModel.GetType(), org, app, instanceOwnerId, dataGuid);
             }
 


### PR DESCRIPTION
I'm working on writing tests, but this change is mostly about changing expected behaviour, not really testable logic.

The location I added the check for locked has a few behaviour changes I think is fine
* I don't run `ProcessDataRead` for locked elements (it seems strange to fake change data)
* I don't set `ReadStatus` to `read` for locked elements. (it is set when fetching an instance, so I'm puzzled how anyone is supposed to get a data element with a unknown guid without first fetching the instance).

## Related Issue(s)
- I don't think an issue was created.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
