### PR TITLE
Feat/471 default task events refactor revert breaking changes

### DIFF
--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/EndEventEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/EndEventEventHandler.cs
@@ -27,10 +27,6 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers
         /// <summary>
         /// Execute the event handler logic.
         /// </summary>
-        /// <param name="instanceEvent"></param>
-        /// <param name="instance"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentException"></exception>
         public async Task Execute(InstanceEvent instanceEvent, Instance instance)
         {
             string? endEvent = instanceEvent.ProcessInfo?.EndEvent;

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/Interfaces/IEndEventEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/Interfaces/IEndEventEventHandler.cs
@@ -10,9 +10,6 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers
         /// <summary>
         /// Execute the end event handler
         /// </summary>
-        /// <param name="instanceEvent"></param>
-        /// <param name="instance"></param>
-        /// <returns></returns>
         Task Execute(InstanceEvent instanceEvent, Instance instance);
     }
 }

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/AbandonTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/AbandonTaskEventHandler.cs
@@ -14,7 +14,6 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
         /// <summary>
         /// This event handler is responsible for handling the abandon event for a process task.
         /// </summary>
-        /// <param name="processTaskAbondons"></param>
         public AbandonTaskEventHandler(IEnumerable<IProcessTaskAbandon> processTaskAbondons)
         {
             _processTaskAbondons = processTaskAbondons;
@@ -23,10 +22,6 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
         /// <summary>
         /// Handles the abandon event for a process task.
         /// </summary>
-        /// <param name="processTask"></param>
-        /// <param name="taskId"></param>
-        /// <param name="instance"></param>
-        /// <returns></returns>
         public async Task Execute(IProcessTask processTask, string taskId, Instance instance)
         {
             await processTask.Abandon(taskId, instance);
@@ -36,9 +31,6 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
         /// <summary>
         /// Runs IProcessTaskAbandons defined in the app.
         /// </summary>
-        /// <param name="taskId"></param>
-        /// <param name="instance"></param>
-        /// <returns></returns>
         private async Task RunAppDefinedProcessTaskAbandonHandlers(string taskId, Instance instance)
         {
             foreach (IProcessTaskAbandon taskAbandon in _processTaskAbondons)

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
@@ -42,10 +42,6 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
         /// <summary>
         /// Execute the event handler logic.
         /// </summary>
-        /// <param name="processTask"></param>
-        /// <param name="taskId"></param>
-        /// <param name="instance"></param>
-        /// <returns></returns>
         public async Task Execute(IProcessTask processTask, string taskId, Instance instance)
         {
             await processTask.End(taskId, instance);
@@ -71,9 +67,6 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
         /// <summary>
         /// Runs IProcessTaskEnds defined in the app.
         /// </summary>
-        /// <param name="endEvent"></param>
-        /// <param name="instance"></param>
-        /// <returns></returns>
         private async Task RunAppDefinedProcessTaskEndHandlers(string endEvent, Instance instance)
         {
             foreach (IProcessTaskEnd taskEnd in _processTaskEnds)

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/StartTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/StartTaskEventHandler.cs
@@ -30,11 +30,6 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
         /// <summary>
         /// Execute the event handler logic.
         /// </summary>
-        /// <param name="processTask"></param>
-        /// <param name="taskId"></param>
-        /// <param name="instance"></param>
-        /// <param name="prefill"></param>
-        /// <returns></returns>
         public async Task Execute(IProcessTask processTask, string taskId, Instance instance,
             Dictionary<string, string>? prefill)
         {
@@ -47,10 +42,6 @@ namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask
         /// <summary>
         /// Runs IProcessTaskStarts defined in the app.
         /// </summary>
-        /// <param name="taskId"></param>
-        /// <param name="instance"></param>
-        /// <param name="prefill"></param>
-        /// <returns></returns>
         private async Task RunAppDefinedProcessTaskStartHandlers(string taskId, Instance instance,
             Dictionary<string, string>? prefill)
         {

--- a/src/Altinn.App.Core/Internal/Process/ProcessEventHandlingDelegator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEventHandlingDelegator.cs
@@ -40,10 +40,6 @@ namespace Altinn.App.Core.Internal.Process
         /// <summary>
         /// Loops through all events and delegates the event to the correct event handler.
         /// </summary>
-        /// <param name="instance"></param>
-        /// <param name="events"></param>
-        /// <param name="prefill"></param>
-        /// <returns></returns>
         public async Task HandleEvents(Instance instance, Dictionary<string, string>? prefill, List<InstanceEvent>? events)
         {
             if (events == null)
@@ -94,7 +90,6 @@ namespace Altinn.App.Core.Internal.Process
         /// <summary>
         /// Identify the correct task implementation
         /// </summary>
-        /// <returns></returns>
         private IProcessTask GetProcessTaskInstance(string? altinnTaskType)
         {
             if (string.IsNullOrEmpty(altinnTaskType))

--- a/src/Altinn.App.Core/Internal/Process/ServiceTasks/Interfaces/IServiceTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ServiceTasks/Interfaces/IServiceTask.cs
@@ -10,8 +10,5 @@ public interface IServiceTask
     /// <summary>
     /// Executes the service task.
     /// </summary>
-    /// <param name="taskId"></param>
-    /// <param name="instance"></param>
-    /// <returns></returns>
     public Task Execute(string taskId, Instance instance);
 }

--- a/src/Altinn.App.Core/Models/UserAction/UserActionResult.cs
+++ b/src/Altinn.App.Core/Models/UserAction/UserActionResult.cs
@@ -28,7 +28,12 @@ public class UserActionResult
     /// <summary>
     /// Gets or sets a value indicating whether the user action was a success
     /// </summary>
-    public ResultType ResultType { get; init; }
+    public bool Success { get; init; }
+    
+    /// <summary>
+    /// Indicates the type of result
+    /// </summary>
+    public ResultType ResultType { get; set; }
 
     /// <summary>
     /// Gets or sets a dictionary of updated data models. Key should be elementId and value should be the updated data model
@@ -61,12 +66,12 @@ public class UserActionResult
     /// <returns></returns>
     public static UserActionResult SuccessResult(List<ClientAction>? clientActions = null)
     {
-        var userActionResult = new UserActionResult
+        return new UserActionResult
         {
+            Success = true,
             ResultType = ResultType.Success,
             ClientActions = clientActions
         };
-        return userActionResult;
     }
 
     /// <summary>
@@ -93,6 +98,7 @@ public class UserActionResult
     {
         return new UserActionResult
         {
+            Success = true,
             ResultType = ResultType.Redirect,
             RedirectUrl = redirectUrl
         };

--- a/src/Altinn.App.Core/Models/UserAction/UserActionResult.cs
+++ b/src/Altinn.App.Core/Models/UserAction/UserActionResult.cs
@@ -29,7 +29,7 @@ public class UserActionResult
     /// Gets or sets a value indicating whether the user action was a success
     /// </summary>
     public bool Success { get; init; }
-    
+
     /// <summary>
     /// Indicates the type of result
     /// </summary>


### PR DESCRIPTION
Looked through dfd5cff7e473f5fadadcf67e1f3e524671486278 and tried to spot any breaking change of consequence.

Reverting "Success" property that was removed from UserActionResult.

Other than that I used @ivarne's tool to download all TE repos and used VS Code to search for these interfaces and classes, which have been removed in the commit:

	ITaskEvents
	DefaultTaskEvents
	ITask
	TaskBase
	ConfirmationTask
	DataTask
	FeedbackTask
	NullTask
	
I didn't find any usage of these in TE code.
I also checked some of the integral classes in the process engine code, without finding any.

I took a couple of the applications that had done custom stuff using the process engine (UserAction, IProcessStart, IProcessEnd) and upped the version number to https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.1.0-preview.6 and built successfully.

## Related Issue(s)
- #471 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
