### PR TITLE
Debugs issue labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,3 @@
-# Add 'triage' label to all new issues
-'status/triage':
+# Temporarily adds a label without special characters for debug
+bugfix:
   - '/.*/'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,3 @@
 # Add 'triage' label to all new issues
-status/triage:
+'status/triage':
   - '/.*/'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,3 @@
 # Add 'triage' label to all new issues
-"status/triage":
+status/triage:
   - '/.*/'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,18 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  apply-labels:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.4
+      with:
+        configuration-path: .github/labeler.yml
+        enable-versioned-regex: 0
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         configuration-path: .github/labeler.yml
         enable-versioned-regex: 0
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.ASSIGN_PROJECT_TOKEN }}


### PR DESCRIPTION
Temporarily switches to a label with only standard characters in its name, to eliminate the possibility of config/formatting errors.