### PR TITLE
Add proper using statement on JsonDocument.Parse

### DIFF
--- a/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
@@ -59,14 +59,14 @@ public class ExpressionValidator : IFormDataValidator
             return new List<ValidationIssue>();
         }
 
-        var validationConfig = JsonDocument.Parse(rawValidationConfig).RootElement;
+        using var validationConfig = JsonDocument.Parse(rawValidationConfig);
         var appMetadata = await _appMetadata.GetApplicationMetadata();
-        var layoutSet = _appResourceService.GetLayoutSetForTask(appMetadata.DataTypes.First(dt=>dt.Id == dataElement.DataType).TaskId);
+        var layoutSet = _appResourceService.GetLayoutSetForTask(appMetadata.DataTypes.First(dt => dt.Id == dataElement.DataType).TaskId);
         var evaluatorState = await _layoutEvaluatorStateInitializer.Init(instance, data, layoutSet?.Id);
         var hiddenFields = LayoutEvaluator.GetHiddenFieldsForRemoval(evaluatorState, true);
 
         var validationIssues = new List<ValidationIssue>();
-        var expressionValidations = ParseExpressionValidationConfig(validationConfig, _logger);
+        var expressionValidations = ParseExpressionValidationConfig(validationConfig.RootElement, _logger);
         foreach (var validationObject in expressionValidations)
         {
             var baseField = validationObject.Key;
@@ -74,7 +74,8 @@ public class ExpressionValidator : IFormDataValidator
             var validations = validationObject.Value;
             foreach (var resolvedField in resolvedFields)
             {
-                if (hiddenFields.Contains(resolvedField)) {
+                if (hiddenFields.Contains(resolvedField))
+                {
                     continue;
                 }
                 var context = new ComponentContext(component: null, rowIndices: DataModel.GetRowIndices(resolvedField), rowLength: null);
@@ -106,7 +107,7 @@ public class ExpressionValidator : IFormDataValidator
                             validationIssues.Add(validationIssue);
                         }
                     }
-                    catch(Exception e)
+                    catch (Exception e)
                     {
                         _logger.LogError(e, "Error while evaluating expression validation for {resolvedField}", resolvedField);
                         throw;


### PR DESCRIPTION
Just a small issue with a missing `using` statement for JsonDocument https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/use-dom#use-jsondocument

Also incude a few formatting issues

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
