### PR TITLE
Add back filtration of ignored validators in patch endpoint

### DIFF
--- a/src/Altinn.App.Core/Internal/Validation/ValidationService.cs
+++ b/src/Altinn.App.Core/Internal/Validation/ValidationService.cs
@@ -138,6 +138,7 @@ public class ValidationService : IValidationService
 
         // Locate the relevant data validator services from normal and keyed services
         var dataValidators = _validatorFactory.GetFormDataValidators(dataType.Id)
+            .Where(dv => ignoredValidators?.Contains(dv.ValidationSource) != true) // Filter out ignored validators
             .Where(dv => previousData is null || dv.HasRelevantChanges(data, previousData))
             .ToArray();
 

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit.Abstractions;
+using Altinn.App.Core.Models.Validation;
 
 namespace Altinn.App.Api.Tests.Controllers;
 
@@ -510,5 +511,50 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
         var (_, responseString, _) = await CallPatchApi<DataPatchResponse>(patch, null, HttpStatusCode.OK);
 
         responseString.Should().Contain("\"severity\":1");
+    }
+
+    [Fact]
+    public async Task IgnoredValidators_NotExecuted()
+    {
+        // Common setup
+        _dataProcessorMock.Setup(p => p.ProcessDataWrite(It.IsAny<Instance>(), It.IsAny<Guid?>(), It.IsAny<object>(), It.IsAny<object?>(), null))
+            .Returns((Instance instance, Guid? dataGuid, object skjema, object? existingData, string? language) => Task.CompletedTask)
+            .Verifiable(Times.Exactly(2));
+
+        // Add extra validator that should be ignored
+        _formDataValidatorMock.Setup(fdv => fdv.ValidateFormData(
+            It.IsAny<Instance>(),
+            It.IsAny<DataElement>(),
+            It.IsAny<object>(),
+            It.IsAny<string?>()))
+            .ReturnsAsync(new List<ValidationIssue>
+            {
+                new()
+                {
+                    Severity = ValidationIssueSeverity.Error,
+                    Description = "Ignored validator",
+                }
+            })
+            .Verifiable(Times.Once);
+        _formDataValidatorMock.SetupGet(fdv => fdv.ValidationSource).Returns("ignored");
+        _formDataValidatorMock.SetupGet(fdv => fdv.DataType).Returns("default");
+        _formDataValidatorMock.Setup(fdv => fdv.HasRelevantChanges(It.IsAny<object>(), It.IsAny<object>())).Returns(true);
+
+
+        var patch = new JsonPatch(
+            PatchOperation.Replace(JsonPointer.Create("melding", "name"), JsonNode.Parse("\"Ola Olsen\"")));
+
+        var (_, _, parsedResponse1) = await CallPatchApi<DataPatchResponse>(patch, ["ignored"], HttpStatusCode.OK);
+
+        // Verify that no issues from the ignored validator are present
+        parsedResponse1.ValidationIssues.Should().NotContainKey("ignored");
+
+        var (_, _, parsedResponse2) = await CallPatchApi<DataPatchResponse>(patch, null, HttpStatusCode.OK);
+
+        // Verify that issues from the ignored validator are present
+        parsedResponse2.ValidationIssues.Should().ContainKey("ignored").WhoseValue.Should().ContainSingle().Which.Description.Should().Be("Ignored validator");
+
+        _dataProcessorMock.Verify();
+        _formDataValidatorMock.Verify();
     }
 }


### PR DESCRIPTION
This was erroniously removed in #423

see: https://github.com/Altinn/app-lib-dotnet/commit/56915792556051f50f8bbd73e24590c567e58eda#diff-a7c144cbd45865be3234552[…]a8e42ea7ff099ccb80182d3bL133


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
