### PR TITLE
Ensure that swagger files in repo is in sync with real swagger output when controllers change

### DIFF
--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.cs
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.cs
@@ -22,7 +22,7 @@ public class OpenApiSpecChangeDetection : ApiTestBase, IClassFixture<WebApplicat
         response.EnsureSuccessStatusCode();
         var originalSpec = await File.ReadAllTextAsync("../../../OpenApi/swagger.json");
         await File.WriteAllTextAsync("../../../OpenApi/swagger.json", openApiSpec);
-        openApiSpec.Should().BeEquivalentTo(originalSpec, because: "The OpenAPI spec in the repo should be up do date with the code. If this test fails, update the OpenAPI spec in the repo with the new one from the code. This ensures that tests fails in CI if spec is not updated.");
+        openApiSpec.ReplaceLineEndings().Should().BeEquivalentTo(originalSpec.ReplaceLineEndings(), because: "The OpenAPI spec in the repo should be up do date with the code. If this test fails, update the OpenAPI spec in the repo with the new one from the code. This ensures that tests fails in CI if spec is not updated.");
     }
 
     [Fact]
@@ -37,6 +37,6 @@ public class OpenApiSpecChangeDetection : ApiTestBase, IClassFixture<WebApplicat
         response.EnsureSuccessStatusCode();
         var originalSpec = await File.ReadAllTextAsync("../../../OpenApi/swagger.yaml");
         await File.WriteAllTextAsync("../../../OpenApi/swagger.yaml", openApiSpec);
-        openApiSpec.Should().BeEquivalentTo(originalSpec, because: "The OpenAPI spec in the repo should be up do date with the code. If this test fails, update the OpenAPI spec in the repo with the new one from the code. This ensures that tests fails in CI if spec is not updated.");
+        openApiSpec.ReplaceLineEndings().Should().BeEquivalentTo(originalSpec.ReplaceLineEndings(), because: "The OpenAPI spec in the repo should be up do date with the code. If this test fails, update the OpenAPI spec in the repo with the new one from the code. This ensures that tests fails in CI if spec is not updated.");
     }
 }

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.cs
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.cs
@@ -19,9 +19,10 @@ public class OpenApiSpecChangeDetection : ApiTestBase, IClassFixture<WebApplicat
         // The test project exposes swagger.json at /swagger/v1/swagger.json not /{org}/{app}/swagger/v1/swagger.json
         HttpResponseMessage response = await client.GetAsync("/swagger/v1/swagger.json");
         string openApiSpec = await response.Content.ReadAsStringAsync();
-        _outputHelper.WriteLine(openApiSpec);
         response.EnsureSuccessStatusCode();
+        var originalSpec = await File.ReadAllTextAsync("../../../OpenApi/swagger.json");
         await File.WriteAllTextAsync("../../../OpenApi/swagger.json", openApiSpec);
+        openApiSpec.Should().BeEquivalentTo(originalSpec, because: "The OpenAPI spec in the repo should be up do date with the code. If this test fails, update the OpenAPI spec in the repo with the new one from the code. This ensures that tests fails in CI if spec is not updated.");
     }
 
     [Fact]
@@ -33,8 +34,9 @@ public class OpenApiSpecChangeDetection : ApiTestBase, IClassFixture<WebApplicat
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/yaml"));
         HttpResponseMessage response = await client.SendAsync(request);
         string openApiSpec = await response.Content.ReadAsStringAsync();
-        _outputHelper.WriteLine(openApiSpec);
         response.EnsureSuccessStatusCode();
+        var originalSpec = await File.ReadAllTextAsync("../../../OpenApi/swagger.yaml");
         await File.WriteAllTextAsync("../../../OpenApi/swagger.yaml", openApiSpec);
+        openApiSpec.Should().BeEquivalentTo(originalSpec, because: "The OpenAPI spec in the repo should be up do date with the code. If this test fails, update the OpenAPI spec in the repo with the new one from the code. This ensures that tests fails in CI if spec is not updated.");
     }
 }

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -123,6 +123,12 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict"
+          },
+          "500": {
+            "description": "Server Error"
+          },
           "401": {
             "description": "Unauthorized"
           }

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -76,6 +76,10 @@ paths:
             text/xml:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+        '409':
+          description: Conflict
+        '500':
+          description: Server Error
         '401':
           description: Unauthorized
   '/{org}/{app}/api/v1/applicationlanguages':


### PR DESCRIPTION
I think it makes sense to auto update these locally when running tests, but fail the tests when there are changes, so that CI fails when a Controller change is not reflected in the swagger files.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
