### PR TITLE
Add automatic labeling of pr from branch name

### DIFF
--- a/.github/workflows/label-pr-from-branch-name.yml
+++ b/.github/workflows/label-pr-from-branch-name.yml
@@ -1,0 +1,31 @@
+name: Label PR based on Branch Name
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  label_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+             const branchName =  context.payload.pull_request.head.ref;
+             console.log('Branch Name:', branchName);
+             const labelsToAdd = ["bug", "feat", "ignore"];
+             const prefix = branchName.split('/')[0];
+             console.log('Prefix:', prefix);
+             if (labelsToAdd.includes(prefix)) {
+               console.log('Adding label:', prefix);
+               await github.rest.issues.addLabels({
+                 issue_number: context.issue.number,
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 labels: [prefix]
+               });
+             } else {
+               console.log('No matching label found for prefix:', prefix);
+             }


### PR DESCRIPTION
This did not work, because I have not yet fixed the mapping from branch name to label and heading.

The currently used labels for the different headings can be seen in [.github/release.yaml](https://github.com/Altinn/app-lib-dotnet/blob/main/.github/release.yml)

I suggest to add the following mapping and will do so when I get some feedback

| Header | Branch Prefix | Label |
|--------|--------|--------|
| Breaking Changes 🛠 | `break*/` | `breaking-change` |
| New Features 🎉 | `feat*/` |`feature ` |
| Bugfixes 🐛 | `fix*/` | `bugfix `|
| Dependency Upgrades 📦 |`dep*/` | `dependency `|
| (Ignore) | `chore*/` | `ignore-for-release`| 