### PR TITLE
Refactor: Case sensitive file extensions-> move comparator settings into mimetype map

### DIFF
--- a/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
+++ b/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
@@ -167,7 +167,6 @@ public static class DataRestrictionValidation
 
     internal static string GetFileTypeFromFileName(string filename)
     {
-        string[] splitFilename = filename.Split('.');
-        return splitFilename[^1].ToLower();
+        return filename.Split('.')[^1];
     }
 }

--- a/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
+++ b/src/Altinn.App.Api/Helpers/RequestHandling/DataRestrictionValidation.cs
@@ -92,7 +92,7 @@ public static class DataRestrictionValidation
             return (true, errors);
         }
 
-        string filetype = GetFileTypeFromFileName(filename);
+        string filetype = Path.GetExtension(filename);
         var mimeType = MimeTypeMap.GetMimeType(filetype);
 
         if (!request.Headers.TryGetValue("Content-Type", out StringValues contentType))
@@ -163,10 +163,5 @@ public static class DataRestrictionValidation
         filename = filename?.Trim('\"').AsFileName(false);
 
         return filename;
-    }
-
-    internal static string GetFileTypeFromFileName(string filename)
-    {
-        return filename.Split('.')[^1];
     }
 }

--- a/src/Altinn.App.Core/Helpers/MimeTypeMap.cs
+++ b/src/Altinn.App.Core/Helpers/MimeTypeMap.cs
@@ -621,7 +621,7 @@ public static class MimeTypeMap
             #endregion
         };
 
-        return mappings.ToFrozenDictionary();
+        return mappings.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
@@ -259,7 +259,7 @@ public class DataRestrictionValidationTests
     [InlineData("name.pdf", "pdf")]
     [InlineData("name.PDF", "PDF")]
     [InlineData("my.name.is.pdf", "pdf")]
-    public void GetFileTypeFromFileName_returns_lowercase_filetype(string filename, string asExpected)
+    public void GetFileTypeFromFileName_returns_case_sensitive_filetype(string filename, string asExpected)
     {
         string fileType = DataRestrictionValidation.GetFileTypeFromFileName(filename);
         fileType.Should().Be(asExpected);

--- a/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
@@ -254,14 +254,4 @@ public class DataRestrictionValidationTests
         valid.Should().BeTrue();
         errors.Should().BeEmpty();
     }
-
-    [Theory]
-    [InlineData("name.pdf", "pdf")]
-    [InlineData("name.PDF", "PDF")]
-    [InlineData("my.name.is.pdf", "pdf")]
-    public void GetFileTypeFromFileName_returns_case_sensitive_filetype(string filename, string asExpected)
-    {
-        string fileType = DataRestrictionValidation.GetFileTypeFromFileName(filename);
-        fileType.Should().Be(asExpected);
-    }
 }

--- a/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
@@ -256,13 +256,12 @@ public class DataRestrictionValidationTests
     }
 
     [Theory]
-    [InlineData("name.pdf")]
-    [InlineData("name.PDF")]
-    [InlineData("name.Pdf")]
-    [InlineData("my.name.is.pDf")]
-    public void GetFileTypeFromFileName_returns_lowercase_filetype(string filename)
+    [InlineData("name.pdf", "pdf")]
+    [InlineData("name.PDF", "PDF")]
+    [InlineData("my.name.is.pdf", "pdf")]
+    public void GetFileTypeFromFileName_returns_lowercase_filetype(string filename, string asExpected)
     {
         string fileType = DataRestrictionValidation.GetFileTypeFromFileName(filename);
-        fileType.Should().Be("pdf");
+        fileType.Should().Be(asExpected);
     }
 }

--- a/test/Altinn.App.Core.Tests/Helpers/MimeTypeMapTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/MimeTypeMapTests.cs
@@ -7,12 +7,11 @@ namespace Altinn.App.Core.Tests.Helpers;
 
 public class MimeTypeMapTests
 {
-    [Fact]
-    public void GetMimeType_ShouldReturnCorrectMimeType_for_pdf()
+    [Theory]
+    [InlineData("pdf")]
+    [InlineData("pDF")]
+    public void GetMimeType_ShouldNotBe_CaseSensitive(string extension)
     {
-        // Arrange
-        string extension = ".pdf";
-
         // Act
         var mimeType = MimeTypeMap.GetMimeType(extension);
 

--- a/test/Altinn.App.Core.Tests/Helpers/MimeTypeMapTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/MimeTypeMapTests.cs
@@ -8,8 +8,8 @@ namespace Altinn.App.Core.Tests.Helpers;
 public class MimeTypeMapTests
 {
     [Theory]
-    [InlineData("pdf")]
-    [InlineData("pDF")]
+    [InlineData(".pdf")]
+    [InlineData(".pDF")]
     public void GetMimeType_ShouldNotBe_CaseSensitive(string extension)
     {
         // Act

--- a/test/Altinn.App.Core.Tests/Helpers/MimeTypeMapTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/MimeTypeMapTests.cs
@@ -20,6 +20,19 @@ public class MimeTypeMapTests
     }
 
     [Fact]
+    public void GetMimeType_ShouldReturnCorrectMimeType_for_pdf()
+    {
+        // Arrange
+        string extension = ".pdf";
+
+        // Act
+        var mimeType = MimeTypeMap.GetMimeType(extension);
+
+        // Assert
+        mimeType.ToString().Should().BeEquivalentTo("application/pdf");
+    }
+
+    [Fact]
     public void GetMimeType_ShouldReturnCorrectMimeType_for_pdf_without_leading_dot()
     {
         // Arrange


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move the logic for toLower into the mime type map

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

