### PR TITLE
Fix NotificationEndoint base URL to match the others in PlatformSettings

### DIFF
--- a/src/Altinn.App.Core/Configuration/PlatformSettings.cs
+++ b/src/Altinn.App.Core/Configuration/PlatformSettings.cs
@@ -44,7 +44,7 @@ namespace Altinn.App.Core.Configuration
         /// <summary>
         /// Gets or sets the url for the Notification API endpoint.
         /// </summary>
-        public string NotificationEndpoint { get; set; } = "http://localhost:5101/notifications";
+        public string NotificationEndpoint { get; set; } = "http://localhost:5101/notifications/api/v1/";
 
         /// <summary>
         /// Gets or sets the subscription key value to use in requests against the platform.

--- a/src/Altinn.App.Core/Features/Notifications/Email/EmailNotificationClient.cs
+++ b/src/Altinn.App.Core/Features/Notifications/Email/EmailNotificationClient.cs
@@ -53,7 +53,7 @@ internal sealed class EmailNotificationClient : IEmailNotificationClient
         {
             var application = await _appMetadata.GetApplicationMetadata();
 
-            var uri = _platformSettings.NotificationEndpoint.TrimEnd('/') + "/api/v1/orders/email";
+            var uri = _platformSettings.NotificationEndpoint.TrimEnd('/') + "/orders/email";
             var body = JsonSerializer.Serialize(emailNotification);
 
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri)

--- a/src/Altinn.App.Core/Features/Notifications/Sms/SmsNotificationClient.cs
+++ b/src/Altinn.App.Core/Features/Notifications/Sms/SmsNotificationClient.cs
@@ -54,7 +54,7 @@ internal sealed class SmsNotificationClient : ISmsNotificationClient
         {
             Models.ApplicationMetadata? application = await _appMetadata.GetApplicationMetadata();
 
-            var uri = _platformSettings.NotificationEndpoint.TrimEnd('/') + "/api/v1/orders/sms";
+            var uri = _platformSettings.NotificationEndpoint.TrimEnd('/') + "/orders/sms";
             var body = JsonSerializer.Serialize(smsNotification);
 
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri)


### PR DESCRIPTION
## Description
Makes sure `PlatformSettings.NotificationEndpoint` matches the convention (and what get's configured when deployed)

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x} Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
