### PR TITLE
Remove `Scrutor` as dependency, refactor `ProfileClient`

### DIFF
--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Scrutor" Version="4.2.2" />
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta09" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.8.1" />
   </ItemGroup>

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -40,7 +40,6 @@ using Altinn.App.Core.Internal.Process.EventHandlers;
 using Altinn.App.Core.Internal.Process.EventHandlers.ProcessTask;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.App.Core.Internal.Process.ServiceTasks;
-using Altinn.App.Core.Internal.Profile;
 using Altinn.App.Core.Internal.Registers;
 using Altinn.App.Core.Internal.Secrets;
 using Altinn.App.Core.Internal.Sign;
@@ -97,8 +96,7 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient<IInstanceClient, InstanceClient>();
         services.AddHttpClient<IInstanceEventClient, InstanceEventClient>();
         services.AddHttpClient<IEventsClient, EventsClient>();
-        services.AddHttpClient<IProfileClient, ProfileClient>();
-        services.Decorate<IProfileClient, ProfileClientCachingDecorator>();
+        services.AddProfileClient();
         services.AddHttpClient<IAltinnPartyClient, AltinnPartyClient>();
 #pragma warning disable CS0618 // Type or member is obsolete
         services.AddHttpClient<IText, TextClient>();

--- a/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
@@ -11,10 +11,25 @@ using Altinn.Common.AccessTokenClient.Services;
 using Altinn.Platform.Profile.Models;
 using AltinnCore.Authentication.Utils;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Altinn.App.Core.Infrastructure.Clients.Profile;
+
+internal static class ProfileClientDI
+{
+    public static IServiceCollection AddProfileClient(this IServiceCollection services)
+    {
+        services.AddTransient<IProfileClient>(sp => new ProfileClientCachingDecorator(
+            ActivatorUtilities.CreateInstance<ProfileClient>(sp),
+            sp.GetRequiredService<IMemoryCache>(),
+            sp.GetRequiredService<IOptions<CacheSettings>>()
+        ));
+        return services;
+    }
+}
 
 /// <summary>
 /// A client for retrieving profiles from Altinn Platform.

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Profile/ProfileClientTests.Returns_Test_Profile.verified.txt
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Profile/ProfileClientTests.Returns_Test_Profile.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Activities: [
+    {
+      ActivityName: ProfileClient.GetUserProfile,
+      Tags: [
+        {
+          user.id: 1234
+        }
+      ],
+      IdFormat: W3C
+    }
+  ],
+  Metrics: []
+}

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Profile/ProfileClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Profile/ProfileClientTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Text.Json;
+using Altinn.App.Common.Tests;
+using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Infrastructure.Clients.Profile;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Profile;
+using Altinn.App.Core.Models;
+using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+
+namespace Altinn.App.Core.Tests.Infrastructure.Clients.Profile;
+
+public class ProfileClientTests
+{
+    private readonly record struct Fixture(ServiceProvider ServiceProvider, Mock<HttpMessageHandler> Handler)
+        : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ServiceProvider.DisposeAsync();
+    }
+
+    private Fixture BuildFixture(Func<UserProfile?>? userProfileFactory = null)
+    {
+        var services = new ServiceCollection();
+
+        userProfileFactory ??= () => new UserProfile { UserId = 1234, };
+
+        var httpContextMock = new Mock<HttpContext>();
+        httpContextMock.Setup(x => x.Request.Cookies["AltinnStudioRuntime"]).Returns("");
+        var httpContextAccessor = new Mock<IHttpContextAccessor>();
+        httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContextMock.Object);
+        httpContextAccessor.Setup(x => x.HttpContext!.Request!.Headers["Authorization"]).Returns("Bearer token");
+        services.AddSingleton(httpContextAccessor.Object);
+
+        var appMetadataMock = new Mock<IAppMetadata>();
+        ApplicationMetadata appMetadata =
+            new("ttd/test")
+            {
+                DataTypes = new List<DataType>()
+                {
+                    new DataType()
+                    {
+                        Id = "test",
+                        TaskId = "Task_1",
+                        EnableFileScan = false,
+                        ValidationErrorOnPendingFileScan = false,
+                    }
+                }
+            };
+        appMetadataMock.Setup(am => am.GetApplicationMetadata()).ReturnsAsync(appMetadata);
+        services.AddSingleton(appMetadataMock.Object);
+
+        var tokenGenerator = new Mock<IAccessTokenGenerator>();
+        tokenGenerator.Setup(t => t.GenerateAccessToken("ttd", "test")).Returns("access-token");
+        services.AddSingleton(tokenGenerator.Object);
+
+        services.AddTelemetrySink();
+        services.AddSingleton<ILogger<ProfileClient>>(NullLogger<ProfileClient>.Instance);
+        services.Configure<PlatformSettings>(_ => { });
+        services.Configure<AppSettings>(o => o.RuntimeCookieName = "AltinnStudioRuntime");
+        services.Configure<CacheSettings>(o => o.ProfileCacheLifetimeSeconds = 1);
+
+        var handler = new Mock<HttpMessageHandler>();
+        handler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() =>
+            {
+                var profile = userProfileFactory();
+                return new HttpResponseMessage
+                {
+                    StatusCode = profile is null ? HttpStatusCode.NotFound : HttpStatusCode.OK,
+                    Content = new StringContent(JsonSerializer.Serialize(profile))
+                };
+            })
+            .Verifiable();
+        var httpClient = new HttpClient(handler.Object);
+        services.AddMemoryCache();
+        services.AddSingleton(_ => httpClient);
+        services.AddProfileClient();
+        return new(services.BuildServiceProvider(), handler);
+    }
+
+    [Fact]
+    public async Task Builds_From_DI_Container()
+    {
+        await using var fixture = BuildFixture();
+
+        var client = fixture.ServiceProvider.GetRequiredService<IProfileClient>();
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public async Task Returns_Test_Profile()
+    {
+        const int userId = 1234;
+        TelemetrySink telemetry;
+        {
+            await using var fixture = BuildFixture(() => new UserProfile { UserId = userId, });
+            telemetry = fixture.ServiceProvider.GetRequiredService<TelemetrySink>();
+
+            var client = fixture.ServiceProvider.GetRequiredService<IProfileClient>();
+
+            var profile = await client.GetUserProfile(userId);
+            Assert.NotNull(profile);
+            Assert.Equal(userId, profile.UserId);
+        }
+
+        await Verify(telemetry.GetSnapshot());
+    }
+
+    [Fact]
+    public async Task Returns_Test_Profile_Cached()
+    {
+        const int userId = 1234;
+        await using var fixture = BuildFixture(() => new UserProfile { UserId = userId, });
+
+        var client1 = fixture.ServiceProvider.GetRequiredService<IProfileClient>();
+        var client2 = fixture.ServiceProvider.GetRequiredService<IProfileClient>();
+        Assert.NotSame(client1, client2);
+
+        var profile1 = await client1.GetUserProfile(userId);
+        var profile2 = await client2.GetUserProfile(userId);
+        Assert.Same(profile1, profile2);
+        fixture
+            .Handler.Protected()
+            .Verify("SendAsync", Times.Once(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Cache_Expires()
+    {
+        const int userId = 1234;
+        await using var fixture = BuildFixture(() => new UserProfile { UserId = userId, });
+
+        var client = fixture.ServiceProvider.GetRequiredService<IProfileClient>();
+        var cacheExpirySeconds = fixture
+            .ServiceProvider.GetRequiredService<IOptions<CacheSettings>>()
+            .Value.ProfileCacheLifetimeSeconds;
+
+        var profile1 = await client.GetUserProfile(userId);
+        fixture
+            .Handler.Protected()
+            .Verify("SendAsync", Times.Once(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+
+        await Task.Delay((cacheExpirySeconds * 1000) + 50);
+
+        var profile2 = await client.GetUserProfile(userId);
+        Assert.NotSame(profile1, profile2);
+        fixture
+            .Handler.Protected()
+            .Verify(
+                "SendAsync",
+                Times.Exactly(2),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task Retries_On_Previous_Null()
+    {
+        const int userId = 1234;
+        await using var fixture = BuildFixture(() => null);
+
+        var client = fixture.ServiceProvider.GetRequiredService<IProfileClient>();
+
+        var profile1 = await client.GetUserProfile(userId);
+        var profile2 = await client.GetUserProfile(userId);
+        Assert.Null(profile1);
+        Assert.Null(profile2);
+        fixture
+            .Handler.Protected()
+            .Verify(
+                "SendAsync",
+                Times.Exactly(2),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            );
+    }
+}


### PR DESCRIPTION
## Description
In #589 we migrated the protobuf-net metrics that were used in service decorators to use `System.Diagnostics` stuff in `Telemetry`. So now there was only cache decorator for `ProfileClient` left. This PR moves caching inside the client and removed the package dep

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
