### PR TITLE
Make `System.Text.Json.JsonSerializerOptions` instances static

### DIFF
--- a/src/Altinn.App.Api/Controllers/ApplicationSettingsController.cs
+++ b/src/Altinn.App.Api/Controllers/ApplicationSettingsController.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Api.Controllers
     [ApiController]
     public class ApplicationSettingsController : ControllerBase
     {
-        private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
         {
             DictionaryKeyPolicy = JsonNamingPolicy.CamelCase
         };
@@ -43,7 +43,7 @@ namespace Altinn.App.Api.Controllers
                 frontEndSettings.Add(nameof(_appSettings.AppOidcProvider), _appSettings.AppOidcProvider);
             }
 
-            return new JsonResult(frontEndSettings, _serializerOptions);
+            return new JsonResult(frontEndSettings, _jsonSerializerOptions);
         }
     }
 }

--- a/src/Altinn.App.Api/Controllers/ApplicationSettingsController.cs
+++ b/src/Altinn.App.Api/Controllers/ApplicationSettingsController.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Api.Controllers
     [ApiController]
     public class ApplicationSettingsController : ControllerBase
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             DictionaryKeyPolicy = JsonNamingPolicy.CamelCase
         };

--- a/src/Altinn.App.Api/Controllers/HomeController.cs
+++ b/src/Altinn.App.Api/Controllers/HomeController.cs
@@ -15,9 +15,9 @@ namespace Altinn.App.Api.Controllers
     /// </summary>
     public class HomeController : Controller
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase 
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
 
         private readonly IAntiforgery _antiforgery;

--- a/src/Altinn.App.Api/Controllers/HomeController.cs
+++ b/src/Altinn.App.Api/Controllers/HomeController.cs
@@ -15,7 +15,7 @@ namespace Altinn.App.Api.Controllers
     /// </summary>
     public class HomeController : Controller
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase 
         };

--- a/src/Altinn.App.Api/Controllers/HomeController.cs
+++ b/src/Altinn.App.Api/Controllers/HomeController.cs
@@ -15,6 +15,11 @@ namespace Altinn.App.Api.Controllers
     /// </summary>
     public class HomeController : Controller
     {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() 
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase 
+        };
+
         private readonly IAntiforgery _antiforgery;
         private readonly PlatformSettings _platformSettings;
         private readonly IWebHostEnvironment _env;
@@ -132,12 +137,11 @@ namespace Altinn.App.Api.Controllers
         private DataType? GetStatelessDataType(ApplicationMetadata application)
         {
             string layoutSetsString = _appResources.GetLayoutSets();
-            JsonSerializerOptions options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
             // Stateless apps only work with layousets
             if (!string.IsNullOrEmpty(layoutSetsString))
             {
-                LayoutSets? layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, options);
+                LayoutSets? layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, _jsonSerializerOptions);
                 string? dataTypeId = layoutSets?.Sets?.Find(set => set.Id == application.OnEntry?.Show)?.DataType;
                 return application.DataTypes.Find(d => d.Id == dataTypeId);
             }

--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -19,6 +19,11 @@ namespace Altinn.App.Api.Controllers
     [ApiController]
     public class PdfController : ControllerBase
     {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() 
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
         private readonly IInstanceClient _instanceClient;
 #pragma warning disable CS0618 // Type or member is obsolete
         private readonly IPdfFormatter _pdfFormatter;
@@ -117,14 +122,12 @@ namespace Altinn.App.Api.Controllers
             string appModelclassRef = _resources.GetClassRefForLogicDataType(dataElement.DataType);
             Type dataType = _appModel.GetModelType(appModelclassRef);
 
-            JsonSerializerOptions options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-
             string layoutSetsString = _resources.GetLayoutSets();
             LayoutSets? layoutSets = null;
             LayoutSet? layoutSet = null;
             if (!string.IsNullOrEmpty(layoutSetsString))
             {
-                layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, options)!;
+                layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, _jsonSerializerOptions)!;
                 layoutSet = layoutSets.Sets?.FirstOrDefault(t => t.DataType.Equals(dataElement.DataType) && t.Tasks.Contains(taskId));
             }
 
@@ -133,7 +136,7 @@ namespace Altinn.App.Api.Controllers
             LayoutSettings? layoutSettings = null;
             if (!string.IsNullOrEmpty(layoutSettingsFileContent))
             {
-                layoutSettings = JsonSerializer.Deserialize<LayoutSettings>(layoutSettingsFileContent, options)!;
+                layoutSettings = JsonSerializer.Deserialize<LayoutSettings>(layoutSettingsFileContent, _jsonSerializerOptions)!;
             }
 
             // Ensure layoutsettings are initialized in FormatPdf

--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -19,7 +19,7 @@ namespace Altinn.App.Api.Controllers
     [ApiController]
     public class PdfController : ControllerBase
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };

--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -19,7 +19,7 @@ namespace Altinn.App.Api.Controllers
     [ApiController]
     public class PdfController : ControllerBase
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };

--- a/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
+++ b/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
@@ -15,7 +15,7 @@ namespace Altinn.App.Core.Features.Action;
 /// </summary>
 public class UniqueSignatureAuthorizer : IUserActionAuthorizer
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         PropertyNameCaseInsensitive = true,

--- a/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
+++ b/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
@@ -15,6 +15,12 @@ namespace Altinn.App.Core.Features.Action;
 /// </summary>
 public class UniqueSignatureAuthorizer : IUserActionAuthorizer
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
     private readonly IAppMetadata _appMetadata;
     private readonly IProcessReader _processReader;
     private readonly IInstanceClient _instanceClient;
@@ -67,12 +73,7 @@ public class UniqueSignatureAuthorizer : IUserActionAuthorizer
         await using var data = await _dataClient.GetBinaryData(appIdentifier.Org, appIdentifier.App, instanceIdentifier.InstanceOwnerPartyId, instanceIdentifier.InstanceGuid, Guid.Parse(dataElement.Id));
         try
         {
-            JsonSerializerOptions options = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true,
-            };
-            var signDocument = await JsonSerializer.DeserializeAsync<SignDocument>(data, options);
+            var signDocument = await JsonSerializer.DeserializeAsync<SignDocument>(data, _jsonSerializerOptions);
             return signDocument?.SigneeInfo.UserId ?? "";
         }
         catch (JsonException)

--- a/src/Altinn.App.Core/Features/Options/AppOptionsFileHandler.cs
+++ b/src/Altinn.App.Core/Features/Options/AppOptionsFileHandler.cs
@@ -11,7 +11,7 @@ namespace Altinn.App.Core.Features.Options
     public class AppOptionsFileHandler : IAppOptionsFileHandler
     {
         private readonly AppSettings _settings;
-        private static readonly JsonSerializerOptions JSON_SERIALIZER_SETTINGS = new(JsonSerializerDefaults.Web)
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web)
         {
             ReadCommentHandling = JsonCommentHandling.Skip,
             AllowTrailingCommas = true,
@@ -35,7 +35,7 @@ namespace Altinn.App.Core.Features.Options
             if (File.Exists(filename))
             {
                 string fileData = await File.ReadAllTextAsync(filename, Encoding.UTF8);
-                List<AppOption> options = JsonSerializer.Deserialize<List<AppOption>>(fileData, JSON_SERIALIZER_SETTINGS)!;
+                List<AppOption> options = JsonSerializer.Deserialize<List<AppOption>>(fileData, _jsonSerializerOptions)!;
                 return options;
             }
 

--- a/src/Altinn.App.Core/Features/Options/AppOptionsFileHandler.cs
+++ b/src/Altinn.App.Core/Features/Options/AppOptionsFileHandler.cs
@@ -10,12 +10,13 @@ namespace Altinn.App.Core.Features.Options
     /// <inheritdoc/>
     public class AppOptionsFileHandler : IAppOptionsFileHandler
     {
-        private readonly AppSettings _settings;
         private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web)
         {
             ReadCommentHandling = JsonCommentHandling.Skip,
             AllowTrailingCommas = true,
         };
+
+        private readonly AppSettings _settings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AppOptionsFileHandler"/> class.

--- a/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
@@ -14,16 +14,16 @@ namespace Altinn.App.Core.Features.Validation.Default;
 /// </summary>
 public class ExpressionValidator : IFormDataValidator
 {
-    private readonly ILogger<ExpressionValidator> _logger;
-    private readonly IAppResources _appResourceService;
-    private readonly LayoutEvaluatorStateInitializer _layoutEvaluatorStateInitializer;
-    private readonly IAppMetadata _appMetadata;
-
-    private static readonly JsonSerializerOptions _jsonOptions = new()
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         ReadCommentHandling = JsonCommentHandling.Skip,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
+
+    private readonly ILogger<ExpressionValidator> _logger;
+    private readonly IAppResources _appResourceService;
+    private readonly LayoutEvaluatorStateInitializer _layoutEvaluatorStateInitializer;
+    private readonly IAppMetadata _appMetadata;
 
     /// <summary>
     /// Constructor for the expression validator
@@ -124,7 +124,7 @@ public class ExpressionValidator : IFormDataValidator
     {
         var resolvedDefinition = new RawExpressionValidation();
 
-        var rawDefinition = definition.Deserialize<RawExpressionValidation>(_jsonOptions);
+        var rawDefinition = definition.Deserialize<RawExpressionValidation>(_jsonSerializerOptions);
         if (rawDefinition == null)
         {
             logger.LogError("Validation definition {name} could not be parsed", name);
@@ -199,7 +199,7 @@ public class ExpressionValidator : IFormDataValidator
         }
         else
         {
-            var expressionDefinition = definition.Deserialize<RawExpressionValidation>(_jsonOptions);
+            var expressionDefinition = definition.Deserialize<RawExpressionValidation>(_jsonSerializerOptions);
             if (expressionDefinition == null)
             {
                 logger.LogError("Validation for field {field} could not be parsed", field);

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Core.Helpers.Serialization
     /// </summary>
     public class ModelDeserializer
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
         private readonly ILogger _logger;
         private readonly Type _modelType;

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Core.Helpers.Serialization
     /// </summary>
     public class ModelDeserializer
     {
-        private static readonly JsonSerializerOptions JSON_SERIALIZER_OPTIONS = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
 
         private readonly ILogger _logger;
         private readonly Type _modelType;
@@ -71,7 +71,7 @@ namespace Altinn.App.Core.Helpers.Serialization
             {
                 using StreamReader reader = new StreamReader(stream, Encoding.UTF8);
                 string content = await reader.ReadToEndAsync();
-                return JsonSerializer.Deserialize(content, _modelType, JSON_SERIALIZER_OPTIONS)!;
+                return JsonSerializer.Deserialize(content, _modelType, _jsonSerializerOptions)!;
             }
             catch (JsonException jsonReaderException)
             {

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -24,7 +24,7 @@ namespace Altinn.App.Core.Implementation
         private readonly IWebHostEnvironment _hostingEnvironment;
         private readonly ILogger _logger;
 
-        private static readonly JsonSerializerOptions DESERIALIZER_OPTIONS = new()
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             AllowTrailingCommas = true,
             ReadCommentHandling = JsonCommentHandling.Skip,
@@ -71,7 +71,7 @@ namespace Altinn.App.Core.Implementation
 
             using (FileStream fileStream = new(fullFileName, FileMode.Open, FileAccess.Read))
             {
-                TextResource textResource = (await System.Text.Json.JsonSerializer.DeserializeAsync<TextResource>(fileStream, DESERIALIZER_OPTIONS))!;
+                TextResource textResource = (await System.Text.Json.JsonSerializer.DeserializeAsync<TextResource>(fileStream, _jsonSerializerOptions))!;
                 textResource.Id = $"{org}-{app}-{language}";
                 textResource.Org = org;
                 textResource.Language = language;
@@ -249,7 +249,7 @@ namespace Altinn.App.Core.Implementation
             string? layoutSetsString = GetLayoutSets();
             if (layoutSetsString is not null)
             {
-                return System.Text.Json.JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, DESERIALIZER_OPTIONS);
+                return System.Text.Json.JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, _jsonSerializerOptions);
             }
 
             return null;
@@ -297,7 +297,7 @@ namespace Altinn.App.Core.Implementation
                 var pageBytes = File.ReadAllBytes(Path.Join(folder, page + ".json"));
                 // Set the PageName using AsyncLocal before deserializing.
                 PageComponentConverter.SetAsyncLocalPageName(page);
-                layoutModel.Pages[page] = System.Text.Json.JsonSerializer.Deserialize<PageComponent>(pageBytes.RemoveBom(), DESERIALIZER_OPTIONS) ?? throw new InvalidDataException(page + ".json is \"null\"");
+                layoutModel.Pages[page] = System.Text.Json.JsonSerializer.Deserialize<PageComponent>(pageBytes.RemoveBom(), _jsonSerializerOptions) ?? throw new InvalidDataException(page + ".json is \"null\"");
             }
 
             return layoutModel;

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -19,17 +19,17 @@ namespace Altinn.App.Core.Implementation
     /// </summary>
     public class AppResourcesSI : IAppResources
     {
-        private readonly AppSettings _settings;
-        private readonly IAppMetadata _appMetadata;
-        private readonly IWebHostEnvironment _hostingEnvironment;
-        private readonly ILogger _logger;
-
         private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             AllowTrailingCommas = true,
             ReadCommentHandling = JsonCommentHandling.Skip,
             PropertyNameCaseInsensitive = true,
         };
+
+        private readonly AppSettings _settings;
+        private readonly IAppMetadata _appMetadata;
+        private readonly IWebHostEnvironment _hostingEnvironment;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AppResourcesSI"/> class.

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
@@ -15,6 +15,8 @@ namespace Altinn.App.Core.Infrastructure.Clients.Events
     /// </summary>
     public class EventsSubscriptionClient : IEventsSubscription
     {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
+
         private readonly PlatformSettings _platformSettings;
         private readonly GeneralSettings _generalSettings;
         private readonly HttpClient _client;
@@ -70,7 +72,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Events
             if (response.IsSuccessStatusCode)
             {
                 var content = await response.Content.ReadAsStringAsync();
-                Subscription? subscription = JsonSerializer.Deserialize<Subscription>(content, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+                Subscription? subscription = JsonSerializer.Deserialize<Subscription>(content, _jsonSerializerOptions);
 
                 return subscription ?? throw new NullReferenceException("Successfully added a subscription, but the returned subscription deserialized to null!");
             }

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
@@ -15,7 +15,10 @@ namespace Altinn.App.Core.Infrastructure.Clients.Events
     /// </summary>
     public class EventsSubscriptionClient : IEventsSubscription
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() 
+        {
+            PropertyNameCaseInsensitive = true
+        };
 
         private readonly PlatformSettings _platformSettings;
         private readonly GeneralSettings _generalSettings;

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
@@ -15,7 +15,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Events
     /// </summary>
     public class EventsSubscriptionClient : IEventsSubscription
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
         {
             PropertyNameCaseInsensitive = true
         };

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
@@ -15,7 +15,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Events
     /// </summary>
     public class EventsSubscriptionClient : IEventsSubscription
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             PropertyNameCaseInsensitive = true
         };

--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -18,16 +18,16 @@ namespace Altinn.App.Core.Infrastructure.Clients.Pdf;
 /// </summary>
 public class PdfGeneratorClient : IPdfGeneratorClient
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     private readonly HttpClient _httpClient;
     private readonly PdfGeneratorSettings _pdfGeneratorSettings;
     private readonly PlatformSettings _platformSettings;
     private readonly IUserTokenProvider _userTokenProvider;
     private readonly IHttpContextAccessor _httpContextAccessor;
-
-    private readonly JsonSerializerOptions _jsonSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PdfGeneratorClient"/> class.

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
@@ -22,16 +22,16 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
     /// </summary>
     public class PersonClient : IPersonClient
     {
-        private readonly HttpClient _httpClient;
-        private readonly IAppMetadata _appMetadata;
-        private readonly IAccessTokenGenerator _accessTokenGenerator;
-        private readonly IUserTokenProvider _userTokenProvider;
-
-        private readonly JsonSerializerOptions _jsonSerializerOptions = new()
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             PropertyNameCaseInsensitive = true
         };
+
+        private readonly HttpClient _httpClient;
+        private readonly IAppMetadata _appMetadata;
+        private readonly IAccessTokenGenerator _accessTokenGenerator;
+        private readonly IUserTokenProvider _userTokenProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PersonClient"/> class.

--- a/src/Altinn.App.Core/Internal/App/AppMetadata.cs
+++ b/src/Altinn.App.Core/Internal/App/AppMetadata.cs
@@ -11,7 +11,7 @@ namespace Altinn.App.Core.Internal.App
     /// </summary>
     public class AppMetadata : IAppMetadata
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             PropertyNameCaseInsensitive = true,

--- a/src/Altinn.App.Core/Internal/App/AppMetadata.cs
+++ b/src/Altinn.App.Core/Internal/App/AppMetadata.cs
@@ -11,6 +11,13 @@ namespace Altinn.App.Core.Internal.App
     /// </summary>
     public class AppMetadata : IAppMetadata
     {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            AllowTrailingCommas = true
+        };
+
         private readonly AppSettings _settings;
         private readonly IFrontendFeatures _frontendFeatures;
         private ApplicationMetadata? _application;
@@ -44,14 +51,8 @@ namespace Altinn.App.Core.Internal.App
             {
                 if (File.Exists(filename))
                 {
-                    JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions()
-                    {
-                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                        PropertyNameCaseInsensitive = true,
-                        AllowTrailingCommas = true
-                    };
                     using FileStream fileStream = File.OpenRead(filename);
-                    var application = await JsonSerializer.DeserializeAsync<ApplicationMetadata>(fileStream, jsonSerializerOptions);
+                    var application = await JsonSerializer.DeserializeAsync<ApplicationMetadata>(fileStream, _jsonSerializerOptions);
                     if (application == null)
                     {
                         throw new ApplicationConfigException($"Deserialization returned null, Could indicate problems with deserialization of {filename}");

--- a/src/Altinn.App.Core/Internal/Data/DataService.cs
+++ b/src/Altinn.App.Core/Internal/Data/DataService.cs
@@ -8,10 +8,10 @@ namespace Altinn.App.Core.Internal.Data
     /// <inheritdoc/>
     internal class DataService : IDataService
     {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
         private readonly IDataClient _dataClient;
         private readonly IAppMetadata _appMetadata;
-
-        private readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
 
         /// <summary>

--- a/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
@@ -11,7 +11,7 @@ namespace Altinn.App.Core.Internal.Language
     /// </summary>
     public class ApplicationLanguage : IApplicationLanguage
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };

--- a/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
@@ -11,7 +11,7 @@ namespace Altinn.App.Core.Internal.Language
     /// </summary>
     public class ApplicationLanguage : IApplicationLanguage
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };

--- a/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
@@ -11,6 +11,11 @@ namespace Altinn.App.Core.Internal.Language
     /// </summary>
     public class ApplicationLanguage : IApplicationLanguage
     {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions() 
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
         private readonly AppSettings _settings;
         private readonly ILogger _logger;
 
@@ -34,13 +39,12 @@ namespace Altinn.App.Core.Internal.Language
             var directoryInfo = new DirectoryInfo(pathTextsResourceFolder);
             var textResourceFilesInDirectory = directoryInfo.GetFiles();
             var applicationLanguages = new List<Models.ApplicationLanguage>();
-            JsonSerializerOptions options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
             foreach (var fileInfo in textResourceFilesInDirectory)
             {
                 await using (FileStream fileStream = new(fileInfo.FullName, FileMode.Open, FileAccess.Read))
                 {
-                    var applicationLanguage = (await JsonSerializer.DeserializeAsync<Models.ApplicationLanguage>(fileStream, options))!;
+                    var applicationLanguage = (await JsonSerializer.DeserializeAsync<Models.ApplicationLanguage>(fileStream, _jsonSerializerOptions))!;
                     applicationLanguages.Add(applicationLanguage);
                 }
             }

--- a/src/Altinn.App.Core/Internal/Patch/PatchService.cs
+++ b/src/Altinn.App.Core/Internal/Patch/PatchService.cs
@@ -25,7 +25,7 @@ public class PatchService : IPatchService
     private readonly IValidationService _validationService;
     private readonly IEnumerable<IDataProcessor> _dataProcessors;
 
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
         PropertyNameCaseInsensitive = true,
@@ -119,7 +119,7 @@ public class PatchService : IPatchService
     {
         try
         {
-            var model = patchResult.Deserialize(type, JsonSerializerOptions);
+            var model = patchResult.Deserialize(type, _jsonSerializerOptions);
             if (model is null)
             {
                 return "Deserialize patched model returned null";

--- a/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
+++ b/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
@@ -18,7 +18,7 @@ namespace Altinn.App.Core.Internal.Process
     /// </summary>
     public class ExpressionsExclusiveGateway : IProcessExclusiveGateway
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             AllowTrailingCommas = true,
             ReadCommentHandling = JsonCommentHandling.Skip,

--- a/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
+++ b/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
@@ -18,6 +18,17 @@ namespace Altinn.App.Core.Internal.Process
     /// </summary>
     public class ExpressionsExclusiveGateway : IProcessExclusiveGateway
     {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
+        {
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            PropertyNameCaseInsensitive = true,
+        };
+        private static readonly JsonSerializerOptions _jsonSerializerOptionsCamelCase = new() 
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
         private readonly LayoutEvaluatorStateInitializer _layoutStateInit;
         private readonly IAppResources _resources;
         private readonly IAppMetadata _appMetadata;
@@ -101,29 +112,22 @@ namespace Altinn.App.Core.Internal.Process
 
         private static Expression GetExpressionFromCondition(string condition)
         {
-            JsonSerializerOptions options = new()
-            {
-                AllowTrailingCommas = true,
-                ReadCommentHandling = JsonCommentHandling.Skip,
-                PropertyNameCaseInsensitive = true,
-            };
             Utf8JsonReader reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(condition));
             reader.Read();
-            var expressionFromCondition = ExpressionConverter.ReadNotNull(ref reader, options);
+            var expressionFromCondition = ExpressionConverter.ReadNotNull(ref reader, _jsonSerializerOptions);
             return expressionFromCondition;
         }
 
         private LayoutSet? GetLayoutSet(Instance instance)
         {
             string taskId = instance.Process.CurrentTask.ElementId;
-            JsonSerializerOptions options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
 
             string layoutSetsString = _resources.GetLayoutSets();
             LayoutSet? layoutSet = null;
             if (!string.IsNullOrEmpty(layoutSetsString))
             {
-                LayoutSets? layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, options);
+                LayoutSets? layoutSets = JsonSerializer.Deserialize<LayoutSets>(layoutSetsString, _jsonSerializerOptionsCamelCase);
                 layoutSet = layoutSets?.Sets?.Find(t => t.Tasks.Contains(taskId));
             }
 

--- a/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
+++ b/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
@@ -24,7 +24,7 @@ namespace Altinn.App.Core.Internal.Process
             ReadCommentHandling = JsonCommentHandling.Skip,
             PropertyNameCaseInsensitive = true,
         };
-        private static readonly JsonSerializerOptions _jsonSerializerOptionsCamelCase = new() 
+        private static readonly JsonSerializerOptions _jsonSerializerOptionsCamelCase = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizer.cs
@@ -113,6 +113,7 @@ public class ProcessTaskFinalizer : IProcessTaskFinalizer
         {
             var modifier = new IgnorePropertiesWithPrefix(dataType.AppLogic.ShadowFields.Prefix);
 
+            // TODO: should cache, like comment says below
 #pragma warning disable CA1869 //Not caching options since dynamic param is being used. Consider dict cache.
             JsonSerializerOptions options = new()
 #pragma warning restore CA1869

--- a/test/Altinn.App.Api.Tests/Controllers/ApplicationMetadataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ApplicationMetadataControllerTests.cs
@@ -3,7 +3,6 @@ using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
@@ -13,6 +12,8 @@ namespace Altinn.App.Api.Tests.Controllers;
 
 public class ApplicationMetadataControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
     private readonly Mock<IAppMetadata> _appMetadataMock = new();
 
     public ApplicationMetadataControllerTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
@@ -25,7 +26,7 @@ public class ApplicationMetadataControllerTests : ApiTestBase, IClassFixture<Web
         var org = "tdd";
         var appId = "contributer-restriction";
         var appMetadataSample = $"{{\"id\":\"{org}/{appId}\",\"org\":\"{org}\",\"title\":{{\"nb\":\"Bestillingseksempelapp\"}},\"dataTypes\":[],\"partyTypesAllowed\":{{}},\"extra_Unknown_list\":[3,\"tre\",{{\"verdi\":3}}]}}";
-        var application = JsonSerializer.Deserialize<ApplicationMetadata>(appMetadataSample, new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+        var application = JsonSerializer.Deserialize<ApplicationMetadata>(appMetadataSample, _jsonSerializerOptions)!;
         _appMetadataMock.Setup(m => m.GetApplicationMetadata()).ReturnsAsync(application);
         OverrideServicesForThisTest = (services) =>
         {

--- a/test/Altinn.App.Api.Tests/Controllers/ApplicationMetadataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ApplicationMetadataControllerTests.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Api.Tests.Controllers;
 
 public class ApplicationMetadataControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
     private readonly Mock<IAppMetadata> _appMetadataMock = new();
 

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -25,6 +25,14 @@ namespace Altinn.App.Api.Tests.Controllers;
 
 public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        UnknownTypeHandling = JsonUnknownTypeHandling.JsonElement,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
     // Define constants
     private const string Org = "tdd";
     private const string App = "contributer-restriction";
@@ -36,15 +44,6 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
     // Define mocks
     private readonly Mock<IDataProcessor> _dataProcessorMock = new(MockBehavior.Strict);
     private readonly Mock<IFormDataValidator> _formDataValidatorMock = new(MockBehavior.Strict);
-
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-        UnknownTypeHandling = JsonUnknownTypeHandling.JsonElement,
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-    };
-
 
     // Constructor with common setup
     public DataControllerPatchTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
@@ -76,7 +75,7 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
         {
             Patch = patch,
             IgnoredValidators = ignoredValidators,
-        }, JsonSerializerOptions);
+        }, _jsonSerializerOptions);
         _outputHelper.WriteLine(serializedPatch);
         using var updateDataElementContent =
             new StringContent(serializedPatch, System.Text.Encoding.UTF8, "application/json");
@@ -84,9 +83,9 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
         var responseString = await response.Content.ReadAsStringAsync();
         using var responseParsedRaw = JsonDocument.Parse(responseString);
         _outputHelper.WriteLine("\nResponse:");
-        _outputHelper.WriteLine(JsonSerializer.Serialize(responseParsedRaw, JsonSerializerOptions));
+        _outputHelper.WriteLine(JsonSerializer.Serialize(responseParsedRaw, _jsonSerializerOptions));
         response.Should().HaveStatusCode(expectedStatus);
-        var responseObject = JsonSerializer.Deserialize<TResponse>(responseString, JsonSerializerOptions)!;
+        var responseObject = JsonSerializer.Deserialize<TResponse>(responseString, _jsonSerializerOptions)!;
         return (response, responseString, responseObject);
     }
 
@@ -465,9 +464,9 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
         var responseString = await response.Content.ReadAsStringAsync();
         using var responseParsedRaw = JsonDocument.Parse(responseString);
         _outputHelper.WriteLine("\nResponse:");
-        _outputHelper.WriteLine(JsonSerializer.Serialize(responseParsedRaw, JsonSerializerOptions));
+        _outputHelper.WriteLine(JsonSerializer.Serialize(responseParsedRaw, _jsonSerializerOptions));
         response.Should().HaveStatusCode(HttpStatusCode.OK);
-        var responseObject = JsonSerializer.Deserialize<Skjema>(responseString, JsonSerializerOptions)!;
+        var responseObject = JsonSerializer.Deserialize<Skjema>(responseString, _jsonSerializerOptions)!;
 
         responseObject.Melding!.Random.Should().Be("randomFromDataRead");
 

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
@@ -16,12 +16,12 @@ namespace Altinn.App.Api.Tests.Controllers;
 
 public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
 {
-    private readonly Mock<IDataProcessor> _dataProcessor = new();
-
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
+
+    private readonly Mock<IDataProcessor> _dataProcessor = new();
 
     public DataController_PutTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
     {
@@ -47,7 +47,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
             await client.PostAsync($"{org}/{app}/instances/?instanceOwnerPartyId={instanceOwnerPartyId}", null);
         var createResponseContent = await createResponse.Content.ReadAsStringAsync();
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var createResponseParsed = JsonSerializer.Deserialize<Instance>(createResponseContent, JsonSerializerOptions)!;
+        var createResponseParsed = JsonSerializer.Deserialize<Instance>(createResponseContent, _jsonSerializerOptions)!;
         var instanceId = createResponseParsed.Id;
 
         // Create data element (not sure why it isn't created when the instance is created, autoCreate is true)
@@ -58,7 +58,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         var createDataElementResponseContent = await createDataElementResponse.Content.ReadAsStringAsync();
         createDataElementResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var createDataElementResponseParsed =
-            JsonSerializer.Deserialize<DataElement>(createDataElementResponseContent, JsonSerializerOptions)!;
+            JsonSerializer.Deserialize<DataElement>(createDataElementResponseContent, _jsonSerializerOptions)!;
         var dataGuid = createDataElementResponseParsed.Id;
 
         // Update data element
@@ -109,7 +109,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
             await client.PostAsync($"{org}/{app}/instances/?instanceOwnerPartyId={instanceOwnerPartyId}", null);
         var createResponseContent = await createResponse.Content.ReadAsStringAsync();
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
-        var createResponseParsed = JsonSerializer.Deserialize<Instance>(createResponseContent, JsonSerializerOptions)!;
+        var createResponseParsed = JsonSerializer.Deserialize<Instance>(createResponseContent, _jsonSerializerOptions)!;
         var instanceId = createResponseParsed.Id;
 
         // Create data element (not sure why it isn't created when the instance is created, autoCreate is true)
@@ -121,7 +121,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         var createDataElementResponseContent = await createDataElementResponse.Content.ReadAsStringAsync();
         createDataElementResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var createDataElementResponseParsed =
-            JsonSerializer.Deserialize<DataElement>(createDataElementResponseContent, JsonSerializerOptions)!;
+            JsonSerializer.Deserialize<DataElement>(createDataElementResponseContent, _jsonSerializerOptions)!;
         var dataGuid = createDataElementResponseParsed.Id;
 
         // Verify stored data

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
@@ -16,12 +16,12 @@ namespace Altinn.App.Api.Tests.Controllers;
 
 public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
 {
-    private readonly Mock<IDataProcessor> _dataProcessor = new();
-
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
+
+    private readonly Mock<IDataProcessor> _dataProcessor = new();
 
     public InstancesController_PostNewInstanceTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
     {

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
@@ -18,7 +18,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
 {
     private readonly Mock<IDataProcessor> _dataProcessor = new();
 
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions()
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
@@ -52,7 +52,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         var createResponseContent = await createResponse.Content.ReadAsStringAsync();
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createResponseContent);
 
-        var createResponseParsed = JsonSerializer.Deserialize<Instance>(createResponseContent, JsonSerializerOptions)!;
+        var createResponseParsed = JsonSerializer.Deserialize<Instance>(createResponseContent, _jsonSerializerOptions)!;
 
         // Verify Data id
         var instanceId = createResponseParsed.Id;

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
@@ -27,18 +27,17 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
     private static readonly Guid InstanceGuid = new("5a2fa5ec-f97c-4816-b57a-dc78a981917e");
     private static readonly string InstanceId = $"{InstanceOwnerPartyId}/{InstanceGuid}";
     private static readonly Guid DataGuid = new("cd691c32-ae36-4555-8aee-0b7054a413e4");
-
-    // Define mocks
-    private readonly Mock<IDataProcessor> _dataProcessorMock = new(MockBehavior.Strict);
-    private readonly Mock<IFormDataValidator> _formDataValidatorMock = new(MockBehavior.Strict);
-
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = true,
         UnknownTypeHandling = JsonUnknownTypeHandling.JsonElement,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
+
+    // Define mocks
+    private readonly Mock<IDataProcessor> _dataProcessorMock = new(MockBehavior.Strict);
+    private readonly Mock<IFormDataValidator> _formDataValidatorMock = new(MockBehavior.Strict);
 
     // Constructor with common setup
     public ProcessControllerTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
@@ -197,7 +196,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
 
             // Verify that data element is locked while pdf is being generated
             var lockedInstanceString = await File.ReadAllTextAsync(dataElementPath);
-            var lockedInstance = JsonSerializer.Deserialize<DataElement>(lockedInstanceString, JsonSerializerOptions)!;
+            var lockedInstance = JsonSerializer.Deserialize<DataElement>(lockedInstanceString, _jsonSerializerOptions)!;
             lockedInstance.Locked.Should().BeTrue();
 
             sendAsyncCalled = true;
@@ -214,7 +213,7 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
 
         // Verify that the instance is not locked after pdf failed
         var unLockedInstanceString = await File.ReadAllTextAsync(dataElementPath);
-        var unLockedInstance = JsonSerializer.Deserialize<DataElement>(unLockedInstanceString, JsonSerializerOptions)!;
+        var unLockedInstance = JsonSerializer.Deserialize<DataElement>(unLockedInstanceString, _jsonSerializerOptions)!;
         unLockedInstance.Locked.Should().BeFalse();
     }
 

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateController_ValidateInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateController_ValidateInstanceTests.cs
@@ -27,17 +27,16 @@ public class ValidateControllerValidateInstanceTests : ApiTestBase, IClassFixtur
     private static readonly Guid InstanceGuid = new("3102f61d-1446-4ca5-9fed-3c7c7d67249c");
     private static readonly string InstanceId = $"{InstanceOwnerPartyId}/{InstanceGuid}";
     private static readonly Guid DataGuid = new("5240d834-dca6-44d3-b99a-1b7ca9b862af");
-
-    private readonly Mock<IDataProcessor> _dataProcessorMock = new(MockBehavior.Strict);
-    private readonly Mock<IFormDataValidator> _formDataValidatorMock = new(MockBehavior.Strict);
-
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = true,
         UnknownTypeHandling = JsonUnknownTypeHandling.JsonElement,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
+
+    private readonly Mock<IDataProcessor> _dataProcessorMock = new(MockBehavior.Strict);
+    private readonly Mock<IFormDataValidator> _formDataValidatorMock = new(MockBehavior.Strict);
 
     public ValidateControllerValidateInstanceTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper) : base(factory, outputHelper)
     {
@@ -73,13 +72,13 @@ public class ValidateControllerValidateInstanceTests : ApiTestBase, IClassFixtur
     {
         var responseString = await response.Content.ReadAsStringAsync();
         using var responseParsedRaw = JsonDocument.Parse(responseString);
-        _outputHelper.WriteLine(JsonSerializer.Serialize(responseParsedRaw, JsonSerializerOptions));
+        _outputHelper.WriteLine(JsonSerializer.Serialize(responseParsedRaw, _jsonSerializerOptions));
         return responseString;
 
     }
     private static TResponse ParseResponse<TResponse>(string responseString)
     {
-        return JsonSerializer.Deserialize<TResponse>(responseString, JsonSerializerOptions)!;
+        return JsonSerializer.Deserialize<TResponse>(responseString, _jsonSerializerOptions)!;
     }
 
     [Fact]

--- a/test/Altinn.App.Api.Tests/Data/TestData.cs
+++ b/test/Altinn.App.Api.Tests/Data/TestData.cs
@@ -9,6 +9,13 @@ namespace Altinn.App.Api.Tests.Data;
 
 public static class TestData
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
     public static string GetTestDataRootDirectory()
     {
         var assemblyPath = new Uri(typeof(TestData).Assembly.Location).LocalPath;
@@ -185,17 +192,10 @@ public static class TestData
         }
     }
 
-    private static JsonSerializerOptions JsonSerializerOptions => new(JsonSerializerDefaults.Web)
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true,
-        Converters = { new JsonStringEnumConverter() }
-    };
-
     public static async Task<Instance> GetInstance(string org, string app, int instanceOwnerPartyId, Guid instanceGuid)
     {
         var path = GetInstancePath(org, app, instanceOwnerPartyId, instanceGuid);
         var instanceJson = await File.ReadAllTextAsync(path);
-        return JsonSerializer.Deserialize<Instance>(instanceJson, JsonSerializerOptions)!;
+        return JsonSerializer.Deserialize<Instance>(instanceJson, _jsonSerializerOptions)!;
     }
 }

--- a/test/Altinn.App.Api.Tests/Mocks/AltinnPartyClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AltinnPartyClientMock.cs
@@ -8,7 +8,7 @@ namespace Altinn.App.Api.Tests.Mocks;
 
 public class AltinnPartyClientMock : IAltinnPartyClient
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web)
     {
         Converters = { new JsonStringEnumConverter() }
     };

--- a/test/Altinn.App.Api.Tests/Mocks/AltinnPartyClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AltinnPartyClientMock.cs
@@ -8,16 +8,18 @@ namespace Altinn.App.Api.Tests.Mocks;
 
 public class AltinnPartyClientMock : IAltinnPartyClient
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
     private readonly string _partyFolder = TestData.GetAltinnProfilePath();
 
     public async Task<Party?> GetParty(int partyId)
     {
         var file = Path.Join(_partyFolder, $"{partyId}.json");
         await using var fileHandle = File.OpenRead(file); // Throws exception if missing (helps with debugging tests)
-        return await JsonSerializer.DeserializeAsync<Party>(fileHandle, new JsonSerializerOptions(JsonSerializerDefaults.Web)
-        {
-            Converters = { new JsonStringEnumConverter() }
-        });
+        return await JsonSerializer.DeserializeAsync<Party>(fileHandle, _jsonSerializerOptions);
     }
 
     public async Task<Party> LookupParty(PartyLookup partyLookup)

--- a/test/Altinn.App.Api.Tests/Mocks/AppMetadataMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AppMetadataMock.cs
@@ -15,6 +15,13 @@ namespace App.IntegrationTests.Mocks.Services
 {
     public class AppMetadataMock : IAppMetadata
     {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            AllowTrailingCommas = true
+        };
+
         private readonly AppSettings _settings;
         private readonly IFrontendFeatures _frontendFeatures;
         private ApplicationMetadata? _application;
@@ -58,14 +65,8 @@ namespace App.IntegrationTests.Mocks.Services
             {
                 if (File.Exists(filename))
                 {
-                    JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions()
-                    {
-                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                        PropertyNameCaseInsensitive = true,
-                        AllowTrailingCommas = true
-                    };
                     using FileStream fileStream = File.OpenRead(filename);
-                    var application = await JsonSerializer.DeserializeAsync<ApplicationMetadata>(fileStream, jsonSerializerOptions);
+                    var application = await JsonSerializer.DeserializeAsync<ApplicationMetadata>(fileStream, _jsonSerializerOptions);
                     if (application == null)
                     {
                         throw new ApplicationConfigException($"Deserialization returned null, Could indicate problems with deserialization of {filename}");

--- a/test/Altinn.App.Api.Tests/Mocks/AppMetadataMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AppMetadataMock.cs
@@ -15,7 +15,7 @@ namespace App.IntegrationTests.Mocks.Services
 {
     public class AppMetadataMock : IAppMetadata
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             PropertyNameCaseInsensitive = true,

--- a/test/Altinn.App.Api.Tests/Mocks/DataClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/DataClientMock.cs
@@ -16,7 +16,7 @@ namespace App.IntegrationTests.Mocks.Services
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IAppMetadata _appMetadata;
-        private static readonly JsonSerializerOptions _serializerOptions = new()
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
         {
             WriteIndented = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -48,7 +48,7 @@ namespace App.IntegrationTests.Mocks.Services
 
                 }
 
-                if (JsonSerializer.Deserialize<DataElement>(fileContent, _serializerOptions) is not DataElement dataElement)
+                if (JsonSerializer.Deserialize<DataElement>(fileContent, _jsonSerializerOptions) is not DataElement dataElement)
                 {
                     throw new Exception($"Unable to deserialize data element for org: {org}/{app} party: {instanceOwnerPartyId} instance: {instanceGuid} data: {dataGuid}. Tried path: {dataElementPath}");
                 }
@@ -373,7 +373,7 @@ namespace App.IntegrationTests.Mocks.Services
         {
             string dataElementPath = TestData.GetDataElementPath(org, app, instanceOwnerPartyId, Guid.Parse(dataElement.InstanceGuid), Guid.Parse(dataElement.Id));
 
-            string jsonData = JsonSerializer.Serialize(dataElement, _serializerOptions);
+            string jsonData = JsonSerializer.Serialize(dataElement, _jsonSerializerOptions);
 
             using StreamWriter sw = new(dataElementPath);
 
@@ -396,7 +396,7 @@ namespace App.IntegrationTests.Mocks.Services
             foreach (string file in files)
             {
                 string content = File.ReadAllText(Path.Combine(path, file));
-                DataElement? dataElement = JsonSerializer.Deserialize<DataElement>(content, _serializerOptions);
+                DataElement? dataElement = JsonSerializer.Deserialize<DataElement>(content, _jsonSerializerOptions);
 
                 if (dataElement != null)
                 {

--- a/test/Altinn.App.Api.Tests/Mocks/ProfileClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/ProfileClientMock.cs
@@ -8,13 +8,15 @@ namespace Altinn.App.Api.Tests.Mocks;
 
 public class ProfileClientMock : IProfileClient
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
     public async Task<UserProfile> GetUserProfile(int userId)
     {
         var folder = TestData.GetRegisterProfilePath();
         var file = Path.Join(folder, $"{userId}.json");
-        return (await JsonSerializer.DeserializeAsync<UserProfile>(File.OpenRead(file), new JsonSerializerOptions(JsonSerializerDefaults.Web)
-        {
-            Converters = { new JsonStringEnumConverter() }
-        }))!;
+        return (await JsonSerializer.DeserializeAsync<UserProfile>(File.OpenRead(file), _jsonSerializerOptions))!;
     }
 }

--- a/test/Altinn.App.Api.Tests/Mocks/ProfileClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/ProfileClientMock.cs
@@ -8,7 +8,7 @@ namespace Altinn.App.Api.Tests.Mocks;
 
 public class ProfileClientMock : IProfileClient
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web)
     {
         Converters = { new JsonStringEnumConverter() }
     };

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -88,7 +88,7 @@ public class ExpressionValidatorTests
 
 public class ExpressionTestAttribute : DataAttribute
 {
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
     {
         ReadCommentHandling = JsonCommentHandling.Skip,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -105,7 +105,7 @@ public class ExpressionTestAttribute : DataAttribute
             var data = File.ReadAllText(file);
             ExpressionValidationTestModel testCase = JsonSerializer.Deserialize<ExpressionValidationTestModel>(
                 data,
-                JsonSerializerOptions)!;
+                _jsonSerializerOptions)!;
             yield return new object[] { testCase };
         }
     }

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -88,7 +88,7 @@ public class ExpressionValidatorTests
 
 public class ExpressionTestAttribute : DataAttribute
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         ReadCommentHandling = JsonCommentHandling.Skip,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/test/Altinn.App.Core.Tests/Helpers/MultiDecisionHelperTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/MultiDecisionHelperTests.cs
@@ -11,17 +11,17 @@ namespace Altinn.App.Core.Tests.Helpers;
 
 public class MultiDecisionHelperTests
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+    {
+        WriteIndented = true
+    };
+
     private readonly ITestOutputHelper _output;
 
     public MultiDecisionHelperTests(ITestOutputHelper output)
     {
         _output = output;
     }
-
-    private static readonly JsonSerializerOptions SerializerOptions = new()
-    {
-        WriteIndented = true
-    };
 
     [Fact]
     public void CreateMultiDecisionRequest_generates_multidecisionrequest_with_all_actions_current_task_elemtnId()
@@ -248,7 +248,7 @@ public class MultiDecisionHelperTests
 
     private static string XacmlJsonRequestRootToString(XacmlJsonRequestRoot request)
     {
-        return JsonSerializer.Serialize(request, SerializerOptions);
+        return JsonSerializer.Serialize(request, _jsonSerializerOptions);
     }
 
     private void CompareWithOrUpdateGoldenFile(string testId, XacmlJsonRequestRoot xacmlJsonRequestRoot)

--- a/test/Altinn.App.Core.Tests/Helpers/ShadowFieldsConverterTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ShadowFieldsConverterTests.cs
@@ -45,6 +45,8 @@ public class ShadowFieldsConverterTests
         Assert.Contains("AltinnSF_", serializedDataWithoutModifier);
 
         var modifier = new IgnorePropertiesWithPrefix("AltinnSF_");
+
+        // TODO: could be cached in a dictionary with the prefix as key, since serializer options _should_ be static/reused
         JsonSerializerOptions options = new()
         {
             TypeInfoResolver = new DefaultJsonTypeInfoResolver

--- a/test/Altinn.App.Core.Tests/Helpers/ShadowFieldsConverterTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ShadowFieldsConverterTests.cs
@@ -46,7 +46,6 @@ public class ShadowFieldsConverterTests
 
         var modifier = new IgnorePropertiesWithPrefix("AltinnSF_");
 
-        // TODO: could be cached in a dictionary with the prefix as key, since serializer options _should_ be static/reused
         JsonSerializerOptions options = new()
         {
             TypeInfoResolver = new DefaultJsonTypeInfoResolver

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -16,10 +16,10 @@ namespace Altinn.App.Core.Tests.Internal.App
 {
     public class AppMedataTest
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
-        { 
-            WriteIndented = true, 
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         };
 
         private readonly string appBasePath = Path.Combine("Internal", "App", "TestData") + Path.DirectorySeparatorChar;

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -1,4 +1,5 @@
 #nullable disable
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Internal.App;
@@ -15,6 +16,12 @@ namespace Altinn.App.Core.Tests.Internal.App
 {
     public class AppMedataTest
     {
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions 
+        { 
+            WriteIndented = true, 
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping 
+        };
+
         private readonly string appBasePath = Path.Combine("Internal", "App", "TestData") + Path.DirectorySeparatorChar;
 
         [Fact]
@@ -482,7 +489,7 @@ namespace Altinn.App.Core.Tests.Internal.App
             AppSettings appSettings = GetAppSettings("AppMetadata", "unmapped-properties.applicationmetadata.json");
             IAppMetadata appMetadata = SetupAppMedata(Options.Create(appSettings));
             var appMetadataObj = await appMetadata.GetApplicationMetadata();
-            string serialized = JsonSerializer.Serialize(appMetadataObj, new JsonSerializerOptions { WriteIndented = true, Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+            string serialized = JsonSerializer.Serialize(appMetadataObj, _jsonSerializerOptions);
             string expected = File.ReadAllText(Path.Join(appBasePath, "AppMetadata", "unmapped-properties.applicationmetadata.expected.json"));
             expected = expected.Replace("--AltinnNugetVersion--", typeof(ApplicationMetadata).Assembly!.GetName().Version!.ToString());
             serialized.Should().Be(expected);

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -16,7 +16,7 @@ namespace Altinn.App.Core.Tests.Internal.App
 {
     public class AppMedataTest
     {
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions 
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
         { 
             WriteIndented = true, 
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping 

--- a/test/Altinn.App.Core.Tests/Internal/Data/DataServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Data/DataServiceTests.cs
@@ -10,11 +10,11 @@ namespace Altinn.App.Core.Tests.Internal.Data
 {
     public class DataServiceTests
     {
+        private readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
         private readonly Mock<IDataClient> _mockDataClient;
         private readonly Mock<IAppMetadata> _mockAppMetadata;
         private readonly DataService _dataService;
-
-        private readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
         public DataServiceTests()
         {

--- a/test/Altinn.App.Core.Tests/Internal/Data/DataServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Data/DataServiceTests.cs
@@ -10,7 +10,7 @@ namespace Altinn.App.Core.Tests.Internal.Data
 {
     public class DataServiceTests
     {
-        private readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
         private readonly Mock<IDataClient> _mockDataClient;
         private readonly Mock<IAppMetadata> _mockAppMetadata;

--- a/test/Altinn.App.Core.Tests/Internal/Process/ExpressionsExclusiveGatewayTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ExpressionsExclusiveGatewayTests.cs
@@ -21,7 +21,7 @@ namespace Altinn.App.Core.Tests.Internal.Process;
 
 public class ExpressionsExclusiveGatewayTests
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = true,

--- a/test/Altinn.App.Core.Tests/Internal/Process/ExpressionsExclusiveGatewayTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ExpressionsExclusiveGatewayTests.cs
@@ -21,6 +21,12 @@ namespace Altinn.App.Core.Tests.Internal.Process;
 
 public class ExpressionsExclusiveGatewayTests
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
     [Fact]
     public async Task FilterAsync_NoExpressions_ReturnsAllFlows()
     {
@@ -373,12 +379,5 @@ public class ExpressionsExclusiveGatewayTests
         return new ExpressionsExclusiveGateway(layoutStateInit, resources.Object, appModel.Object, appMetadata.Object, dataClient.Object);
     }
 
-    private static string LayoutSetsToString(LayoutSets layoutSets)
-    {
-        return JsonSerializer.Serialize(layoutSets, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = true,
-        });
-    }
+    private static string LayoutSetsToString(LayoutSets layoutSets) => JsonSerializer.Serialize(layoutSets, _jsonSerializerOptions);
 }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestBackendExclusiveFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestBackendExclusiveFunctions.cs
@@ -95,6 +95,12 @@ public class TestBackendExclusiveFunctions
 
 public class ExclusiveTestAttribute : DataAttribute
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     private readonly string _folder;
 
     public ExclusiveTestAttribute(string folder)
@@ -111,13 +117,7 @@ public class ExclusiveTestAttribute : DataAttribute
             var data = File.ReadAllText(file);
             try
             {
-                testCase = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(
-                    data,
-                    new JsonSerializerOptions
-                    {
-                        ReadCommentHandling = JsonCommentHandling.Skip,
-                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    })!;
+                testCase = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(data, _jsonSerializerOptions)!;
             }
             catch (Exception e)
             {

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestBackendExclusiveFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestBackendExclusiveFunctions.cs
@@ -95,7 +95,7 @@ public class TestBackendExclusiveFunctions
 
 public class ExclusiveTestAttribute : DataAttribute
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         ReadCommentHandling = JsonCommentHandling.Skip,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Core.Tests.LayoutExpressions;
 
 public class TestContextList
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions 
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
     { 
         WriteIndented = true, 
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault 
@@ -77,7 +77,7 @@ public class TestContextList
 
 public class SharedTestContextListAttribute : DataAttribute
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         ReadCommentHandling = JsonCommentHandling.Skip,
     };

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
@@ -12,10 +12,10 @@ namespace Altinn.App.Core.Tests.LayoutExpressions;
 
 public class TestContextList
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
-    { 
-        WriteIndented = true, 
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault 
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
     };
 
     private readonly ITestOutputHelper _output;

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
-
+using System.Text.Json.Serialization;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Tests.Helpers;
 using FluentAssertions;
@@ -12,6 +12,12 @@ namespace Altinn.App.Core.Tests.LayoutExpressions;
 
 public class TestContextList
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions 
+    { 
+        WriteIndented = true, 
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault 
+    };
+
     private readonly ITestOutputHelper _output;
 
     public TestContextList(ITestOutputHelper output)
@@ -49,7 +55,7 @@ public class TestContextList
         test.ParsingException.Should().BeNull("Loading of test failed");
 
         var results = state.GetComponentContexts().Select(c => ComponentContextForTestSpec.FromContext(c)).ToList();
-        _output.WriteLine(JsonSerializer.Serialize(new { resultContexts = results }, new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault }));
+        _output.WriteLine(JsonSerializer.Serialize(new { resultContexts = results }, _jsonSerializerOptions));
 
         foreach (var (result, expected, index) in results.Zip(test.Expected, Enumerable.Range(0, int.MaxValue)))
         {
@@ -71,6 +77,11 @@ public class TestContextList
 
 public class SharedTestContextListAttribute : DataAttribute
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
     private readonly string _folder;
 
     public SharedTestContextListAttribute(string folder)
@@ -87,12 +98,7 @@ public class SharedTestContextListAttribute : DataAttribute
             var data = File.ReadAllText(file);
             try
             {
-                testCase = JsonSerializer.Deserialize<ContextListRoot>(
-                    data,
-                    new JsonSerializerOptions
-                    {
-                        ReadCommentHandling = JsonCommentHandling.Skip,
-                    })!;
+                testCase = JsonSerializer.Deserialize<ContextListRoot>(data, _jsonSerializerOptions)!;
             }
             catch (Exception e)
             {

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
@@ -190,7 +190,7 @@ public class TestFunctions
 
 public class SharedTestAttribute : DataAttribute
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         ReadCommentHandling = JsonCommentHandling.Skip,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
@@ -190,6 +190,12 @@ public class TestFunctions
 
 public class SharedTestAttribute : DataAttribute
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     private readonly string _folder;
 
     public SharedTestAttribute(string folder)
@@ -206,13 +212,7 @@ public class SharedTestAttribute : DataAttribute
             var data = File.ReadAllText(file);
             try
             {
-                testCase = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(
-                    data,
-                    new JsonSerializerOptions
-                    {
-                        ReadCommentHandling = JsonCommentHandling.Skip,
-                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    })!;
+                testCase = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(data, _jsonSerializerOptions)!;
             }
             catch (Exception e)
             {

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
@@ -12,6 +12,12 @@ namespace Altinn.App.Core.Tests.LayoutExpressions;
 
 public class TestInvalid
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     private readonly ITestOutputHelper _output;
 
     public TestInvalid(ITestOutputHelper output)
@@ -28,13 +34,7 @@ public class TestInvalid
         _output.WriteLine(testCase.FullPath);
         Action act = () =>
         {
-            var test = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(
-                testCase.RawJson!,
-                new JsonSerializerOptions
-                {
-                    ReadCommentHandling = JsonCommentHandling.Skip,
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                })!;
+            var test = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(testCase.RawJson!, _jsonSerializerOptions)!;
             var state = new LayoutEvaluatorState(
                 new JsonDataModel(test.DataModel),
                 test.ComponentModel,

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Core.Tests.LayoutExpressions;
 
 public class TestInvalid
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         ReadCommentHandling = JsonCommentHandling.Skip,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/LayoutTestUtils.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/LayoutTestUtils.cs
@@ -15,7 +15,7 @@ namespace Altinn.App.Core.Tests.LayoutExpressions;
 
 public static class LayoutTestUtils
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
     public static async Task<LayoutEvaluatorState> GetLayoutModelTools(object model, string folder)
     {

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/LayoutTestUtils.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/LayoutTestUtils.cs
@@ -15,6 +15,8 @@ namespace Altinn.App.Core.Tests.LayoutExpressions;
 
 public static class LayoutTestUtils
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+
     public static async Task<LayoutEvaluatorState> GetLayoutModelTools(object model, string folder)
     {
         var services = new ServiceCollection();
@@ -31,11 +33,9 @@ public static class LayoutTestUtils
             var layout = await File.ReadAllBytesAsync(layoutFile);
             string pageName = layoutFile.Replace(layoutsPath + "/", string.Empty).Replace(".json", string.Empty);
 
-            var pageOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-
             PageComponentConverter.SetAsyncLocalPageName(pageName);
 
-            layoutModel.Pages[pageName] = JsonSerializer.Deserialize<PageComponent>(layout.RemoveBom(), pageOptions)!;
+            layoutModel.Pages[pageName] = JsonSerializer.Deserialize<PageComponent>(layout.RemoveBom(), _jsonSerializerOptions)!;
         }
 
         resources.Setup(r => r.GetLayoutModel(null)).Returns(layoutModel);

--- a/test/Altinn.App.Core.Tests/Models/PageComponentConverterTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/PageComponentConverterTests.cs
@@ -53,10 +53,10 @@ public class PageComponentConverterTests
 
 public class PageComponentConverterTestAttribute : DataAttribute
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
-    { 
-        ReadCommentHandling = JsonCommentHandling.Skip, 
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase 
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
     public override IEnumerable<object[]> GetData(MethodInfo methodInfo)

--- a/test/Altinn.App.Core.Tests/Models/PageComponentConverterTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/PageComponentConverterTests.cs
@@ -53,7 +53,7 @@ public class PageComponentConverterTests
 
 public class PageComponentConverterTestAttribute : DataAttribute
 {
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions 
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new() 
     { 
         ReadCommentHandling = JsonCommentHandling.Skip, 
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase 

--- a/test/Altinn.App.Core.Tests/Models/PageComponentConverterTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/PageComponentConverterTests.cs
@@ -53,6 +53,12 @@ public class PageComponentConverterTests
 
 public class PageComponentConverterTestAttribute : DataAttribute
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions 
+    { 
+        ReadCommentHandling = JsonCommentHandling.Skip, 
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase 
+    };
+
     public override IEnumerable<object[]> GetData(MethodInfo methodInfo)
     {
         var files = Directory.GetFiles(Path.Join("Models", "page-component-converter-tests"));
@@ -60,7 +66,7 @@ public class PageComponentConverterTestAttribute : DataAttribute
         foreach (var file in files)
         {
             var data = File.ReadAllText(file);
-            var testCase = JsonSerializer.Deserialize<PageComponentConverterTestModel>(data, new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip, PropertyNamingPolicy = JsonNamingPolicy.CamelCase })!;
+            var testCase = JsonSerializer.Deserialize<PageComponentConverterTestModel>(data, _jsonSerializerOptions)!;
             yield return new object[] { testCase };
         }
     }


### PR DESCRIPTION
## Description

`JsonSerializerOptions` should not be created per serializer call, but should be cached and reused as it keeps some cached state internally that it then doesn't have to recreate every time.

Docs: 
https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/configure-options?pivots=dotnet-8-0#reuse-jsonserializeroptions-instances

Improved adherence to some conventions
* Names  = `_jsonSerializerOptions` (when private)
* Statics to the top of the class (along with other statics)
* Target typed new

In the future we should probably consolidate since there is at least some duplication

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
