### PR TITLE
Use System.Text.Json consistently on models

### DIFF
--- a/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
@@ -1,13 +1,9 @@
-using System;
-using System.IO;
 using System.Text;
-using System.Threading.Tasks;
+using System.Text.Json;
 using System.Xml;
 using System.Xml.Serialization;
 
 using Microsoft.Extensions.Logging;
-
-using Newtonsoft.Json;
 
 namespace Altinn.App.Core.Helpers.Serialization
 {
@@ -16,6 +12,8 @@ namespace Altinn.App.Core.Helpers.Serialization
     /// </summary>
     public class ModelDeserializer
     {
+        JsonSerializerOptions JSON_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
         private readonly ILogger _logger;
         private readonly Type _modelType;
 
@@ -73,9 +71,9 @@ namespace Altinn.App.Core.Helpers.Serialization
             {
                 using StreamReader reader = new StreamReader(stream, Encoding.UTF8);
                 string content = await reader.ReadToEndAsync();
-                return JsonConvert.DeserializeObject(content, _modelType)!;
+                return JsonSerializer.Deserialize(content, _modelType, JSON_SERIALIZER_OPTIONS)!;
             }
-            catch (JsonReaderException jsonReaderException)
+            catch (JsonException jsonReaderException)
             {
                 Error = jsonReaderException.Message;
                 return null;

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Core.Helpers.Serialization
     /// </summary>
     public class ModelDeserializer
     {
-        JsonSerializerOptions JSON_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        private static readonly JsonSerializerOptions JSON_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web);
 
         private readonly ILogger _logger;
         private readonly Type _modelType;


### PR DESCRIPTION
System.Text.Json is already used for serialising the model when returning to frontend, and in the new PATCH endpoint. I think it makes sense to be consistent.

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/345
- More complete version in https://github.com/Altinn/app-lib-dotnet/issues/345 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
