### PR TITLE
Add utility to make it simpler to assert on http responses.

### DIFF
--- a/test/Altinn.App.Api.Tests/Utils/JsonUtils.cs
+++ b/test/Altinn.App.Api.Tests/Utils/JsonUtils.cs
@@ -13,7 +13,7 @@ public static class JsonUtils
             var bytes = Encoding.UTF8.GetBytes(json);
             var parser = new Utf8JsonReader(bytes);
             using var outStream = new MemoryStream(bytes.Length * 2);
-            var writer = new Utf8JsonWriter((outStream), new JsonWriterOptions { Indented = true });
+            using var writer = new Utf8JsonWriter((outStream), new JsonWriterOptions { Indented = true });
 
             while (parser.Read())
             {

--- a/test/Altinn.App.Api.Tests/Utils/JsonUtils.cs
+++ b/test/Altinn.App.Api.Tests/Utils/JsonUtils.cs
@@ -1,0 +1,72 @@
+namespace Altinn.App.Api.Tests.Utils;
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Unicode;
+
+public static class JsonUtils
+{
+    public static string IndentJson(string json)
+    {
+        try
+        {
+            var bytes = Encoding.UTF8.GetBytes(json);
+            var parser = new Utf8JsonReader(bytes);
+            using var outStream = new MemoryStream(bytes.Length * 2);
+            var writer = new Utf8JsonWriter((outStream), new JsonWriterOptions { Indented = true });
+
+            while (parser.Read())
+            {
+                switch (parser.TokenType)
+                {
+                    case JsonTokenType.StartObject:
+                        writer.WriteStartObject();
+                        break;
+                    case JsonTokenType.EndObject:
+                        writer.WriteEndObject();
+                        break;
+                    case JsonTokenType.StartArray:
+                        writer.WriteStartArray();
+                        break;
+                    case JsonTokenType.EndArray:
+                        writer.WriteEndArray();
+                        break;
+                    case JsonTokenType.PropertyName:
+                        writer.WritePropertyName(parser.GetString()!);
+                        break;
+                    case JsonTokenType.String:
+                        writer.WriteStringValue(parser.GetString());
+                        break;
+                    case JsonTokenType.Number:
+                        if (parser.TryGetInt64(out long longValue))
+                        {
+                            writer.WriteNumberValue(longValue);
+                        }
+                        else if (parser.TryGetDouble(out double doubleValue))
+                        {
+                            writer.WriteNumberValue(doubleValue);
+                        }
+                        break;
+                    case JsonTokenType.True:
+                        writer.WriteBooleanValue(true);
+                        break;
+                    case JsonTokenType.False:
+                        writer.WriteBooleanValue(false);
+                        break;
+                    case JsonTokenType.Null:
+                        writer.WriteNullValue();
+                        break;
+                }
+            }
+
+            writer.Flush();
+            outStream.Position = 0;
+
+            return Encoding.UTF8.GetString(outStream.ToArray());
+        }
+        catch (JsonException)
+        {
+            return json;
+        }
+    }
+}

--- a/test/Altinn.App.Api.Tests/Utils/ReflectionUtils.cs
+++ b/test/Altinn.App.Api.Tests/Utils/ReflectionUtils.cs
@@ -1,0 +1,21 @@
+namespace Altinn.App.Api.Tests.Utils;
+
+public class ReflectionUtils
+{
+    public static string GetTypeNameWithGenericArguments<T>()
+    {
+        return GetTypeNameWithGenericArguments(typeof(T));
+    }
+
+    private static string GetTypeNameWithGenericArguments(Type type)
+    {
+        if (!type.IsGenericType)
+        {
+            return type.Name;
+        }
+
+        var genericArguments = type.GetGenericArguments();
+        var genericArgumentsString = string.Join(", ", genericArguments.Select(GetTypeNameWithGenericArguments));
+        return $"{type.Name.Split('`')[0]}<{genericArgumentsString}>"; // Remove the `1, `2, etc. from the type name
+    }
+}


### PR DESCRIPTION
This has to be a method on the custom WebApplicationFactory to access the _outputHelper

I saw this utility suggested in a testing course on Pluralsight, and wanted to try to see if I liked it (and I did).



## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
