### PR TITLE
Handle null values in lists when removing and initializing AltinnRowId

### DIFF
--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -42,7 +42,10 @@ public static class ObjectUtils
                     foreach (var item in (IList)value)
                     {
                         // Recurse into values of a list
-                        InitializeAltinnRowId(item);
+                        if (item is not null)
+                        {
+                            InitializeAltinnRowId(item);
+                        }
                     }
                 }
             }
@@ -70,6 +73,8 @@ public static class ObjectUtils
     /// </summary>
     public static void RemoveAltinnRowId(object model)
     {
+        ArgumentNullException.ThrowIfNull(model);
+
         foreach (var prop in model.GetType().GetProperties())
         {
             // Handle guid fields named "AltinnRowId"
@@ -86,7 +91,10 @@ public static class ObjectUtils
                     foreach (var item in (IList)value)
                     {
                         // Recurse into values of a list
-                        RemoveAltinnRowId(item);
+                        if (item is not null)
+                        {
+                            RemoveAltinnRowId(item);
+                        }
                     }
                 }
             }

--- a/test/Altinn.App.Core.Tests/Helpers/ObjectUtilsTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ObjectUtilsTests.cs
@@ -167,4 +167,92 @@ public class ObjectUtilsTests
         test.Child.Child.Children.Should().ContainSingle().Which.AltinnRowId.Should().Be(Guid.Empty);
         test.Child.Child.Children.Should().ContainSingle().Which.Child!.AltinnRowId.Should().Be(Guid.Empty);
     }
+
+    [Fact]
+    public void TestRemoveAltinnRowIdWithNulls()
+    {
+        var test = new TestClass()
+        {
+            AltinnRowId = Guid.NewGuid(),
+            Child = new()
+            {
+                AltinnRowId = Guid.NewGuid(),
+                Child = new()
+                {
+                    AltinnRowId = Guid.NewGuid(),
+                    Children = new()
+                    {
+                        new TestClass()
+                        {
+                            AltinnRowId = Guid.NewGuid(),
+                            Child = new()
+                            {
+                                AltinnRowId = Guid.NewGuid()
+                            }
+                        },
+                        null!,
+                    }
+                }
+            }
+        };
+        test.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.Child.AltinnRowId.Should().NotBe(Guid.Empty);
+        var childArray = test.Child.Child.Children.Should().HaveCount(2).And;
+        childArray.ContainSingle(d => d != null).Which.AltinnRowId.Should().NotBe(Guid.Empty);
+        childArray.ContainSingle(d => d == null);
+
+        ObjectUtils.RemoveAltinnRowId(test);
+
+        test.AltinnRowId.Should().Be(Guid.Empty);
+        test.Child.AltinnRowId.Should().Be(Guid.Empty);
+        test.Child.Child.AltinnRowId.Should().Be(Guid.Empty);
+        childArray = test.Child.Child.Children.Should().HaveCount(2).And;
+        childArray.ContainSingle(d => d != null).Which.AltinnRowId.Should().Be(Guid.Empty);
+        childArray.ContainSingle(d => d == null);
+    }
+
+    [Fact]
+    public void TestInitializeRowIdWithNulls()
+    {
+        var test = new TestClass()
+        {
+            AltinnRowId = Guid.Empty,
+            Child = new()
+            {
+                AltinnRowId = Guid.Empty,
+                Child = new()
+                {
+                    AltinnRowId = Guid.Empty,
+                    Children = new()
+                    {
+                        new TestClass()
+                        {
+                            AltinnRowId = Guid.Empty,
+                            Child = new()
+                            {
+                                AltinnRowId = Guid.Empty
+                            }
+                        },
+                        null!,
+                    }
+                }
+            }
+        };
+        test.AltinnRowId.Should().Be(Guid.Empty);
+        test.Child.AltinnRowId.Should().Be(Guid.Empty);
+        test.Child.Child.AltinnRowId.Should().Be(Guid.Empty);
+        var childArray = test.Child.Child.Children.Should().HaveCount(2).And;
+        childArray.ContainSingle(d => d != null).Which.AltinnRowId.Should().Be(Guid.Empty);
+        childArray.ContainSingle(d => d == null);
+
+        ObjectUtils.InitializeAltinnRowId(test);
+
+        test.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.Child.AltinnRowId.Should().NotBe(Guid.Empty);
+        childArray = test.Child.Child.Children.Should().HaveCount(2).And;
+        childArray.ContainSingle(d => d != null).Which.AltinnRowId.Should().NotBe(Guid.Empty);
+        childArray.ContainSingle(d => d == null);
+    }
 }


### PR DESCRIPTION
Maybe we should think that `null` is an invalid value in a list in the data model, but it should not fail the AltinnRowId initialisation or removal, but be a separate validation step.

## Related Issue(s)
- #489

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
