### PR TITLE
Fix issue where datamodel decimal properties are stored with greater precision than is supported by frontend

### DIFF
--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -148,6 +148,18 @@ public static class ObjectUtils
                 PrepareModelForXmlStorage(value, depth - 1);
 
                 SetToDefaultIfShouldSerializeFalse(model, prop, methodInfos);
+
+                if (value is decimal decimalValue)
+                {
+                    // This will make sure we only store double precision values in the database
+                    // since frontend/JS doesn't have anything else than 64bit numbers,
+                    // this will make sure that what we store is also what the frontend sees.
+                    var doublePrecisionValue = (decimal)(double)decimalValue;
+                    if (doublePrecisionValue != decimalValue)
+                    {
+                        prop.SetValue(model, doublePrecisionValue);
+                    }
+                }
             }
         }
     }

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -857,7 +857,7 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
     }
 
     [Fact]
-    public async Task Decimals()
+    public async Task Decimals_Which_Lose_Precision_In_Frontend_Work_For_Subsequent_Patches()
     {
         const decimal number = 2.2556390977443609022556390977m;
         // To simulate what happens in frontend - there is only 64bits
@@ -876,13 +876,11 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
             .Returns(
                 (Instance instance, Guid? dataGuid, object data, object? existingData, string language) =>
                 {
-                    if (data is Skjema skjema)
-                    {
-                        Assert.NotNull(skjema.Melding?.TagWithAttribute);
-                        var attr = skjema.Melding.TagWithAttribute;
-                        if (attr.orid is 0 or 34730)
-                            attr.orid = number;
-                    }
+                    var skjema = data.Should().BeOfType<Skjema>().Which;
+                    var attr = skjema.Melding?.TagWithAttribute;
+                    Assert.NotNull(attr);
+                    if (attr.orid is 0 or 34730)
+                        attr.orid = number;
                     return Task.CompletedTask;
                 }
             );


### PR DESCRIPTION
## Description
Suggested fix for resolving issues around decimal precisions across systems

A datamodel generated by Studio might look like this:
![image](https://github.com/Altinn/app-lib-dotnet/assets/5425986/6097a256-91de-42ac-a48a-568d9433a68f)

In some cases, apps have calculated fields that are decimal, which can lead to a lot of precision being used.
When this data is stored, all 128bits of `decimal` precision come with, but the frontend which lives in JS land
will only have 64bit numbers. So when data is posted back (for whatever reason, maybe they shouldn't in this scenario), the `test` JSON patch operation will fail because the field has higher precision coming from storage than it has from the client request.

Alternatives
* Keep storing 128bit precision, but make JSON patch more tolerant instead (comparison based on double precision)
* Don't allow decimal properties in datamodels
* ???

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/2066

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
