### PR TITLE
Refactor to remove null-forgiving operator related to `AltinnPaymentConfiguration.PaymentDataType`

### DIFF
--- a/src/Altinn.App.Api/Controllers/PaymentController.cs
+++ b/src/Altinn.App.Api/Controllers/PaymentController.cs
@@ -29,15 +29,15 @@ public class PaymentController : ControllerBase
     /// Initializes a new instance of the <see cref="PaymentController"/> class.
     /// </summary>
     public PaymentController(
+        IServiceProvider serviceProvider,
         IInstanceClient instanceClient,
         IProcessReader processReader,
-        IPaymentService paymentService,
         IOrderDetailsCalculator? orderDetailsCalculator = null
     )
     {
         _instanceClient = instanceClient;
         _processReader = processReader;
-        _paymentService = paymentService;
+        _paymentService = serviceProvider.GetRequiredService<IPaymentService>();
         _orderDetailsCalculator = orderDetailsCalculator;
     }
 
@@ -71,9 +71,11 @@ public class PaymentController : ControllerBase
             throw new PaymentException("Payment configuration not found in AltinnTaskExtension");
         }
 
+        var validPaymentConfiguration = paymentConfiguration.Validate();
+
         PaymentInformation paymentInformation = await _paymentService.CheckAndStorePaymentStatus(
             instance,
-            paymentConfiguration,
+            validPaymentConfiguration,
             language
         );
 

--- a/src/Altinn.App.Core/Features/Action/PaymentUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/PaymentUserAction.cs
@@ -68,7 +68,7 @@ namespace Altinn.App.Core.Features.Action
 
             (PaymentInformation paymentInformation, bool alreadyPaid) = await _paymentService.StartPayment(
                 context.Instance,
-                paymentConfiguration,
+                paymentConfiguration.Validate(),
                 context.Language
             );
 

--- a/src/Altinn.App.Core/Features/Payment/Services/IPaymentService.cs
+++ b/src/Altinn.App.Core/Features/Payment/Services/IPaymentService.cs
@@ -7,14 +7,14 @@ namespace Altinn.App.Core.Features.Payment.Services
     /// <summary>
     /// Service for handling payment.
     /// </summary>
-    public interface IPaymentService
+    internal interface IPaymentService
     {
         /// <summary>
         /// Start payment for an instance. Will clean up any existing non-completed payment before starting a new payment.
         /// </summary>
         Task<(PaymentInformation paymentInformation, bool alreadyPaid)> StartPayment(
             Instance instance,
-            AltinnPaymentConfiguration paymentConfiguration,
+            ValidAltinnPaymentConfiguration paymentConfiguration,
             string? language
         );
 
@@ -23,18 +23,18 @@ namespace Altinn.App.Core.Features.Payment.Services
         /// </summary>
         Task<PaymentInformation> CheckAndStorePaymentStatus(
             Instance instance,
-            AltinnPaymentConfiguration paymentConfiguration,
+            ValidAltinnPaymentConfiguration paymentConfiguration,
             string? language
         );
 
         /// <summary>
         /// Check our internal state to see if payment is complete.
         /// </summary>
-        Task<bool> IsPaymentCompleted(Instance instance, AltinnPaymentConfiguration paymentConfiguration);
+        Task<bool> IsPaymentCompleted(Instance instance, ValidAltinnPaymentConfiguration paymentConfiguration);
 
         /// <summary>
         /// Cancel payment with payment processor and delete internal payment information.
         /// </summary>
-        Task CancelAndDeleteAnyExistingPayment(Instance instance, AltinnPaymentConfiguration paymentConfiguration);
+        Task CancelAndDeleteAnyExistingPayment(Instance instance, ValidAltinnPaymentConfiguration paymentConfiguration);
     }
 }

--- a/src/Altinn.App.Core/Features/Payment/Services/PaymentService.cs
+++ b/src/Altinn.App.Core/Features/Payment/Services/PaymentService.cs
@@ -38,7 +38,7 @@ internal class PaymentService : IPaymentService
     /// <inheritdoc/>
     public async Task<(PaymentInformation paymentInformation, bool alreadyPaid)> StartPayment(
         Instance instance,
-        AltinnPaymentConfiguration paymentConfiguration,
+        ValidAltinnPaymentConfiguration paymentConfiguration,
         string? language
     )
     {
@@ -51,8 +51,7 @@ internal class PaymentService : IPaymentService
             );
         }
 
-        var validPaymentConfiguration = paymentConfiguration.Validate();
-        string dataTypeId = validPaymentConfiguration.PaymentDataType;
+        string dataTypeId = paymentConfiguration.PaymentDataType;
 
         (Guid dataElementId, PaymentInformation? existingPaymentInformation) =
             await _dataService.GetByType<PaymentInformation>(instance, dataTypeId);
@@ -116,7 +115,7 @@ internal class PaymentService : IPaymentService
     /// <inheritdoc/>
     public async Task<PaymentInformation> CheckAndStorePaymentStatus(
         Instance instance,
-        AltinnPaymentConfiguration paymentConfiguration,
+        ValidAltinnPaymentConfiguration paymentConfiguration,
         string? language
     )
     {
@@ -129,9 +128,7 @@ internal class PaymentService : IPaymentService
             );
         }
 
-        var validPaymentConfiguration = paymentConfiguration.Validate();
-
-        string dataTypeId = validPaymentConfiguration.PaymentDataType;
+        string dataTypeId = paymentConfiguration.PaymentDataType;
         (Guid dataElementId, PaymentInformation? paymentInformation) = await _dataService.GetByType<PaymentInformation>(
             instance,
             dataTypeId
@@ -201,11 +198,9 @@ internal class PaymentService : IPaymentService
     }
 
     /// <inheritdoc/>
-    public async Task<bool> IsPaymentCompleted(Instance instance, AltinnPaymentConfiguration paymentConfiguration)
+    public async Task<bool> IsPaymentCompleted(Instance instance, ValidAltinnPaymentConfiguration paymentConfiguration)
     {
-        var validPaymentConfiguration = paymentConfiguration.Validate();
-
-        string dataTypeId = validPaymentConfiguration.PaymentDataType;
+        string dataTypeId = paymentConfiguration.PaymentDataType;
         (Guid _, PaymentInformation? paymentInformation) = await _dataService.GetByType<PaymentInformation>(
             instance,
             dataTypeId
@@ -222,12 +217,10 @@ internal class PaymentService : IPaymentService
     /// <inheritdoc/>
     public async Task CancelAndDeleteAnyExistingPayment(
         Instance instance,
-        AltinnPaymentConfiguration paymentConfiguration
+        ValidAltinnPaymentConfiguration paymentConfiguration
     )
     {
-        var validPaymentConfiguration = paymentConfiguration.Validate();
-
-        string dataTypeId = validPaymentConfiguration.PaymentDataType;
+        string dataTypeId = paymentConfiguration.PaymentDataType;
         (Guid dataElementId, PaymentInformation? paymentInformation) = await _dataService.GetByType<PaymentInformation>(
             instance,
             dataTypeId

--- a/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnPaymentConfiguration.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnPaymentConfiguration.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Xml.Serialization;
+using Altinn.App.Core.Internal.App;
 
 namespace Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties
 {
@@ -12,5 +14,45 @@ namespace Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties
         /// </summary>
         [XmlElement("paymentDataType", Namespace = "http://altinn.no/process")]
         public string? PaymentDataType { get; set; }
+
+        internal ValidAltinnPaymentConfiguration Validate()
+        {
+            List<string>? errorMessages = null;
+
+            var paymentDataType = PaymentDataType;
+
+            if (paymentDataType.IsNullOrWhitespace(ref errorMessages, "PaymentDataType is missing."))
+                ThrowApplicationConfigException(errorMessages);
+
+            return new ValidAltinnPaymentConfiguration(paymentDataType);
+        }
+
+        [DoesNotReturn]
+        private static void ThrowApplicationConfigException(List<string> errorMessages)
+        {
+            throw new ApplicationConfigException(
+                "Payment process task configuration is not valid: " + string.Join(",\n", errorMessages)
+            );
+        }
+    }
+
+    internal readonly record struct ValidAltinnPaymentConfiguration(string PaymentDataType);
+
+    file static class ValidationExtensions
+    {
+        internal static bool IsNullOrWhitespace(
+            [NotNullWhen(false)] this string? value,
+            [NotNullWhen(true)] ref List<string>? errors,
+            string error
+        )
+        {
+            var result = string.IsNullOrWhiteSpace(value);
+            if (result)
+            {
+                errors ??= new List<string>(1);
+                errors.Add(error);
+            }
+            return result;
+        }
     }
 }

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/PaymentProcessTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/PaymentProcessTask.cs
@@ -44,7 +44,7 @@ namespace Altinn.App.Core.Internal.Process.ProcessTasks
         public async Task Start(string taskId, Instance instance)
         {
             AltinnPaymentConfiguration paymentConfiguration = GetAltinnPaymentConfiguration(taskId);
-            await _paymentService.CancelAndDeleteAnyExistingPayment(instance, paymentConfiguration);
+            await _paymentService.CancelAndDeleteAnyExistingPayment(instance, paymentConfiguration.Validate());
         }
 
         /// <inheritdoc/>
@@ -52,7 +52,7 @@ namespace Altinn.App.Core.Internal.Process.ProcessTasks
         {
             AltinnPaymentConfiguration paymentConfiguration = GetAltinnPaymentConfiguration(taskId);
 
-            if (!await _paymentService.IsPaymentCompleted(instance, paymentConfiguration))
+            if (!await _paymentService.IsPaymentCompleted(instance, paymentConfiguration.Validate()))
                 throw new PaymentException("The payment is not completed.");
 
             Stream pdfStream = await _pdfService.GeneratePdf(instance, taskId, CancellationToken.None);
@@ -73,7 +73,7 @@ namespace Altinn.App.Core.Internal.Process.ProcessTasks
         public async Task Abandon(string taskId, Instance instance)
         {
             AltinnPaymentConfiguration paymentConfiguration = GetAltinnPaymentConfiguration(taskId);
-            await _paymentService.CancelAndDeleteAnyExistingPayment(instance, paymentConfiguration);
+            await _paymentService.CancelAndDeleteAnyExistingPayment(instance, paymentConfiguration.Validate());
         }
 
         private AltinnPaymentConfiguration GetAltinnPaymentConfiguration(string taskId)

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/PaymentProcessTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/PaymentProcessTask.cs
@@ -57,12 +57,11 @@ namespace Altinn.App.Core.Internal.Process.ProcessTasks
 
             Stream pdfStream = await _pdfService.GeneratePdf(instance, taskId, CancellationToken.None);
 
-            // ! TODO: restructure code to avoid assertion. Codepaths above have already validated this field
-            var paymentDataType = paymentConfiguration.PaymentDataType!;
+            var validatedPaymentConfiguration = paymentConfiguration.Validate();
 
             await _dataClient.InsertBinaryData(
                 instance.Id,
-                paymentDataType,
+                validatedPaymentConfiguration.PaymentDataType,
                 PdfContentType,
                 ReceiptFileName,
                 pdfStream,
@@ -90,12 +89,7 @@ namespace Altinn.App.Core.Internal.Process.ProcessTasks
                 );
             }
 
-            if (string.IsNullOrWhiteSpace(paymentConfiguration.PaymentDataType))
-            {
-                throw new ApplicationConfigException(
-                    "PaymentDataType is missing in the payment process task configuration."
-                );
-            }
+            _ = paymentConfiguration.Validate();
 
             return paymentConfiguration;
         }

--- a/test/Altinn.App.Core.Tests/Features/Action/PaymentUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/PaymentUserActionTests.cs
@@ -55,7 +55,7 @@ public class PaymentUserActionTests
 
         _paymentServiceMock
             .Setup(x =>
-                x.StartPayment(It.IsAny<Instance>(), It.IsAny<AltinnPaymentConfiguration>(), It.IsAny<string>())
+                x.StartPayment(It.IsAny<Instance>(), It.IsAny<ValidAltinnPaymentConfiguration>(), It.IsAny<string>())
             )
             .ReturnsAsync((paymentInformation, false));
 
@@ -94,7 +94,7 @@ public class PaymentUserActionTests
 
         _paymentServiceMock
             .Setup(x =>
-                x.StartPayment(It.IsAny<Instance>(), It.IsAny<AltinnPaymentConfiguration>(), It.IsAny<string>())
+                x.StartPayment(It.IsAny<Instance>(), It.IsAny<ValidAltinnPaymentConfiguration>(), It.IsAny<string>())
             )
             .ReturnsAsync((paymentInformation, false));
 
@@ -131,7 +131,7 @@ public class PaymentUserActionTests
 
         _paymentServiceMock
             .Setup(x =>
-                x.StartPayment(It.IsAny<Instance>(), It.IsAny<AltinnPaymentConfiguration>(), It.IsAny<string>())
+                x.StartPayment(It.IsAny<Instance>(), It.IsAny<ValidAltinnPaymentConfiguration>(), It.IsAny<string>())
             )
             .ReturnsAsync((paymentInformation, true));
 

--- a/test/Altinn.App.Core.Tests/Features/Payment/AltinnPaymentConfigurationTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Payment/AltinnPaymentConfigurationTests.cs
@@ -1,0 +1,32 @@
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
+using FluentAssertions;
+
+namespace Altinn.App.Core.Tests.Features.Payment;
+
+public class AltinnPaymentConfigurationTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Validation_ThrowsException_When_PaymentDataType_Is_Invalid(string? paymentDataType)
+    {
+        AltinnPaymentConfiguration paymentConfiguration = new() { PaymentDataType = paymentDataType };
+
+        var action = () => paymentConfiguration.Validate();
+
+        action.Should().Throw<ApplicationConfigException>();
+    }
+
+    [Fact]
+    public void Validation_Succeeds()
+    {
+        var paymentDataType = "paymentDataType";
+        AltinnPaymentConfiguration paymentConfiguration = new() { PaymentDataType = paymentDataType };
+        paymentConfiguration.PaymentDataType.Should().Be(paymentDataType);
+
+        var validPaymentConfiguration = paymentConfiguration.Validate();
+        validPaymentConfiguration.PaymentDataType.Should().Be(paymentDataType);
+    }
+}

--- a/test/Altinn.App.Core.Tests/Features/Payment/PaymentServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Payment/PaymentServiceTests.cs
@@ -10,7 +10,6 @@ using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 
 namespace Altinn.App.Core.Tests.Features.Payment;
 

--- a/test/Altinn.App.Core.Tests/Features/Payment/PaymentServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Payment/PaymentServiceTests.cs
@@ -36,7 +36,7 @@ public class PaymentServiceTests
     {
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         PaymentInformation paymentInformation = CreatePaymentInformation();
         PaymentDetails paymentDetails =
             paymentInformation.PaymentDetails ?? throw new NullReferenceException("PaymentDetails should not be null");
@@ -87,7 +87,7 @@ public class PaymentServiceTests
     {
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         const string language = "nb";
 
         _paymentProcessor.Setup(pp => pp.PaymentProcessorId).Returns(orderDetails.PaymentProcessorId);
@@ -123,7 +123,7 @@ public class PaymentServiceTests
     public async Task StartPayment_ThrowsException_WhenOrderDetailsCannotBeRetrieved()
     {
         Instance instance = CreateInstance();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         const string language = "nb";
 
         _dataService
@@ -147,7 +147,7 @@ public class PaymentServiceTests
     {
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         const string language = "nb";
 
         _dataService
@@ -169,7 +169,7 @@ public class PaymentServiceTests
     {
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         PaymentInformation paymentInformation = CreatePaymentInformation();
         PaymentDetails paymentDetails =
             paymentInformation.PaymentDetails ?? throw new NullReferenceException("PaymentDetails should not be null");
@@ -196,7 +196,7 @@ public class PaymentServiceTests
     {
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         const string language = "nb";
 
         _orderDetailsCalculator.Setup(p => p.CalculateOrderDetails(instance, language)).ReturnsAsync(orderDetails);
@@ -224,7 +224,7 @@ public class PaymentServiceTests
     {
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         PaymentInformation paymentInformation = CreatePaymentInformation();
         const string language = "nb";
 
@@ -258,7 +258,7 @@ public class PaymentServiceTests
     {
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         PaymentInformation paymentInformation = CreatePaymentInformation();
         const string language = "nb";
 
@@ -312,7 +312,7 @@ public class PaymentServiceTests
     {
         // Arrange
         Instance instance = CreateInstance();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         OrderDetails orderDetails = CreateOrderDetails();
         PaymentInformation paymentInformation = CreatePaymentInformation();
         PaymentDetails paymentDetails =
@@ -364,7 +364,7 @@ public class PaymentServiceTests
         // Arrange
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         PaymentInformation paymentInformation = CreatePaymentInformation();
         PaymentDetails paymentDetails =
             paymentInformation.PaymentDetails ?? throw new NullReferenceException("PaymentDetails should not be null");
@@ -402,7 +402,7 @@ public class PaymentServiceTests
     {
         // Arrange
         Instance instance = CreateInstance();
-        AltinnPaymentConfiguration paymentConfiguration = new() { PaymentDataType = "paymentDataType" };
+        ValidAltinnPaymentConfiguration paymentConfiguration = new() { PaymentDataType = "paymentDataType" };
 
         IPaymentProcessor[] paymentProcessors = []; //No payment processor added.
         var paymentService = new PaymentService(paymentProcessors, _dataService.Object, _logger.Object);
@@ -429,7 +429,7 @@ public class PaymentServiceTests
 
         // Act
         Func<Task> act = async () =>
-            await paymentService.CheckAndStorePaymentStatus(instance, paymentConfiguration, "en");
+            await paymentService.CheckAndStorePaymentStatus(instance, paymentConfiguration.Validate(), "en");
 
         // Assert
         await act.Should()
@@ -444,7 +444,7 @@ public class PaymentServiceTests
     {
         // Arrange
         Instance instance = CreateInstance();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
 
         string paymentDataType =
             paymentConfiguration.PaymentDataType
@@ -466,7 +466,7 @@ public class PaymentServiceTests
     {
         // Arrange
         Instance instance = CreateInstance();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         PaymentInformation paymentInformation = CreatePaymentInformation();
         paymentInformation.Status = PaymentStatus.Paid;
 
@@ -490,7 +490,7 @@ public class PaymentServiceTests
     {
         // Arrange
         Instance instance = CreateInstance();
-        AltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
+        ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         PaymentInformation paymentInformation = CreatePaymentInformation();
 
         string paymentDataType =
@@ -558,8 +558,8 @@ public class PaymentServiceTests
         };
     }
 
-    private static AltinnPaymentConfiguration CreatePaymentConfiguration()
+    private static ValidAltinnPaymentConfiguration CreatePaymentConfiguration()
     {
-        return new AltinnPaymentConfiguration { PaymentDataType = "paymentInformation" };
+        return new AltinnPaymentConfiguration { PaymentDataType = "paymentInformation" }.Validate();
     }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/PaymentProcessTaskTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/PaymentProcessTaskTests.cs
@@ -56,7 +56,7 @@ public class PaymentProcessTaskTests
 
             // Assert
             _paymentServiceMock.Verify(x =>
-                x.CancelAndDeleteAnyExistingPayment(instance, altinnTaskExtension.PaymentConfiguration)
+                x.CancelAndDeleteAnyExistingPayment(instance, altinnTaskExtension.PaymentConfiguration.Validate())
             );
         }
 
@@ -74,7 +74,7 @@ public class PaymentProcessTaskTests
             _processReaderMock.Setup(x => x.GetAltinnTaskExtension(It.IsAny<string>())).Returns(altinnTaskExtension);
 
             _paymentServiceMock
-                .Setup(x => x.IsPaymentCompleted(It.IsAny<Instance>(), It.IsAny<AltinnPaymentConfiguration>()))
+                .Setup(x => x.IsPaymentCompleted(It.IsAny<Instance>(), It.IsAny<ValidAltinnPaymentConfiguration>()))
                 .ReturnsAsync(true);
 
             // Act
@@ -108,7 +108,7 @@ public class PaymentProcessTaskTests
             _processReaderMock.Setup(x => x.GetAltinnTaskExtension(It.IsAny<string>())).Returns(altinnTaskExtension);
 
             _paymentServiceMock
-                .Setup(x => x.IsPaymentCompleted(It.IsAny<Instance>(), It.IsAny<AltinnPaymentConfiguration>()))
+                .Setup(x => x.IsPaymentCompleted(It.IsAny<Instance>(), It.IsAny<ValidAltinnPaymentConfiguration>()))
                 .ReturnsAsync(false);
 
             // Act and assert
@@ -147,7 +147,7 @@ public class PaymentProcessTaskTests
 
             // Assert
             _paymentServiceMock.Verify(x =>
-                x.CancelAndDeleteAnyExistingPayment(instance, altinnTaskExtension.PaymentConfiguration)
+                x.CancelAndDeleteAnyExistingPayment(instance, altinnTaskExtension.PaymentConfiguration.Validate())
             );
         }
 
@@ -193,7 +193,7 @@ public class PaymentProcessTaskTests
                 );
 
             _paymentServiceMock
-                .Setup(ps => ps.IsPaymentCompleted(It.IsAny<Instance>(), It.IsAny<AltinnPaymentConfiguration>()))
+                .Setup(ps => ps.IsPaymentCompleted(It.IsAny<Instance>(), It.IsAny<ValidAltinnPaymentConfiguration>()))
                 .ReturnsAsync(true);
 
             using var memoryStream = new MemoryStream();


### PR DESCRIPTION
## Description
While rebasing #636 based on the new payment stuff I noticed an opportunity to restructure some things around `AltinnPaymentConfiguration` so that we

* Don't have the same validation logic several places
* Express the validated state in a type `ValidAltinnPaymentConfiguration`

which in the end let's us remove the null-forgiving operator where `AltinnPaymentConfiguration.PaymentDataType` is used

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
