### PR TITLE
Fix issue where URL encoding was missing when building query string for `InstanceClient.GetInstances`

### DIFF
--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
@@ -10,6 +10,7 @@ using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using AltinnCore.Authentication.Utils;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -95,22 +96,13 @@ namespace Altinn.App.Core.Infrastructure.Clients.Storage
         /// <inheritdoc />
         public async Task<List<Instance>> GetInstances(Dictionary<string, StringValues> queryParams)
         {
-            StringBuilder apiUrl = new($"instances?");
-
-            foreach (var queryParameter in queryParams)
-            {
-                foreach (string? value in queryParameter.Value)
-                {
-                    // TODO: remember to escape the value here
-                    apiUrl.Append($"&{queryParameter.Key}={value}");
-                }
-            }
+            var apiUrl = QueryHelpers.AddQueryString("instances", queryParams);
 
             string token = JwtTokenUtil.GetTokenFromContext(
                 _httpContextAccessor.HttpContext,
                 _settings.RuntimeCookieName
             );
-            QueryResponse<Instance> queryResponse = await QueryInstances(token, apiUrl.ToString());
+            QueryResponse<Instance> queryResponse = await QueryInstances(token, apiUrl);
 
             if (queryResponse.Count == 0)
             {

--- a/test/Altinn.App.Core.Tests/Implementation/InstanceClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/InstanceClientTests.cs
@@ -437,7 +437,7 @@ namespace Altinn.App.PlatformServices.Tests.Implementation
                     Count = 1,
                     Instances = new List<Instance> { new Instance { Id = $"{1337}/{Guid.NewGuid()}" } },
                     Next =
-                        "https://platform.altinn.no/storage/api/instances?&appId=ttd/apps-test&instanceOwner.partyId=1337&status.isArchived=false&status.isSoftDeleted=false&continuationtoken=abcd"
+                        "https://platform.altinn.no/storage/api/instances?appId=ttd%2Fapps-test&instanceOwner.partyId=1337&status.isArchived=false&status.isSoftDeleted=false&continuationtoken=abcd"
                 };
 
             QueryResponse<Instance> queryResponse2 =
@@ -448,9 +448,9 @@ namespace Altinn.App.PlatformServices.Tests.Implementation
                 };
 
             string urlPart1 =
-                "instances?&appId=ttd/apps-test&instanceOwner.partyId=1337&status.isArchived=false&status.isSoftDeleted=false";
+                "instances?appId=ttd%2Fapps-test&instanceOwner.partyId=1337&status.isArchived=false&status.isSoftDeleted=false";
             string urlPart2 =
-                "https://platform.altinn.no/storage/api/instances?&appId=ttd/apps-test&instanceOwner.partyId=1337&status.isArchived=false&status.isSoftDeleted=false&continuationtoken=abcd";
+                "https://platform.altinn.no/storage/api/instances?appId=ttd%2Fapps-test&instanceOwner.partyId=1337&status.isArchived=false&status.isSoftDeleted=false&continuationtoken=abcd";
 
             HttpResponseMessage httpResponseMessage1 = new HttpResponseMessage
             {


### PR DESCRIPTION
## Description
`InstanceClient.GetInstances` did not ensure URL encoding of input query parameters when building the query string passed onto Storage API. This PR encodes the parameters using ASP.NET Core `QueryHelpers`

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
