### PR TITLE
Set csharp_style_prefer_primary_constructors = false:suggestion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -74,6 +74,7 @@ csharp_style_expression_bodied_accessors = true:silent
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
 csharp_indent_labels = one_less_than_current
+csharp_style_prefer_primary_constructors = false:suggestion
 
 [Program.cs]
 dotnet_diagnostic.CA1050.severity = none


### PR DESCRIPTION
Set csharp_style_prefer_primary_constructors = false:suggestion. 
As far as I can remember @ivarne and @tjololo agree.
We prefer classical constructor for now. Especially when there are injected dependencies in the class.