### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,8 +19,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    if: |
-      github.event.pull_request.user.login != 'renovate[bot]'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "v8" ]
+    branches: 
+      - "main"
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main", "v8" ]
+    branches: 
+      - "main"
   schedule:
     - cron: '37 20 * * 3'
 
@@ -17,7 +19,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
+    if: |
+      github.event.pull_request.user.login != 'renovate'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       security-events: write
     if: |
-      github.event.pull_request.user.login != 'renovate'
+      github.event.pull_request.user.login != 'renovate[bot]'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   verify-no-changes:
     if: |
-      github.event.pull_request.user.login != 'renovate'
+      github.event.pull_request.user.login != 'renovate[bot]'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -2,11 +2,13 @@ name: Verify dotnet format
 
 on:
   pull_request:
-    branches: [ "main", "v8" ]
+    branches: 
+      - "main"
 
 jobs:
-  build:
-
+  verify-no-changes:
+    if: |
+      github.event.pull_request.user.login != 'renovate'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1,9 +1,11 @@
 name: Build and Test on windows, macos and ubuntu
 on:
   push:
-    branches: [ main, v8 ]
+    branches:
+      - "main"
   pull_request:
-    branches: [ main, v8 ]
+    branches:
+      - "main"
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 jobs:

--- a/.github/workflows/test-and-analyze-fork.yml
+++ b/.github/workflows/test-and-analyze-fork.yml
@@ -1,7 +1,8 @@
 name: Code test and analysis (fork)
 on:
   pull_request:
-    branches: [ main, v8 ]
+    branches:
+      - "main"
     types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   test:

--- a/.github/workflows/test-and-analyze.yml
+++ b/.github/workflows/test-and-analyze.yml
@@ -1,14 +1,17 @@
 name: Code test and analysis
 on:
   push:
-    branches: [ main, v8 ]
+    branches:
+      - "main"
   pull_request:
-    branches: [ main, v8 ]
+    branches:
+      - "main"
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 jobs:
   analyze:
     if: |
+     github.event.pull_request.user.login != 'renovate' &&
      github.repository_owner == 'Altinn' &&
      (github.event_name != 'pull_request' && github.event.repository.fork == false) ||
      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)

--- a/.github/workflows/test-and-analyze.yml
+++ b/.github/workflows/test-and-analyze.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     if: |
-     github.event.pull_request.user.login != 'renovate' &&
+     github.event.pull_request.user.login != 'renovate[bot]' &&
      github.repository_owner == 'Altinn' &&
      (github.event_name != 'pull_request' && github.event.repository.fork == false) ||
      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)


### PR DESCRIPTION
I noticed that we run lots of pull request actions for renovate PRs when we merge to main, so this will disable a few of the less likely actions to fail for renovate.

* Don't run code analyzis on renovate pull requests (they trigger on every merge to master)
* Use list syntax for branches
* Don't refernece the v8 branch


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

