### PR TITLE
Add a few more cases to the Linq to json path used for CreateValidationIssue

### DIFF
--- a/test/Altinn.App.Core.Tests/Helpers/LinqExpressionHelpersTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/LinqExpressionHelpersTests.cs
@@ -76,4 +76,37 @@ public class LinqExpressionHelpersTests
             propertyName.Should().Be($"Children[{index}].age");
         }
     }
+
+    [Fact]
+    public void GetJsonPath_AritmeticExpression()
+    {
+        var list = new List<string>
+        {
+            "one",
+            "two"
+        };
+        var propertyName = LinqExpressionHelpers.GetJsonPath<MyModel, int?>(m => m.Children![list.Count - 1].Age);
+        propertyName.Should().Be("Children[1].age");
+    }
+
+    [Fact]
+    public void GetJsonPath_AritmeticExpressionOnRecursiveModel()
+    {
+        var model = new MyModel
+        {
+            Children = new()
+            {
+                new()
+                {
+                    Age = 3
+                },
+                new()
+                {
+                    Age = 4
+                }
+            }
+        };
+        var propertyName = LinqExpressionHelpers.GetJsonPath<MyModel, int?>(m => m.Children![model.Children.Count + 1].Age);
+        propertyName.Should().Be("Children[3].age");
+    }
 }


### PR DESCRIPTION
Makes this code possible

```C#
CreateValidationIssue(m => m.Children![model.Children.Count - 1].Age, "validationTextKey");
```

## Related Issue(s)
- #506 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
