### PR TITLE
Unlock task data elements if PDF service task fails

### DIFF
--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
@@ -64,7 +64,7 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
                 await _processTaskDataLocker.Unlock(taskId, instance);
                 throw;
             }
-            
+
             await _eformidlingServiceTask.Execute(taskId, instance);
         }
 

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
@@ -3,6 +3,7 @@ using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.App.Core.Internal.Process.ServiceTasks;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
 {
@@ -16,6 +17,7 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
         private readonly IServiceTask _pdfServiceTask;
         private readonly IServiceTask _eformidlingServiceTask;
         private readonly IEnumerable<IProcessTaskEnd> _processTaskEnds;
+        private readonly ILogger<EndTaskEventHandler> _logger;
 
         /// <summary>
         /// This event handler is responsible for handling the end event for a process task.
@@ -25,7 +27,8 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
             IProcessTaskFinalizer processTaskFinisher,
             [FromKeyedServices("pdfService")] IServiceTask pdfServiceTask,
             [FromKeyedServices("eFormidlingService")] IServiceTask eformidlingServiceTask,
-            IEnumerable<IProcessTaskEnd> processTaskEnds
+            IEnumerable<IProcessTaskEnd> processTaskEnds,
+            ILogger<EndTaskEventHandler> logger
         )
         {
             _processTaskDataLocker = processTaskDataLocker;
@@ -33,6 +36,7 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
             _pdfServiceTask = pdfServiceTask;
             _eformidlingServiceTask = eformidlingServiceTask;
             _processTaskEnds = processTaskEnds;
+            _logger = logger;
         }
 
         /// <summary>
@@ -50,7 +54,17 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
             await _processTaskDataLocker.Lock(taskId, instance);
 
             //These two services are scheduled to be removed and replaced by services tasks defined in the processfile.
-            await _pdfServiceTask.Execute(taskId, instance);
+            try
+            {
+                await _pdfServiceTask.Execute(taskId, instance);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error executing pdf service task. Unlocking data again.");
+                await _processTaskDataLocker.Unlock(taskId, instance);
+                throw;
+            }
+            
             await _eformidlingServiceTask.Execute(taskId, instance);
         }
 

--- a/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
@@ -122,5 +122,5 @@ public class EndTaskEventHandlerTests
 
         // Make sure eFormidling service task is not called if PDF failed.
         _eformidlingServiceTask.Verify(p => p.Execute("Task_1", instance), Times.Never);
-    } 
+    }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
@@ -17,7 +17,7 @@ public class EndTaskEventHandlerTests
     private readonly Mock<IServiceTask> _pdfServiceTask = new();
     private readonly Mock<IServiceTask> _eformidlingServiceTask = new();
     private IEnumerable<IProcessTaskEnd> _processTaskEnds = new List<IProcessTaskEnd>();
-    private ILogger<EndTaskEventHandler> _logger = new NullLogger<EndTaskEventHandler>();
+    private readonly ILogger<EndTaskEventHandler> _logger = new NullLogger<EndTaskEventHandler>();
 
     [Fact]
     public async Task Execute_handles_no_IProcessTaskAbandon_injected()

--- a/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
@@ -103,24 +103,25 @@ public class EndTaskEventHandlerTests
             AppId = "ttd/test",
         };
 
+        var taskId = "Task_1";
         Mock<IProcessTask> mockProcessTask = new();
 
         // Make PDF service task throw exception to simulate a failure situation.
         _pdfServiceTask.Setup(x => x.Execute(It.IsAny<string>(), instance)).ThrowsAsync(new Exception());
 
         // Expect exception to be thrown
-        await Assert.ThrowsAsync<Exception>(async () => await eteh.Execute(mockProcessTask.Object, "Task_1", instance));
+        await Assert.ThrowsAsync<Exception>(async () => await eteh.Execute(mockProcessTask.Object, taskId, instance));
 
         // Assert normal flow until the exception is thrown
-        _processTaskDataLocker.Verify(p => p.Lock("Task_1", instance));
-        _processTaskFinisher.Verify(p => p.Finalize("Task_1", instance));
-        mockProcessTask.Verify(p => p.End("Task_1", instance));
-        _pdfServiceTask.Verify(p => p.Execute("Task_1", instance));
+        _processTaskDataLocker.Verify(p => p.Lock(taskId, instance));
+        _processTaskFinisher.Verify(p => p.Finalize(taskId, instance));
+        mockProcessTask.Verify(p => p.End(taskId, instance));
+        _pdfServiceTask.Verify(p => p.Execute(taskId, instance));
 
         // Make sure unlock data is called
-        _processTaskDataLocker.Verify(p => p.Unlock("Task_1", instance));
+        _processTaskDataLocker.Verify(p => p.Unlock(taskId, instance));
 
         // Make sure eFormidling service task is not called if PDF failed.
-        _eformidlingServiceTask.Verify(p => p.Execute("Task_1", instance), Times.Never);
+        _eformidlingServiceTask.Verify(p => p.Execute(taskId, instance), Times.Never);
     }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
@@ -3,6 +3,8 @@ using Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.App.Core.Internal.Process.ServiceTasks;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -15,6 +17,7 @@ public class EndTaskEventHandlerTests
     private readonly Mock<IServiceTask> _pdfServiceTask = new();
     private readonly Mock<IServiceTask> _eformidlingServiceTask = new();
     private IEnumerable<IProcessTaskEnd> _processTaskEnds = new List<IProcessTaskEnd>();
+    private ILogger<EndTaskEventHandler> _logger = new NullLogger<EndTaskEventHandler>();
 
     [Fact]
     public async Task Execute_handles_no_IProcessTaskAbandon_injected()
@@ -24,7 +27,8 @@ public class EndTaskEventHandlerTests
             _processTaskFinisher.Object,
             _pdfServiceTask.Object,
             _eformidlingServiceTask.Object,
-            _processTaskEnds);
+            _processTaskEnds,
+            _logger);
         var instance = new Instance()
         {
             Id = "1337/fa0678ad-960d-4307-aba2-ba29c9804c9d",
@@ -56,7 +60,8 @@ public class EndTaskEventHandlerTests
             _processTaskFinisher.Object,
             _pdfServiceTask.Object,
             _eformidlingServiceTask.Object,
-            _processTaskEnds);
+            _processTaskEnds,
+            _logger);
         var instance = new Instance()
         {
             Id = "1337/fa0678ad-960d-4307-aba2-ba29c9804c9d",
@@ -80,4 +85,42 @@ public class EndTaskEventHandlerTests
         endOne.VerifyNoOtherCalls();
         endTwo.VerifyNoOtherCalls();
     }
+
+    [Fact]
+    public async Task Calls_unlock_if_pdf_fails()
+    {
+        EndTaskEventHandler eteh = new(
+            _processTaskDataLocker.Object,
+            _processTaskFinisher.Object,
+            _pdfServiceTask.Object,
+            _eformidlingServiceTask.Object,
+            _processTaskEnds,
+            _logger);
+
+        var instance = new Instance()
+        {
+            Id = "1337/fa0678ad-960d-4307-aba2-ba29c9804c9d",
+            AppId = "ttd/test",
+        };
+
+        Mock<IProcessTask> mockProcessTask = new();
+
+        // Make PDF service task throw exception to simulate a failure situation.
+        _pdfServiceTask.Setup(x => x.Execute(It.IsAny<string>(), instance)).ThrowsAsync(new Exception());
+
+        // Expect exception to be thrown
+        await Assert.ThrowsAsync<Exception>(async () => await eteh.Execute(mockProcessTask.Object, "Task_1", instance));
+
+        // Assert normal flow until the exception is thrown
+        _processTaskDataLocker.Verify(p => p.Lock("Task_1", instance));
+        _processTaskFinisher.Verify(p => p.Finalize("Task_1", instance));
+        mockProcessTask.Verify(p => p.End("Task_1", instance));
+        _pdfServiceTask.Verify(p => p.Execute("Task_1", instance));
+
+        // Make sure unlock data is called
+        _processTaskDataLocker.Verify(p => p.Unlock("Task_1", instance));
+
+        // Make sure eFormidling service task is not called if PDF failed.
+        _eformidlingServiceTask.Verify(p => p.Execute("Task_1", instance), Times.Never);
+    } 
 }


### PR DESCRIPTION
Unlock data elements again if any exception happens inside pdf generation service task.
Should allow for another attempt at submitting the form.

This will change in service task refactor.

## Related Issue(s)
- #504 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
