### PR TITLE
Revert "Make AppOptions.Options required"

### DIFF
--- a/src/Altinn.App.Core/Models/AppOptions.cs
+++ b/src/Altinn.App.Core/Models/AppOptions.cs
@@ -8,7 +8,7 @@ namespace Altinn.App.Core.Models
         /// <summary>
         /// Gets or sets the list of options. Null indicates that no options are found
         /// </summary>
-        public required List<AppOption>? Options { get; set; }
+        public List<AppOption>? Options { get; set; }
 
         /// <summary>
         /// Gets or sets the parameters used to generate the options.

--- a/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
@@ -12,8 +12,7 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Options = null,
-                Parameters = new Dictionary<string, string?>
+                Parameters = new Dictionary<string, string>
                 {
                     { "lang", "nb" },
                     { "level", "1" }
@@ -33,8 +32,7 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Options = null,
-                Parameters = new Dictionary<string, string?>()
+                Parameters = new Dictionary<string, string>()
             };
 
             IHeaderDictionary headers = new HeaderDictionary
@@ -50,7 +48,6 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Options = null,
                 Parameters = null!
             };
 
@@ -67,8 +64,7 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Options = null,
-                Parameters = new Dictionary<string, string?>
+                Parameters = new Dictionary<string, string>
                 {
                     { "lang", "nb" },
                     { "level", "1" },


### PR DESCRIPTION
Reverts Altinn/app-lib-dotnet#505

Adding `required` was considered a breaking change.