### PR TITLE
Rename the ?lang= parameter in process/next to ?language

### DIFF
--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -219,10 +219,7 @@ namespace Altinn.App.Api.Controllers
         /// <param name="instanceOwnerPartyId">unique id of the party that is the owner of the instance</param>
         /// <param name="instanceGuid">unique id to identify the instance</param>
         /// <param name="elementId">obsolete: alias for action</param>
-        /// <param name="lang">Optional parameter to pass on the language used in the form if this differs from the profile language,
-        /// which otherwise is used automatically. The language is picked up when generating the PDF when leaving a step, 
-        /// and is not used for anything else.
-        /// </param>
+        /// <param name="language">Signal the language to use for pdf generation, error messages...</param>
         [HttpPut("next")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -233,7 +230,7 @@ namespace Altinn.App.Api.Controllers
             [FromRoute] int instanceOwnerPartyId,
             [FromRoute] Guid instanceGuid,
             [FromQuery] string? elementId = null,
-            [FromQuery] string? lang = null)
+            [FromQuery] string? language = null)
         {
             try
             {

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -138,7 +138,8 @@ public class PdfService : IPdfService
         // language directly in the form, then use the selected language.
         if (_httpContextAccessor.HttpContext != null)
         {
-            bool hasQueryLanguage = _httpContextAccessor.HttpContext.Request.Query.TryGetValue("lang", out StringValues queryLanguage);
+            StringValues queryLanguage;
+            bool hasQueryLanguage = _httpContextAccessor.HttpContext.Request.Query.TryGetValue("language", out queryLanguage) ||  _httpContextAccessor.HttpContext.Request.Query.TryGetValue("lang", out queryLanguage);
             if (hasQueryLanguage)
             {
                 return queryLanguage.ToString();


### PR DESCRIPTION
This is to match other endpoints and make a more uniform api

Obviously while keeping backwards compatibility

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/1774

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
