### PR TITLE
Remove reference to Microsoft.AspNet.WebApi.Client

### DIFF
--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="JsonPatch.Net" Version="2.1.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Scrutor" Version="4.2.2" />


### PR DESCRIPTION
as it  uses Newtonsoft.json and is not used by apps anymore.

This reference was erroneously added back in https://github.com/Altinn/app-lib-dotnet/pull/404, after it was removed in https://github.com/Altinn/app-lib-dotnet/pull/363

## Related Issue(s)
- Replaces #484
- #363

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
