### PR TITLE
Remove BOM on C# files now that .editorconfig states that BOM should not be used

### DIFF
--- a/src/Altinn.App.Api/Controllers/ApplicationLanguageController.cs
+++ b/src/Altinn.App.Api/Controllers/ApplicationLanguageController.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Internal.Language;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Altinn.App.Api/Controllers/DataListsController.cs
+++ b/src/Altinn.App.Api/Controllers/DataListsController.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.DataLists;
+using Altinn.App.Core.Features.DataLists;
 using Altinn.App.Core.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Altinn.App.Api/Controllers/EventsReceiverController.cs
+++ b/src/Altinn.App.Api/Controllers/EventsReceiverController.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.App.Core.Configuration;

--- a/src/Altinn.App.Api/Controllers/FileScanController.cs
+++ b/src/Altinn.App.Api/Controllers/FileScanController.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Api.Models;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Models;

--- a/src/Altinn.App.Api/Controllers/StatelessPagesController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessPagesController.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;

--- a/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Api.Controllers;
+using Altinn.App.Api.Controllers;
 using Altinn.App.Api.Infrastructure.Filters;
 using Altinn.App.Api.Infrastructure.Health;
 using Altinn.App.Api.Infrastructure.Telemetry;

--- a/src/Altinn.App.Api/Helpers/RequestHandling/RequestPartValidator.cs
+++ b/src/Altinn.App.Api/Helpers/RequestHandling/RequestPartValidator.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Api.Helpers.RequestHandling
 {

--- a/src/Altinn.App.Api/Infrastructure/Health/HealthCheck.cs
+++ b/src/Altinn.App.Api/Infrastructure/Health/HealthCheck.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Altinn.App.Api.Infrastructure.Health

--- a/src/Altinn.App.Api/Infrastructure/Telemetry/HealthTelemetryFilter.cs
+++ b/src/Altinn.App.Api/Infrastructure/Telemetry/HealthTelemetryFilter.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;

--- a/src/Altinn.App.Api/Models/DataElementFileScanResult.cs
+++ b/src/Altinn.App.Api/Models/DataElementFileScanResult.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System.Text.Json.Serialization;
 using Altinn.Platform.Storage.Interface.Enums;
 

--- a/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
+++ b/src/Altinn.App.Api/Models/InstanceFileScanResult.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Enums;

--- a/src/Altinn.App.Core/Configuration/CacheSettings.cs
+++ b/src/Altinn.App.Core/Configuration/CacheSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Configuration
+namespace Altinn.App.Core.Configuration
 {
     /// <summary>
     /// Represents caching settings used by the platform services

--- a/src/Altinn.App.Core/EFormidling/EformidlingConstants.cs
+++ b/src/Altinn.App.Core/EFormidling/EformidlingConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.EFormidling
+namespace Altinn.App.Core.EFormidling
 {
     /// <summary>
     /// Shared constants within the Eformidling area.

--- a/src/Altinn.App.Core/EFormidling/EformidlingStartup.cs
+++ b/src/Altinn.App.Core/EFormidling/EformidlingStartup.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Infrastructure.Clients.Events;
+using Altinn.App.Core.Infrastructure.Clients.Events;
 using Altinn.App.Core.Internal.Events;
 using Altinn.App.Core.Models;
 using Microsoft.Extensions.Hosting;

--- a/src/Altinn.App.Core/EFormidling/Implementation/EformidlingDeliveryException.cs
+++ b/src/Altinn.App.Core/EFormidling/Implementation/EformidlingDeliveryException.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.EFormidling.Implementation
+namespace Altinn.App.Core.EFormidling.Implementation
 {
     /// <summary>
     /// Exception thrown when Eformidling is unable to process the message delivered to

--- a/src/Altinn.App.Core/EFormidling/Implementation/EformidlingStatusCheckEventHandler.cs
+++ b/src/Altinn.App.Core/EFormidling/Implementation/EformidlingStatusCheckEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
 using Altinn.ApiClients.Maskinporten.Config;

--- a/src/Altinn.App.Core/EFormidling/Implementation/EformidlingStatusCheckEventHandler2.cs
+++ b/src/Altinn.App.Core/EFormidling/Implementation/EformidlingStatusCheckEventHandler2.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Headers;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Constants;

--- a/src/Altinn.App.Core/Extensions/DictionaryExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/DictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Text;
 
 namespace Altinn.App.Core.Extensions

--- a/src/Altinn.App.Core/Extensions/HttpContextExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/HttpContextExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http.Headers;
+using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 

--- a/src/Altinn.App.Core/Extensions/StringExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Extensions
+namespace Altinn.App.Core.Extensions
 {
     /// <summary>
     /// Extension methods for string

--- a/src/Altinn.App.Core/Features/DataLists/DataListsFactory.cs
+++ b/src/Altinn.App.Core/Features/DataLists/DataListsFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Features/DataLists/DataListsService.cs
+++ b/src/Altinn.App.Core/Features/DataLists/DataListsService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Features/DataLists/IDataListsService.cs
+++ b/src/Altinn.App.Core/Features/DataLists/IDataListsService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Features/DataLists/InstanceDataListsFactory.cs
+++ b/src/Altinn.App.Core/Features/DataLists/InstanceDataListsFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Features/DataLists/NullDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/DataLists/NullDataListProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Features/DataLists/NullInstanceDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/DataLists/NullInstanceDataListProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Features/FeatureFlags.cs
+++ b/src/Altinn.App.Core/Features/FeatureFlags.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Features;
+namespace Altinn.App.Core.Features;
 
 /// <summary>
 /// Class representing active feature flag constants.

--- a/src/Altinn.App.Core/Features/FileAnalyzis/FileAnalyserFactory.cs
+++ b/src/Altinn.App.Core/Features/FileAnalyzis/FileAnalyserFactory.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.FileAnalysis;
+using Altinn.App.Core.Features.FileAnalysis;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Features.FileAnalyzis

--- a/src/Altinn.App.Core/Features/FileAnalyzis/FileAnalysisResult.cs
+++ b/src/Altinn.App.Core/Features/FileAnalyzis/FileAnalysisResult.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.FileAnalyzis;
+using Altinn.App.Core.Features.FileAnalyzis;
 
 namespace Altinn.App.Core.Features.FileAnalysis
 {

--- a/src/Altinn.App.Core/Features/FileAnalyzis/FileAnalysisService.cs
+++ b/src/Altinn.App.Core/Features/FileAnalyzis/FileAnalysisService.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.FileAnalysis;
+using Altinn.App.Core.Features.FileAnalysis;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Features.FileAnalyzis

--- a/src/Altinn.App.Core/Features/FileAnalyzis/IFileAnalyser.cs
+++ b/src/Altinn.App.Core/Features/FileAnalyzis/IFileAnalyser.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Features.FileAnalysis
+namespace Altinn.App.Core.Features.FileAnalysis
 {
     /// <summary>
     /// Interface for doing extended binary file analysing.

--- a/src/Altinn.App.Core/Features/FileAnalyzis/IFileAnalyserFactory.cs
+++ b/src/Altinn.App.Core/Features/FileAnalyzis/IFileAnalyserFactory.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.FileAnalysis;
+using Altinn.App.Core.Features.FileAnalysis;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Features.FileAnalyzis

--- a/src/Altinn.App.Core/Features/FileAnalyzis/IFileAnalysisService.cs
+++ b/src/Altinn.App.Core/Features/FileAnalyzis/IFileAnalysisService.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.FileAnalysis;
+using Altinn.App.Core.Features.FileAnalysis;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Features.FileAnalyzis

--- a/src/Altinn.App.Core/Features/IDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/IDataListProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Features/IEventHandler.cs
+++ b/src/Altinn.App.Core/Features/IEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Models;
+using Altinn.App.Core.Models;
 
 namespace Altinn.App.Core.Features
 {

--- a/src/Altinn.App.Core/Features/IInstanceDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataListProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Features/IPdfFormatter.cs
+++ b/src/Altinn.App.Core/Features/IPdfFormatter.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Models;
+using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Features;

--- a/src/Altinn.App.Core/Features/PageOrder/DefaultPageOrder.cs
+++ b/src/Altinn.App.Core/Features/PageOrder/DefaultPageOrder.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Models;
 
 namespace Altinn.App.Core.Features.PageOrder

--- a/src/Altinn.App.Core/Features/Pdf/NullPdfFormatter.cs
+++ b/src/Altinn.App.Core/Features/Pdf/NullPdfFormatter.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Models;
+using Altinn.App.Core.Models;
 
 namespace Altinn.App.Core.Features.Pdf
 {

--- a/src/Altinn.App.Core/Features/Validation/IFileValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/IFileValidator.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.FileAnalysis;
+using Altinn.App.Core.Features.FileAnalysis;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 

--- a/src/Altinn.App.Core/Implementation/UserTokenProvider.cs
+++ b/src/Altinn.App.Core/Implementation/UserTokenProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Internal.Auth;
 using AltinnCore.Authentication.Utils;

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/Subscription.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/Subscription.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Infrastructure.Clients.Events
+namespace Altinn.App.Core.Infrastructure.Clients.Events
 {
     /// <summary>
     /// Class that describes an events subscription

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/SubscriptionRequest.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/SubscriptionRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Infrastructure.Clients.Events
+namespace Altinn.App.Core.Infrastructure.Clients.Events
 {
     /// <summary>
     /// Class that describes the events subscription request model

--- a/src/Altinn.App.Core/Infrastructure/Clients/Maskinporten/IX509CertificateProvider.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Maskinporten/IX509CertificateProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Altinn.App.Core.Infrastructure.Clients.Maskinporten
 {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Internal.Auth;

--- a/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClientCachingDecorator.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClientCachingDecorator.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Internal.Profile;
 using Altinn.Platform.Profile.Models;
 using Microsoft.Extensions.Caching.Memory;

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;

--- a/src/Altinn.App.Core/Interface/IPersonLookup.cs
+++ b/src/Altinn.App.Core/Interface/IPersonLookup.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Platform.Register.Models;
+using Altinn.Platform.Register.Models;
 
 namespace Altinn.App.Core.Interface
 {

--- a/src/Altinn.App.Core/Interface/IPersonRetriever.cs
+++ b/src/Altinn.App.Core/Interface/IPersonRetriever.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Platform.Register.Models;
+using Altinn.Platform.Register.Models;
 
 namespace Altinn.App.Core.Interface
 {

--- a/src/Altinn.App.Core/Interface/IUserTokenProvider.cs
+++ b/src/Altinn.App.Core/Interface/IUserTokenProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Interface
+namespace Altinn.App.Core.Interface
 {
     /// <summary>
     /// Defines the methods required for an implementation of a user JSON Web Token provider.

--- a/src/Altinn.App.Core/Internal/Auth/IUserTokenProvider.cs
+++ b/src/Altinn.App.Core/Internal/Auth/IUserTokenProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Internal.Auth
+namespace Altinn.App.Core.Internal.Auth
 {
     /// <summary>
     /// Defines the methods required for an implementation of a user JSON Web Token provider.

--- a/src/Altinn.App.Core/Internal/Data/DataService.cs
+++ b/src/Altinn.App.Core/Internal/Data/DataService.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;

--- a/src/Altinn.App.Core/Internal/Data/IDataService.cs
+++ b/src/Altinn.App.Core/Internal/Data/IDataService.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Models;
+using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Data

--- a/src/Altinn.App.Core/Internal/Events/EventHandlerResolver.cs
+++ b/src/Altinn.App.Core/Internal/Events/EventHandlerResolver.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features;
+using Altinn.App.Core.Features;
 
 namespace Altinn.App.Core.Internal.Events
 {

--- a/src/Altinn.App.Core/Internal/Events/IEventHandlerResolver.cs
+++ b/src/Altinn.App.Core/Internal/Events/IEventHandlerResolver.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features;
+using Altinn.App.Core.Features;
 
 namespace Altinn.App.Core.Internal.Events
 {

--- a/src/Altinn.App.Core/Internal/Events/IEventSecretCodeProvider.cs
+++ b/src/Altinn.App.Core/Internal/Events/IEventSecretCodeProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Internal.Events
+namespace Altinn.App.Core.Internal.Events
 {
     /// <summary>
     /// Interface for providing a secret code to be used when

--- a/src/Altinn.App.Core/Internal/Events/KeyVaultSecretCodeProvider.cs
+++ b/src/Altinn.App.Core/Internal/Events/KeyVaultSecretCodeProvider.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Internal.Secrets;
+using Altinn.App.Core.Internal.Secrets;
 
 namespace Altinn.App.Core.Internal.Events
 {

--- a/src/Altinn.App.Core/Internal/Events/SubscriptionValidationHandler.cs
+++ b/src/Altinn.App.Core/Internal/Events/SubscriptionValidationHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features;
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 
 namespace Altinn.App.Core.Internal.Events

--- a/src/Altinn.App.Core/Internal/Events/UnhandledEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Events/UnhandledEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 

--- a/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Implementation;
 using Microsoft.Extensions.Logging;

--- a/src/Altinn.App.Core/Internal/Language/IApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Internal/Language/IApplicationLanguage.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Internal.Language
+namespace Altinn.App.Core.Internal.Language
 {
     /// <summary>
     /// Interface for retrieving languages supported by the application.

--- a/src/Altinn.App.Core/Internal/Maskinporten/IMaskinportenTokenProvider.cs
+++ b/src/Altinn.App.Core/Internal/Maskinporten/IMaskinportenTokenProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Internal.Maskinporten;
+namespace Altinn.App.Core.Internal.Maskinporten;
 
 /// <summary>
 /// Defines the interface required for an implementation of a Maskinporte token provider.

--- a/src/Altinn.App.Core/Internal/Maskinporten/MaskinportenExtensions.cs
+++ b/src/Altinn.App.Core/Internal/Maskinporten/MaskinportenExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.ApiClients.Maskinporten.Config;
+using Altinn.ApiClients.Maskinporten.Config;
 using Altinn.ApiClients.Maskinporten.Interfaces;
 using Altinn.App.Core.Internal.Secrets;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Altinn.App.Core/Internal/Maskinporten/MaskinportenJwkTokenProvider.cs
+++ b/src/Altinn.App.Core/Internal/Maskinporten/MaskinportenJwkTokenProvider.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.ApiClients.Maskinporten.Config;
+using Altinn.ApiClients.Maskinporten.Config;
 using Altinn.ApiClients.Maskinporten.Interfaces;
 using Altinn.ApiClients.Maskinporten.Models;
 using Altinn.App.Core.Internal.Secrets;

--- a/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Internal.Pdf;
+namespace Altinn.App.Core.Internal.Pdf;
 
 /// <summary>
 /// Defines the required operations on a client of the PDF generator service.

--- a/src/Altinn.App.Core/Internal/Pdf/IPdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/IPdfService.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Pdf
 {

--- a/src/Altinn.App.Core/Internal/Pdf/PdfGenerationException.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfGenerationException.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace Altinn.App.Core.Internal.Pdf
 {

--- a/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Internal.Pdf;
+namespace Altinn.App.Core.Internal.Pdf;
 
 /// <summary>
 /// Represents a set of settings and options used by the PDF generator client.

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 using System.Xml.Serialization;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Extensions;

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/EndEventEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/EndEventEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/Interfaces/IEndEventEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/Interfaces/IEndEventEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Process.EventHandlers
 {

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/AbandonTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/AbandonTaskEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features;
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.Platform.Storage.Interface.Models;
 

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features;
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.App.Core.Internal.Process.ServiceTasks;
 using Altinn.Platform.Storage.Interface.Models;

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/Interfaces/IAbandonTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/Interfaces/IAbandonTaskEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Internal.Process.ProcessTasks;
+using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/Interfaces/IEndTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/Interfaces/IEndTaskEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Internal.Process.ProcessTasks;
+using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/Interfaces/IStartTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/Interfaces/IStartTaskEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Internal.Process.ProcessTasks;
+using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/StartTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/StartTaskEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features;
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.Platform.Storage.Interface.Models;
 

--- a/src/Altinn.App.Core/Internal/Process/Interfaces/IProcessEventHandlerDelegator.cs
+++ b/src/Altinn.App.Core/Internal/Process/Interfaces/IProcessEventHandlerDelegator.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Process
 {

--- a/src/Altinn.App.Core/Internal/Process/ProcessEventHandlingDelegator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEventHandlingDelegator.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Internal.Process.EventHandlers;
+using Altinn.App.Core.Internal.Process.EventHandlers;
 using Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.Platform.Storage.Interface.Enums;

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/SigningProcessTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/SigningProcessTask.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Platform.Storage.Interface.Models;
+using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Process.ProcessTasks
 {

--- a/src/Altinn.App.Core/Internal/Registers/IPersonClient.cs
+++ b/src/Altinn.App.Core/Internal/Registers/IPersonClient.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.Platform.Register.Models;
+using Altinn.Platform.Register.Models;
 
 namespace Altinn.App.Core.Internal.Registers
 {

--- a/src/Altinn.App.Core/Internal/Validation/FileValidationService.cs
+++ b/src/Altinn.App.Core/Internal/Validation/FileValidationService.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.FileAnalysis;
+using Altinn.App.Core.Features.FileAnalysis;
 using Altinn.App.Core.Features.Validation;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;

--- a/src/Altinn.App.Core/Internal/Validation/FileValidatorFactory.cs
+++ b/src/Altinn.App.Core/Internal/Validation/FileValidatorFactory.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.Validation;
+using Altinn.App.Core.Features.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Validation

--- a/src/Altinn.App.Core/Internal/Validation/IFileValidationService.cs
+++ b/src/Altinn.App.Core/Internal/Validation/IFileValidationService.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.FileAnalysis;
+using Altinn.App.Core.Features.FileAnalysis;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 

--- a/src/Altinn.App.Core/Internal/Validation/IFileValidatorFactory.cs
+++ b/src/Altinn.App.Core/Internal/Validation/IFileValidatorFactory.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Features.Validation;
+using Altinn.App.Core.Features.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Validation

--- a/src/Altinn.App.Core/Models/ApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Models/ApplicationLanguage.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Altinn.App.Core.Models
 {

--- a/src/Altinn.App.Core/Models/DataList.cs
+++ b/src/Altinn.App.Core/Models/DataList.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Models/DataListMetadata.cs
+++ b/src/Altinn.App.Core/Models/DataListMetadata.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Altinn.App.Core/Models/Notifications/Sms/SmsNotification.cs
+++ b/src/Altinn.App.Core/Models/Notifications/Sms/SmsNotification.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 using Altinn.App.Core.Features;
 
 namespace Altinn.App.Core.Models.Notifications.Sms;

--- a/src/Altinn.App.Core/Models/Notifications/Sms/SmsNotificationClientException.cs
+++ b/src/Altinn.App.Core/Models/Notifications/Sms/SmsNotificationClientException.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Models.Notifications.Sms;
+namespace Altinn.App.Core.Models.Notifications.Sms;
 
 /// <summary>
 /// Class representing an exception thrown when a SMS notificcation order could not be created

--- a/src/Altinn.App.Core/Models/Pdf/PdfGeneratorCookieOptions.cs
+++ b/src/Altinn.App.Core/Models/Pdf/PdfGeneratorCookieOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Models.Pdf;
+namespace Altinn.App.Core.Models.Pdf;
 
 /// <summary>
 /// This class is created to match the PDF generator cookie options.

--- a/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequest.cs
+++ b/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Models.Pdf;
+namespace Altinn.App.Core.Models.Pdf;
 
 /// <summary>
 /// This class is created to match the input required to generate a PDF by the PDF generator service.

--- a/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequestOptions.cs
+++ b/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequestOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Models.Pdf;
+namespace Altinn.App.Core.Models.Pdf;
 
 /// <summary>
 /// This class is created to match the PDF generator options used by the PDF generator.

--- a/test/Altinn.App.Api.Tests/Constants/XacmlRequestAttribute.cs
+++ b/test/Altinn.App.Api.Tests/Constants/XacmlRequestAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Api.Tests.Constants
+namespace Altinn.App.Api.Tests.Constants
 {
     public static class XacmlRequestAttribute
     {

--- a/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Headers;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Utils;

--- a/test/Altinn.App.Api.Tests/Controllers/EventsReceiverControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/EventsReceiverControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/FileScanControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Api.Controllers;
+using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 using FluentAssertions;

--- a/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
+++ b/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http.Headers;
+using System.Net.Http.Headers;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Core.Configuration;

--- a/test/Altinn.App.Api.Tests/Data/TestData.cs
+++ b/test/Altinn.App.Api.Tests/Data/TestData.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Api.Tests.Mocks;

--- a/test/Altinn.App.Api.Tests/EFormidling/EformidlingStatusCheckEventHandlerTests.cs
+++ b/test/Altinn.App.Api.Tests/EFormidling/EformidlingStatusCheckEventHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.X509Certificates;
 using Altinn.ApiClients.Maskinporten.Config;
 using Altinn.ApiClients.Maskinporten.Interfaces;
 using Altinn.ApiClients.Maskinporten.Services;

--- a/test/Altinn.App.Api.Tests/Mocks/AppMetadataMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AppMetadataMock.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Text.Json;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Mocks;

--- a/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Register.Models;

--- a/test/Altinn.App.Api.Tests/Mocks/Event/DummyFailureEventHandler.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/Event/DummyFailureEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 

--- a/test/Altinn.App.Api.Tests/Mocks/Event/DummySuccessEventHandler.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/Event/DummySuccessEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 

--- a/test/Altinn.App.Api.Tests/Mocks/Event/EventSecretCodeProviderStub.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/Event/EventSecretCodeProviderStub.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Altinn.App.Core.Internal.Events;
 
 namespace Altinn.App.Api.Tests.Mocks.Event

--- a/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Api.Tests.Data;
+using Altinn.App.Api.Tests.Data;
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.Instances;

--- a/test/Altinn.App.Api.Tests/Mocks/JwtTokenMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/JwtTokenMock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Security.Claims;

--- a/test/Altinn.App.Api.Tests/Mocks/PepWithPDPAuthorizationMockSI.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/PepWithPDPAuthorizationMockSI.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 using System.Xml;
 using Altinn.App.Api.Tests.Constants;
 using Altinn.App.Api.Tests.Data;

--- a/test/Altinn.App.Api.Tests/Models/InstanceFileScanResultTests.cs
+++ b/test/Altinn.App.Api.Tests/Models/InstanceFileScanResultTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Altinn.App.Api.Models;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Enums;

--- a/test/Altinn.App.Api.Tests/Models/XacmlResourceAttributes.cs
+++ b/test/Altinn.App.Api.Tests/Models/XacmlResourceAttributes.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Api.Tests.Models
+namespace Altinn.App.Api.Tests.Models
 {
     public class XacmlResourceAttributes
     {

--- a/test/Altinn.App.Api.Tests/Program.cs
+++ b/test/Altinn.App.Api.Tests/Program.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Api.Extensions;
+using Altinn.App.Api.Extensions;
 using Altinn.App.Api.Helpers;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Mocks;

--- a/test/Altinn.App.Api.Tests/Utils/PrincipalUtil.cs
+++ b/test/Altinn.App.Api.Tests/Utils/PrincipalUtil.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 using Altinn.App.Api.Tests.Mocks;
 using AltinnCore.Authentication.Constants;
 

--- a/test/Altinn.App.Core.Tests/DataLists/DataListsFactoryTest.cs
+++ b/test/Altinn.App.Core.Tests/DataLists/DataListsFactoryTest.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.DataLists;
 using Altinn.App.Core.Models;

--- a/test/Altinn.App.Core.Tests/DataLists/InstanceDataListsFactoryTest.cs
+++ b/test/Altinn.App.Core.Tests/DataLists/InstanceDataListsFactoryTest.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.DataLists;
 using Altinn.App.Core.Models;

--- a/test/Altinn.App.Core.Tests/DataLists/NullDataListProviderTest.cs
+++ b/test/Altinn.App.Core.Tests/DataLists/NullDataListProviderTest.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Features.DataLists;
 using FluentAssertions;
 using Xunit;

--- a/test/Altinn.App.Core.Tests/DataLists/NullInstanceDataListProviderTest.cs
+++ b/test/Altinn.App.Core.Tests/DataLists/NullInstanceDataListProviderTest.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Features.DataLists;
 using Altinn.App.Core.Models;
 using FluentAssertions;

--- a/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Extensions;
+using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Models;
 using Microsoft.AspNetCore.Http;
 using Xunit;

--- a/test/Altinn.App.Core.Tests/Extensions/ServiceCollectionTests.cs
+++ b/test/Altinn.App.Core.Tests/Extensions/ServiceCollectionTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Infrastructure.Clients.Events;
 using Altinn.App.Core.Internal.Events;

--- a/test/Altinn.App.Core.Tests/Extensions/StringExtensionTests.cs
+++ b/test/Altinn.App.Core.Tests/Extensions/StringExtensionTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Extensions;
 using Xunit;
 

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Email/EmailNotificationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Email/EmailNotificationClientTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Tests.Features.Notifications.Email;
+namespace Altinn.App.Core.Tests.Features.Notifications.Email;
 
 using System.Net;
 using System.Net.Http;

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Sms/SmsNotificationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Sms/SmsNotificationClientTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.App.Core.Tests.Features.Notifications.Sms;
+namespace Altinn.App.Core.Tests.Features.Notifications.Sms;
 
 using System.Net;
 using System.Net.Http;

--- a/test/Altinn.App.Core.Tests/Helpers/EmbeddedResource.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/EmbeddedResource.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 
 namespace Altinn.App.PlatformServices.Tests.Helpers;
 

--- a/test/Altinn.App.Core.Tests/Helpers/SelfLinkHelperTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/SelfLinkHelperTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Http;
 using Moq;

--- a/test/Altinn.App.Core.Tests/Implementation/PersonClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/PersonClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/EventsSubscriptionClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/EventsSubscriptionClientTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System.Net;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;

--- a/test/Altinn.App.Core.Tests/Internal/Data/DataServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Data/DataServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Models;

--- a/test/Altinn.App.Core.Tests/Internal/Events/EventHandlerResolverTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Events/EventHandlerResolverTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Events;
 using Altinn.App.Core.Models;

--- a/test/Altinn.App.Core.Tests/Internal/Events/UnhandledEventHandlerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Events/UnhandledEventHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Internal.Events;
 using FluentAssertions;
 using Xunit;

--- a/test/Altinn.App.Core.Tests/Internal/Maskinporten/MaskinportenExtensionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Maskinporten/MaskinportenExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Extensions;
+using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Internal.Maskinporten;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/Altinn.App.Core.Tests/Internal/Maskinporten/MaskinportenJwkTokenProviderTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Maskinporten/MaskinportenJwkTokenProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.ApiClients.Maskinporten.Config;
+using Altinn.ApiClients.Maskinporten.Config;
 using Altinn.ApiClients.Maskinporten.Interfaces;
 using Altinn.ApiClients.Maskinporten.Models;
 using Altinn.App.Core.Internal.Maskinporten;

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Infrastructure.Clients.Pdf;
 using Altinn.App.Core.Internal.App;

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskDataLockerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskDataLockerTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.App.Core.Models;

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizerTests.cs
@@ -1,4 +1,4 @@
-﻿using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;

--- a/test/Altinn.App.Core.Tests/Mocks/DelegatingHandlerStub.cs
+++ b/test/Altinn.App.Core.Tests/Mocks/DelegatingHandlerStub.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using System.Net;
 
 namespace Altinn.App.PlatformServices.Tests.Mocks

--- a/test/Altinn.App.Core.Tests/Mocks/RequestInterceptor.cs
+++ b/test/Altinn.App.Core.Tests/Mocks/RequestInterceptor.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 
 namespace Altinn.App.PlatformServices.Tests.Mocks
 {

--- a/test/Altinn.App.Core.Tests/Models/AppIdentifierTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/AppIdentifierTests.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 using Altinn.App.Core.Models;
 using FluentAssertions;
 using Xunit;


### PR DESCRIPTION
This causes a massive list of changes when using dotnet format

The alternative would be to not specify utf-8 in editor config

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/pull/533

https://github.com/Altinn/app-lib-dotnet/pull/533/files#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR3
