### PR TITLE
Remove archived date from pretest file. Was there by mistake.

### DIFF
--- a/test/Altinn.App.Api.Tests/Data/Instances/tdd/contributer-restriction/500600/5a2fa5ec-f97c-4816-b57a-dc78a981917e.pretest.json
+++ b/test/Altinn.App.Api.Tests/Data/Instances/tdd/contributer-restriction/500600/5a2fa5ec-f97c-4816-b57a-dc78a981917e.pretest.json
@@ -23,7 +23,6 @@
     },
     "status": {
         "isArchived": false,
-        "archived": "2024-02-10T15:04:22.179525Z",
         "isSoftDeleted": false,
         "isHardDeleted": false,
         "readStatus": "Read"


### PR DESCRIPTION
Small fix of pretest file. Instance was not ment to be archived in these tests.