### PR TITLE
Fix flaky AppInsights DI tests

### DIFF
--- a/test/Altinn.App.Api.Tests/DITests.cs
+++ b/test/Altinn.App.Api.Tests/DITests.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.Tracing;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -49,8 +51,20 @@ public class DITests
 
     private sealed class AppInsightsListener : EventListener
     {
+        private readonly object _lock = new();
         private readonly List<EventSource> _eventSources = [];
-        public readonly List<EventWrittenEventArgs> Events = [];
+        private readonly List<EventWrittenEventArgs> _events = [];
+
+        public EventWrittenEventArgs[] Events
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _events.ToArray();
+                }
+            }
+        }
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
@@ -70,7 +84,10 @@ public class DITests
                 return;
             }
 
-            Events.Add(eventData);
+            lock (_lock)
+            {
+                _events.Add(eventData);
+            }
             base.OnEventWritten(eventData);
         }
 
@@ -84,8 +101,35 @@ public class DITests
         }
     }
 
+    private sealed class TelemetryProcessor(ITelemetryProcessor next) : ITelemetryProcessor
+    {
+        private static readonly object _lock = new();
+
+        private static readonly List<ITelemetry> _items = new();
+
+        public static ITelemetry[] Items
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _items.ToArray();
+                }
+            }
+        }
+
+        public void Process(ITelemetry item)
+        {
+            lock (_lock)
+            {
+                _items.Add(item);
+            }
+            next.Process(item);
+        }
+    }
+
     [Fact]
-    public void AppInsights_Registers_Correctly()
+    public async Task AppInsights_Registers_Correctly()
     {
         using var listener = new AppInsightsListener();
 
@@ -102,16 +146,34 @@ public class DITests
             .Build();
 
         Extensions.ServiceCollectionExtensions.AddAltinnAppServices(services, config, env);
+        services.AddApplicationInsightsTelemetryProcessor<TelemetryProcessor>();
 
-        using var sp = services.BuildServiceProvider();
+        await using (var sp = services.BuildServiceProvider())
+        {
+            var telemetryConfig = sp.GetRequiredService<TelemetryConfiguration>();
+            Assert.NotNull(telemetryConfig);
 
-        var telemetryConfig = sp.GetRequiredService<TelemetryConfiguration>();
-        Assert.NotNull(telemetryConfig);
+            var client = sp.GetRequiredService<TelemetryClient>();
+            Assert.NotNull(client);
 
-        var client = sp.GetRequiredService<TelemetryClient>();
-        Assert.NotNull(client);
+            client.TrackEvent("TestEvent");
+            await client.FlushAsync(default);
+        }
+
+        await Task.Yield();
 
         EventLevel[] errorLevels = [EventLevel.Error, EventLevel.Critical];
-        Assert.Empty(listener.Events.Where(e => errorLevels.Contains(e.Level)));
+        var events = listener.Events;
+        Assert.Empty(events.Where(e => errorLevels.Contains(e.Level)));
+
+        var telemetryItems = TelemetryProcessor.Items;
+        var customEvents = telemetryItems
+            .Select(e => e as EventTelemetry)
+            .Where(e => e?.Name is not null)
+            .Select(e => e?.Name)
+            .ToArray();
+        Assert.Single(customEvents);
+        var customEvent = customEvents[0];
+        Assert.Equal("TestEvent", customEvent);
     }
 }

--- a/test/Altinn.App.Api.Tests/DITests.cs
+++ b/test/Altinn.App.Api.Tests/DITests.cs
@@ -176,4 +176,42 @@ public class DITests
         var customEvent = customEvents[0];
         Assert.Equal("TestEvent", customEvent);
     }
+
+    [Fact]
+    public async Task KeyedServices_Produces_Error_Diagnostics()
+    {
+        // This test just verifies that we rootcaused the issues re: https://github.com/Altinn/app-lib-dotnet/pull/594
+
+        using var listener = new AppInsightsListener();
+
+        var services = new ServiceCollection();
+        var env = new FakeWebHostEnvironment { EnvironmentName = "Development" };
+
+        services.AddSingleton<IWebHostEnvironment>(env);
+        services.AddSingleton<IHostingEnvironment>(env);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                [new KeyValuePair<string, string?>("ApplicationInsights:InstrumentationKey", "test")]
+            )
+            .Build();
+
+        // AppInsights SDK currently can't handle keyed services in the container
+        // Hopefully we can remove all this soon
+        services.AddKeyedSingleton<ITelemetryProcessor, TelemetryProcessor>("test");
+
+        Extensions.ServiceCollectionExtensions.AddAltinnAppServices(services, config, env);
+
+        await using (var sp = services.BuildServiceProvider())
+        {
+            var client = sp.GetService<TelemetryClient>();
+            Assert.Null(client);
+        }
+
+        await Task.Yield();
+
+        EventLevel[] errorLevels = [EventLevel.Error, EventLevel.Critical];
+        var events = listener.Events;
+        Assert.NotEmpty(events.Where(e => errorLevels.Contains(e.Level)));
+    }
 }


### PR DESCRIPTION
## Description
Hopefully fixes flaky DI tests for App Insights.
Example race: https://github.com/Altinn/app-lib-dotnet/actions/runs/8967112868/job/24623968605

## Related Issue(s)
- #633

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
