### PR TITLE
Make TelemetryClient optional in EmailNotificationClient

### DIFF
--- a/src/Altinn.App.Core/Infrastructure/Clients/Email/EmailNotificationClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Email/EmailNotificationClient.cs
@@ -21,7 +21,7 @@ public sealed class EmailNotificationClient : IEmailNotificationClient
     private readonly IAppMetadata _appMetadata;
     private readonly PlatformSettings _platformSettings;
     private readonly IAccessTokenGenerator _accessTokenGenerator;
-    private readonly TelemetryClient _telemetryClient;
+    private readonly TelemetryClient? _telemetryClient;
     private static readonly Counter _orderCount = Metrics
         .CreateCounter("altinn_app_notification_order_request_count", "Number of notification order requests.", labelNames: ["type", "result"]);
 
@@ -38,7 +38,7 @@ public sealed class EmailNotificationClient : IEmailNotificationClient
         IOptions<PlatformSettings> platformSettings,
         IAppMetadata appMetadata,
         IAccessTokenGenerator accessTokenGenerator,
-        TelemetryClient telemetryClient)
+        TelemetryClient? telemetryClient = null)
     {
         _platformSettings = platformSettings.Value;
         _httpClientFactory = httpClientFactory;
@@ -106,7 +106,7 @@ public sealed class EmailNotificationClient : IEmailNotificationClient
             httpResponseMessage?.Dispose();
 
             timer.Stop();
-            _telemetryClient.TrackDependency(
+            _telemetryClient?.TrackDependency(
                 "Altinn.Notifications",
                 "OrderEmailNotification",
                 "",


### PR DESCRIPTION
ApplicationInsigts is optionally registrered and should not be required for code to run.

The issue was discovered because WebApplicationFactory tests failed in the test runner inside Rider on Mac

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/pull/511

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
