### PR TITLE
Add GenericFormDataValidator2 that doesn't take DataType in constructor

### DIFF
--- a/src/Altinn.App.Core/Features/IFormDataValidator.cs
+++ b/src/Altinn.App.Core/Features/IFormDataValidator.cs
@@ -20,6 +20,7 @@ public interface IFormDataValidator
 
     /// <summary>
     /// Used for partial validation to ensure that the validator only runs when relevant fields have changed.
+    /// A default "return true" implementation can be used if the validator is quick and does not call external APIs.
     /// </summary>
     /// <param name="current">The current state of the form data</param>
     /// <param name="previous">The previous state of the form data</param>

--- a/src/Altinn.App.Core/Features/Validation/GenericFormDataValidator2.cs
+++ b/src/Altinn.App.Core/Features/Validation/GenericFormDataValidator2.cs
@@ -10,24 +10,13 @@ namespace Altinn.App.Core.Features.Validation;
 /// Simple wrapper for validation of form data that does the type checking for you.
 /// </summary>
 /// <typeparam name="TModel">The type of the model this class will validate</typeparam>
-// TODO: Consider marking this as obsolete and use the new GenericFormDataValidator2 instead
-//[Obsolete("Use GenericFormDataValidator2 instead")]
-public abstract class GenericFormDataValidator<TModel> : IFormDataValidator
+public abstract class GenericFormDataValidator2<TModel> : IFormDataValidator
 {
-    /// <summary>
-    /// Constructor to force the DataType to be set.
-    /// </summary>
-    /// <param name="dataType">The data type this validator should run on</param>
-    protected GenericFormDataValidator(string dataType)
-    {
-        DataType = dataType;
-    }
-
-    /// <inheritdoc />
-    public string DataType { get; private init; }
-
     // ReSharper disable once StaticMemberInGenericType
     private static readonly AsyncLocal<List<ValidationIssue>> _validationIssues = new();
+
+    /// <inheritdoc />
+    public abstract string DataType { get; }
 
     /// <summary>
     /// Default implementation that calls the same method with TModel arguments.

--- a/test/Altinn.App.Core.Tests/Features/Validators/GenericValidatorTests2.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/GenericValidatorTests2.cs
@@ -1,0 +1,80 @@
+using System.Text.Json.Serialization;
+using Altinn.App.Core.Features.Validation;
+using Altinn.App.Core.Models.Validation;
+using Altinn.Platform.Storage.Interface.Models;
+using FluentAssertions;
+
+namespace Altinn.App.Core.Tests.Features.Validators;
+
+public class GenericValidatorTests2
+{
+    private class MyModel
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("age")]
+        public int? Age { get; set; }
+
+        [JsonPropertyName("children")]
+        public List<MyModel>? Children { get; set; }
+    }
+
+    private class TestValidator : GenericFormDataValidator2<MyModel>
+    {
+        public override string DataType => "MyType";
+
+        protected override bool HasRelevantChanges(MyModel current, MyModel previous)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override Task ValidateFormData(
+            Instance instance,
+            DataElement dataElement,
+            MyModel data,
+            string? language
+        )
+        {
+            AddValidationIssue(
+                new ValidationIssue() { Severity = ValidationIssueSeverity.Informational, Description = "Test info", }
+            );
+
+            CreateValidationIssue(c => c.Name, "Test warning", severity: ValidationIssueSeverity.Warning);
+            var childIndex = 4;
+            CreateValidationIssue(
+                c => c.Children![childIndex].Children![0].Name,
+                "childrenError",
+                severity: ValidationIssueSeverity.Error
+            );
+
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task VerifyTestValidator()
+    {
+        var testValidator = new TestValidator();
+        var instance = new Instance();
+        var dataElement = new DataElement();
+        var data = new MyModel();
+
+        var validationIssues = await testValidator.ValidateFormData(instance, dataElement, data, null);
+        validationIssues.Should().HaveCount(3);
+
+        var info = validationIssues
+            .Should()
+            .ContainSingle(c => c.Severity == ValidationIssueSeverity.Informational)
+            .Which;
+        info.Description.Should().Be("Test info");
+
+        var warning = validationIssues.Should().ContainSingle(c => c.Severity == ValidationIssueSeverity.Warning).Which;
+        warning.Description.Should().Be("Test warning");
+        warning.Field.Should().Be("name");
+
+        var error = validationIssues.Should().ContainSingle(c => c.Severity == ValidationIssueSeverity.Error).Which;
+        error.Description.Should().Be("childrenError");
+        error.Field.Should().Be("children[4].children[0].name");
+    }
+}


### PR DESCRIPTION
`GenericFormDataValidator<TModel>` is a (currently undocumented) convenience abstract class for implementing `IFormDataValidator`. The benefit is that `HasRelevantChanges` and `ValidateFormData` has a signature of `TModel` instead of `object` and the helper method `CreateValidationIssue` that takes an expression (aka linq) instead of providing the field the issue relates to as a string. In addition `ValidateFormData` does not return a list of issues, but instead you register them with `AddValidationIssue` and `CreateValidationIssue`.

The previous version of this abstract class defined the `DataType` property and to ensure that users actually set this property, it was a required parameter in the constructor. Today I realised that it was hard to read and understand how that magic string ended up in the `base()` call, and that an abstract class can declare an abstract property so that inheriting classes is required to implement the property. I think this results in much prettier code.
 
```c#
// Define constructor in order to set `DataType` to a hard coded value
public TestValidator() : base("MyType"){}
```
The new way is almost the same as when you implement the `IFormDataValidator` interface directly (needs the `override` keyword because of the abstract class)
```c#
// Just override the property (as required by the compiler) and set the value directly.
public override string DataType => "MyType";
```

## Breaking change, alternatives?
This is a breaking change which will cause those apps that has started to use `GenericFormDataValidator<TModel>`. As it is not documented, I think that would be very few cases.

### Add obsolete message, to better explain the change
We can improve the error message by adding the following constructors.
```c#
    /// <summary>
    /// Default constructor
    /// </summary>
    public GenericFormDataValidator() { }

    [Obsolete("Override DataType instead of setting in constructor `public override string DataType => \"MyType\";`", error: true)]
    public GenericFormDataValidator(string dataType) { }
```
### Create a new abstract class
As this is just a utility class, we could potentially just add a new one with a new name and the slightly changed semantics. This will ensure that no direct changes will be needed until the old (obsolete) version is removed in v9. Good suggestions for names would be very welcome. See suggestion [here](https://github.com/Altinn/app-lib-dotnet/compare/ivarne/FormDataValidator?expand=1)

## Related Issue(s)
- #369 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
