### PR TITLE
Adds issue labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'triage' label to all new issues
+"status/triage":
+  - '/.*/'


### PR DESCRIPTION
Not entirely sure how to handle the slash in the `status/triage` label name. Adding quotations seem to satisfy the yaml schema, but it's currently unknown if this will satisfy the `issue-labeler` action.