### PR TITLE
Set .editorconfig max_line_length = 160. Allows slightly longer lines…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,6 +55,7 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 tab_width = 4
 indent_size = 4
+max_line_length = 160
 end_of_line = crlf
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 


### PR DESCRIPTION
I think reformat code is being a bit aggressive when it comes to wrapping long lines.