### PR TITLE
Ignore warning during pack due to Azure.Monitor prerelease dep

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0-beta.1" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0-beta.1" NoWarn="NU5104" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Altinn.App.Core\Altinn.App.Core.csproj" />


### PR DESCRIPTION
## Description
8.2 release failed due to NuGet pack target failing with a warning (treated as error) that we have a prerelease dep on Azure Monitor OTLP exporter

https://github.com/Altinn/app-lib-dotnet/actions/runs/9253080701/job/25452043812#step:6:221

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
