### PR TITLE
Make AppOptions.Options required

### DIFF
--- a/src/Altinn.App.Core/Models/AppOptions.cs
+++ b/src/Altinn.App.Core/Models/AppOptions.cs
@@ -8,7 +8,7 @@ namespace Altinn.App.Core.Models
         /// <summary>
         /// Gets or sets the list of options. Null indicates that no options are found
         /// </summary>
-        public List<AppOption>? Options { get; set; }
+        public required List<AppOption>? Options { get; set; }
 
         /// <summary>
         /// Gets or sets the parameters used to generate the options.

--- a/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
@@ -12,7 +12,8 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Parameters = new Dictionary<string, string>
+                Options = null,
+                Parameters = new Dictionary<string, string?>
                 {
                     { "lang", "nb" },
                     { "level", "1" }
@@ -32,7 +33,8 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Parameters = new Dictionary<string, string>()
+                Options = null,
+                Parameters = new Dictionary<string, string?>()
             };
 
             IHeaderDictionary headers = new HeaderDictionary
@@ -48,6 +50,7 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
+                Options = null,
                 Parameters = null!
             };
 
@@ -64,7 +67,8 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Parameters = new Dictionary<string, string>
+                Options = null,
+                Parameters = new Dictionary<string, string?>
                 {
                     { "lang", "nb" },
                     { "level", "1" },


### PR DESCRIPTION
It does not make much sense to not specify Options and it can be null. I spotted the folowing code that caused an error

```c#
var options = new AppOptions();
foreach(var item in items)
{
    options.Options.Add(new()
    {
       Value = item.Value,
       Label = item.Label
    })
}
```
which failed because Options was uninitialized.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
