### PR TITLE
Properly dispose `HttpResponseMessage`  instances from `HttpClient`

### DIFF
--- a/src/Altinn.App.Core/EFormidling/Implementation/EformidlingStatusCheckEventHandler.cs
+++ b/src/Altinn.App.Core/EFormidling/Implementation/EformidlingStatusCheckEventHandler.cs
@@ -116,7 +116,7 @@ namespace Altinn.App.Core.EFormidling.Implementation
             TokenResponse altinnToken = await GetOrganizationToken();
             HttpClient httpClient = _httpClientFactory.CreateClient();
 
-            HttpResponseMessage response = await httpClient.PutAsync(altinnToken.AccessToken, url, new StringContent(string.Empty));
+            using HttpResponseMessage response = await httpClient.PutAsync(altinnToken.AccessToken, url, new StringContent(string.Empty));
 
             if (response.IsSuccessStatusCode)
             {
@@ -146,7 +146,7 @@ namespace Altinn.App.Core.EFormidling.Implementation
             httpClient.DefaultRequestHeaders.Add(General.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            HttpResponseMessage response = await httpClient.PostAsync(altinnToken.AccessToken, url, new StringContent(string.Empty));
+            using HttpResponseMessage response = await httpClient.PostAsync(altinnToken.AccessToken, url, new StringContent(string.Empty));
 
             if (response.StatusCode == HttpStatusCode.OK)
             {

--- a/src/Altinn.App.Core/EFormidling/Implementation/EformidlingStatusCheckEventHandler2.cs
+++ b/src/Altinn.App.Core/EFormidling/Implementation/EformidlingStatusCheckEventHandler2.cs
@@ -105,7 +105,7 @@ namespace Altinn.App.Core.EFormidling.Implementation
             string altinnToken = await GetOrganizationToken();
             HttpClient httpClient = _httpClientFactory.CreateClient();
 
-            HttpResponseMessage response = await httpClient.PutAsync(altinnToken, url, new StringContent(string.Empty));
+            using HttpResponseMessage response = await httpClient.PutAsync(altinnToken, url, new StringContent(string.Empty));
 
             if (response.IsSuccessStatusCode)
             {
@@ -135,7 +135,7 @@ namespace Altinn.App.Core.EFormidling.Implementation
             httpClient.DefaultRequestHeaders.Add(General.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            HttpResponseMessage response = await httpClient.PostAsync(altinnToken, url, new StringContent(string.Empty));
+            using HttpResponseMessage response = await httpClient.PostAsync(altinnToken, url, new StringContent(string.Empty));
 
             if (response.StatusCode == HttpStatusCode.OK)
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Authentication/AuthenticationClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Authentication/AuthenticationClient.cs
@@ -46,7 +46,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Authentication
         {
             string endpointUrl = $"refresh";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, General.RuntimeCookieName);
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
+            using HttpResponseMessage response = await _client.GetAsync(token, endpointUrl);
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
@@ -73,7 +73,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Authorization
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
             try
             {
-                HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+                using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
 
                 if (response.StatusCode == System.Net.HttpStatusCode.OK)
                 {
@@ -96,7 +96,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Authorization
             string apiUrl = $"parties/{partyId}/validate?userid={userId}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsClient.cs
@@ -91,7 +91,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Events
 
             string serializedCloudEvent = JsonSerializer.Serialize(cloudEvent);
 
-            HttpResponseMessage response = await _client.PostAsync(
+            using HttpResponseMessage response = await _client.PostAsync(
                 token,
                 "app",
                 new StringContent(serializedCloudEvent, Encoding.UTF8, "application/json"),

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
@@ -63,7 +63,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Events
             string serializedSubscriptionRequest = JsonSerializer.Serialize(subscriptionRequest);
 
             _logger.LogInformation("About to send the following subscription request {subscriptionJson}", serializedSubscriptionRequest);
-            HttpResponseMessage response = await _client.PostAsync(
+            using HttpResponseMessage response = await _client.PostAsync(
                 "subscriptions",
                 new StringContent(serializedSubscriptionRequest, Encoding.UTF8, "application/json"));
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -88,6 +88,8 @@ public class PdfGeneratorClient : IPdfGeneratorClient
 
         string requestContent = JsonSerializer.Serialize(generatorRequest, _jsonSerializerOptions);
         using StringContent stringContent = new(requestContent, Encoding.UTF8, "application/json");
+        // TODO: can't dispose the response here, as the stream is returned below
+        // in the future we should make sure we dispose both the stream and the response
         var httpResponseMessage = await _httpClient.PostAsync(
             _platformSettings.ApiPdf2Endpoint,
             stringContent,

--- a/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
@@ -66,7 +66,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Profile
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
             ApplicationMetadata applicationMetadata = await _appMetadata.GetApplicationMetadata();
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, _accessTokenGenerator.GenerateAccessToken(applicationMetadata.Org, applicationMetadata.AppIdentifier.App));
+            using HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, _accessTokenGenerator.GenerateAccessToken(applicationMetadata.Org, applicationMetadata.AppIdentifier.App));
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {
                 userProfile = await JsonSerializerPermissive.DeserializeAsync<UserProfile>(response.Content);

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -66,7 +66,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
             string endpointUrl = $"parties/{partyId}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
             ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App));
+            using HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App));
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 party = await JsonSerializerPermissive.DeserializeAsync<Party>(response.Content);
@@ -104,7 +104,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
             ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
             request.Headers.Add("PlatformAccessToken", _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App));
 
-            HttpResponseMessage response = await _client.SendAsync(request);
+            using HttpResponseMessage response = await _client.SendAsync(request);
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 party = await JsonSerializerPermissive.DeserializeAsync<Party>(response.Content);

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
@@ -68,7 +68,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
             request.Headers.Add("X-Ai-NationalIdentityNumber", nationalIdentityNumber);
             request.Headers.Add("X-Ai-LastName", ConvertToBase64(lastName));
 
-            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
+            using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
 
             return await ReadResponse(response, ct);
         }

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/RegisterERClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/RegisterERClient.cs
@@ -66,7 +66,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
             ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
-            HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App));
+            using HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App));
 
             if (response.StatusCode == System.Net.HttpStatusCode.OK)
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/ApplicationClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/ApplicationClient.cs
@@ -47,7 +47,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             Application? application = null;
             string getApplicationMetadataUrl = $"applications/{appId}";
 
-            HttpResponseMessage response = await _client.GetAsync(getApplicationMetadataUrl);
+            using HttpResponseMessage response = await _client.GetAsync(getApplicationMetadataUrl);
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 string applicationData = await response.Content.ReadAsStringAsync();

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
@@ -80,7 +80,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             stream.Position = 0;
             StreamContent streamContent = new StreamContent(stream);
             streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/xml");
-            HttpResponseMessage response = await _client.PostAsync(token, apiUrl, streamContent);
+            using HttpResponseMessage response = await _client.PostAsync(token, apiUrl, streamContent);
 
             if (response.IsSuccessStatusCode)
             {
@@ -109,7 +109,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             StreamContent streamContent = new StreamContent(stream);
             streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/xml");
 
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, streamContent);
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, streamContent);
 
             if (response.IsSuccessStatusCode)
             {
@@ -143,6 +143,8 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
 
             string token = _userTokenProvider.GetUserToken();
 
+            // Not disposing this since the stream is returned to the caller
+            // TODO: wrap the stream in an object that disposes both the resopnse and the stream?
             HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
 
             if (response.IsSuccessStatusCode)
@@ -164,10 +166,10 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceIdentifier}/data/{dataId}";
             string token = _userTokenProvider.GetUserToken();
 
-            HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
             if (response.IsSuccessStatusCode)
             {
-                using Stream stream = await response.Content.ReadAsStreamAsync();
+                await using Stream stream = await response.Content.ReadAsStreamAsync();
                 ModelDeserializer deserializer = new ModelDeserializer(_logger, type);
                 object? model = await deserializer.DeserializeAsync(stream, "application/xml");
 
@@ -193,7 +195,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             DataElementList dataList;
             List<AttachmentList> attachmentList = new List<AttachmentList>();
 
-            HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 string instanceData = await response.Content.ReadAsStringAsync();
@@ -255,7 +257,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceIdentifier}/data/{dataGuid}?delay={delay}";
             string token = _userTokenProvider.GetUserToken();
 
-            HttpResponseMessage response = await _client.DeleteAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.DeleteAsync(token, apiUrl);
 
             if (response.IsSuccessStatusCode)
             {
@@ -276,7 +278,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
 
             StreamContent content = request.CreateContentStream();
 
-            HttpResponseMessage response = await _client.PostAsync(token, apiUrl, content);
+            using HttpResponseMessage response = await _client.PostAsync(token, apiUrl, content);
 
             if (response.IsSuccessStatusCode)
             {
@@ -312,7 +314,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
                 };
             }
 
-            HttpResponseMessage response = await _client.PostAsync(token, apiUrl, content);
+            using HttpResponseMessage response = await _client.PostAsync(token, apiUrl, content);
 
             if (response.IsSuccessStatusCode)
             {
@@ -335,7 +337,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
 
             StreamContent content = request.CreateContentStream();
 
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, content);
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, content);
 
             if (response.IsSuccessStatusCode)
             {
@@ -361,7 +363,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
                 FileName = filename,
                 FileNameStar = filename
             };
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, content);
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, content);
             _logger.LogInformation("Update binary data result: {ResultCode}", response.StatusCode);
             if (response.IsSuccessStatusCode)
             {
@@ -380,7 +382,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string token = _userTokenProvider.GetUserToken();
 
             StringContent jsonString = new StringContent(JsonConvert.SerializeObject(dataElement), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, jsonString);
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, jsonString);
 
             if (response.IsSuccessStatusCode)
             {
@@ -398,7 +400,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"{_platformSettings.ApiStorageEndpoint}instances/{instanceIdentifier}/data/{dataGuid}/lock";
             string token = _userTokenProvider.GetUserToken();
             _logger.LogDebug("Locking data element {DataGuid} for instance {InstanceIdentifier} URL: {Url}", dataGuid, instanceIdentifier, apiUrl);
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, content: null);
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, content: null);
             if (response.IsSuccessStatusCode)
             {
                 DataElement result = JsonConvert.DeserializeObject<DataElement>(await response.Content.ReadAsStringAsync())!;
@@ -414,7 +416,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"{_platformSettings.ApiStorageEndpoint}instances/{instanceIdentifier}/data/{dataGuid}/lock";
             string token = _userTokenProvider.GetUserToken();
             _logger.LogDebug("Unlocking data element {DataGuid} for instance {InstanceIdentifier} URL: {Url}", dataGuid, instanceIdentifier, apiUrl);
-            HttpResponseMessage response = await _client.DeleteAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.DeleteAsync(token, apiUrl);
             if (response.IsSuccessStatusCode)
             {
                 DataElement result = JsonConvert.DeserializeObject<DataElement>(await response.Content.ReadAsStringAsync())!;

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
@@ -63,7 +63,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceIdentifier}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 string instanceData = await response.Content.ReadAsStringAsync();
@@ -124,7 +124,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
 
         private async Task<QueryResponse<Instance>> QueryInstances(string token, string url)
         {
-            HttpResponseMessage response = await _client.GetAsync(token, url);
+            using HttpResponseMessage response = await _client.GetAsync(token, url);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -151,7 +151,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             _logger.LogInformation($"update process state: {processStateString}");
 
             StringContent httpContent = new StringContent(processStateString, Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, httpContent);
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, httpContent);
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 string instanceData = await response.Content.ReadAsStringAsync();
@@ -173,7 +173,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
             StringContent content = new StringContent(JsonConvert.SerializeObject(instanceTemplate), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await _client.PostAsync(token, apiUrl, content);
+            using HttpResponseMessage response = await _client.PostAsync(token, apiUrl, content);
 
             if (response.IsSuccessStatusCode)
             {
@@ -192,7 +192,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/complete";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.PostAsync(token, apiUrl, new StringContent(string.Empty));
+            using HttpResponseMessage response = await _client.PostAsync(token, apiUrl, new StringContent(string.Empty));
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -210,7 +210,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/readstatus?status={readStatus}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, new StringContent(string.Empty));
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, new StringContent(string.Empty));
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -229,7 +229,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/substatus";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, new StringContent(JsonConvert.SerializeObject(substatus), Encoding.UTF8, "application/json"));
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, new StringContent(JsonConvert.SerializeObject(substatus), Encoding.UTF8, "application/json"));
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -247,7 +247,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/presentationtexts";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, new StringContent(JsonConvert.SerializeObject(presentationTexts), Encoding.UTF8, "application/json"));
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, new StringContent(JsonConvert.SerializeObject(presentationTexts), Encoding.UTF8, "application/json"));
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -265,7 +265,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/datavalues";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.PutAsync(token, apiUrl, new StringContent(JsonConvert.SerializeObject(dataValues), Encoding.UTF8, "application/json"));
+            using HttpResponseMessage response = await _client.PutAsync(token, apiUrl, new StringContent(JsonConvert.SerializeObject(dataValues), Encoding.UTF8, "application/json"));
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -283,7 +283,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}?hard={hard}";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.DeleteAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.DeleteAsync(token, apiUrl);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceEventClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceEventClient.cs
@@ -70,7 +70,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
                 apiUrl += $"{paramSeparator}from={from}&to={to}";
             }
 
-            HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
 
             if (response.IsSuccessStatusCode)
             {
@@ -91,7 +91,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceEvent.InstanceId}/events";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.PostAsync(token, apiUrl, new StringContent(instanceEvent.ToString(), Encoding.UTF8, "application/json"));
+            using HttpResponseMessage response = await _client.PostAsync(token, apiUrl, new StringContent(instanceEvent.ToString(), Encoding.UTF8, "application/json"));
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/ProcessClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/ProcessClient.cs
@@ -67,7 +67,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"instances/{instanceOwnerPartyId}/{instanceGuid}/process/history";
             string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _appSettings.RuntimeCookieName);
 
-            HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+            using HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/SignClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/SignClient.cs
@@ -45,7 +45,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
         {
             string apiUrl = $"instances/{signatureContext.InstanceIdentifier}/sign";
             string token = _userTokenProvider.GetUserToken();
-            HttpResponseMessage response = await _client.PostAsync(token, apiUrl, BuildSignRequest(signatureContext));
+            using HttpResponseMessage response = await _client.PostAsync(token, apiUrl, BuildSignRequest(signatureContext));
             if (response.IsSuccessStatusCode)
             {
                 return;

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/TextClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/TextClient.cs
@@ -71,7 +71,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
                 string url = $"applications/{org}/{app}/texts/{language}";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 
-                HttpResponseMessage response = await _client.GetAsync(token, url);
+                using HttpResponseMessage response = await _client.GetAsync(token, url);
                 if (response.StatusCode == System.Net.HttpStatusCode.OK)
                 {
                     textResource = await JsonSerializerPermissive.DeserializeAsync<TextResource>(response.Content);

--- a/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
@@ -37,7 +37,7 @@ namespace Altinn.App.Api.Tests.Controllers
 
 
             using var content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json"); // empty valid json
-            var response = await client.PostAsync($"/{org}/{app}/instances/{instanceOwnerPartyId}/{guid}/data", content);
+            using var response = await client.PostAsync($"/{org}/{app}/instances/{instanceOwnerPartyId}/{guid}/data", content);
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             var responseContent = await response.Content.ReadAsStringAsync();
             responseContent.Should().Contain("dataType");
@@ -72,7 +72,7 @@ namespace Altinn.App.Api.Tests.Controllers
             };
 
             // This is where it happens
-            HttpResponseMessage response = await client.SendAsync(request);
+            using HttpResponseMessage response = await client.SendAsync(request);
 
             // Cleanup testdata
             TestData.DeleteInstanceAndData(org, app, 1337, guid);
@@ -109,7 +109,7 @@ namespace Altinn.App.Api.Tests.Controllers
             };
 
             // This is where it happens
-            HttpResponseMessage response = await client.SendAsync(request);
+            using HttpResponseMessage response = await client.SendAsync(request);
 
             // Cleanup testdata
             TestData.DeleteInstanceAndData(org, app, 1337, guid);
@@ -148,7 +148,7 @@ namespace Altinn.App.Api.Tests.Controllers
             };
 
             // This is where it happens
-            HttpResponseMessage response = await client.SendAsync(request);
+            using HttpResponseMessage response = await client.SendAsync(request);
             string responseContent = await response.Content.ReadAsStringAsync();
 
             // Cleanup testdata

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
@@ -43,7 +43,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         // Create instance
-        var createResponse =
+        using var createResponse =
             await client.PostAsync($"{org}/{app}/instances/?instanceOwnerPartyId={instanceOwnerPartyId}", null);
         var createResponseContent = await createResponse.Content.ReadAsStringAsync();
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -53,7 +53,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         // Create data element (not sure why it isn't created when the instance is created, autoCreate is true)
         using var createDataElementContent =
             new StringContent("""{"melding":{"name": "Ivar"}}""", System.Text.Encoding.UTF8, "application/json");
-        var createDataElementResponse =
+        using var createDataElementResponse =
             await client.PostAsync($"/{org}/{app}/instances/{instanceId}/data?dataType=default", createDataElementContent);
         var createDataElementResponseContent = await createDataElementResponse.Content.ReadAsStringAsync();
         createDataElementResponse.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -64,11 +64,11 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         // Update data element
         using var updateDataElementContent =
             new StringContent("""{"melding":{"name": "Ola Olsen"}}""", System.Text.Encoding.UTF8, "application/json");
-        var response = await client.PutAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}", updateDataElementContent);
+        using var response = await client.PutAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}", updateDataElementContent);
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         // Verify stored data
-        var readDataElementResponse = await client.GetAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}");
+        using var readDataElementResponse = await client.GetAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}");
         readDataElementResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var readDataElementResponseContent = await readDataElementResponse.Content.ReadAsStringAsync();
         var readDataElementResponseParsed =
@@ -105,7 +105,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         // Create instance
-        var createResponse =
+        using var createResponse =
             await client.PostAsync($"{org}/{app}/instances/?instanceOwnerPartyId={instanceOwnerPartyId}", null);
         var createResponseContent = await createResponse.Content.ReadAsStringAsync();
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -115,7 +115,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         // Create data element (not sure why it isn't created when the instance is created, autoCreate is true)
         using var createDataElementContent =
             new StringContent("""{"melding":{"name": "Ivar"}}""", System.Text.Encoding.UTF8, "application/json");
-        var createDataElementResponse =
+        using var createDataElementResponse =
             await client.PostAsync($"/{org}/{app}/instances/{instanceId}/data?dataType=default",
                 createDataElementContent);
         var createDataElementResponseContent = await createDataElementResponse.Content.ReadAsStringAsync();
@@ -125,7 +125,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         var dataGuid = createDataElementResponseParsed.Id;
 
         // Verify stored data
-        var firstReadDataElementResponse = await client.GetAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}");
+        using var firstReadDataElementResponse = await client.GetAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}");
         var firstReadDataElementResponseContent = await firstReadDataElementResponse.Content.ReadAsStringAsync();
         var firstReadDataElementResponseParsed =
             JsonSerializer.Deserialize<Skjema>(firstReadDataElementResponseContent)!;
@@ -135,12 +135,12 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         // Update data element
         using var updateDataElementContent =
             new StringContent("""{"melding":{"name": "Ola Olsen"}}""", System.Text.Encoding.UTF8, "application/json");
-        var response = await client.PutAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}", updateDataElementContent);
+        using var response = await client.PutAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}", updateDataElementContent);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
 
         // Verify stored data
-        var readDataElementResponse = await client.GetAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}");
+        using var readDataElementResponse = await client.GetAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}");
         var readDataElementResponseContent = await readDataElementResponse.Content.ReadAsStringAsync();
         var readDataElementResponseParsed =
             JsonSerializer.Deserialize<Skjema>(readDataElementResponseContent)!;

--- a/test/Altinn.App.Api.Tests/Controllers/EventsReceiverControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/EventsReceiverControllerTests.cs
@@ -47,7 +47,7 @@ namespace Altinn.App.Api.Tests.Controllers
                 Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(cloudEvent), Encoding.UTF8, "application/json")
             };
 
-            HttpResponseMessage response = await client.SendAsync(request);
+            using HttpResponseMessage response = await client.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
@@ -76,7 +76,7 @@ namespace Altinn.App.Api.Tests.Controllers
                 Content = new StringContent(System.Text.Json.JsonSerializer.Serialize(cloudEvent), Encoding.UTF8, "application/json")
             };
 
-            HttpResponseMessage response = await client.SendAsync(request);
+            using HttpResponseMessage response = await client.SendAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         }

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
@@ -218,8 +218,9 @@ public class InstancesController_CopyInstanceTests
         Guid instanceGuid = Guid.NewGuid();
 
         // Storage returns Forbidden if the given instance id is wrong.
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.Forbidden);
         PlatformHttpException platformHttpException =
-            await PlatformHttpException.CreateAsync(new HttpResponseMessage(System.Net.HttpStatusCode.Forbidden));
+            await PlatformHttpException.CreateAsync(response);
 
         _httpContextMock.Setup(httpContext => httpContext.User).Returns(PrincipalUtil.GetUserPrincipal(1337, null));
         _appMetadata.Setup(a => a.GetApplicationMetadata())
@@ -253,8 +254,9 @@ public class InstancesController_CopyInstanceTests
         Guid instanceGuid = Guid.NewGuid();
 
         // Simulate a BadGateway respons from Platform
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.BadGateway);
         PlatformHttpException platformHttpException =
-            await PlatformHttpException.CreateAsync(new HttpResponseMessage(System.Net.HttpStatusCode.BadGateway));
+            await PlatformHttpException.CreateAsync(response);
 
         _httpContextMock.Setup(httpContext => httpContext.User).Returns(PrincipalUtil.GetUserPrincipal(1337, null));
         _appMetadata.Setup(a => a.GetApplicationMetadata())

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
@@ -47,7 +47,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         content.Add(new StringContent($$$"""<Skjema><melding><name>{{{testName}}}</name></melding></Skjema>""", System.Text.Encoding.UTF8, "application/xml"), "default");
 
         // Create instance
-        var createResponse =
+        using var createResponse =
             await client.PostAsync($"{org}/{app}/instances/?instanceOwnerPartyId={instanceOwnerPartyId}", content);
         var createResponseContent = await createResponse.Content.ReadAsStringAsync();
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createResponseContent);
@@ -61,7 +61,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
 
 
         // Verify stored data
-        var readDataElementResponse = await client.GetAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}");
+        using var readDataElementResponse = await client.GetAsync($"/{org}/{app}/instances/{instanceId}/data/{dataGuid}");
         readDataElementResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var readDataElementResponseContent = await readDataElementResponse.Content.ReadAsStringAsync();
         var readDataElementResponseParsed =
@@ -86,7 +86,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         content.Add(new StringContent("INVALID XML", System.Text.Encoding.UTF8, "application/xml"), "default");
 
         // Create instance
-        var createResponse =
+        using var createResponse =
             await client.PostAsync($"{org}/{app}/instances/?instanceOwnerPartyId={instanceOwnerPartyId}", content);
         var createResponseContent = await createResponse.Content.ReadAsStringAsync();
         createResponse.StatusCode.Should().Be(HttpStatusCode.InternalServerError, createResponseContent);
@@ -111,7 +111,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         content.Add(new StringContent($$$"""<Skjema><melding><name>{{{testName}}}</name></melding></Skjema>""", System.Text.Encoding.UTF8, "application/xml"), "wrongName");
 
         // Create instance
-        var createResponse =
+        using var createResponse =
             await client.PostAsync($"{org}/{app}/instances/?instanceOwnerPartyId={instanceOwnerPartyId}", content);
         var createResponseContent = await createResponse.Content.ReadAsStringAsync();
         createResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest, createResponseContent);

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -30,7 +30,7 @@ namespace Altinn.App.Api.Tests.Controllers
             HttpClient client = GetRootedClient(org, app);
 
             string url = $"/{org}/{app}/api/options/test?language=esperanto";
-            HttpResponseMessage response = await client.GetAsync(url);
+            using HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
             _outputHelper.WriteLine(content);
             response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -81,7 +81,7 @@ namespace Altinn.App.Api.Tests.Controllers
             HttpClient client = GetRootedClient(org, app);
 
             string url = $"/{org}/{app}/api/options/test?";
-            HttpResponseMessage response = await client.GetAsync(url);
+            using HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
             response.StatusCode.Should().Be(HttpStatusCode.OK, content);
 
@@ -110,7 +110,7 @@ namespace Altinn.App.Api.Tests.Controllers
             HttpClient client = GetRootedClient(org, app);
 
             string url = $"/{org}/{app}/api/options/test";
-            HttpResponseMessage response = await client.GetAsync(url);
+            using HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
             _outputHelper.WriteLine(content);
             response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -128,7 +128,7 @@ namespace Altinn.App.Api.Tests.Controllers
             HttpClient client = GetRootedClient(org, app);
 
             string url = $"/{org}/{app}/api/options/fileSourceOptions";
-            HttpResponseMessage response = await client.GetAsync(url);
+            using HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
             _outputHelper.WriteLine(content);
             response.Should().HaveStatusCode(HttpStatusCode.OK);
@@ -146,7 +146,7 @@ namespace Altinn.App.Api.Tests.Controllers
             HttpClient client = GetRootedClient(org, app);
 
             string url = $"/{org}/{app}/api/options/non-existent-option-list";
-            HttpResponseMessage response = await client.GetAsync(url);
+            using HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
             _outputHelper.WriteLine(content);
             response.Should().HaveStatusCode(HttpStatusCode.NotFound);
@@ -165,7 +165,7 @@ namespace Altinn.App.Api.Tests.Controllers
             HttpClient client = GetRootedClient(org, app);
 
             string url = $"/{org}/{app}/api/options/test";
-            HttpResponseMessage response = await client.GetAsync(url);
+            using HttpResponseMessage response = await client.GetAsync(url);
             var content = await response.Content.ReadAsStringAsync();
             _outputHelper.WriteLine(content);
             response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
@@ -67,7 +67,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         TestData.PrepareInstance(org, app, partyId, instanceId);
 
         string url = $"/{org}/{app}/instances/{partyId}/{instanceId}/process";
-        HttpResponseMessage response = await client.GetAsync(url);
+        using HttpResponseMessage response = await client.GetAsync(url);
         TestData.DeleteInstance(org, app, partyId, instanceId);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -144,7 +144,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         };
         using var client = GetRootedClient(Org, App, 1337, InstanceOwnerPartyId);
         // both "?lang" and "?language" should work
-        var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next?lang={language}", null);
+        using var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next?lang={language}", null);
         var nextResponseContent = await nextResponse.Content.ReadAsStringAsync();
         _outputHelper.WriteLine(nextResponseContent);
         nextResponse.Should().HaveStatusCode(HttpStatusCode.OK);
@@ -174,7 +174,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         };
         using var client = GetRootedClient(Org, App, 1337, InstanceOwnerPartyId);
         // both "?lang" and "?language" should work
-        var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next?language={language}", null);
+        using var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next?language={language}", null);
         var nextResponseContent = await nextResponse.Content.ReadAsStringAsync();
         _outputHelper.WriteLine(nextResponseContent);
         nextResponse.Should().HaveStatusCode(HttpStatusCode.OK);
@@ -239,7 +239,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
             services.AddSingleton(dataValidator.Object);
         };
         using var client = GetRootedClient(Org, App, 1337, InstanceOwnerPartyId);
-        var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next", null);
+        using var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next", null);
         var nextResponseContent = await nextResponse.Content.ReadAsStringAsync();
         _outputHelper.WriteLine(nextResponseContent);
         nextResponse.Should().HaveStatusCode(HttpStatusCode.Conflict);
@@ -297,7 +297,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
             services.AddSingleton(pdfMock.Object);
         };
         using var client = GetRootedClient(Org, App, 1337, InstanceOwnerPartyId);
-        var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next", null);
+        using var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next", null);
         var nextResponseContent = await nextResponse.Content.ReadAsStringAsync();
         _outputHelper.WriteLine(nextResponseContent);
         nextResponse.Should().HaveStatusCode(HttpStatusCode.OK);
@@ -322,7 +322,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
             services.AddSingleton(pdfMock.Object);
         };
         using var client = GetRootedClient(Org, App, 1337, InstanceOwnerPartyId);
-        var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/completeProcess", null);
+        using var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/completeProcess", null);
         var nextResponseContent = await nextResponse.Content.ReadAsStringAsync();
         _outputHelper.WriteLine(nextResponseContent);
         nextResponse.Should().HaveStatusCode(HttpStatusCode.OK);
@@ -346,7 +346,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         };
         using var client = GetRootedClient(Org, App, 1337, InstanceOwnerPartyId);
         using var content = new StringContent("""{"action": "unknown-action_unauthorized"}""", Encoding.UTF8, "application/json");
-        var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next", content);
+        using var nextResponse = await client.PutAsync($"{Org}/{App}/instances/{InstanceId}/process/next", content);
         var nextResponseContent = await nextResponse.Content.ReadAsStringAsync();
         _outputHelper.WriteLine(nextResponseContent);
         nextResponse.Should().HaveStatusCode(HttpStatusCode.Forbidden);

--- a/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
@@ -135,7 +135,7 @@ public class StatelessDataControllerTests
         });
 
         // Act
-        var response = await client.SendAsync(request);
+        using var response = await client.SendAsync(request);
         var responseText = await response.Content.ReadAsStringAsync();
 
         // Assert
@@ -163,7 +163,7 @@ public class StatelessDataControllerTests
 
 
         // Act
-        var response = await client.SendAsync(request);
+        using var response = await client.SendAsync(request);
 
         // Assert
         response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden);

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateControllerTests.cs
@@ -180,7 +180,7 @@ public class ValidateControllerTests
             }
         };
 
-        var updateProcessResult = new HttpResponseMessage(HttpStatusCode.Forbidden);
+        using var updateProcessResult = new HttpResponseMessage(HttpStatusCode.Forbidden);
         PlatformHttpException exception = await PlatformHttpException.CreateAsync(updateProcessResult);
 
         instanceMock.Setup(i => i.GetInstance(app, org, instanceOwnerPartyId, instanceId))
@@ -223,7 +223,7 @@ public class ValidateControllerTests
             }
         };
 
-        var updateProcessResult = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        using var updateProcessResult = new HttpResponseMessage(HttpStatusCode.BadRequest);
         PlatformHttpException exception = await PlatformHttpException.CreateAsync(updateProcessResult);
 
         instanceMock.Setup(i => i.GetInstance(app, org, instanceOwnerPartyId, instanceId))

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateController_ValidateInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateController_ValidateInstanceTests.cs
@@ -59,16 +59,6 @@ public class ValidateControllerValidateInstanceTests : ApiTestBase, IClassFixtur
         return await httpClient.GetAsync($"/{Org}/{App}/instances/{InstanceId}/validate");
     }
 
-    private async Task<(HttpResponseMessage response, string responseString)> CallValidateDataApi()
-    {
-        using var httpClient = GetRootedClient(Org, App);
-        string token = PrincipalUtil.GetToken(1337, null);
-        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        var response = await httpClient.GetAsync($"/{Org}/{App}/instances/{InstanceId}/data/{DataGuid}/validate");
-        var responseString = await LogResponse(response);
-        return (response, responseString);
-    }
-
     private async Task<string> LogResponse(HttpResponseMessage response)
     {
         var responseString = await response.Content.ReadAsStringAsync();
@@ -85,7 +75,7 @@ public class ValidateControllerValidateInstanceTests : ApiTestBase, IClassFixtur
     [Fact]
     public async Task ValidateInstance_NoSetup()
     {
-        var response = await CallValidateInstanceApi();
+        using var response = await CallValidateInstanceApi();
         var responseString = await LogResponse(response);
 
         response.Should().HaveStatusCode(HttpStatusCode.OK);
@@ -120,7 +110,7 @@ public class ValidateControllerValidateInstanceTests : ApiTestBase, IClassFixtur
         {
             services.AddSingleton(oldTaskValidatorMock.Object);
         };
-        var response = await CallValidateInstanceApi();
+        using var response = await CallValidateInstanceApi();
         var responseString = await LogResponse(response);
 
         response.Should().HaveStatusCode(HttpStatusCode.OK);

--- a/test/Altinn.App.Api.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
+++ b/test/Altinn.App.Api.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
@@ -27,7 +27,7 @@ public class SecurityHeadersMiddlewareTests
             })
             .StartAsync();
         // Act
-        var response = await host.GetTestClient().GetAsync("/");
+        using var response = await host.GetTestClient().GetAsync("/");
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         Assert.Equal("deny", response.Headers.GetValues("X-Frame-Options").FirstOrDefault());

--- a/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
@@ -243,8 +243,9 @@ namespace Altinn.App.Api.Tests.Mocks
 
             if (substatus == null || string.IsNullOrEmpty(substatus.Label))
             {
-                throw await PlatformHttpException.CreateAsync(
-                    new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.BadRequest });
+                using var response = 
+                    new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.BadRequest };
+                throw await PlatformHttpException.CreateAsync(response);
             }
 
             string instancePath = GetInstancePath(instanceOwnerPartyId, instanceGuid);
@@ -402,7 +403,7 @@ namespace Altinn.App.Api.Tests.Mocks
             if (!string.IsNullOrEmpty(invalidKey))
             {
                 // platform exceptions.
-                HttpResponseMessage res = new()
+                using HttpResponseMessage res = new()
                 {
                     StatusCode = System.Net.HttpStatusCode.BadRequest,
                     Content = new StringContent($"Unknown query parameter: {invalidKey}")

--- a/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
@@ -243,7 +243,7 @@ namespace Altinn.App.Api.Tests.Mocks
 
             if (substatus == null || string.IsNullOrEmpty(substatus.Label))
             {
-                using var response = 
+                using var response =
                     new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.BadRequest };
                 throw await PlatformHttpException.CreateAsync(response);
             }

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.cs
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.cs
@@ -17,7 +17,7 @@ public class OpenApiSpecChangeDetection : ApiTestBase, IClassFixture<WebApplicat
     {
         HttpClient client = GetRootedClient("tdd", "contributer-restriction");
         // The test project exposes swagger.json at /swagger/v1/swagger.json not /{org}/{app}/swagger/v1/swagger.json
-        HttpResponseMessage response = await client.GetAsync("/swagger/v1/swagger.json");
+        using HttpResponseMessage response = await client.GetAsync("/swagger/v1/swagger.json");
         string openApiSpec = await response.Content.ReadAsStringAsync();
         response.EnsureSuccessStatusCode();
         var originalSpec = await File.ReadAllTextAsync("../../../OpenApi/swagger.json");
@@ -32,7 +32,7 @@ public class OpenApiSpecChangeDetection : ApiTestBase, IClassFixture<WebApplicat
         // The test project exposes swagger.json at /swagger/v1/swagger.json not /{org}/{app}/swagger/v1/swagger.json
         using var request = new HttpRequestMessage(HttpMethod.Get, "/swagger/v1/swagger.yaml");
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/yaml"));
-        HttpResponseMessage response = await client.SendAsync(request);
+        using HttpResponseMessage response = await client.SendAsync(request);
         string openApiSpec = await response.Content.ReadAsStringAsync();
         response.EnsureSuccessStatusCode();
         var originalSpec = await File.ReadAllTextAsync("../../../OpenApi/swagger.yaml");

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/InstanceClientMetricsDecoratorTests.cs
@@ -46,7 +46,8 @@ public class InstanceClientMetricsDecoratorTests
     {
         // Arrange
         var instanceClient = new Mock<IInstanceClient>();
-        var platformHttpException = new PlatformHttpException(new HttpResponseMessage(HttpStatusCode.BadRequest), "test");
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var platformHttpException = new PlatformHttpException(response, "test");
         instanceClient.Setup(i => i.CreateInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Instance>())).ThrowsAsync(platformHttpException);
         var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
         var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
@@ -90,7 +91,8 @@ public class InstanceClientMetricsDecoratorTests
     {
         // Arrange
         var instanceClient = new Mock<IInstanceClient>();
-        var platformHttpException = new PlatformHttpException(new HttpResponseMessage(HttpStatusCode.BadRequest), "test");
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var platformHttpException = new PlatformHttpException(response, "test");
         instanceClient.Setup(i => i.AddCompleteConfirmation(It.IsAny<int>(), It.IsAny<Guid>())).ThrowsAsync(platformHttpException);
         var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
         var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();
@@ -153,7 +155,8 @@ public class InstanceClientMetricsDecoratorTests
     {
         // Arrange
         var instanceClient = new Mock<IInstanceClient>();
-        var platformHttpException = new PlatformHttpException(new HttpResponseMessage(HttpStatusCode.BadRequest), "test");
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        var platformHttpException = new PlatformHttpException(response, "test");
         instanceClient.Setup(i => i.DeleteInstance(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<bool>())).ThrowsAsync(platformHttpException);
         var instanceClientMetricsDecorator = new InstanceClientMetricsDecorator(instanceClient.Object);
         var preUpdateMetrics = await PrometheusTestHelper.ReadPrometheusMetricsToString();


### PR DESCRIPTION
A lot of HTTP responses aren't disposed, this fixes that

## Description
Makes sure all instances of `HttpResponseMessage` are disposed after use. Most changes are simply inserting `using` to make responses `using`-statements. Exceptions:

* The underlying content stream is returned directly to the caller, making it not safe to dispose the response:
  * `PdfGeneratorClient` https://github.com/Altinn/app-lib-dotnet/compare/chore/dispose-http-responses?expand=1#diff-e57271a48749f6cf298b2b3c6f896b7c4048580adbf8489cc61466a56d01a15dR91
  * `DataClient` - https://github.com/Altinn/app-lib-dotnet/compare/chore/dispose-http-responses?expand=1#diff-faf65e5c88ef85660768341399b8faa5ca3a17ce0cd3b8f68d23c6d16331609bR147
* `GetAltinn2Codelist` was refactored slightly to make control flow simpler when disposing the responses
  * This should probably be tested manually even if it is part of a lot of tests

Proposal for future work
*  `PlatformHttpException` should not expose the whole `HttpResponseMessage` object as an instance, since the content now can't be read (since it's disposed). We can create properties for the response information that is safe to read. All we read now is `StatusCode`, which is completely safe
* I saw some places where `JsonSerializerOptions` was new'ed up per request, but these options are meant to be cached as they hold some state/cache for underlying serializers

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
