### PR TITLE
Split out and improve PrepareModelForXmlStorage from InitializeAltinnRowId

### DIFF
--- a/src/Altinn.App.Api/Controllers/ActionsController.cs
+++ b/src/Altinn.App.Api/Controllers/ActionsController.cs
@@ -181,6 +181,7 @@ public class ActionsController : ControllerBase
             }
 
             ObjectUtils.InitializeAltinnRowId(newModel);
+            ObjectUtils.PrepareModelForXmlStorage(newModel);
 
             var dataElement = instance.Data.First(d => d.Id.Equals(elementId, StringComparison.OrdinalIgnoreCase));
             await _dataClient.UpdateData(newModel, instanceIdentifier.InstanceGuid, newModel.GetType(), instance.Org, instance.AppId.Split('/')[1], instanceIdentifier.InstanceOwnerPartyId, Guid.Parse(dataElement.Id));

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -568,6 +568,7 @@ namespace Altinn.App.Api.Controllers
             int instanceOwnerPartyId = int.Parse(instance.InstanceOwner.PartyId);
 
             ObjectUtils.InitializeAltinnRowId(appModel);
+            ObjectUtils.PrepareModelForXmlStorage(appModel);
 
             DataElement dataElement = await _dataClient.InsertFormData(appModel, instanceGuid, _appModel.GetModelType(classRef), org, app, instanceOwnerPartyId, dataType);
             SelfLinkHelper.SetDataAppSelfLinks(instanceOwnerPartyId, instanceGuid, dataElement, Request);
@@ -741,6 +742,7 @@ namespace Altinn.App.Api.Controllers
             await UpdateDataValuesOnInstance(instance, dataType.Id, serviceModel);
 
             ObjectUtils.InitializeAltinnRowId(serviceModel);
+            ObjectUtils.PrepareModelForXmlStorage(serviceModel);
 
             // Save Formdata to database
             DataElement updatedDataElement = await _dataClient.UpdateData(

--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -1,5 +1,7 @@
 using System.Collections;
 using System.Reflection;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Altinn.App.Core.Helpers;
 
@@ -9,9 +11,7 @@ namespace Altinn.App.Core.Helpers;
 public static class ObjectUtils
 {
     /// <summary>
-    /// Recursively initialize all <see cref="List{T}"/> properties on the object that are currently null
-    /// Also ensure that all string properties that are empty are set to null
-    /// And set empty Guid properties named "AltinnRowId" to a new random guid
+    /// Set empty Guid properties named "AltinnRowId" to a new random guid
     /// </summary>
     /// <param name="model">The object to mutate</param>
     public static void InitializeAltinnRowId(object model)
@@ -32,12 +32,7 @@ public static class ObjectUtils
             else if (prop.PropertyType.IsGenericType && prop.PropertyType.GetGenericTypeDefinition() == typeof(List<>))
             {
                 var value = prop.GetValue(model);
-                if (value is null)
-                {
-                    // Initialize IList with null value
-                    prop.SetValue(model, Activator.CreateInstance(prop.PropertyType));
-                }
-                else
+                if (value is not null)
                 {
                     foreach (var item in (IList)value)
                     {
@@ -49,23 +44,122 @@ public static class ObjectUtils
                     }
                 }
             }
-            else if (prop.GetIndexParameters().Length == 0)
+            // property does not have an index parameter, nor is a value type, thus we should recurse into the property
+            else if (prop.GetIndexParameters().Length == 0 && prop.PropertyType.IsValueType == false)
             {
                 var value = prop.GetValue(model);
 
-                if (value is "")
-                {
-                    // Initialize string with null value (xml serialization does not always preserve "")
-                    prop.SetValue(model, null);
-                }
-
                 // continue recursion over all properties that are not null or value types
-                if (value?.GetType().IsValueType == false)
+                if (value is not null)
                 {
                     InitializeAltinnRowId(value);
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Xml serialization-deserialization does not preserve all properties, and we sometimes need
+    /// to know how it looks when it comes back from storage.
+    /// * Recursively initialize all <see cref="List{T}"/> properties on the object that are currently null
+    /// * Ensure that all string properties with `[XmlTextAttribute]` that are empty or whitespace are set to null
+    /// * If a class has `[XmlTextAttribute]` and no value, set the parent property to null (if the other properties has [BindNever] attribute)
+    /// </summary>
+    /// <param name="model">The object to mutate</param>
+    public static void PrepareModelForXmlStorage(object model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        // Iterate over properties of the model
+        foreach (var prop in model.GetType().GetProperties())
+        {
+            // Property has a generic type that is a subtype of List<>
+            if (prop.PropertyType.IsGenericType && prop.PropertyType.GetGenericTypeDefinition() == typeof(List<>))
+            {
+                var value = prop.GetValue(model);
+                if (value is null)
+                {
+                    // Initialize IList with null value (this is what comes back from xml deserialization)
+                    prop.SetValue(model, Activator.CreateInstance(prop.PropertyType));
+                }
+                else
+                {
+                    // Recurse into values of a list
+                    foreach (var item in (IList)value)
+                    {
+                        if (item is not null)
+                        {
+                            PrepareModelForXmlStorage(item);
+                        }
+                    }
+                }
+            }
+            else if (prop.GetIndexParameters().Length > 0)
+            {
+                // Ignore properties with index parameters
+            }
+            else
+            {
+                // Property does not have an index parameter, thus we should recurse into the property
+                var value = prop.GetValue(model);
+                if (value is null)
+                    continue;
+
+                // Only touch string properties with the [XmlText] attribute and contains only whitespace
+                if (value is string s &&
+                string.IsNullOrWhiteSpace(s) &&
+                prop.GetCustomAttributes<XmlTextAttribute>().SingleElement() is not null)
+                {
+                    // Ensure empty strings are set to null
+                    prop.SetValue(model, null);
+                }
+
+                // continue recursion over all properties that are NOT null or value types
+                else if (value.GetType().IsValueType == false)
+                {
+                    PrepareModelForXmlStorage(value);
+                }
+
+                NullParentIfEmptyXmlTextProperty(model, value, prop);
+            }
+        }
+    }
+
+    private static void NullParentIfEmptyXmlTextProperty(object model, object value, PropertyInfo propertyInfo)
+    {
+        var properties = value.GetType().GetProperties();
+        // Get the number of properties that have the [BindNever] attribute (typically fixed values)
+        var attributePropertyCount = properties.Count(p => p.GetCustomAttributes<BindNeverAttribute>().Any());
+        if (attributePropertyCount + 1 != properties.Length)
+        {
+            // If there are more than one property WITHOUT the [BindNever] attribute, we should not null the parent
+            return;
+        }
+
+        // Get the property that has the [XmlText] attribute
+        var xmlTextProperty = properties.Where(p => p.GetCustomAttributes<XmlTextAttribute>().Any()).SingleElement();
+
+        if (xmlTextProperty is null)
+        {
+            return;
+        }
+
+        if (xmlTextProperty.GetValue(value) is null)
+        {
+            // set the parent property to null if the [XmlText] property is null
+            propertyInfo.SetValue(model, null);
+        }
+    }
+
+    private static T? SingleElement<T>(this IEnumerable<T> source)
+    {
+        using var enumerator = source.GetEnumerator();
+        if (!enumerator.MoveNext())
+        {
+            return default(T);
+        }
+        var result = enumerator.Current;
+        return enumerator.MoveNext() ? default(T) : result;
     }
 
     /// <summary>

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
@@ -125,7 +125,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
         // to avoid issue introduced with .Net when MS introduced BOM by default
         // when serializing ref. https://github.com/dotnet/runtime/issues/63585
         // Will be fixed with  https://github.com/dotnet/runtime/pull/75637
-        private static void Serialize<T>(T dataToSerialize, Type type, MemoryStream targetStream)
+        internal static void Serialize<T>(T dataToSerialize, Type type, MemoryStream targetStream)
         {
             XmlWriterSettings xmlWriterSettings = new XmlWriterSettings() { Encoding = new UTF8Encoding(false) };
             XmlWriter xmlWriter = XmlWriter.Create(targetStream, xmlWriterSettings);

--- a/src/Altinn.App.Core/Internal/Patch/PatchService.cs
+++ b/src/Altinn.App.Core/Internal/Patch/PatchService.cs
@@ -93,8 +93,8 @@ public class PatchService : IPatchService
             await dataProcessor.ProcessDataWrite(instance, dataElementId, result.Ok, oldModel, language);
         }
 
-        // Ensure that all lists are changed from null to empty list.
         ObjectUtils.InitializeAltinnRowId(result.Ok);
+        ObjectUtils.PrepareModelForXmlStorage(result.Ok);
 
         var validationIssues = await _validationService.ValidateFormData(instance, dataElement, dataType, result.Ok, oldModel, ignoredValidators, language);
 

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskInitializer.cs
@@ -76,6 +76,7 @@ public class ProcessTaskInitializer : IProcessTaskInitializer
             Type type = _appModel.GetModelType(dataType.AppLogic.ClassRef);
 
             ObjectUtils.InitializeAltinnRowId(data);
+            ObjectUtils.PrepareModelForXmlStorage(data);
 
             DataElement createdDataElement = await _dataClient.InsertFormData(instance, dataType.Id, data, type);
             instance.Data ??= [];

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -248,6 +248,32 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
 
         _dataProcessorMock.VerifyNoOtherCalls();
     }
+    
+    [Fact]
+    public async Task SetXmlTextPropertyToEmtpy_ReturnsCorrectDataModel()
+    {
+        _dataProcessorMock.Setup(p => p.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid?>(), It.IsAny<object>(), It.IsAny<object?>(), null))
+            .Returns((Instance instance, Guid? dataGuid, object skjema, object? existingData, string language) => Task.CompletedTask);
+
+        var pointer = JsonPointer.Create("melding", "tag-with-attribute");
+        var createFirstElementPatch = new JsonPatch(
+            PatchOperation.Test(pointer, JsonNode.Parse("null")),
+            PatchOperation.Add(pointer, JsonNode.Parse("""{"value": "" }""")));
+
+        var (_, _, firstResponse) = await CallPatchApi<DataPatchResponse>(createFirstElementPatch, null, HttpStatusCode.OK);
+
+        var firstData = firstResponse.NewDataModel.Should().BeOfType<JsonElement>().Which;
+        var emptyValue = firstData.GetProperty("melding").GetProperty("tag-with-attribute");
+        emptyValue.ValueKind.Should().Be(JsonValueKind.Null);
+
+        var addValuePatch = new JsonPatch(
+            PatchOperation.Test(pointer, emptyValue.AsNode()),
+            PatchOperation.Replace(pointer, JsonNode.Parse("""{"value": "mySecondValue" }""")));
+        var (_, _, secondResponse) = await CallPatchApi<DataPatchResponse>(addValuePatch, null, HttpStatusCode.OK);
+        var secondData = secondResponse.NewDataModel.Should().BeOfType<JsonElement>().Which;
+        var secondValue = secondData.GetProperty("melding").GetProperty("tag-with-attribute").GetProperty("value");
+        secondValue.GetString().Should().Be("mySecondValue");
+    }
 
     [Fact]
     public async Task UpdateContainerWithListProperty_ReturnsCorrectDataModel()
@@ -319,7 +345,8 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
 
         var firstData = firstResponse.NewDataModel.Should().BeOfType<JsonElement>().Which;
         var firstListItem = firstData.GetProperty("melding").GetProperty("name");
-        firstListItem.ValueKind.Should().Be(JsonValueKind.Null);
+        firstListItem.ValueKind.Should().Be(JsonValueKind.String);
+        firstListItem.GetString().Should().BeEmpty();
 
         var addValuePatch = new JsonPatch(
             PatchOperation.Test(pointer, firstListItem.AsNode()),
@@ -346,11 +373,11 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
 
         var firstData = firstResponse.NewDataModel.Should().BeOfType<JsonElement>().Which;
         var firstListItem = firstData.GetProperty("melding").GetProperty("tag-with-attribute");
-        firstListItem.GetProperty("value").ValueKind.Should().Be(JsonValueKind.Null);
+        firstListItem.ValueKind.Should().Be(JsonValueKind.Null);
 
         var addValuePatch = new JsonPatch(
-            PatchOperation.Test(pointer, firstListItem.AsNode()),
-            PatchOperation.Replace(pointer.Combine("value"), JsonNode.Parse("null")));
+            PatchOperation.Test(pointer, JsonNode.Parse("null")),
+            PatchOperation.Add(pointer.Combine("value"), JsonNode.Parse("null")));
         var (_, _, secondResponse) = await CallPatchApi<DataPatchResponse>(addValuePatch, null, HttpStatusCode.OK);
         var secondData = secondResponse.NewDataModel.Should().BeOfType<JsonElement>().Which;
         var secondValue = secondData.GetProperty("melding").GetProperty("name");

--- a/test/Altinn.App.Core.Tests/Helpers/ObjectUtilsTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ObjectUtilsTests.cs
@@ -30,6 +30,7 @@ public class ObjectUtilsTests
         test.Children.Should().BeNull();
 
         ObjectUtils.InitializeAltinnRowId(test);
+        ObjectUtils.PrepareModelForXmlStorage(test);
 
         test.Children.Should().BeEmpty();
     }
@@ -44,6 +45,7 @@ public class ObjectUtilsTests
         test.Children.Should().BeNull();
 
         ObjectUtils.InitializeAltinnRowId(test);
+        ObjectUtils.PrepareModelForXmlStorage(test);
 
         test.Children.Should().BeEmpty();
         test.StringValue.Should().Be("some");
@@ -95,6 +97,7 @@ public class ObjectUtilsTests
 
         // Act
         ObjectUtils.InitializeAltinnRowId(test);
+        ObjectUtils.PrepareModelForXmlStorage(test);
 
         // Assert
         test.Children.Should().BeEmpty();

--- a/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
@@ -1,0 +1,240 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Infrastructure.Clients.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+// ReSharper disable InconsistentNaming
+#pragma warning disable SA1300 // Inconsistent casing on property
+
+namespace Altinn.App.Core.Tests.Helpers;
+
+public class ObjectUtils_XmlSerializationTests(ITestOutputHelper output)
+{
+    private readonly ITestOutputHelper _output = output;
+    private readonly Mock<ILogger> _loggerMock = new();
+
+    [XmlRoot(ElementName = "model")]
+    public class YttersteObjekt
+    {
+        [XmlElement("aarets", Order = 1)]
+        [JsonPropertyName("aarets")]
+        public DesimalMedORID? aarets { get; set; }
+
+        [XmlElement("aarets2", Order = 2)]
+        [JsonPropertyName("aarets2")]
+        public StringMedORID? aarets2 { get; set; }
+
+        [XmlElement("aarets3", Order = 3)]
+        [JsonPropertyName("aarets3")]
+        public string? aarets3 { get; set; }
+
+        [XmlElement("children", Order = 4)]
+        public List<YttersteObjekt>? children { get; set; }
+    }
+
+    public class DesimalMedORID
+    {
+        [XmlIgnore]
+        public decimal? value { get; set; }
+
+        [XmlText]
+        [JsonIgnore]
+        public string? valueAsString
+        {
+            get => value?.ToString();
+            set
+            {
+                this.value = value == null ? null : (decimal?)decimal.Parse(value);
+            }
+        }
+
+        [XmlAttribute("orid")]
+        [BindNever]
+        public string orid => "30320";
+    }
+
+    public class StringMedORID
+    {
+        [XmlText()]
+        public string? value { get; set; }
+
+        [XmlAttribute("orid")]
+        [BindNever]
+        public string orid => "30321";
+    }
+
+    public static TheoryData<string?, string?> StringTests => new()
+    {
+        // originalValue, storedValue
+        { null,  null },
+        { "some", "some" },
+        { string.Empty, null },
+        { " ", null },
+        { "  ", null },
+        { "  a", "  a" },
+        { "  a ", "  a " },
+        { "a  ", "a  " },
+        { "a", "a" },
+        { "a.", "a." },
+        { "a.📚", "a.📚" },
+    };
+
+    [Theory]
+    [MemberData(nameof(StringTests))]
+    public void TestPrepareForStorage(string? value, string? storedValue)
+    {
+        var test = CreateObject(value);
+
+        ObjectUtils.PrepareModelForXmlStorage(test);
+
+        // prepareForXmlStorage should set all empty strings to null
+        // but serialization only sets [XmlText] strings to null
+        AssertObject(test, value, storedValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(StringTests))]
+    public async Task TestSerializeDeserializeAsStorage(string? value, string? storedValue)
+    {
+        var test = CreateObject(value);
+
+        // Serialize and deserialize twice to ensure that all changes in serialization is applied
+        var testResult = await SerializeDeserialize(test);
+        testResult = await SerializeDeserialize(testResult);
+
+        if (storedValue is null)
+        {
+            // XmlSerialization does not set the parent object aarets2 to null, so we do that manually for all test cases to work
+            testResult.aarets2.Should().NotBeNull();
+            testResult.aarets2!.value.Should().BeNull();
+            testResult.aarets2 = null;
+            var child = testResult.children.Should().ContainSingle().Which;
+            child.aarets2.Should().NotBeNull();
+            child.aarets2!.value.Should().BeNull();
+            child.aarets2 = null;
+        }
+
+        AssertObject(testResult, value, storedValue);
+    }
+
+    private async Task<YttersteObjekt> SerializeDeserialize(YttersteObjekt test)
+    {
+        // Serialize
+        using var serializationStream = new MemoryStream();
+        DataClient.Serialize<YttersteObjekt>(test, typeof(YttersteObjekt), serializationStream);
+
+        serializationStream.Seek(0, SeekOrigin.Begin);
+        _output.WriteLine(System.Text.Encoding.UTF8.GetString(serializationStream.ToArray()));
+
+        // Deserialize
+        ModelDeserializer serializer = new ModelDeserializer(_loggerMock.Object, typeof(YttersteObjekt));
+        var deserialized = await serializer.DeserializeAsync(serializationStream, "application/xml");
+        var testResult = deserialized.Should().BeOfType<YttersteObjekt>().Which;
+
+        return testResult;
+    }
+
+    [Theory]
+    [MemberData(nameof(StringTests))]
+    public void TestSerializeDeserializeAsJson(string? value, string? storedValue)
+    {
+        _output.WriteLine($"Direct Json Serialization does not change {value} into {storedValue}");
+
+        var test = CreateObject(value);
+
+        // Serialize
+        var json = JsonSerializer.Serialize(test);
+        _output.WriteLine(json);
+
+        // Deserialize
+        var testResult = JsonSerializer.Deserialize<YttersteObjekt>(json)!;
+
+        if (value is null)
+        {
+            // JsonSerialization does not set the parent object aarets2 to null, so we do that manually for all test cases to work
+            testResult.aarets2.Should().NotBeNull();
+            testResult.aarets2!.value.Should().BeNull();
+            testResult.aarets2 = null;
+            var child = testResult.children.Should().ContainSingle().Which;
+            child.aarets2.Should().NotBeNull();
+            child.aarets2!.value.Should().BeNull();
+            child.aarets2 = null;
+        }
+
+        AssertObject(testResult, value, value);
+    }
+
+    private static YttersteObjekt CreateObject(string? value)
+    {
+        var test = new YttersteObjekt
+        {
+            aarets2 = new StringMedORID
+            {
+                value = value
+            },
+            aarets3 = value,
+            children = new List<YttersteObjekt>
+            {
+                new YttersteObjekt
+                {
+                    aarets2 = new StringMedORID
+                    {
+                        value = value
+                    },
+                    aarets3 = value,
+                }
+            }
+        };
+
+        test.aarets.Should().BeNull();
+        test.aarets2.Should().NotBeNull();
+        test.aarets2!.value.Should().Be(value);
+        test.aarets2.orid.Should().Be("30321");
+        var child = test.children.Should().ContainSingle().Which;
+        child.aarets.Should().BeNull();
+        child.aarets2.Should().NotBeNull();
+        child.aarets2!.value.Should().Be(value);
+        child.aarets2.orid.Should().Be("30321");
+        child.aarets3.Should().Be(value);
+        return test;
+    }
+
+    private static void AssertObject(YttersteObjekt test, string? normalValue, string? xmlTextValue)
+    {
+        test.aarets.Should().BeNull();
+        if (xmlTextValue is null)
+        {
+            test.aarets2.Should().BeNull();
+        }
+        else
+        {
+            test.aarets2.Should().NotBeNull();
+            test.aarets2!.value.Should().Be(xmlTextValue);
+            test.aarets2.orid.Should().Be("30321");
+        }
+
+        test.aarets3.Should().Be(normalValue);
+        var child = test.children.Should().ContainSingle().Which;
+        child.aarets.Should().BeNull();
+        if (xmlTextValue is null)
+        {
+            child.aarets2.Should().BeNull();
+        }
+        else
+        {
+            child.aarets2.Should().NotBeNull();
+            child.aarets2!.value.Should().Be(xmlTextValue);
+            child.aarets2.orid.Should().Be("30321");
+        }
+
+        child.aarets3.Should().Be(normalValue);
+    }
+}


### PR DESCRIPTION
This PR has 4 changes
1. Split out `PrepareModelForXmlStorage` from `InitializeAltinnRowId` (just the part that converts `""` to null everywhere)
2. Convert all strings that is `string.IsNullOrWithespace` to null, but only if the `[XmlText]` attribute is set (to match xml serialization)
3. If a class only has a single property without `[BindNever]` and that property has `[XmlText]`, set the parent element to null, as it makes no sense to store a tagg without a value, even if there are `fixed` attributes.

bullet 3 was suggested by @kentare, but now that I think about it, I don't really like that we change behaviour with regards to that issue.

## Related Issue(s)
- Fixes #517
- Part of a solution for #552 (but the issue with xml not allowing `decimal`)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
