### PR TITLE
Implementation for JoinedOptionsProvider

### DIFF
--- a/src/Altinn.App.Api/Controllers/OptionsController.cs
+++ b/src/Altinn.App.Api/Controllers/OptionsController.cs
@@ -85,7 +85,7 @@ namespace Altinn.App.Api.Controllers
 
             // Only return NotFound if we can't find an options provider.
             // If we find the options provider, but it doesnt' have values, return empty list.
-            if (appOptions.Options == null)
+            if (appOptions?.Options == null)
             {
                 return NotFound();
             }

--- a/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ using Prometheus;
 namespace Altinn.App.Api.Extensions
 {
     /// <summary>
-    /// Class for registering requiered services to run an Altinn application.
+    /// Class for registering required services to run an Altinn application.
     /// </summary>
     public static class ServiceCollectionExtensions
     {

--- a/src/Altinn.App.Core/Features/Options/Altinn2Provider/Altinn2CodeListProvider.cs
+++ b/src/Altinn.App.Core/Features/Options/Altinn2Provider/Altinn2CodeListProvider.cs
@@ -70,12 +70,12 @@ namespace Altinn.App.Core.Features.Options.Altinn2Provider
                 _ => "1044", // default to norwegian bokmål
             };
 
-            return await _cache.GetOrCreateAsync($"{_metadataApiId}{langCode}{_codeListVersion}", async (entry) =>
+            return (await _cache.GetOrCreateAsync($"{_metadataApiId}{langCode}{_codeListVersion}", async (entry) =>
             {
                 entry.Priority = CacheItemPriority.NeverRemove;
                 entry.AbsoluteExpiration = DateTimeOffset.MaxValue;
                 return await _client.GetAltinn2Codelist(_metadataApiId, langCode, _codeListVersion);
-            });
+            }))!;
         }
 
         /// <inheritdoc/>

--- a/src/Altinn.App.Core/Features/Options/AppOptionsServiceExtentions.cs
+++ b/src/Altinn.App.Core/Features/Options/AppOptionsServiceExtentions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.App.Core.Features.Options;
+
+/// <summary>
+/// Extension methods for <see cref="IServiceCollection"/> for adding app options providers
+/// </summary>
+public static class AppOptionsServiceExtentions
+{
+    /// <summary>
+    /// Join multiple app options providers into one
+    /// </summary>
+    public static void AddJoinedAppOptions(this IServiceCollection services, string id, params string[] subLists)
+    {
+        services.AddTransient<IAppOptionsProvider>(sp =>
+            new JoinedAppOptionsProvider(
+                id,
+                subLists,
+                sp.GetRequiredService<AppOptionsFactory>));
+    }
+}

--- a/src/Altinn.App.Core/Features/Options/JoinedAppOptionsProvider.cs
+++ b/src/Altinn.App.Core/Features/Options/JoinedAppOptionsProvider.cs
@@ -1,0 +1,60 @@
+using Altinn.App.Core.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.App.Core.Features.Options;
+
+/// <summary>
+/// Utility class for joining multiple app options providers into one
+/// </summary>
+public class JoinedAppOptionsProvider : IAppOptionsProvider
+{
+    private readonly IEnumerable<string> _subOptions;
+    private readonly Func<AppOptionsFactory> _appOptionsFactory;
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="id">The option id used in layouts to reference this code list</param>
+    /// <param name="subOptions">A list of other options to include</param>
+    /// <param name="appOptionsFactory">The factory to use to get the sub options</param>
+    public JoinedAppOptionsProvider(string id, IEnumerable<string> subOptions, Func<AppOptionsFactory> appOptionsFactory)
+    {
+        Id = id;
+        _subOptions = subOptions;
+        _appOptionsFactory = appOptionsFactory;
+    }
+
+    /// <inheritdoc />
+    public string Id { get; }
+
+    /// <inheritdoc />
+    public async Task<AppOptions> GetAppOptionsAsync(string? language, Dictionary<string, string> keyValuePairs)
+    {
+        // Pretend this isn't the same as injecting the ServiceProvider
+        var appOptionsFactory = _appOptionsFactory();
+        var appOptions = await Task.WhenAll(
+            _subOptions
+                .Select(async optionId =>
+                {
+                    var p = appOptionsFactory.GetOptionsProvider(optionId);
+                    return (p.Id, AppOption: await p.GetAppOptionsAsync(language, keyValuePairs));
+                }));
+
+        // Flatten all options to a single list
+        var options = appOptions.SelectMany(o => o.AppOption.Options).ToList();
+        // Flatten all parameters to a single dictionary, prefixing the key with the option id
+        var parameters = appOptions
+            .SelectMany(o =>
+                o.AppOption.Parameters.Select(p=>
+                    new KeyValuePair<string,string?>($"{o.Id}_{p.Key}", p.Value)))
+            .ToDictionary();
+
+        // Return the combined AppOptions object
+        return new AppOptions
+        {
+            IsCacheable = appOptions.All(o=>o.AppOption.IsCacheable),
+            Options = options,
+            Parameters = parameters
+        };
+    }
+}

--- a/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2MetadataApiClientHttpMessageHandlerMoq.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2MetadataApiClientHttpMessageHandlerMoq.cs
@@ -1,11 +1,7 @@
 #nullable enable
-using System;
 using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Altinn.App.PlatformServices.Tests.Options.Altinn2Provider
+namespace Altinn.App.Core.Tests.Features.Options.Altinn2Provider
 {
     public class Altinn2MetadataApiClientHttpMessageHandlerMoq : HttpMessageHandler
     {

--- a/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2OptionsCacheTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2OptionsCacheTests.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Features.Options.Altinn2Provider;
@@ -8,7 +5,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace Altinn.App.PlatformServices.Tests.Options.Altinn2Provider
+namespace Altinn.App.Core.Tests.Features.Options.Altinn2Provider
 {
     public class Altinn2OptionsCacheTests
     {

--- a/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2OptionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2OptionsTests.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Features.Options.Altinn2Provider;
@@ -8,13 +5,13 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace Altinn.App.PlatformServices.Tests.Options.Altinn2Provider
+namespace Altinn.App.Core.Tests.Features.Options.Altinn2Provider
 {
     public class Altinn2OptionsTests
     {
         /// <summary>
         /// Change this to false to test with real https://www.altinn.no/api/metadata/codelists instead of
-        /// the moq in <see cref="Altinn.App.PlatformServices.Tests.Options.Altinn2Provider.Altinn2MetadataApiClientHttpMessageHandlerMoq"/>
+        /// the moq in <see cref="Altinn2MetadataApiClientHttpMessageHandlerMoq"/>
         /// </summary>
         private readonly bool _shouldMoqAltinn2Api = true;
 

--- a/test/Altinn.App.Core.Tests/Features/Options/AppOptionsFactoryTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/AppOptionsFactoryTests.cs
@@ -5,7 +5,7 @@ using FluentAssertions;
 using Moq;
 using Xunit;
 
-namespace Altinn.App.PlatformServices.Tests.Options
+namespace Altinn.App.Core.Tests.Features.Options
 {
     public class AppOptionsFactoryTests
     {
@@ -29,7 +29,7 @@ namespace Altinn.App.PlatformServices.Tests.Options
 
             IAppOptionsProvider optionsProvider1 = factory.GetOptionsProvider("fylke");
             IAppOptionsProvider optionsProvider2 = factory.GetOptionsProvider("kommune");
-            
+
             optionsProvider1.Id.Should().Be("fylke");
             optionsProvider2.Id.Should().Be("kommune");
         }
@@ -39,7 +39,7 @@ namespace Altinn.App.PlatformServices.Tests.Options
         {
             var factory = new AppOptionsFactory(new List<IAppOptionsProvider>());
 
-            Action action = () => factory.GetOptionsProvider("country");
+            System.Action action = () => factory.GetOptionsProvider("country");
 
             action.Should().Throw<KeyNotFoundException>();
         }
@@ -80,7 +80,7 @@ namespace Altinn.App.PlatformServices.Tests.Options
             options.Parameters.First(x => x.Key == "key").Value.Should().Be("value");
         }
 
-        internal class CountryAppOptionsProvider : IAppOptionsProvider
+        private class CountryAppOptionsProvider : IAppOptionsProvider
         {
             public string Id { get; set; } = "country";
 

--- a/test/Altinn.App.Core.Tests/Features/Options/InstanceAppOptionsFactoryTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/InstanceAppOptionsFactoryTests.cs
@@ -1,12 +1,10 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Models;
 using FluentAssertions;
 using Xunit;
 
-namespace Altinn.App.PlatformServices.Tests.Options
+namespace Altinn.App.Core.Tests.Features.Options
 {
     public class InstanceAppOptionsFactoryTests
     {

--- a/test/Altinn.App.Core.Tests/Features/Options/JoinedAppOptionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/JoinedAppOptionsTests.cs
@@ -1,0 +1,90 @@
+#nullable enable
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Features.Options;
+using Altinn.App.Core.Models;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Altinn.App.Core.Tests.Features.Options;
+
+public class JoinedAppOptionsTests
+{
+    private readonly Mock<IAppOptionsProvider> _neverUsedOptionsProviderMock = new(MockBehavior.Strict);
+    private readonly Mock<IAppOptionsProvider> _countryAppOptionsMock = new(MockBehavior.Strict);
+    private readonly Mock<IAppOptionsProvider> _sentinelOptionsProviderMock = new(MockBehavior.Strict);
+    private readonly ServiceCollection _serviceCollection = new();
+
+    private const string Language = "nb";
+    private static readonly List<AppOption> AppOptionsCountries = new()
+    {
+        new AppOption
+        {
+            Value = "no",
+            Label = "Norway"
+        },
+        new AppOption
+        {
+            Value = "se",
+            Label = "Sweden"
+        }
+    };
+
+    private static readonly List<AppOption> AppOptionsSentinel = new()
+    {
+        new AppOption
+        {
+            Value = null,
+            Label = "Sentinel"
+        }
+    };
+
+    public JoinedAppOptionsTests()
+    {
+        _countryAppOptionsMock.Setup(p => p.Id).Returns("country-no-sentinel");
+        _countryAppOptionsMock
+            .Setup(p => p.GetAppOptionsAsync(Language, It.IsAny<Dictionary<string, string>>()))
+            .ReturnsAsync((string language, Dictionary<string, string> keyValuePairs) => new AppOptions()
+            {
+                Options = AppOptionsCountries,
+                Parameters = keyValuePairs.ToDictionary()!,
+            });
+        _serviceCollection.AddSingleton(_countryAppOptionsMock.Object);
+
+        _sentinelOptionsProviderMock.Setup(p => p.Id).Returns("sentinel");
+        _sentinelOptionsProviderMock
+            .Setup(p => p.GetAppOptionsAsync(Language, It.IsAny<Dictionary<string, string>>()))
+            .ReturnsAsync((string language, Dictionary<string, string> keyValuePairs) => new AppOptions()
+            {
+                Options = AppOptionsSentinel,
+                Parameters = keyValuePairs.ToDictionary()!,
+            });
+        _serviceCollection.AddSingleton(_sentinelOptionsProviderMock.Object);
+
+        // This provider should never be used and cause an error if it is
+        _neverUsedOptionsProviderMock.Setup(p => p.Id).Returns("never-used").Verifiable(Times.AtMost(1));
+
+        _serviceCollection.AddSingleton<AppOptionsFactory>();
+
+        _serviceCollection.AddJoinedAppOptions("country", "country-no-sentinel", "sentinel");
+    }
+
+    [Fact]
+    public async Task JoinedOptionsProvider_ReturnsOptionsFromBothProviders()
+    {
+        using var sp = _serviceCollection.BuildServiceProvider();
+        var factory = sp.GetRequiredService<AppOptionsFactory>();
+        IAppOptionsProvider optionsProvider = factory.GetOptionsProvider("country");
+
+        optionsProvider.Should().BeOfType<JoinedAppOptionsProvider>();
+        optionsProvider.Id.Should().Be("country");
+        var appOptions = await optionsProvider.GetAppOptionsAsync(Language, new Dictionary<string, string>());
+        appOptions.Options.Should().HaveCount(3);
+        appOptions.Options.Should().BeEquivalentTo(AppOptionsCountries.Concat(AppOptionsSentinel));
+
+        _neverUsedOptionsProviderMock.VerifyAll();
+        _countryAppOptionsMock.VerifyAll();
+        _sentinelOptionsProviderMock.VerifyAll();
+    }
+}

--- a/test/Altinn.App.Core.Tests/Features/Options/NullInstanceAppOptionsProviderTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/NullInstanceAppOptionsProviderTests.cs
@@ -1,11 +1,9 @@
-using System;
-using System.Collections.Generic;
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Models;
 using FluentAssertions;
 using Xunit;
 
-namespace Altinn.App.PlatformServices.Tests.Options
+namespace Altinn.App.Core.Tests.Features.Options
 {
     public class NullInstanceAppOptionsProviderTests
     {

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Configuration;
-using Altinn.App.Core.Features.Validation;
 using Altinn.App.Core.Features.Validation.Default;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.App;
@@ -27,7 +26,7 @@ public class ExpressionValidatorTests
     private readonly ExpressionValidator _validator;
     private readonly Mock<ILogger<ExpressionValidator>> _logger = new();
     private readonly Mock<IAppResources> _appResources = new(MockBehavior.Strict);
-    private readonly IOptions<FrontEndSettings> _frontendSettings = Options.Create(new FrontEndSettings());
+    private readonly IOptions<FrontEndSettings> _frontendSettings = Microsoft.Extensions.Options.Options.Create(new FrontEndSettings());
     private readonly Mock<LayoutEvaluatorStateInitializer> _layoutInitializer;
 
     public ExpressionValidatorTests()

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/LegacyIValidationFormDataTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/LegacyIValidationFormDataTests.cs
@@ -22,7 +22,7 @@ namespace Altinn.App.Core.Tests.Features.Validators.Default
         {
             var generalSettings = new GeneralSettings();
             _validator =
-                new LegacyIInstanceValidatorFormDataValidator(Options.Create(generalSettings), _instanceValidator.Object);
+                new LegacyIInstanceValidatorFormDataValidator(Microsoft.Extensions.Options.Options.Create(generalSettings), _instanceValidator.Object);
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace Altinn.App.Core.Tests.Features.Validators.Default
             // Arrange
             var data = new object();
 
-            var validator = new LegacyIInstanceValidatorFormDataValidator(Options.Create(new GeneralSettings()), null);
+            var validator = new LegacyIInstanceValidatorFormDataValidator(Microsoft.Extensions.Options.Options.Create(new GeneralSettings()), null);
             validator.HasRelevantChanges(data, data).Should().BeFalse();
 
             // Act


### PR DESCRIPTION
The main point of this PR is to be able to join two AppOptions lists to a single list. This can typically be used when you want to add custom text for a non-answer.

To use this, you need to already registrer two (or more) AppOptions (eg `"country-no-sentinel"` and `"sentinel"`), and then use the custom registrer function
```c#
services.AddJoinedAppOptions("country", "country-no-sentinel", "sentinel");
```
the `"country"` app option can then be used as any other optionId

If the providers set `Parameters`, the parameters from all subLists gets combined in a single dictionary with the `optionId` prefixed on each key.

## Remaining
- [ ] Write tests that verifies the combination of parameters.

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/443

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
