### PR TITLE
Add test for empty dataTypesToSign failure case, fix others

### DIFF
--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -72,7 +72,7 @@ public class SigningUserAction : IUserAction
             var dataTypeIds =
                 currentTask.ExtensionElements?.TaskExtension?.SignatureConfiguration?.DataTypesToSign ?? [];
             var dataTypesToSign = appMetadata
-                ?.DataTypes?.Where(d => dataTypeIds.Contains(d.Id, StringComparer.OrdinalIgnoreCase))
+                .DataTypes?.Where(d => dataTypeIds.Contains(d.Id, StringComparer.OrdinalIgnoreCase))
                 .ToList();
 
             if (

--- a/test/Altinn.App.Core.Tests/Features/Action/TestData/signing-task-process-empty-datatypes-to-sign.bpmn
+++ b/test/Altinn.App.Core.Tests/Features/Action/TestData/signing-task-process-empty-datatypes-to-sign.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:altinn="http://altinn.no/process"
+                  id="Definitions_1eqx4ru" targetNamespace="http://bpmn.io/schema/bpmn"
+                  exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="10.2.0">
+  <bpmn:process id="Process_1rq9ej8" isExecutable="false">
+    <bpmn:startEvent id="StartEvent">
+      <bpmn:outgoing>Flow1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow1" sourceRef="StartEvent" targetRef="Task1"/>
+    <bpmn:task id="Task1">
+      <bpmn:incoming>Flow1</bpmn:incoming>
+      <bpmn:outgoing>Flow2</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:actions>
+            <altinn:action id="submit"/>
+          </altinn:actions>
+          <altinn:taskType>data</altinn:taskType>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow2" sourceRef="Task1" targetRef="Task2"/>
+    <bpmn:task id="Task2">
+      <bpmn:incoming>Flow2</bpmn:incoming>
+      <bpmn:outgoing>Flow3</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:actions>
+            <altinn:action id="sign"/>
+            <altinn:action id="reject"/>
+          </altinn:actions>
+          <altinn:taskType>signing</altinn:taskType>
+          <altinn:signatureConfig>
+            <altinn:dataTypesToSign />
+            <altinn:signatureDataType>signature</altinn:signatureDataType>
+          </altinn:signatureConfig>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow3" sourceRef="Task2" targetRef="EndEvent"/>
+    <bpmn:endEvent id="EndEvent">
+      <bpmn:incoming>Flow3</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

* `ApplicationMetadata` always non-null, to make sure we test the right thing
* Test for `<altinn:dataTypesToSign />` case

## Related Issue(s)
-N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
