### PR TITLE
Fix the recursion bug in RemoveAltinnRowId

### DIFF
--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -104,7 +104,7 @@ public static class ObjectUtils
                 var value = prop.GetValue(model);
 
                 // continue recursion over all properties
-                if (value is not null)
+                if (value?.GetType().IsValueType == false)
                 {
                     RemoveAltinnRowId(value);
                 }

--- a/test/Altinn.App.Core.Tests/Helpers/ObjectUtilsTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ObjectUtilsTests.cs
@@ -115,6 +115,12 @@ public class ObjectUtilsTests
         test.DateTime.Should().Be(dateTime);
         test.NullableDecimal.Should().Be(1.1m);
         test.Decimal.Should().Be(2.2m);
+
+        ObjectUtils.RemoveAltinnRowId(test);
+
+        test.AltinnRowId.Should().Be(Guid.Empty);
+        test.Child.AltinnRowId.Should().Be(Guid.Empty);
+        test.Children.Should().AllSatisfy(c => c.AltinnRowId.Should().Be(Guid.Empty));
     }
 
     [Fact]
@@ -153,6 +159,14 @@ public class ObjectUtilsTests
         test.Child.Child.AltinnRowId.Should().Be(Guid.Empty);
         test.Child.Child.Children.Should().ContainSingle().Which.AltinnRowId.Should().Be(Guid.Empty);
         test.Child.Child.Children.Should().ContainSingle().Which.Child!.AltinnRowId.Should().Be(Guid.Empty);
+
+        ObjectUtils.InitializeAltinnRowId(test);
+
+        test.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.Child.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.Child.Children.Should().ContainSingle().Which.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.Child.Children.Should().ContainSingle().Which.Child!.AltinnRowId.Should().NotBe(Guid.Empty);
     }
 
     [Fact]
@@ -194,6 +208,15 @@ public class ObjectUtilsTests
         childArray = test.Child.Child.Children.Should().HaveCount(2).And;
         childArray.ContainSingle(d => d != null).Which.AltinnRowId.Should().Be(Guid.Empty);
         childArray.ContainSingle(d => d == null);
+
+        ObjectUtils.InitializeAltinnRowId(test);
+
+        test.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.AltinnRowId.Should().NotBe(Guid.Empty);
+        test.Child.Child.AltinnRowId.Should().NotBe(Guid.Empty);
+        childArray = test.Child.Child.Children.Should().HaveCount(2).And;
+        childArray.ContainSingle(d => d != null).Which.AltinnRowId.Should().NotBe(Guid.Empty);
+        childArray.ContainSingle(d => d == null);
     }
 
     [Fact]
@@ -234,6 +257,15 @@ public class ObjectUtilsTests
         test.Child.Child.AltinnRowId.Should().NotBe(Guid.Empty);
         childArray = test.Child.Child.Children.Should().HaveCount(2).And;
         childArray.ContainSingle(d => d != null).Which.AltinnRowId.Should().NotBe(Guid.Empty);
+        childArray.ContainSingle(d => d == null);
+
+        ObjectUtils.RemoveAltinnRowId(test);
+
+        test.AltinnRowId.Should().Be(Guid.Empty);
+        test.Child.AltinnRowId.Should().Be(Guid.Empty);
+        test.Child.Child.AltinnRowId.Should().Be(Guid.Empty);
+        childArray = test.Child.Child.Children.Should().HaveCount(2).And;
+        childArray.ContainSingle(d => d != null).Which.AltinnRowId.Should().Be(Guid.Empty);
         childArray.ContainSingle(d => d == null);
     }
 }


### PR DESCRIPTION
I missed a rather obvious case when I remove Altinn row Id after submission when I fixed the initialisation in #538

This fix is wrong, because the issue has nothing to do with value types vs reference types, but the fact that `DateTime` has `.Date` and `.Time` properties that returns `DateTime` objects with `.Date` and `.Time` properties forever.

## Related Issue(s)
- Same bug as in https://github.com/Altinn/app-lib-dotnet/pull/538
- A better fix is available in #590, but this is a quick fix with improved tests.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
