### PR TITLE
Add fake logging to test so that they can be written to TestOutput instead of std out

### DIFF
--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -16,6 +16,7 @@
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.1.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="Moq" Version="4.20.70" />
 		<PackageReference Include="xunit" Version="2.6.5" />

--- a/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
@@ -11,12 +11,13 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Altinn.App.Api.Tests.Controllers;
 
 public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
 {
-    public ActionsControllerTests(WebApplicationFactory<Program> factory) : base(factory)
+    public ActionsControllerTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
     {
     }
 

--- a/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
@@ -10,12 +10,13 @@ using Altinn.App.Core.Features.Validation;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
+using Xunit.Abstractions;
 
 namespace Altinn.App.Api.Tests.Controllers
 {
     public class DataControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
     {
-        public DataControllerTests(WebApplicationFactory<Program> factory) : base(factory)
+        public DataControllerTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
         {
         }
 

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
@@ -10,6 +10,7 @@ using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using Xunit.Abstractions;
 
 namespace Altinn.App.Api.Tests.Controllers;
 
@@ -22,7 +23,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
 
-    public DataController_PutTests(WebApplicationFactory<Program> factory) : base(factory)
+    public DataController_PutTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
     {
         OverrideServicesForAllTests = (services) =>
         {

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Altinn.App.Api.Tests.Controllers;
 
@@ -22,7 +23,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
 
-    public InstancesController_PostNewInstanceTests(WebApplicationFactory<Program> factory) : base(factory)
+    public InstancesController_PostNewInstanceTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
     {
         OverrideServicesForAllTests = (services) =>
         {
@@ -65,7 +66,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         var readDataElementResponseContent = await readDataElementResponse.Content.ReadAsStringAsync();
         var readDataElementResponseParsed =
             JsonSerializer.Deserialize<Skjema>(readDataElementResponseContent)!;
-        readDataElementResponseParsed.Melding.Name.Should().Be(testName);
+        readDataElementResponseParsed.Melding!.Name.Should().Be(testName);
     }
 
     [Fact]

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -11,11 +11,9 @@ namespace Altinn.App.Api.Tests.Controllers
 {
     public class OptionsControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
     {
-        private readonly ITestOutputHelper _testOutput;
 
-        public OptionsControllerTests(ITestOutputHelper testOutput, WebApplicationFactory<Program> factory) : base(factory)
+        public OptionsControllerTests(ITestOutputHelper outputHelper, WebApplicationFactory<Program> factory) : base(factory, outputHelper)
         {
-            _testOutput = testOutput;
         }
 
         [Fact]
@@ -33,7 +31,7 @@ namespace Altinn.App.Api.Tests.Controllers
             string url = $"/{org}/{app}/api/options/test?language=esperanto";
             HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
-            _testOutput.WriteLine(content);
+            _outputHelper.WriteLine(content);
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var headerValue = response.Headers.GetValues("Altinn-DownstreamParameters");
@@ -56,7 +54,7 @@ namespace Altinn.App.Api.Tests.Controllers
             string url = $"/{org}/{app}/api/options/test";
             HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
-            _testOutput.WriteLine(content);
+            _outputHelper.WriteLine(content);
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var headerValue = response.Headers.GetValues("Altinn-DownstreamParameters");
@@ -74,7 +72,7 @@ namespace Altinn.App.Api.Tests.Controllers
             string url = $"/{org}/{app}/api/options/fileSourceOptions";
             HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
-            _testOutput.WriteLine(content);
+            _outputHelper.WriteLine(content);
             response.Should().HaveStatusCode(HttpStatusCode.OK);
             content.Should()
                 .Be(
@@ -92,7 +90,7 @@ namespace Altinn.App.Api.Tests.Controllers
             string url = $"/{org}/{app}/api/options/non-existent-option-list";
             HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
-            _testOutput.WriteLine(content);
+            _outputHelper.WriteLine(content);
             response.Should().HaveStatusCode(HttpStatusCode.NotFound);
         }
 
@@ -111,7 +109,7 @@ namespace Altinn.App.Api.Tests.Controllers
             string url = $"/{org}/{app}/api/options/test";
             HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
-            _testOutput.WriteLine(content);
+            _outputHelper.WriteLine(content);
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
             content.Should().Be("[{\"value\":null,\"label\":\"\"},{\"value\":\"SomeString\",\"label\":\"False\"},{\"value\":true,\"label\":\"True\"},{\"value\":0,\"label\":\"Zero\"},{\"value\":1,\"label\":\"One\",\"description\":\"This is a description\",\"helpText\":\"This is a help text\"}]");

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
@@ -7,12 +7,13 @@ using Altinn.App.Api.Tests.Utils;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Altinn.App.Api.Tests.Controllers;
 
 public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
 {
-    public ProcessControllerTests(WebApplicationFactory<Program> factory) : base(factory)
+    public ProcessControllerTests(WebApplicationFactory<Program> factory, ITestOutputHelper testOutput) : base(factory, testOutput)
     {
     }
 

--- a/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
@@ -100,6 +100,13 @@ public class StatelessDataControllerTests
         {
             base.ConfigureWebHost(builder);
 
+            builder.ConfigureLogging(options =>
+            {
+                // Don't write logs to the console
+                // consider writing logs to a test output
+                options.ClearProviders();
+            });
+
             builder.ConfigureServices(services=>
             {
                 services.AddTransient<IProfileClient>((sp)=>ProfileClientMoq.Object);

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateController_ValidateInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateController_ValidateInstanceTests.cs
@@ -39,12 +39,9 @@ public class ValidateControllerValidateInstanceTests : ApiTestBase, IClassFixtur
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
 
-    private readonly ITestOutputHelper _outputHelper;
-
-    public ValidateControllerValidateInstanceTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory)
+    public ValidateControllerValidateInstanceTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
     {
         _formDataValidatorMock.Setup(v => v.DataType).Returns("Not a valid data type");
-        _outputHelper = outputHelper;
         OverrideServicesForAllTests = (services) =>
         {
             services.AddSingleton(_dataProcessorMock.Object);

--- a/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
+++ b/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
@@ -1,19 +1,37 @@
-﻿using Altinn.App.Api.Tests.Data;
+﻿using System.Net.Http.Headers;
+using Altinn.App.Api.Tests.Data;
+using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Core.Configuration;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit.Abstractions;
 
 namespace Altinn.App.Api.Tests;
 
 public class ApiTestBase
 {
+    protected readonly ITestOutputHelper _outputHelper;
     private readonly WebApplicationFactory<Program> _factory;
 
-    public ApiTestBase(WebApplicationFactory<Program> factory)
+    public ApiTestBase(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
     {
         _factory = factory;
+        _outputHelper = outputHelper;
+    }
+
+    public HttpClient GetRootedClient(string org, string app, int userId, int? partyId, int authenticationLevel = 2)
+    {
+        var client = GetRootedClient(org, app);
+        string token = PrincipalUtil.GetToken(userId, partyId, authenticationLevel);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
     }
 
     /// <summary>
@@ -33,13 +51,24 @@ public class ApiTestBase
 
             configuration.GetSection("AppSettings:AppBasePath").Value = appRootPath;
             IConfigurationSection appSettingSection = configuration.GetSection("AppSettings");
-            
+
+            builder.ConfigureLogging(ConfigureFakeLogging);
+
             builder.ConfigureServices(services => services.Configure<AppSettings>(appSettingSection));
             builder.ConfigureTestServices(services => OverrideServicesForAllTests(services));
             builder.ConfigureTestServices(OverrideServicesForThisTest);
         }).CreateClient(new WebApplicationFactoryClientOptions() { AllowAutoRedirect = false });
 
         return client;
+    }
+
+    private void ConfigureFakeLogging(ILoggingBuilder builder)
+    {
+        builder.ClearProviders()
+            .AddFakeLogging(options =>
+            {
+                options.OutputSink = (message) => _outputHelper.WriteLine(message);
+            });
     }
 
     /// <summary>

--- a/test/Altinn.App.Api.Tests/Program.cs
+++ b/test/Altinn.App.Api.Tests/Program.cs
@@ -27,7 +27,13 @@ using Microsoft.Extensions.Options;
 // External interfaces like Platform related services, Authenication, Authorization
 // external api's etc. should be mocked.
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(new WebApplicationOptions() { ApplicationName = "Altinn.App.Api.Tests" });
+WebApplicationBuilder builder = WebApplication.CreateBuilder(
+    new WebApplicationOptions()
+    {
+        ApplicationName = "Altinn.App.Api.Tests",
+        WebRootPath = Path.Join(TestData.GetTestDataRootDirectory(), "apps", "tdd", "contributer-restriction")
+    });
+
 builder.Configuration.AddJsonFile(Path.Join(TestData.GetTestDataRootDirectory(), "apps", "tdd", "contributer-restriction", "appsettings.json"));
 builder.Configuration.GetSection("MetricsSettings:Enabled").Value = "false";
 


### PR DESCRIPTION
Microsoft finally released a FakeLogger that was very easy to adapt to send logs to `ITestOutputHelper` from xunit.

This means that logs from WebApplicationFactory tests no longer gets dumped in a messy console, but associated with the test and shown in console only when the test fails (and always available in test explorer in Rider)


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
