### PR TITLE
Treat build warnings as errors (in CI and optionally locally), fix and suppress all warnings

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -31,4 +31,4 @@ jobs:
           dotnet build AppLibDotnet.sln -v m
       - name: Test
         run: |
-          dotnet test AppLibDotnet.sln -v m --no-build
+          dotnet test AppLibDotnet.sln -v m --no-restore --no-build

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -32,4 +32,4 @@ jobs:
           dotnet build AppLibDotnet.sln -v m
       - name: Test
         run: |
-              dotnet test AppLibDotnet.sln -v m --no-build
+          dotnet test AppLibDotnet.sln -v m --no-build

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -12,11 +12,12 @@ jobs:
   analyze:
     strategy:
       matrix:
-        os: [macos-latest,windows-latest,ubuntu-latest] # TODO: Fix test to run on ubuntu-latest also
+        os: [macos-latest, windows-latest, ubuntu-latest]
     name: Run dotnet build and test
     runs-on: ${{ matrix.os}}
-    env: 
+    env:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false
+      DOTNET_TREATWARNINGSASERRORS: true
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -25,10 +26,10 @@ jobs:
             8.0.x
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Build
         run: |
-           dotnet build AppLibDotnet.sln -v m
+          dotnet build AppLibDotnet.sln -v m
       - name: Test
         run: |
-           dotnet test AppLibDotnet.sln -v m
+              dotnet test AppLibDotnet.sln -v m --no-build

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ${{ matrix.os}}
     env:
       DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE: false
-      DOTNET_TREATWARNINGSASERRORS: true
     steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "redhat.vscode-yaml",
+        "ms-dotnettools.csdevkit"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "[csharp]": {
         "editor.defaultFormatter": "csharpier.csharpier-vscode",
         "editor.formatOnSave": true
-    }
+    },
+    "[github-actions-workflow]": {
+        "editor.defaultFormatter": "redhat.vscode-yaml"
+    },
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,18 @@
 <Project>
+    <PropertyGroup>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="CSharpier.MsBuild" Version="0.28.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
+        <!-- TODO: enable this at some point, when we've got a handle on NRTs -->
+        <!-- <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6169">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+          </PackageReference> -->
     </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(DOTNET_TREATWARNINGSASERRORS)' == 'true'">
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+    <PropertyGroup>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,8 @@
 <Project>
-    <PropertyGroup Condition="'$(DOTNET_TREATWARNINGSASERRORS)' == 'true'">
+    <PropertyGroup Condition="'$(DOTNET_TREATWARNINGSASERRORS)' == 'true' OR '$(CI)' == 'true'">
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
+
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -226,6 +226,11 @@ namespace Altinn.App.Api.Controllers
                         return BadRequest(await GetErrorDetails(validationIssues));
                     }
 
+                    if (streamContent.Headers.ContentType is null)
+                    {
+                        return StatusCode(500, "Content-Type not defined");
+                    }
+
                     fileStream.Seek(0, SeekOrigin.Begin);
                     return await CreateBinaryData(
                         instance,

--- a/src/Altinn.App.Api/Controllers/PartiesController.cs
+++ b/src/Altinn.App.Api/Controllers/PartiesController.cs
@@ -85,7 +85,11 @@ namespace Altinn.App.Api.Controllers
         public async Task<IActionResult> ValidateInstantiation(string org, string app, [FromQuery] int partyId)
         {
             UserContext userContext = await _userHelper.GetUserContext(HttpContext);
-            UserProfile user = await _profileClient.GetUserProfile(userContext.UserId);
+            UserProfile? user = await _profileClient.GetUserProfile(userContext.UserId);
+            if (user is null)
+            {
+                return StatusCode(500, "Could not retrieve user profile");
+            }
             List<Party>? partyList = await _authorizationClient.GetPartyList(userContext.UserId);
             Application application = await _appMetadata.GetApplicationMetadata();
 

--- a/src/Altinn.App.Api/Controllers/PartiesController.cs
+++ b/src/Altinn.App.Api/Controllers/PartiesController.cs
@@ -88,7 +88,7 @@ namespace Altinn.App.Api.Controllers
             UserProfile? user = await _profileClient.GetUserProfile(userContext.UserId);
             if (user is null)
             {
-                return StatusCode(500, "Could not retrieve user profile");
+                return StatusCode(500, "Could not get user profile while validating instantiation");
             }
             List<Party>? partyList = await _authorizationClient.GetPartyList(userContext.UserId);
             Application application = await _appMetadata.GetApplicationMetadata();

--- a/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
+++ b/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
@@ -154,7 +154,10 @@ namespace Altinn.App.Api.Helpers.RequestHandling
         /// </summary>
         public static string? GetFileNameFromHeader(StringValues headerValues)
         {
-            ContentDispositionHeaderValue contentDisposition = ContentDispositionHeaderValue.Parse(headerValues);
+            string? headerValue = headerValues;
+            ArgumentNullException.ThrowIfNull(headerValue, nameof(headerValues));
+
+            ContentDispositionHeaderValue contentDisposition = ContentDispositionHeaderValue.Parse(headerValue);
             string? filename = contentDisposition.FileNameStar ?? contentDisposition.FileName;
 
             // We actively remove quotes because we don't want them replaced with '_'.

--- a/src/Altinn.App.Core/Configuration/AppSettings.cs
+++ b/src/Altinn.App.Core/Configuration/AppSettings.cs
@@ -65,6 +65,7 @@ namespace Altinn.App.Core.Configuration
         // TODO: can this be removed?
         // Env var being set is ServiceRepositorySettings__BaseResourceFolderContainer, but this prop is not used anywhere
 #nullable disable
+        [Obsolete("This is not used, and will be removed in the next major version")]
         public string BaseResourceFolderContainer { get; set; }
 
 #nullable restore

--- a/src/Altinn.App.Core/Configuration/AppSettings.cs
+++ b/src/Altinn.App.Core/Configuration/AppSettings.cs
@@ -215,7 +215,5 @@ namespace Altinn.App.Core.Configuration
         /// Enable the functionality to run expression validation in backend
         /// </summary>
         public bool ExpressionValidation { get; set; } = false;
-
-        public string RandomThing { get; set; }
     }
 }

--- a/src/Altinn.App.Core/Configuration/AppSettings.cs
+++ b/src/Altinn.App.Core/Configuration/AppSettings.cs
@@ -6,6 +6,7 @@ namespace Altinn.App.Core.Configuration
     /// <summary>
     /// Class that represents the ServiceRepositorySettings
     /// </summary>
+    // TODO: IOptions validation so that we know which of these properties are required
     public class AppSettings
     {
         /// <summary>
@@ -61,7 +62,12 @@ namespace Altinn.App.Core.Configuration
         /// <summary>
         /// Gets or sets the BaseResourceFolderContainer that identifies where in the docker container the runtime can find files needed
         /// </summary>
+        // TODO: can this be removed?
+        // Env var being set is ServiceRepositorySettings__BaseResourceFolderContainer, but this prop is not used anywhere
+#nullable disable
         public string BaseResourceFolderContainer { get; set; }
+
+#nullable restore
 
         /// <summary>
         /// Gets or sets The name of the FormLayout json file Name
@@ -142,6 +148,7 @@ namespace Altinn.App.Core.Configuration
         /// <summary>
         /// Open Id Connect Well known endpoint
         /// </summary>
+#nullable disable
         public string OpenIdWellKnownEndpoint { get; set; }
 
         /// <summary>
@@ -153,6 +160,8 @@ namespace Altinn.App.Core.Configuration
         /// Name of the cookie for runtime
         /// </summary>
         public string RuntimeCookieName { get; set; }
+
+#nullable restore
 
         /// <summary>
         /// Option to disable csrf check
@@ -186,7 +195,10 @@ namespace Altinn.App.Core.Configuration
         /// <summary>
         /// Gets or sets the version of the application.
         /// </summary>
+#nullable disable
         public string AppVersion { get; set; }
+
+#nullable restore
 
         /// <summary>
         /// Enable the functionality to load layout in backend and remove data from hidden components before task completion

--- a/src/Altinn.App.Core/Configuration/AppSettings.cs
+++ b/src/Altinn.App.Core/Configuration/AppSettings.cs
@@ -215,5 +215,7 @@ namespace Altinn.App.Core.Configuration
         /// Enable the functionality to run expression validation in backend
         /// </summary>
         public bool ExpressionValidation { get; set; } = false;
+
+        public string RandomThing { get; set; }
     }
 }

--- a/src/Altinn.App.Core/Configuration/PlatformSettings.cs
+++ b/src/Altinn.App.Core/Configuration/PlatformSettings.cs
@@ -51,6 +51,8 @@ namespace Altinn.App.Core.Configuration
         /// A new subscription key is generated automatically every time an app is deployed to an environment. The new key is then automatically
         /// added to the environment for the app code during deploy. This will override the value stored in app settings.
         /// </summary>
+#nullable disable
         public string SubscriptionKey { get; set; }
+#nullable restore
     }
 }

--- a/src/Altinn.App.Core/EFormidling/Implementation/DefaultEFormidlingService.cs
+++ b/src/Altinn.App.Core/EFormidling/Implementation/DefaultEFormidlingService.cs
@@ -125,6 +125,11 @@ public class DefaultEFormidlingService : IEFormidlingService
         Instance instance
     )
     {
+        if (_appSettings is null)
+        {
+            throw new Exception("AppSettings not initialized");
+        }
+
         DateTime completedTime = DateTime.UtcNow;
 
         Sender digdirSender = new Sender

--- a/src/Altinn.App.Core/Extensions/DataProtectionConfiguration.cs
+++ b/src/Altinn.App.Core/Extensions/DataProtectionConfiguration.cs
@@ -15,14 +15,21 @@ namespace Altinn.App.Core.Extensions
         /// <param name="services">The service collections</param>
         public static void ConfigureDataProtection(this IServiceCollection services)
         {
-            services.AddDataProtection().PersistKeysToFileSystem(GetKeysDirectory());
+            var dir = GetKeysDirectory();
+            if (dir is null)
+            {
+                throw new DirectoryNotFoundException(
+                    "Could not find a suitable directory for storing DataProtection keys"
+                );
+            }
+            services.AddDataProtection().PersistKeysToFileSystem(dir);
         }
 
         /// <summary>
         /// Return a directory based on the running operating system. It is possible to override the directory based on the ALTINN_KEYS_DIRECTORY environment variable.
         /// </summary>
         /// <returns></returns>
-        private static DirectoryInfo GetKeysDirectory()
+        private static DirectoryInfo? GetKeysDirectory()
         {
             var environmentVariable = System.Environment.GetEnvironmentVariable("ALTINN_KEYS_DIRECTORY");
             if (!string.IsNullOrWhiteSpace(environmentVariable))

--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -142,6 +142,10 @@ public class SigningUserAction : IUserAction
     private async Task<Signee> GetSignee(int userId)
     {
         var userProfile = await _profileClient.GetUserProfile(userId);
+        if (userProfile is null)
+        {
+            throw new Exception("Could not get user profile.");
+        }
         return new Signee
         {
             UserId = userProfile.UserId.ToString(),

--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -141,11 +141,10 @@ public class SigningUserAction : IUserAction
 
     private async Task<Signee> GetSignee(int userId)
     {
-        var userProfile = await _profileClient.GetUserProfile(userId);
-        if (userProfile is null)
-        {
-            throw new Exception("Could not get user profile while getting signee");
-        }
+        var userProfile =
+            await _profileClient.GetUserProfile(userId)
+            ?? throw new Exception("Could not get user profile while getting signee");
+
         return new Signee
         {
             UserId = userProfile.UserId.ToString(),

--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -144,7 +144,7 @@ public class SigningUserAction : IUserAction
         var userProfile = await _profileClient.GetUserProfile(userId);
         if (userProfile is null)
         {
-            throw new Exception("Could not get user profile.");
+            throw new Exception("Could not get user profile while getting signee");
         }
         return new Signee
         {

--- a/src/Altinn.App.Core/Features/DataLists/NullDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/DataLists/NullDataListProvider.cs
@@ -20,7 +20,9 @@ namespace Altinn.App.Core.Features.DataLists
         /// <inheritdoc/>
         public Task<DataList> GetDataListAsync(string? language, Dictionary<string, string> keyValuePairs)
         {
+#nullable disable
             return Task.FromResult(new DataList() { ListItems = null });
+#nullable restore
         }
     }
 }

--- a/src/Altinn.App.Core/Features/DataLists/NullInstanceDataListProvider.cs
+++ b/src/Altinn.App.Core/Features/DataLists/NullInstanceDataListProvider.cs
@@ -24,7 +24,9 @@ namespace Altinn.App.Core.Features.DataLists
             Dictionary<string, string> keyValuePairs
         )
         {
+#nullable disable
             return Task.FromResult(new DataList() { ListItems = null });
+#nullable restore
         }
     }
 }

--- a/src/Altinn.App.Core/Features/PageOrder/DefaultPageOrder.cs
+++ b/src/Altinn.App.Core/Features/PageOrder/DefaultPageOrder.cs
@@ -21,7 +21,7 @@ namespace Altinn.App.Core.Features.PageOrder
         }
 
         /// <inheritdoc />
-        public async Task<List<string>> GetPageOrder(
+        public Task<List<string>> GetPageOrder(
             AppIdentifier appIdentifier,
             InstanceIdentifier instanceIdentifier,
             string layoutSetId,
@@ -40,8 +40,9 @@ namespace Altinn.App.Core.Features.PageOrder
             {
                 layoutSettings = _resources.GetLayoutSettingsForSet(layoutSetId);
             }
-
-            return await Task.FromResult(layoutSettings.Pages.Order);
+#nullable disable
+            return Task.FromResult(layoutSettings.Pages.Order);
+#nullable restore
         }
     }
 }

--- a/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
+++ b/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
@@ -51,6 +51,10 @@ namespace Altinn.App.Core.Helpers
                 if (canPartyInstantiate && isChildPartyAllowed)
                 {
                     party.ChildParties = new List<Party>();
+                    if (allowedChildParties is null)
+                    {
+                        throw new Exception("List of allowed child parties unexpectedly null");
+                    }
                     party.ChildParties.AddRange(allowedChildParties);
                     allowed.Add(party);
                 }
@@ -58,6 +62,10 @@ namespace Altinn.App.Core.Helpers
                 {
                     party.ChildParties = new List<Party>();
                     party.OnlyHierarchyElementWithNoAccess = true;
+                    if (allowedChildParties is null)
+                    {
+                        throw new Exception("List of allowed child parties unexpectedly null");
+                    }
                     party.ChildParties.AddRange(allowedChildParties);
                     allowed.Add(party);
                 }

--- a/src/Altinn.App.Core/Helpers/ProcessError.cs
+++ b/src/Altinn.App.Core/Helpers/ProcessError.cs
@@ -5,6 +5,7 @@ namespace Altinn.App.Core.Helpers
     /// </summary>
     public class ProcessError
     {
+#nullable disable
         /// <summary>
         /// Gets or sets a machine readable error code or test resource key.
         /// </summary>
@@ -14,5 +15,6 @@ namespace Altinn.App.Core.Helpers
         /// Gets or sets a human readable error message.
         /// </summary>
         public string Text { get; set; }
+#nullable restore
     }
 }

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
@@ -90,7 +90,7 @@ namespace Altinn.App.Core.Helpers.Serialization
         {
             Error = null;
 
-            string streamContent = null;
+            string? streamContent = null;
             try
             {
                 // In this first try block we assume that the namespace is the same in the model
@@ -116,6 +116,11 @@ namespace Altinn.App.Core.Helpers.Serialization
                     attributes.XmlRoot = new XmlRootAttribute(elementName);
                     attributeOverrides.Add(_modelType, attributes);
 
+                    if (string.IsNullOrWhiteSpace(streamContent))
+                    {
+                        throw new Exception("No XML content read from stream");
+                    }
+
                     using XmlTextReader xmlTextReader = new XmlTextReader(new StringReader(streamContent));
                     XmlSerializer serializer = new XmlSerializer(_modelType, attributeOverrides);
 
@@ -124,7 +129,7 @@ namespace Altinn.App.Core.Helpers.Serialization
                 catch (InvalidOperationException invalidOperationException)
                 {
                     // One possible fail condition is if the XML has a namespace, but the model does not, or that the namespaces are different.
-                    Error = $"{invalidOperationException.Message} {invalidOperationException?.InnerException.Message}";
+                    Error = $"{invalidOperationException.Message} {invalidOperationException?.InnerException?.Message}";
                     return null;
                 }
             }

--- a/src/Altinn.App.Core/Helpers/UserHelper.cs
+++ b/src/Altinn.App.Core/Helpers/UserHelper.cs
@@ -71,7 +71,7 @@ namespace Altinn.App.Core.Helpers
             UserProfile? userProfile = await _profileClient.GetUserProfile(userContext.UserId);
             if (userProfile is null)
             {
-                throw new Exception("Could not get user profile.");
+                throw new Exception("Could not get user profile while getting user context");
             }
             userContext.UserParty = userProfile.Party;
 

--- a/src/Altinn.App.Core/Helpers/UserHelper.cs
+++ b/src/Altinn.App.Core/Helpers/UserHelper.cs
@@ -68,11 +68,9 @@ namespace Altinn.App.Core.Helpers
                 }
             }
 
-            UserProfile? userProfile = await _profileClient.GetUserProfile(userContext.UserId);
-            if (userProfile is null)
-            {
-                throw new Exception("Could not get user profile while getting user context");
-            }
+            UserProfile userProfile =
+                await _profileClient.GetUserProfile(userContext.UserId)
+                ?? throw new Exception("Could not get user profile while getting user context");
             userContext.UserParty = userProfile.Party;
 
             if (context.Request.Cookies[_settings.GetAltinnPartyCookieName] != null)

--- a/src/Altinn.App.Core/Helpers/UserHelper.cs
+++ b/src/Altinn.App.Core/Helpers/UserHelper.cs
@@ -68,7 +68,11 @@ namespace Altinn.App.Core.Helpers
                 }
             }
 
-            UserProfile userProfile = await _profileClient.GetUserProfile(userContext.UserId);
+            UserProfile? userProfile = await _profileClient.GetUserProfile(userContext.UserId);
+            if (userProfile is null)
+            {
+                throw new Exception("Could not get user profile.");
+            }
             userContext.UserParty = userProfile.Party;
 
             if (context.Request.Cookies[_settings.GetAltinnPartyCookieName] != null)

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -249,13 +249,14 @@ namespace Altinn.App.Core.Implementation
         public string GetLayoutSets()
         {
             string filename = Path.Join(_settings.AppBasePath, _settings.UiFolder, _settings.LayoutSetsFileName);
-            string filedata = null;
+            string? filedata = null;
             if (File.Exists(filename))
             {
                 filedata = File.ReadAllText(filename, Encoding.UTF8);
             }
-
+#nullable disable
             return filedata;
+#nullable restore
         }
 
         /// <inheritdoc />
@@ -389,13 +390,15 @@ namespace Altinn.App.Core.Implementation
 
         private byte[] ReadFileByte(string fileName)
         {
-            byte[] filedata = null;
+            byte[]? filedata = null;
             if (File.Exists(fileName))
             {
                 filedata = File.ReadAllBytes(fileName);
             }
 
+#nullable disable
             return filedata;
+#nullable restore
         }
 
         private byte[] ReadFileContentsFromLegalPath(string legalPath, string filePath)
@@ -411,7 +414,9 @@ namespace Altinn.App.Core.Implementation
                 return File.ReadAllBytes(fullFileName);
             }
 
+#nullable disable
             return null;
+#nullable restore
         }
 
         /// <inheritdoc />

--- a/src/Altinn.App.Core/Implementation/PrefillSI.cs
+++ b/src/Altinn.App.Core/Implementation/PrefillSI.cs
@@ -86,7 +86,7 @@ namespace Altinn.App.Core.Implementation
                 allowOverwrite = allowOverwriteToken.ToObject<bool>();
             }
 
-            Party party = await _altinnPartyClientClient.GetParty(int.Parse(partyId));
+            Party? party = await _altinnPartyClientClient.GetParty(int.Parse(partyId));
             if (party == null)
             {
                 string errorMessage = $"Could find party for partyId: {partyId}";
@@ -184,7 +184,7 @@ namespace Altinn.App.Core.Implementation
         /// </summary>
         private void AssignValueToDataModel(
             string[] keys,
-            JToken value,
+            JToken? value,
             object currentObject,
             int index = 0,
             bool continueOnError = false
@@ -215,6 +215,8 @@ namespace Altinn.App.Core.Implementation
                 {
                     if (propertyValue == null || allowOverwrite)
                     {
+                        ArgumentNullException.ThrowIfNull(value);
+
                         // create instance of the property type defined in the datamodel
                         var instance = value.ToObject(property.PropertyType);
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
@@ -58,7 +58,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Authorization
 
             if (!httpClient.DefaultRequestHeaders.Contains(ForwardedForHeaderName))
             {
-                string? clientIpAddress = _httpContextAccessor?.HttpContext?.Request?.Headers?[ForwardedForHeaderName];
+                string? clientIpAddress = _httpContextAccessor.HttpContext?.Request?.Headers?[ForwardedForHeaderName];
                 httpClient.DefaultRequestHeaders.Add(ForwardedForHeaderName, clientIpAddress);
             }
             httpClient.DefaultRequestHeaders.Add(

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
@@ -179,7 +179,9 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             }
             else if (response.StatusCode == HttpStatusCode.NotFound)
             {
+#nullable disable
                 return null;
+#nullable restore
             }
 
             throw await PlatformHttpException.CreateAsync(response);
@@ -451,6 +453,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             string apiUrl = $"{_platformSettings.ApiStorageEndpoint}instances/{instanceIdentifier}/data/{dataGuid}";
             string token = _userTokenProvider.GetUserToken();
             StreamContent content = new StreamContent(stream);
+            ArgumentNullException.ThrowIfNull(contentType);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
             content.Headers.ContentDisposition = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
             {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
@@ -101,6 +101,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             {
                 foreach (string? value in queryParameter.Value)
                 {
+                    // TODO: remember to escape the value here
                     apiUrl.Append($"&{queryParameter.Key}={value}");
                 }
             }

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
@@ -99,7 +99,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
 
             foreach (var queryParameter in queryParams)
             {
-                foreach (string value in queryParameter.Value)
+                foreach (string? value in queryParameter.Value)
                 {
                     apiUrl.Append($"&{queryParameter.Key}={value}");
                 }
@@ -251,7 +251,9 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             _logger.LogError(
                 $"Could not update read status for instance {instanceOwnerPartyId}/{instanceGuid}. Request failed with status code {response.StatusCode}"
             );
+#nullable disable
             return null;
+#nullable restore
         }
 
         /// <inheritdoc/>

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceEventClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceEventClient.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Text;
 using Altinn.App.Core.Configuration;
@@ -116,8 +117,14 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
             if (response.IsSuccessStatusCode)
             {
                 string eventData = await response.Content.ReadAsStringAsync();
-                InstanceEvent result = JsonConvert.DeserializeObject<InstanceEvent>(eventData)!;
-                return result.Id.ToString();
+                InstanceEvent result =
+                    JsonConvert.DeserializeObject<InstanceEvent>(eventData)
+                    ?? throw new Exception("Failed to deserialize instance event");
+                var id = result.Id.ToString();
+                Debug.Assert(id is not null, "Nullable<Guid>.ToString() never returns null");
+                // ^ https://github.com/dotnet/runtime/blob/9b088ab8287a77c52ff7c4ed6fa96be6d3eb87f1/src/libraries/System.Private.CoreLib/src/System/Nullable.cs#L67
+                // ^ https://github.com/dotnet/runtime/blob/9b088ab8287a77c52ff7c4ed6fa96be6d3eb87f1/src/libraries/System.Private.CoreLib/src/System/Guid.cs#L1124
+                return id;
             }
 
             throw await PlatformHttpException.CreateAsync(response);

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -135,7 +135,7 @@ public class PdfService : IPdfService
             UserProfile? userProfile = await _profileClient.GetUserProfile((int)userId);
             if (userProfile is null)
             {
-                throw new Exception("Could not get user profile.");
+                throw new Exception("Could not get user profile while getting language");
             }
 
             if (!string.IsNullOrEmpty(userProfile.ProfileSettingPreference?.Language))

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -132,7 +132,11 @@ public class PdfService : IPdfService
 
         if (userId != null)
         {
-            UserProfile userProfile = await _profileClient.GetUserProfile((int)userId);
+            UserProfile? userProfile = await _profileClient.GetUserProfile((int)userId);
+            if (userProfile is null)
+            {
+                throw new Exception("Could not get user profile.");
+            }
 
             if (!string.IsNullOrEmpty(userProfile.ProfileSettingPreference?.Language))
             {

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -132,11 +132,9 @@ public class PdfService : IPdfService
 
         if (userId != null)
         {
-            UserProfile? userProfile = await _profileClient.GetUserProfile((int)userId);
-            if (userProfile is null)
-            {
-                throw new Exception("Could not get user profile while getting language");
-            }
+            UserProfile userProfile =
+                await _profileClient.GetUserProfile((int)userId)
+                ?? throw new Exception("Could not get user profile while getting language");
 
             if (!string.IsNullOrEmpty(userProfile.ProfileSettingPreference?.Language))
             {

--- a/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnSignatureConfiguration.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnSignatureConfiguration.cs
@@ -18,7 +18,10 @@ public class AltinnSignatureConfiguration
     /// Set what dataTypeId that should be used for storing the signature
     /// </summary>
     [XmlElement("signatureDataType", Namespace = "http://altinn.no/process")]
+#nullable disable
     public string SignatureDataType { get; set; }
+
+#nullable restore
 
     /// <summary>
     /// Define what signature dataypes this signature should be unique from. Users that have sign any of the signatures in the list will not be able to sign this signature

--- a/src/Altinn.App.Core/Internal/Process/Elements/Base/ProcessElement.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/Base/ProcessElement.cs
@@ -11,6 +11,7 @@ public abstract class ProcessElement
     /// Gets or sets the ID of a flow element
     /// </summary>
     [XmlAttribute("id")]
+#nullable disable
     public string Id { get; set; }
 
     /// <summary>
@@ -30,6 +31,8 @@ public abstract class ProcessElement
     /// </summary>
     [XmlElement("outgoing")]
     public List<string> Outgoing { get; set; }
+
+#nullable restore
 
     /// <summary>
     /// String representation of process element type

--- a/src/Altinn.App.Core/Internal/Process/Elements/Definitions.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/Definitions.cs
@@ -13,6 +13,7 @@ namespace Altinn.App.Core.Internal.Process.Elements
         /// Gets or sets the ID of the definition
         /// </summary>
         [XmlAttribute("id")]
+#nullable disable
         public string Id { get; set; }
 
         /// <summary>
@@ -26,5 +27,6 @@ namespace Altinn.App.Core.Internal.Process.Elements
         /// </summary>
         [XmlElement("process")]
         public Process Process { get; set; }
+#nullable restore
     }
 }

--- a/src/Altinn.App.Core/Internal/Process/Elements/Process.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/Process.cs
@@ -11,7 +11,10 @@ namespace Altinn.App.Core.Internal.Process.Elements
         /// Gets or sets the ID of the process of a workflow
         /// </summary>
         [XmlAttribute("id")]
+#nullable disable
         public string Id { get; set; }
+
+#nullable restore
 
         /// <summary>
         /// Gets or sets if the process of a workflow is executable or not
@@ -23,6 +26,7 @@ namespace Altinn.App.Core.Internal.Process.Elements
         /// Gets or sets the start event of the process of a workflow
         /// </summary>
         [XmlElement("startEvent")]
+#nullable disable
         public List<StartEvent> StartEvents { get; set; }
 
         /// <summary>
@@ -48,5 +52,6 @@ namespace Altinn.App.Core.Internal.Process.Elements
         /// </summary>
         [XmlElement("exclusiveGateway")]
         public List<ExclusiveGateway> ExclusiveGateway { get; set; }
+#nullable restore
     }
 }

--- a/src/Altinn.App.Core/Internal/Process/Elements/SequenceFlow.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/SequenceFlow.cs
@@ -11,6 +11,7 @@ namespace Altinn.App.Core.Internal.Process.Elements
         /// Gets or sets the ID of a sequence flow
         /// </summary>
         [XmlAttribute("id")]
+#nullable disable
         public string Id { get; set; }
 
         /// <summary>
@@ -30,6 +31,8 @@ namespace Altinn.App.Core.Internal.Process.Elements
         /// </summary>
         [XmlAttribute("flowtype", Namespace = "http://altinn.no")]
         public string FlowType { get; set; }
+
+#nullable restore
 
         /// <summary>
         /// Gets or sets the condition expression of a sequence flow

--- a/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
@@ -39,7 +39,7 @@ public class ProcessNavigator : IProcessNavigator
         List<ProcessElement> directFlowTargets = _processReader.GetNextElements(currentElement);
         List<ProcessElement> filteredNext = await NextFollowAndFilterGateways(
             instance,
-            directFlowTargets.Cast<ProcessElement?>().ToList(),
+            directFlowTargets as List<ProcessElement?>,
             action
         );
         if (filteredNext.Count == 0)

--- a/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
@@ -37,7 +37,11 @@ public class ProcessNavigator : IProcessNavigator
     public async Task<ProcessElement?> GetNextTask(Instance instance, string currentElement, string? action)
     {
         List<ProcessElement> directFlowTargets = _processReader.GetNextElements(currentElement);
-        List<ProcessElement> filteredNext = await NextFollowAndFilterGateways(instance, directFlowTargets, action);
+        List<ProcessElement> filteredNext = await NextFollowAndFilterGateways(
+            instance,
+            directFlowTargets.Cast<ProcessElement?>().ToList(),
+            action
+        );
         if (filteredNext.Count == 0)
         {
             return null;

--- a/src/Altinn.App.Core/Internal/Sign/SignatureContext.cs
+++ b/src/Altinn.App.Core/Internal/Sign/SignatureContext.cs
@@ -76,7 +76,10 @@ public class Signee
     /// <summary>
     /// User id of the user performing the signing
     /// </summary>
+#nullable disable
     public string UserId { get; set; }
+
+#nullable restore
 
     /// <summary>
     /// The SSN of the user performing the signing, set if the signer is a person

--- a/src/Altinn.App.Core/Models/ApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Models/ApplicationLanguage.cs
@@ -12,6 +12,8 @@ namespace Altinn.App.Core.Models
         /// Example: "nb"
         /// </summary>
         [JsonPropertyName("language")]
+#nullable disable
         public string Language { get; set; }
+#nullable restore
     }
 }

--- a/src/Altinn.App.Core/Models/Attachment.cs
+++ b/src/Altinn.App.Core/Models/Attachment.cs
@@ -8,12 +8,15 @@ namespace Altinn.App.Core.Models
         /// <summary>
         /// The file name
         /// </summary>
+#nullable disable
         public string Name { get; set; }
 
         /// <summary>
         /// The id
         /// </summary>
         public string Id { get; set; }
+
+#nullable restore
 
         /// <summary>
         /// The file size in bytes

--- a/src/Altinn.App.Core/Models/AttachmentList.cs
+++ b/src/Altinn.App.Core/Models/AttachmentList.cs
@@ -8,11 +8,13 @@ namespace Altinn.App.Core.Models
         /// <summary>
         /// The attachment type
         /// </summary>
+#nullable disable
         public string Type { get; set; }
 
         /// <summary>
         /// The attachments
         /// </summary>
         public List<Attachment> Attachments { get; set; }
+#nullable restore
     }
 }

--- a/src/Altinn.App.Core/Models/CloudEvent.cs
+++ b/src/Altinn.App.Core/Models/CloudEvent.cs
@@ -12,6 +12,7 @@ namespace Altinn.App.Core.Models
         /// Gets or sets the id of the event.
         /// </summary>
         [JsonPropertyName("id")]
+#nullable disable
         public string Id { get; set; }
 
         /// <summary>
@@ -38,6 +39,8 @@ namespace Altinn.App.Core.Models
         [JsonPropertyName("subject")]
         public string Subject { get; set; }
 
+#nullable restore
+
         /// <summary>
         /// Gets or sets the time of the event.
         /// </summary>
@@ -48,6 +51,7 @@ namespace Altinn.App.Core.Models
         /// Gets or sets the alternative subject of the event.
         /// </summary>
         [JsonPropertyName("alternativesubject")]
+#nullable disable
         public string AlternativeSubject { get; set; }
 
         /// <summary>
@@ -70,5 +74,6 @@ namespace Altinn.App.Core.Models
         /// </summary>
         [JsonPropertyName("contenttype")]
         public ContentType DataContentType { get; set; }
+#nullable restore
     }
 }

--- a/src/Altinn.App.Core/Models/LayoutSet.cs
+++ b/src/Altinn.App.Core/Models/LayoutSet.cs
@@ -8,6 +8,7 @@ namespace Altinn.App.Core.Models
         /// <summary>
         /// LayoutsetId for layout. This is the foldername
         /// </summary>
+#nullable disable
         public string Id { get; set; }
 
         /// <summary>
@@ -19,5 +20,6 @@ namespace Altinn.App.Core.Models
         /// List of tasks where layuout should be used
         /// </summary>
         public List<string> Tasks { get; set; }
+#nullable restore
     }
 }

--- a/src/Altinn.App.Core/Models/Process/ProcessNextRequest.cs
+++ b/src/Altinn.App.Core/Models/Process/ProcessNextRequest.cs
@@ -8,6 +8,7 @@ namespace Altinn.App.Core.Models.Process;
 /// </summary>
 public class ProcessNextRequest
 {
+#nullable disable
     /// <summary>
     /// The instance to be moved to the next task
     /// </summary>
@@ -17,6 +18,8 @@ public class ProcessNextRequest
     /// The user that is performing the action
     /// </summary>
     public ClaimsPrincipal User { get; set; }
+
+#nullable restore
 
     /// <summary>
     /// The action that is performed

--- a/src/Altinn.App.Core/Models/Process/ProcessStartRequest.cs
+++ b/src/Altinn.App.Core/Models/Process/ProcessStartRequest.cs
@@ -8,6 +8,7 @@ namespace Altinn.App.Core.Models.Process;
 /// </summary>
 public class ProcessStartRequest
 {
+#nullable disable
     /// <summary>
     /// The instance to be started
     /// </summary>
@@ -17,6 +18,8 @@ public class ProcessStartRequest
     /// The user that is starting the process
     /// </summary>
     public ClaimsPrincipal User { get; set; }
+
+#nullable restore
 
     /// <summary>
     /// The prefill data supplied when starting the process

--- a/src/Altinn.App.Core/Models/QueryResponse.cs
+++ b/src/Altinn.App.Core/Models/QueryResponse.cs
@@ -17,6 +17,7 @@ namespace Altinn.App.Core.Models
         /// The current query.
         /// </summary>
         [JsonProperty(PropertyName = "self")]
+#nullable disable
         public string Self { get; set; }
 
         /// <summary>
@@ -30,5 +31,6 @@ namespace Altinn.App.Core.Models
         /// </summary>
         [JsonProperty(PropertyName = "instances")]
         public List<T> Instances { get; set; }
+#nullable restore
     }
 }

--- a/src/Altinn.App.Core/Models/UserContext.cs
+++ b/src/Altinn.App.Core/Models/UserContext.cs
@@ -8,6 +8,7 @@ namespace Altinn.App.Core.Models
     /// </summary>
     public class UserContext
     {
+#nullable disable
         /// <summary>
         /// Gets or sets the social security number
         /// </summary>
@@ -32,6 +33,8 @@ namespace Altinn.App.Core.Models
         /// Gets or sets the claims principal for the user
         /// </summary>
         public ClaimsPrincipal User { get; set; }
+
+#nullable restore
 
         /// <summary>
         /// Gets or sets the ID of the user

--- a/src/Altinn.App.Core/Models/Validation/InstantiationValidationResult.cs
+++ b/src/Altinn.App.Core/Models/Validation/InstantiationValidationResult.cs
@@ -12,6 +12,7 @@ namespace Altinn.App.Core.Models.Validation
         /// </summary>
         public bool Valid { get; set; }
 
+#nullable disable
         /// <summary>
         /// Gets or sets a message
         /// </summary>
@@ -21,5 +22,6 @@ namespace Altinn.App.Core.Models.Validation
         /// Gets or sets a list of parties the user represents that can instantiate
         /// </summary>
         public List<Party> ValidParties { get; set; }
+#nullable restore
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-
+  <Import Project="../Directory.Build.props" />
   <ItemGroup>
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
@@ -10,9 +10,8 @@
     <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
-  
+
   <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!='' AND '$(BuildNumber)' != ''">
     <PropertyGroup>
       <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BuildNumber)</FileVersion>

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -9,6 +9,7 @@
 		<!--
 			CS1591: Don't warn for missing XML doc
 			CS0618: This is a test project, so we usually continue testing [Obsolete] apis
+            CS7022: The entry point of the program is global code; ignoring 'Program.Main(string[])' entry point
 		-->
 	</PropertyGroup>
 

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -5,7 +5,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>false</IsPackable>
-		<NoWarn>$(NoWarn);CS1591;CS0618</NoWarn>
+		<NoWarn>$(NoWarn);CS1591;CS0618;CS7022</NoWarn>
 		<!--
 			CS1591: Don't warn for missing XML doc
 			CS0618: This is a test project, so we usually continue testing [Obsolete] apis

--- a/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
@@ -29,7 +29,7 @@ namespace Altinn.App.Api.Tests.Controllers;
 public class StatelessDataControllerTests
 {
     [Fact]
-    public async void Get_Returns_BadRequest_when_dataType_is_null()
+    public async Task Get_Returns_BadRequest_when_dataType_is_null()
     {
         // Arrange
         var altinnAppModelMock = new Mock<IAppModel>();
@@ -68,7 +68,7 @@ public class StatelessDataControllerTests
     }
 
     [Fact]
-    public async void Get_Returns_BadRequest_when_appResource_classRef_is_null()
+    public async Task Get_Returns_BadRequest_when_appResource_classRef_is_null()
     {
         // Arrange
         var appModelMock = new Mock<IAppModel>();
@@ -136,7 +136,7 @@ public class StatelessDataControllerTests
     }
 
     [Fact]
-    public async void Get_Returns_BadRequest_when_party_header_count_greater_than_one()
+    public async Task Get_Returns_BadRequest_when_party_header_count_greater_than_one()
     {
         // Arrange
         var factory = new StatelessDataControllerWebApplicationFactory();
@@ -164,7 +164,7 @@ public class StatelessDataControllerTests
     }
 
     [Fact]
-    public async void Get_Returns_Forbidden_when_party_has_no_rights()
+    public async Task Get_Returns_Forbidden_when_party_has_no_rights()
     {
         // Arrange
         var factory = new StatelessDataControllerWebApplicationFactory();
@@ -190,7 +190,7 @@ public class StatelessDataControllerTests
     }
 
     [Fact]
-    public async void Get_Returns_BadRequest_when_instance_owner_is_empty_party_header()
+    public async Task Get_Returns_BadRequest_when_instance_owner_is_empty_party_header()
     {
         // Arrange
         var appModelMock = new Mock<IAppModel>();
@@ -228,7 +228,7 @@ public class StatelessDataControllerTests
     }
 
     [Fact]
-    public async void Get_Returns_BadRequest_when_instance_owner_is_empty_user_in_context()
+    public async Task Get_Returns_BadRequest_when_instance_owner_is_empty_user_in_context()
     {
         // Arrange
         var appModelMock = new Mock<IAppModel>();
@@ -272,7 +272,7 @@ public class StatelessDataControllerTests
     }
 
     [Fact]
-    public async void Get_Returns_Forbidden_when_returned_descision_is_Deny()
+    public async Task Get_Returns_Forbidden_when_returned_descision_is_Deny()
     {
         // Arrange
         var appModelMock = new Mock<IAppModel>();
@@ -332,7 +332,7 @@ public class StatelessDataControllerTests
     }
 
     [Fact]
-    public async void Get_Returns_OK_with_appModel()
+    public async Task Get_Returns_OK_with_appModel()
     {
         // Arrange
         var appModelMock = new Mock<IAppModel>();

--- a/test/Altinn.App.Api.Tests/Controllers/TestResources/DummyModel.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/TestResources/DummyModel.cs
@@ -2,7 +2,7 @@ namespace Altinn.App.Api.Tests.Controllers.TestResources;
 
 public class DummyModel
 {
-    public string Name { get; set; }
+    public string? Name { get; set; }
     public int Age { get; set; }
 
     /// <summary>

--- a/test/Altinn.App.Api.Tests/Mocks/DataClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/DataClientMock.cs
@@ -408,7 +408,7 @@ namespace App.IntegrationTests.Mocks.Services
             string instanceId,
             string dataType,
             string contentType,
-            string filename,
+            string? filename,
             Stream stream,
             string? generatedFromTask = null
         )

--- a/test/Altinn.App.Api.Tests/Mocks/ProfileClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/ProfileClientMock.cs
@@ -11,10 +11,10 @@ public class ProfileClientMock : IProfileClient
     private static readonly JsonSerializerOptions _jsonSerializerOptions =
         new(JsonSerializerDefaults.Web) { Converters = { new JsonStringEnumConverter() } };
 
-    public async Task<UserProfile> GetUserProfile(int userId)
+    public async Task<UserProfile?> GetUserProfile(int userId)
     {
         var folder = TestData.GetRegisterProfilePath();
         var file = Path.Join(folder, $"{userId}.json");
-        return (await JsonSerializer.DeserializeAsync<UserProfile>(File.OpenRead(file), _jsonSerializerOptions))!;
+        return await JsonSerializer.DeserializeAsync<UserProfile>(File.OpenRead(file), _jsonSerializerOptions);
     }
 }

--- a/test/Altinn.App.Core.Tests/DataLists/NullInstanceDataListProviderTest.cs
+++ b/test/Altinn.App.Core.Tests/DataLists/NullInstanceDataListProviderTest.cs
@@ -9,7 +9,7 @@ namespace Altinn.App.PlatformServices.Tests.DataLists
     public class NullInstanceDataListProviderTest
     {
         [Fact]
-        public async void Constructor_InitializedWithEmptyValues()
+        public async Task Constructor_InitializedWithEmptyValues()
         {
             var provider = new NullInstanceDataListProvider();
 

--- a/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Extensions/DictionaryExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Parameters = new Dictionary<string, string> { { "lang", "nb" }, { "level", "1" } },
+                Parameters = new Dictionary<string, string?> { { "lang", "nb" }, { "level", "1" } },
             };
 
             IHeaderDictionary headers = new HeaderDictionary
@@ -26,7 +26,7 @@ namespace Altinn.App.Core.Tests.Extensions
         [Fact]
         public void ToNameValueString_OptionParametersWithEmptyValue_ShouldConvertToHttpHeaderFormat()
         {
-            var options = new AppOptions { Parameters = new Dictionary<string, string>() };
+            var options = new AppOptions { Parameters = new Dictionary<string, string?>() };
 
             IHeaderDictionary headers = new HeaderDictionary
             {
@@ -54,7 +54,7 @@ namespace Altinn.App.Core.Tests.Extensions
         {
             var options = new AppOptions
             {
-                Parameters = new Dictionary<string, string>
+                Parameters = new Dictionary<string, string?>
                 {
                     { "lang", "nb" },
                     { "level", "1" },

--- a/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
@@ -23,7 +23,7 @@ namespace Altinn.App.Core.Tests.Features.Action;
 public class SigningUserActionTests
 {
     [Fact]
-    public async void HandleAction_returns_ok_if_user_is_valid()
+    public async Task HandleAction_returns_ok_if_user_is_valid()
     {
         // Arrange
         UserProfile userProfile = new UserProfile()
@@ -67,7 +67,7 @@ public class SigningUserActionTests
     }
 
     [Fact]
-    public async void HandleAction_returns_ok_if_no_dataElementSignature_and_optional_datatypes()
+    public async Task HandleAction_returns_ok_if_no_dataElementSignature_and_optional_datatypes()
     {
         // Arrange
         UserProfile userProfile = new UserProfile()
@@ -115,7 +115,7 @@ public class SigningUserActionTests
     }
 
     [Fact]
-    public async void HandleAction_returns_error_when_UserId_not_set_in_context()
+    public async Task HandleAction_returns_error_when_UserId_not_set_in_context()
     {
         // Arrange
         UserProfile userProfile = new UserProfile()
@@ -149,7 +149,7 @@ public class SigningUserActionTests
     }
 
     [Fact]
-    public async void HandleAction_throws_ApplicationConfigException_when_no_dataElementSignature_and_mandatory_datatypes()
+    public async Task HandleAction_throws_ApplicationConfigException_when_no_dataElementSignature_and_mandatory_datatypes()
     {
         // Arrange
         UserProfile userProfile = new UserProfile()
@@ -190,7 +190,7 @@ public class SigningUserActionTests
     }
 
     [Fact]
-    public async void HandleAction_throws_ApplicationConfigException_if_SignatureDataType_is_null()
+    public async Task HandleAction_throws_ApplicationConfigException_if_SignatureDataType_is_null()
     {
         // Arrange
         UserProfile userProfile = new UserProfile()

--- a/test/Altinn.App.Core.Tests/Features/DataProcessing/NullInstantiationProcessTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/DataProcessing/NullInstantiationProcessTests.cs
@@ -10,7 +10,7 @@ namespace Altinn.App.PlatformServices.Tests.Features.DataProcessing;
 public class NullInstantiationProcessTests
 {
     [Fact]
-    public async void NullInstantiationTest_DataCreation_changes_nothing()
+    public async Task NullInstantiationTest_DataCreation_changes_nothing()
     {
         // Arrange
         var nullInstantiation = new NullInstantiationProcessor();

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Email/EmailNotificationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Email/EmailNotificationClientTests.cs
@@ -26,7 +26,7 @@ public class EmailNotificationClientTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async void Order_VerifyHttpCall(bool includeTelemetryClient)
+    public async Task Order_VerifyHttpCall(bool includeTelemetryClient)
     {
         // Arrange
         var emailNotification = new EmailNotification
@@ -80,7 +80,7 @@ public class EmailNotificationClientTests
     }
 
     [Fact]
-    public async void Order_ShouldReturnOrderId_OnSuccess()
+    public async Task Order_ShouldReturnOrderId_OnSuccess()
     {
         // Arrange
         var handlerMock = new Mock<HttpMessageHandler>();
@@ -120,7 +120,7 @@ public class EmailNotificationClientTests
     }
 
     [Fact]
-    public async void Order_ShouldThrowEmailNotificationException_OnFailure()
+    public async Task Order_ShouldThrowEmailNotificationException_OnFailure()
     {
         // Arrange
         var handlerMock = new Mock<HttpMessageHandler>();
@@ -160,7 +160,7 @@ public class EmailNotificationClientTests
     }
 
     [Fact]
-    public async void Order_ShouldThrowEmailNotificationException_OnInvalidJsonResponse()
+    public async Task Order_ShouldThrowEmailNotificationException_OnInvalidJsonResponse()
     {
         // Arrange
         var handlerMock = new Mock<HttpMessageHandler>();

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Sms/SmsNotificationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Sms/SmsNotificationClientTests.cs
@@ -26,7 +26,7 @@ public class SmsNotificationClientTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async void Order_VerifyHttpCall(bool includeTelemetryClient)
+    public async Task Order_VerifyHttpCall(bool includeTelemetryClient)
     {
         // Arrange
         var smsNotification = new SmsNotification
@@ -81,7 +81,7 @@ public class SmsNotificationClientTests
     }
 
     [Fact]
-    public async void Order_ShouldReturnOrderId_OnSuccess()
+    public async Task Order_ShouldReturnOrderId_OnSuccess()
     {
         // Arrange
         var handlerMock = new Mock<HttpMessageHandler>();
@@ -122,7 +122,7 @@ public class SmsNotificationClientTests
     }
 
     [Fact]
-    public async void Order_ShouldThrowSmsNotificationException_OnFailure()
+    public async Task Order_ShouldThrowSmsNotificationException_OnFailure()
     {
         // Arrange
         var handlerMock = new Mock<HttpMessageHandler>();
@@ -162,7 +162,7 @@ public class SmsNotificationClientTests
     }
 
     [Fact]
-    public async void Order_ShouldThrowSmsNotificationException_OnInvalidJsonResponse()
+    public async Task Order_ShouldThrowSmsNotificationException_OnInvalidJsonResponse()
     {
         // Arrange
         var handlerMock = new Mock<HttpMessageHandler>();

--- a/test/Altinn.App.Core.Tests/Features/Options/NullInstanceAppOptionsProviderTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/NullInstanceAppOptionsProviderTests.cs
@@ -8,7 +8,7 @@ namespace Altinn.App.Core.Tests.Features.Options
     public class NullInstanceAppOptionsProviderTests
     {
         [Fact]
-        public async void Constructor_InitializedWithEmptyValues()
+        public async Task Constructor_InitializedWithEmptyValues()
         {
             var provider = new NullInstanceAppOptionsProvider();
 

--- a/test/Altinn.App.Core.Tests/Features/Validators/NullInstantiationValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/NullInstantiationValidatorTests.cs
@@ -9,7 +9,7 @@ namespace Altinn.App.PlatformServices.Tests.Features.Validators;
 public class NullInstantiationValidatorTests
 {
     [Fact]
-    public async void NullInstantiationTest_Validation_returns_null()
+    public async Task NullInstantiationTest_Validation_returns_null()
     {
         // Arrange
         var nullInstantiation = new NullInstantiationValidator();

--- a/test/Altinn.App.Core.Tests/Helpers/MultiDecisionHelperTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/MultiDecisionHelperTests.cs
@@ -112,7 +112,7 @@ public class MultiDecisionHelperTests
         };
 
         var actions = new List<string>() { "sign", "reject" };
-        Action act = () => MultiDecisionHelper.CreateMultiDecisionRequest(null, instance, actions);
+        Action act = () => MultiDecisionHelper.CreateMultiDecisionRequest(null!, instance, actions);
         act.Should().Throw<ArgumentNullException>().WithMessage("Value cannot be null. (Parameter 'user')");
     }
 
@@ -170,7 +170,7 @@ public class MultiDecisionHelperTests
             { "complete", false },
             { "lookup", false }
         };
-        Action act = () => MultiDecisionHelper.ValidatePdpMultiDecision(actions, null, GetClaims("501337"));
+        Action act = () => MultiDecisionHelper.ValidatePdpMultiDecision(actions, null!, GetClaims("501337"));
         act.Should().Throw<ArgumentNullException>().WithMessage("Value cannot be null. (Parameter 'results')");
     }
 
@@ -185,7 +185,7 @@ public class MultiDecisionHelperTests
             { "complete", false },
             { "lookup", false }
         };
-        Action act = () => MultiDecisionHelper.ValidatePdpMultiDecision(actions, response, null);
+        Action act = () => MultiDecisionHelper.ValidatePdpMultiDecision(actions, response, null!);
         act.Should().Throw<ArgumentNullException>().WithMessage("Value cannot be null. (Parameter 'user')");
     }
 
@@ -234,6 +234,7 @@ public class MultiDecisionHelperTests
         var xacmlJesonRespons = File.ReadAllText(
             Path.Join("Helpers", "TestData", "MultiDecisionHelper", filename + ".json")
         );
-        return JsonSerializer.Deserialize<List<XacmlJsonResult>>(xacmlJesonRespons);
+        return JsonSerializer.Deserialize<List<XacmlJsonResult>>(xacmlJesonRespons)
+            ?? throw new Exception("Deserialization failed for XacmlJsonRespons");
     }
 }

--- a/test/Altinn.App.Core.Tests/Implementation/NullPdfFormatterTests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/NullPdfFormatterTests.cs
@@ -10,7 +10,7 @@ namespace Altinn.App.PlatformServices.Tests.Implementation;
 public class NullPdfFormatterTests
 {
     [Fact]
-    public async void NullPdfFormatter_FormatPdf_returns_Layoutsettings_as_is()
+    public async Task NullPdfFormatter_FormatPdf_returns_Layoutsettings_as_is()
     {
         // Arrange
         var layoutSettings = new LayoutSettings()

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
@@ -878,8 +878,11 @@ namespace Altinn.App.Core.Tests.Infrastructure.Clients.Storage
 
             if (expectedFilename is not null)
             {
+                Assert.NotNull(actualContentDisposition);
+                var actualContentDispositionValue = actualContentDisposition.FirstOrDefault();
+                Assert.NotNull(actualContentDispositionValue);
                 ContentDispositionHeaderValue
-                    .Parse(actualContentDisposition?.FirstOrDefault())
+                    .Parse(actualContentDispositionValue)
                     .FileName?.Should()
                     .BeEquivalentTo(expectedFilename);
             }

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMedataTest.cs
@@ -131,7 +131,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         }
 
         [Fact]
-        public async void GetApplicationMetadata_second_read_from_cache()
+        public async Task GetApplicationMetadata_second_read_from_cache()
         {
             AppSettings appSettings = GetAppSettings("AppMetadata", "default.applicationmetadata.json");
             Mock<IFrontendFeatures> appFeaturesMock = new Mock<IFrontendFeatures>();
@@ -464,7 +464,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         }
 
         [Fact]
-        public async void GetApplicationMetadata_throws_ApplicationConfigException_if_file_not_found()
+        public async Task GetApplicationMetadata_throws_ApplicationConfigException_if_file_not_found()
         {
             AppSettings appSettings = GetAppSettings("AppMetadata", "notfound.applicationmetadata.json");
             IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
@@ -474,7 +474,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         }
 
         [Fact]
-        public async void GetApplicationMetadata_throw_ApplicationConfigException_if_deserialization_fails()
+        public async Task GetApplicationMetadata_throw_ApplicationConfigException_if_deserialization_fails()
         {
             AppSettings appSettings = GetAppSettings("AppMetadata", "invalid.applicationmetadata.json");
             IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
@@ -484,7 +484,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         }
 
         [Fact]
-        public async void GetApplicationMetadata_throws_ApplicationConfigException_if_deserialization_fails_due_to_string_in_int()
+        public async Task GetApplicationMetadata_throws_ApplicationConfigException_if_deserialization_fails_due_to_string_in_int()
         {
             AppSettings appSettings = GetAppSettings("AppMetadata", "invalid-int.applicationmetadata.json");
             IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
@@ -494,7 +494,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         }
 
         [Fact]
-        public async void GetApplicationXACMLPolicy_return_policyfile_as_string()
+        public async Task GetApplicationXACMLPolicy_return_policyfile_as_string()
         {
             AppSettings appSettings = GetAppSettings(subfolder: "AppPolicy", policyFilename: "policy.xml");
             IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
@@ -505,7 +505,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         }
 
         [Fact]
-        public async void GetApplicationXACMLPolicy_throws_FileNotFoundException_if_file_not_found()
+        public async Task GetApplicationXACMLPolicy_throws_FileNotFoundException_if_file_not_found()
         {
             AppSettings appSettings = GetAppSettings(subfolder: "AppPolicy", policyFilename: "notfound.xml");
             IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
@@ -513,7 +513,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         }
 
         [Fact]
-        public async void GetApplicationBPMNProcess_return_process_as_string()
+        public async Task GetApplicationBPMNProcess_return_process_as_string()
         {
             AppSettings appSettings = GetAppSettings(subfolder: "AppProcess", bpmnFilename: "process.bpmn");
             IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));
@@ -524,7 +524,7 @@ namespace Altinn.App.Core.Tests.Internal.App
         }
 
         [Fact]
-        public async void GetApplicationBPMNProcess_throws_ApplicationConfigException_if_file_not_found()
+        public async Task GetApplicationBPMNProcess_throws_ApplicationConfigException_if_file_not_found()
         {
             AppSettings appSettings = GetAppSettings(subfolder: "AppProcess", policyFilename: "notfound.xml");
             IAppMetadata appMetadata = SetupAppMedata(Microsoft.Extensions.Options.Options.Create(appSettings));

--- a/test/Altinn.App.Core.Tests/Internal/Events/EventHandlerResolverTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Events/EventHandlerResolverTests.cs
@@ -11,7 +11,7 @@ namespace Altinn.App.PlatformServices.Tests.Internal.Events
     public class EventHandlerResolverTests
     {
         [Fact]
-        public async void ResolveEventHandler_SubscriptionValidationHandler_ShouldReturnSubscriptionValidationHandler()
+        public async Task ResolveEventHandler_SubscriptionValidationHandler_ShouldReturnSubscriptionValidationHandler()
         {
             var factory = new EventHandlerResolver(new List<IEventHandler>() { new SubscriptionValidationHandler() });
 

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
@@ -15,7 +15,7 @@ namespace Altinn.App.Core.Tests.Internal.Process;
 public class ProcessNavigatorTests
 {
     [Fact]
-    public async void GetNextTask_returns_next_element_if_no_gateway()
+    public async Task GetNextTask_returns_next_element_if_no_gateway()
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-linear.bpmn",
@@ -40,7 +40,7 @@ public class ProcessNavigatorTests
     }
 
     [Fact]
-    public async void NextFollowAndFilterGateways_returns_empty_list_if_no_outgoing_flows()
+    public async Task NextFollowAndFilterGateways_returns_empty_list_if_no_outgoing_flows()
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-linear.bpmn",
@@ -51,7 +51,7 @@ public class ProcessNavigatorTests
     }
 
     [Fact]
-    public async void GetNextTask_returns_default_if_no_filtering_is_implemented_and_default_set()
+    public async Task GetNextTask_returns_default_if_no_filtering_is_implemented_and_default_set()
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-gateway-default.bpmn",
@@ -80,7 +80,7 @@ public class ProcessNavigatorTests
     }
 
     [Fact]
-    public async void GetNextTask_runs_custom_filter_and_returns_result()
+    public async Task GetNextTask_runs_custom_filter_and_returns_result()
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-gateway-with-join-gateway.bpmn",
@@ -111,7 +111,7 @@ public class ProcessNavigatorTests
     }
 
     [Fact]
-    public async void GetNextTask_throws_ProcessException_if_multiple_targets_found()
+    public async Task GetNextTask_throws_ProcessException_if_multiple_targets_found()
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-gateway-with-join-gateway.bpmn",
@@ -128,7 +128,7 @@ public class ProcessNavigatorTests
     }
 
     [Fact]
-    public async void GetNextTask_follows_downstream_gateways()
+    public async Task GetNextTask_follows_downstream_gateways()
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-gateway-with-join-gateway.bpmn",
@@ -150,7 +150,7 @@ public class ProcessNavigatorTests
     }
 
     [Fact]
-    public async void GetNextTask_runs_custom_filter_and_returns_empty_list_if_all_filtered_out()
+    public async Task GetNextTask_runs_custom_filter_and_returns_empty_list_if_all_filtered_out()
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-gateway-with-join-gateway.bpmn",
@@ -170,7 +170,7 @@ public class ProcessNavigatorTests
     }
 
     [Fact]
-    public async void GetNextTask_returns_empty_list_if_element_has_no_next()
+    public async Task GetNextTask_returns_empty_list_if_element_has_no_next()
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-gateway-with-join-gateway.bpmn",

--- a/test/Altinn.App.Core.Tests/Internal/Process/ServiceTasks/EformidlingServiceTaskTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ServiceTasks/EformidlingServiceTaskTests.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.EFormidling.Interface;
 using Altinn.App.Core.Internal.App;

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/ExpressionTestCaseRoot.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/ExpressionTestCaseRoot.cs
@@ -84,6 +84,10 @@ public class ComponentContextForTestSpec
 
     public static ComponentContextForTestSpec FromContext(ComponentContext context)
     {
+        ArgumentNullException.ThrowIfNull(context.Component);
+        ArgumentNullException.ThrowIfNull(context.Component.Id);
+        ArgumentNullException.ThrowIfNull(context.Component.PageId);
+
         return new ComponentContextForTestSpec
         {
             ComponentId = context.Component.Id,


### PR DESCRIPTION
## Description
I've noticed in recent PRs there are still a lot of `!` and warnings sneaking through. This PR makes warnings errors, and removed NRT-related errors

* preserves existing behavior as a first priority
* helps the compiler flow analysis where we can
* change annotations where we can
* supress the rest

Also removed some `async void` functions..

In the future (next time we do a breaking change), we should revisit all instances of `#nullable disable`, 
Maybe we should also use something like `Nullable.Extended.Analyzer` to disallow null-forgiving operator. 

1st commit - project config changes
2nd commit - remove `async void`
3rd commit - fix and suppress warnings where needed

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
