### PR TITLE
Ignore _MS.ProcessedByMetricExtractors for telemetry snapshots

### DIFF
--- a/test/Altinn.App.Common.Tests/TelemetrySink.cs
+++ b/test/Altinn.App.Common.Tests/TelemetrySink.cs
@@ -201,7 +201,10 @@ public class TelemetrySnapshot(
     public readonly IEnumerable<object>? Activities = activities?.Select(a => new
     {
         ActivityName = a.DisplayName,
-        Tags = a.TagObjects.Select(tag => new KeyValuePair<string, string?>(tag.Key, tag.Value?.ToString())),
+        Tags = a
+            .TagObjects.Select(tag => new KeyValuePair<string, string?>(tag.Key, tag.Value?.ToString()))
+            .Where(tag => tag.Key != "_MS.ProcessedByMetricExtractors")
+            .ToList(),
         a.IdFormat,
         a.Status,
         a.Events,


### PR DESCRIPTION
This tag seems to be added when I run the tests in rider, and it causes the TelemetryEnrichingMiddlewareTests tests to fail.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #589 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
