### PR TITLE
Fix issue where AppInsights SDK doesn't load/configure correctly due to keyed services being registered in DI

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -48,4 +48,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
 </Project>

--- a/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
@@ -73,7 +73,13 @@ namespace Altinn.App.Api.Extensions
             services.AddMetricsServer(config);
         }
 
-        private static void AddApplicationInsights(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
+        /// <summary>
+        /// Adds Application Insights to the service collection.
+        /// </summary>
+        /// <param name="services">Services</param>
+        /// <param name="config">Config</param>
+        /// <param name="env">Environment</param>
+        internal static void AddApplicationInsights(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
         {
             string? applicationInsightsKey = env.IsDevelopment()
                 ? config["ApplicationInsights:InstrumentationKey"]

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -27,5 +27,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 </Project>

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -298,8 +298,8 @@ namespace Altinn.App.Core.Extensions
             services.AddTransient<IProcessTask, NullTypeProcessTask>();
 
             //SERVICE TASKS
-            services.AddKeyedTransient<IServiceTask, PdfServiceTask>("pdfService");
-            services.AddKeyedTransient<IServiceTask, EformidlingServiceTask>("eFormidlingService");
+            services.AddTransient<IServiceTask, PdfServiceTask>();
+            services.AddTransient<IServiceTask, EformidlingServiceTask>();
         }
 
         private static void AddActionServices(IServiceCollection services)

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
@@ -2,7 +2,6 @@
 using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.App.Core.Internal.Process.ServiceTasks;
 using Altinn.Platform.Storage.Interface.Models;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
@@ -25,16 +24,17 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
         public EndTaskEventHandler(
             IProcessTaskDataLocker processTaskDataLocker,
             IProcessTaskFinalizer processTaskFinisher,
-            [FromKeyedServices("pdfService")] IServiceTask pdfServiceTask,
-            [FromKeyedServices("eFormidlingService")] IServiceTask eformidlingServiceTask,
+            IEnumerable<IServiceTask> serviceTasks,
             IEnumerable<IProcessTaskEnd> processTaskEnds,
             ILogger<EndTaskEventHandler> logger
         )
         {
             _processTaskDataLocker = processTaskDataLocker;
             _processTaskFinisher = processTaskFinisher;
-            _pdfServiceTask = pdfServiceTask;
-            _eformidlingServiceTask = eformidlingServiceTask;
+            _pdfServiceTask = serviceTasks.FirstOrDefault(x => x is IPdfServiceTask)
+                ?? throw new InvalidOperationException("PdfServiceTask not found in serviceTasks");
+            _eformidlingServiceTask = serviceTasks.FirstOrDefault(x => x is IEformidlingServiceTask)
+                ?? throw new InvalidOperationException("EformidlingServiceTask not found in serviceTasks");
             _processTaskEnds = processTaskEnds;
             _logger = logger;
         }

--- a/src/Altinn.App.Core/Internal/Process/ServiceTasks/EformidlingServiceTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ServiceTasks/EformidlingServiceTask.cs
@@ -9,10 +9,12 @@ using Microsoft.Extensions.Options;
 
 namespace Altinn.App.Core.Internal.Process.ServiceTasks;
 
+internal interface IEformidlingServiceTask : IServiceTask {}
+
 /// <summary>
 /// Service task that sends eFormidling shipment, if EFormidling is enabled in config and EFormidling.SendAfterTaskId matches the current task.
 /// </summary>
-public class EformidlingServiceTask : IServiceTask
+public class EformidlingServiceTask : IEformidlingServiceTask
 {
     private readonly ILogger<EformidlingServiceTask> _logger;
     private readonly IAppMetadata _appMetadata;

--- a/src/Altinn.App.Core/Internal/Process/ServiceTasks/EformidlingServiceTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ServiceTasks/EformidlingServiceTask.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 
 namespace Altinn.App.Core.Internal.Process.ServiceTasks;
 
-internal interface IEformidlingServiceTask : IServiceTask {}
+internal interface IEformidlingServiceTask : IServiceTask { }
 
 /// <summary>
 /// Service task that sends eFormidling shipment, if EFormidling is enabled in config and EFormidling.SendAfterTaskId matches the current task.

--- a/src/Altinn.App.Core/Internal/Process/ServiceTasks/PdfServiceTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ServiceTasks/PdfServiceTask.cs
@@ -5,10 +5,12 @@ using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Process.ServiceTasks;
 
+internal interface IPdfServiceTask : IServiceTask {}
+
 /// <summary>
 /// Service task that generates PDFs for all connected datatypes that have the EnablePdfCreation flag set to true.
 /// </summary>
-public class PdfServiceTask : IServiceTask
+public class PdfServiceTask : IPdfServiceTask
 {
     private readonly IAppMetadata _appMetadata;
     private readonly IPdfService _pdfService;

--- a/src/Altinn.App.Core/Internal/Process/ServiceTasks/PdfServiceTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ServiceTasks/PdfServiceTask.cs
@@ -5,7 +5,7 @@ using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Process.ServiceTasks;
 
-internal interface IPdfServiceTask : IServiceTask {}
+internal interface IPdfServiceTask : IServiceTask { }
 
 /// <summary>
 /// Service task that generates PDFs for all connected datatypes that have the EnablePdfCreation flag set to true.

--- a/test/Altinn.App.Api.Tests/DITests.cs
+++ b/test/Altinn.App.Api.Tests/DITests.cs
@@ -1,0 +1,94 @@
+
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Configuration;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights;
+using System.Diagnostics.Tracing;
+
+namespace Altinn.App.Api.Tests;
+
+public class DITests
+{
+    private sealed record FakeWebHostEnvironment : IWebHostEnvironment, IHostingEnvironment
+    {
+        private string _env = "";
+
+        public string WebRootPath { get => new DirectoryInfo("./").FullName; set => throw new NotImplementedException(); }
+        public IFileProvider WebRootFileProvider { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string ApplicationName { get => "test"; set => throw new NotImplementedException(); }
+        public IFileProvider ContentRootFileProvider { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string ContentRootPath { get => new DirectoryInfo("./").FullName; set => throw new NotImplementedException(); }
+        public string EnvironmentName { get => _env; set => _env = value;  }
+    }
+
+    private sealed class AppInsightsListener : EventListener
+    {
+        private readonly List<EventSource> _eventSources = [];
+        public readonly List<EventWrittenEventArgs> Events = [];
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            
+            if (eventSource.Name == "Microsoft-ApplicationInsights-AspNetCore")
+            {
+                _eventSources.Add(eventSource);
+                EnableEvents(eventSource, EventLevel.Verbose, EventKeywords.All);
+            }
+
+            base.OnEventSourceCreated(eventSource);
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventSource.Name != "Microsoft-ApplicationInsights-AspNetCore")
+            {
+                return;
+            }
+
+            Events.Add(eventData);
+            base.OnEventWritten(eventData);
+        }
+
+        public override void Dispose()
+        {
+            foreach (var eventSource in _eventSources)
+            {
+                DisableEvents(eventSource);
+            }
+            base.Dispose();
+        }
+    } 
+
+    [Fact]
+    public void AppInsights_Registers_Correctly()
+    {
+        using var listener = new AppInsightsListener();
+
+        var services = new ServiceCollection();
+        var env = new FakeWebHostEnvironment { EnvironmentName = "Development" };
+
+        services.AddSingleton<IWebHostEnvironment>(env);
+        services.AddSingleton<IHostingEnvironment>(env);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection([
+                new KeyValuePair<string, string?>("ApplicationInsights:InstrumentationKey", "test")
+            ]).Build();
+
+        Extensions.ServiceCollectionExtensions.AddAltinnAppServices(services, config, env);
+
+        using var sp = services.BuildServiceProvider();
+
+        var telemetryConfig = sp.GetRequiredService<TelemetryConfiguration>();
+        Assert.NotNull(telemetryConfig);
+        
+        var client = sp.GetRequiredService<TelemetryClient>();
+        Assert.NotNull(client);
+
+        EventLevel[] errorLevels = [EventLevel.Error, EventLevel.Critical];
+        Assert.Empty(listener.Events.Where(e => errorLevels.Contains(e.Level)));
+    }
+}

--- a/test/Altinn.App.Api.Tests/DITests.cs
+++ b/test/Altinn.App.Api.Tests/DITests.cs
@@ -21,7 +21,7 @@ public class DITests
         public string ApplicationName { get => "test"; set => throw new NotImplementedException(); }
         public IFileProvider ContentRootFileProvider { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string ContentRootPath { get => new DirectoryInfo("./").FullName; set => throw new NotImplementedException(); }
-        public string EnvironmentName { get => _env; set => _env = value;  }
+        public string EnvironmentName { get => _env; set => _env = value; }
     }
 
     private sealed class AppInsightsListener : EventListener
@@ -31,7 +31,7 @@ public class DITests
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            
+
             if (eventSource.Name == "Microsoft-ApplicationInsights-AspNetCore")
             {
                 _eventSources.Add(eventSource);
@@ -60,7 +60,7 @@ public class DITests
             }
             base.Dispose();
         }
-    } 
+    }
 
     [Fact]
     public void AppInsights_Registers_Correctly()
@@ -84,7 +84,7 @@ public class DITests
 
         var telemetryConfig = sp.GetRequiredService<TelemetryConfiguration>();
         Assert.NotNull(telemetryConfig);
-        
+
         var client = sp.GetRequiredService<TelemetryClient>();
         Assert.NotNull(client);
 

--- a/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
@@ -127,4 +127,38 @@ public class EndTaskEventHandlerTests
         // Make sure eFormidling service task is not called if PDF failed.
         _eformidlingServiceTask.Verify(p => p.Execute(taskId, instance), Times.Never);
     }
+
+    [Fact]
+    public void Throws_If_Missing_Pdf_ServiceTask()
+    {
+        IServiceTask[] serviceTasks = [
+            _eformidlingServiceTask.Object
+        ];
+
+        var ex = Assert.Throws<InvalidOperationException>(() => 
+            new EndTaskEventHandler(
+                _processTaskDataLocker.Object,
+                _processTaskFinisher.Object,
+                serviceTasks,
+                _processTaskEnds,
+                _logger));
+        Assert.Equal("PdfServiceTask not found in serviceTasks", ex.Message);
+    }
+
+    [Fact]
+    public void Throws_If_Missing_Eformidling_ServiceTask()
+    {
+        IServiceTask[] serviceTasks = [
+            _pdfServiceTask.Object
+        ];
+
+        var ex = Assert.Throws<InvalidOperationException>(() => 
+            new EndTaskEventHandler(
+                _processTaskDataLocker.Object,
+                _processTaskFinisher.Object,
+                serviceTasks,
+                _processTaskEnds,
+                _logger));
+        Assert.Equal("EformidlingServiceTask not found in serviceTasks", ex.Message);
+    }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
@@ -135,7 +135,7 @@ public class EndTaskEventHandlerTests
             _eformidlingServiceTask.Object
         ];
 
-        var ex = Assert.Throws<InvalidOperationException>(() => 
+        var ex = Assert.Throws<InvalidOperationException>(() =>
             new EndTaskEventHandler(
                 _processTaskDataLocker.Object,
                 _processTaskFinisher.Object,
@@ -152,7 +152,7 @@ public class EndTaskEventHandlerTests
             _pdfServiceTask.Object
         ];
 
-        var ex = Assert.Throws<InvalidOperationException>(() => 
+        var ex = Assert.Throws<InvalidOperationException>(() =>
             new EndTaskEventHandler(
                 _processTaskDataLocker.Object,
                 _processTaskFinisher.Object,

--- a/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
@@ -14,8 +14,14 @@ public class EndTaskEventHandlerTests
 {
     private readonly Mock<IProcessTaskDataLocker> _processTaskDataLocker = new();
     private readonly Mock<IProcessTaskFinalizer> _processTaskFinisher = new();
-    private readonly Mock<IServiceTask> _pdfServiceTask = new();
-    private readonly Mock<IServiceTask> _eformidlingServiceTask = new();
+    private readonly Mock<IPdfServiceTask> _pdfServiceTask = new();
+    private readonly Mock<IEformidlingServiceTask> _eformidlingServiceTask = new();
+
+    private IServiceTask[] ServiceTasks => [
+        _pdfServiceTask.Object,
+        _eformidlingServiceTask.Object
+    ];
+
     private IEnumerable<IProcessTaskEnd> _processTaskEnds = new List<IProcessTaskEnd>();
     private readonly ILogger<EndTaskEventHandler> _logger = new NullLogger<EndTaskEventHandler>();
 
@@ -25,8 +31,7 @@ public class EndTaskEventHandlerTests
         EndTaskEventHandler eteh = new EndTaskEventHandler(
             _processTaskDataLocker.Object,
             _processTaskFinisher.Object,
-            _pdfServiceTask.Object,
-            _eformidlingServiceTask.Object,
+            ServiceTasks,
             _processTaskEnds,
             _logger);
         var instance = new Instance()
@@ -58,8 +63,7 @@ public class EndTaskEventHandlerTests
         EndTaskEventHandler eteh = new(
             _processTaskDataLocker.Object,
             _processTaskFinisher.Object,
-            _pdfServiceTask.Object,
-            _eformidlingServiceTask.Object,
+            ServiceTasks,
             _processTaskEnds,
             _logger);
         var instance = new Instance()
@@ -92,8 +96,7 @@ public class EndTaskEventHandlerTests
         EndTaskEventHandler eteh = new(
             _processTaskDataLocker.Object,
             _processTaskFinisher.Object,
-            _pdfServiceTask.Object,
-            _eformidlingServiceTask.Object,
+            ServiceTasks,
             _processTaskEnds,
             _logger);
 


### PR DESCRIPTION
## Description
A bug report came in, where logs/telemetry wasn't being shipped to AppInsights.
Upon inspecting the `IServiceCollection` registrations after calling `AddApplicationInsightsTelemetry`, we discovered that everything until (and including) these lines of registrations succeeded:
https://github.com/microsoft/ApplicationInsights-dotnet/blob/4626e3632323b741a2bd56d3d529c283cf7626c9/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs#L134

However the `TelemetryClient` itself was never registered in DI. In the code linked above, if there is an exception, it is (relatively silently) swallowed and registered on the event source for AppInsights.

We traced the event source in a local test app:
```console
dotnet trace collect --providers Microsoft-ApplicationInsights-AspNetCore -- ./bin/Debug/net8.0/Altinn.App
```

Which could be loaded into PerfView

![image](https://github.com/Altinn/app-lib-dotnet/assets/5425986/be0ea679-dcab-4b67-9b62-f2261d047e66)

We see this error:

```
HasStack="True" ThreadID="2,558,902" ProcessorNumber="0" errorMessage="System.InvalidOperationException: This service descriptor is keyed. Your service provider may not support keyed services. at Microsoft.Extensions.DependencyInjection.ServiceDescriptor.ThrowKeyedDescriptor() 
at Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_ImplementationFactory() 
at Microsoft.Extensions.DependencyInjection.ApplicationInsightsExtensions.<>c__28`2.<AddSingletonIfNotExists>b__28_0(ServiceDescriptor o) 
at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate) 
at Microsoft.Extensions.DependencyInjection.ApplicationInsightsExtensions.AddSingletonIfNotExists[TService,TImplementation](IServiceCollection services) 
at Microsoft.Extensions.DependencyInjection.ApplicationInsightsExtensions.AddCommonTelemetryModules(IServiceCollection services) at Microsoft.Extensions.DependencyInjection.ApplicationInsightsExtensions.AddApplicationInsightsTelemetry(IServiceCollection services)" appDomainName="Altinn.App" 
```

Which means that AppInsights thinks that our DI container (Scrutor) doesn't support keyed services. I think that's right? Since there is an open issue on that: https://github.com/khellang/Scrutor/pull/209

This PR replaces keyed services by just injecting multiple services, and introducing a second marker interface to distinguish between them instead.

Other options:
* Use a different DI container (for example the built in one), which supports keyed services right now?
* ?

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
