### PR TITLE
Improve dataAttributeTheoryTests so that they can run individually in Rider

### DIFF
--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -1,5 +1,3 @@
-#nullable disable
-using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -12,12 +10,12 @@ using Altinn.App.Core.Models.Layout;
 using Altinn.App.Core.Models.Validation;
 using Altinn.App.Core.Tests.Helpers;
 using Altinn.App.Core.Tests.LayoutExpressions;
+using Altinn.App.Core.Tests.TestUtils;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
-using Xunit.Sdk;
 
 namespace Altinn.App.Core.Tests.Features.Validators.Default;
 
@@ -37,7 +35,7 @@ public class ExpressionValidatorTests
         _appMetadata
             .Setup(ar => ar.GetApplicationMetadata())
             .ReturnsAsync(new ApplicationMetadata("org/app") { DataTypes = new List<DataType>() { new() { } } });
-        _appResources.Setup(ar => ar.GetLayoutSetForTask(null)).Returns(new LayoutSet());
+        _appResources.Setup(ar => ar.GetLayoutSetForTask(It.IsAny<string>())).Returns(new LayoutSet());
         _layoutInitializer = new(MockBehavior.Strict, _appResources.Object, _frontendSettings) { CallBase = false };
         _validator = new ExpressionValidator(
             _logger.Object,
@@ -47,10 +45,32 @@ public class ExpressionValidatorTests
         );
     }
 
-    [Theory]
-    [ExpressionTest]
-    public async Task RunExpressionValidationTest(ExpressionValidationTestModel testCase)
+    private static readonly JsonSerializerOptions _jsonSerializerOptions =
+        new() { ReadCommentHandling = JsonCommentHandling.Skip, PropertyNamingPolicy = JsonNamingPolicy.CamelCase, };
+
+    public ExpressionValidationTestModel LoadData(string fileName, string folder)
     {
+        var data = File.ReadAllText(Path.Join(folder, fileName));
+        return JsonSerializer.Deserialize<ExpressionValidationTestModel>(data, _jsonSerializerOptions)!;
+    }
+
+    [Theory]
+    [FileNamesInFolderData("Features/Validators/expression-validation-tests/backend")]
+    public async Task RunExpressionValidationTestsForBackend(string fileName, string folder)
+    {
+        await RunExpressionValidationTest(fileName, folder);
+    }
+
+    [Theory]
+    [FileNamesInFolderData(["Features", "Validators", "expression-validation-tests", "shared"])]
+    public async Task RunExpressionValidationTestsForShared(string fileName, string folder)
+    {
+        await RunExpressionValidationTest(fileName, folder);
+    }
+
+    private async Task RunExpressionValidationTest(string fileName, string folder)
+    {
+        var testCase = LoadData(fileName, folder);
         var instance = new Instance();
         var dataElement = new DataElement();
 
@@ -68,7 +88,7 @@ public class ExpressionValidatorTests
             )
             .ReturnsAsync(evaluatorState);
         _appResources
-            .Setup(ar => ar.GetValidationConfiguration(null))
+            .Setup(ar => ar.GetValidationConfiguration(It.IsAny<string>()))
             .Returns(JsonSerializer.Serialize(testCase.ValidationConfig));
 
         var validationIssues = await _validator.ValidateFormData(instance, dataElement, null!, null);
@@ -91,51 +111,28 @@ public class ExpressionValidatorTests
     }
 }
 
-public class ExpressionTestAttribute : DataAttribute
-{
-    private static readonly JsonSerializerOptions _jsonSerializerOptions =
-        new() { ReadCommentHandling = JsonCommentHandling.Skip, PropertyNamingPolicy = JsonNamingPolicy.CamelCase, };
-
-    public override IEnumerable<object[]> GetData(MethodInfo methodInfo)
-    {
-        var files = Directory
-            .GetFiles(Path.Join("Features", "Validators", "expression-validation-tests", "shared"))
-            .Concat(Directory.GetFiles(Path.Join("Features", "Validators", "expression-validation-tests", "backend")));
-
-        foreach (var file in files)
-        {
-            var data = File.ReadAllText(file);
-            ExpressionValidationTestModel testCase = JsonSerializer.Deserialize<ExpressionValidationTestModel>(
-                data,
-                _jsonSerializerOptions
-            )!;
-            yield return new object[] { testCase };
-        }
-    }
-}
-
 public class ExpressionValidationTestModel
 {
-    public string Name { get; set; }
+    public required string Name { get; set; }
 
-    public ExpectedObject[] Expects { get; set; }
+    public required ExpectedObject[] Expects { get; set; }
 
-    public JsonElement ValidationConfig { get; set; }
+    public required JsonElement ValidationConfig { get; set; }
 
-    public JsonObject FormData { get; set; }
+    public required JsonObject FormData { get; set; }
 
     [JsonConverter(typeof(LayoutModelConverterFromObject))]
-    public LayoutModel Layouts { get; set; }
+    public required LayoutModel Layouts { get; set; }
 
     public class ExpectedObject
     {
-        public string Message { get; set; }
+        public required string Message { get; set; }
 
         [JsonConverter(typeof(FrontendSeverityConverter))]
-        public ValidationIssueSeverity Severity { get; set; }
+        public required ValidationIssueSeverity Severity { get; set; }
 
-        public string Field { get; set; }
+        public required string Field { get; set; }
 
-        public string ComponentId { get; set; }
+        public required string ComponentId { get; set; }
     }
 }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestBackendExclusiveFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestBackendExclusiveFunctions.cs
@@ -19,7 +19,11 @@ public class TestBackendExclusiveFunctions
         _output = output;
     }
 
-    private ExpressionTestCaseRoot LoadTestCase(string testName, string folder)
+    [Theory]
+    [ExclusiveTest("gatewayAction")]
+    public void GatewayAction_Theory(string testName, string folder) => RunTestCase(testName, folder);
+
+    private static ExpressionTestCaseRoot LoadTestCase(string testName, string folder)
     {
         var file = Path.Join(folder, testName);
 
@@ -47,10 +51,6 @@ public class TestBackendExclusiveFunctions
 
         return testCase;
     }
-
-    [Theory]
-    [ExclusiveTest("gatewayAction")]
-    public void GatewayAction_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     private void RunTestCase(string testName, string folder)
     {

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
@@ -1,8 +1,10 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Tests.Helpers;
+using Altinn.App.Core.Tests.TestUtils;
 using FluentAssertions;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -21,24 +23,45 @@ public class TestContextList
         _output = output;
     }
 
+    public ContextListRoot LoadTestData(string testName, string folder)
+    {
+        ContextListRoot testCase = new();
+        var data = File.ReadAllText(Path.Join(folder, testName));
+        try
+        {
+            testCase = JsonSerializer.Deserialize<ContextListRoot>(data, _jsonSerializerOptions)!;
+        }
+        catch (Exception e)
+        {
+            testCase.ParsingException = e;
+        }
+
+        testCase.Filename = Path.GetFileName(testName);
+        testCase.FullPath = testName;
+        testCase.Folder = folder;
+        testCase.RawJson = data;
+        return testCase;
+    }
+
     [Theory]
     [SharedTestContextList("simple")]
-    public void Simple_Theory(ContextListRoot test) => RunTestCase(test);
+    public void Simple_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTestContextList("groups")]
-    public void Group_Theory(ContextListRoot test) => RunTestCase(test);
+    public void Group_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTestContextList("nonRepeatingGroups")]
-    public void NonRepeatingGroup_Theory(ContextListRoot test) => RunTestCase(test);
+    public void NonRepeatingGroup_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTestContextList("recursiveGroups")]
-    public void RecursiveGroup_Theory(ContextListRoot test) => RunTestCase(test);
+    public void RecursiveGroup_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
-    private void RunTestCase(ContextListRoot test)
+    private void RunTestCase(string filename, string folder)
     {
+        var test = LoadTestData(filename, folder);
         _output.WriteLine($"{test.Filename} in {test.Folder}");
         _output.WriteLine(test.RawJson);
         _output.WriteLine(test.FullPath);
@@ -80,42 +103,7 @@ public class TestContextList
     }
 }
 
-public class SharedTestContextListAttribute : DataAttribute
-{
-    private static readonly JsonSerializerOptions _jsonSerializerOptions =
-        new() { ReadCommentHandling = JsonCommentHandling.Skip, };
-
-    private readonly string _folder;
-
-    public SharedTestContextListAttribute(string folder)
-    {
-        _folder = folder;
-    }
-
-    public override IEnumerable<object[]> GetData(MethodInfo methodInfo)
-    {
-        var files = Directory.GetFiles(
-            Path.Join("LayoutExpressions", "CommonTests", "shared-tests", "context-lists", _folder)
-        );
-        foreach (var file in files)
-        {
-            ContextListRoot testCase = new();
-            var data = File.ReadAllText(file);
-            try
-            {
-                testCase = JsonSerializer.Deserialize<ContextListRoot>(data, _jsonSerializerOptions)!;
-            }
-            catch (Exception e)
-            {
-                testCase.ParsingException = e;
-            }
-
-            testCase.Filename = Path.GetFileName(file);
-            testCase.FullPath = file;
-            testCase.Folder = _folder;
-            testCase.RawJson = data;
-
-            yield return new object[] { testCase };
-        }
-    }
-}
+public class SharedTestContextListAttribute(string folder)
+    : FileNamesInFolderDataAttribute(
+        Path.Join("LayoutExpressions", "CommonTests", "shared-tests", "context-lists", folder)
+    ) { }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
@@ -23,7 +23,23 @@ public class TestContextList
         _output = output;
     }
 
-    public ContextListRoot LoadTestData(string testName, string folder)
+    [Theory]
+    [SharedTestContextList("simple")]
+    public void Simple_Theory(string testName, string folder) => RunTestCase(testName, folder);
+
+    [Theory]
+    [SharedTestContextList("groups")]
+    public void Group_Theory(string testName, string folder) => RunTestCase(testName, folder);
+
+    [Theory]
+    [SharedTestContextList("nonRepeatingGroups")]
+    public void NonRepeatingGroup_Theory(string testName, string folder) => RunTestCase(testName, folder);
+
+    [Theory]
+    [SharedTestContextList("recursiveGroups")]
+    public void RecursiveGroup_Theory(string testName, string folder) => RunTestCase(testName, folder);
+
+    private static ContextListRoot LoadTestData(string testName, string folder)
     {
         ContextListRoot testCase = new();
         var data = File.ReadAllText(Path.Join(folder, testName));
@@ -42,22 +58,6 @@ public class TestContextList
         testCase.RawJson = data;
         return testCase;
     }
-
-    [Theory]
-    [SharedTestContextList("simple")]
-    public void Simple_Theory(string testName, string folder) => RunTestCase(testName, folder);
-
-    [Theory]
-    [SharedTestContextList("groups")]
-    public void Group_Theory(string testName, string folder) => RunTestCase(testName, folder);
-
-    [Theory]
-    [SharedTestContextList("nonRepeatingGroups")]
-    public void NonRepeatingGroup_Theory(string testName, string folder) => RunTestCase(testName, folder);
-
-    [Theory]
-    [SharedTestContextList("recursiveGroups")]
-    public void RecursiveGroup_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     private void RunTestCase(string filename, string folder)
     {

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
@@ -19,32 +19,6 @@ public class TestFunctions
         _output = output;
     }
 
-    public ExpressionTestCaseRoot LoadTestCase(string file, string folder)
-    {
-        ExpressionTestCaseRoot testCase = new();
-        var data = File.ReadAllText(Path.Join(folder, file));
-        try
-        {
-            testCase = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(data, _jsonSerializerOptions)!;
-        }
-        catch (Exception e)
-        {
-            using var jsonDocument = JsonDocument.Parse(data);
-
-            testCase.Name = jsonDocument.RootElement.GetProperty("name").GetString();
-            testCase.ExpectsFailure = jsonDocument.RootElement.TryGetProperty("expectsFailure", out var expectsFailure)
-                ? expectsFailure.GetString()
-                : null;
-            testCase.ParsingException = e;
-        }
-
-        testCase.Filename = Path.GetFileName(file);
-        testCase.FullPath = file;
-        testCase.Folder = folder;
-        testCase.RawJson = data;
-        return testCase;
-    }
-
     [Theory]
     [SharedTest("and")]
     public void And_Theory(string testName, string folder) => RunTestCase(testName, folder);
@@ -144,6 +118,32 @@ public class TestFunctions
     [Theory]
     [SharedTest("round")]
     public void Round_Theory(string testName, string folder) => RunTestCase(testName, folder);
+
+    private static ExpressionTestCaseRoot LoadTestCase(string file, string folder)
+    {
+        ExpressionTestCaseRoot testCase = new();
+        var data = File.ReadAllText(Path.Join(folder, file));
+        try
+        {
+            testCase = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(data, _jsonSerializerOptions)!;
+        }
+        catch (Exception e)
+        {
+            using var jsonDocument = JsonDocument.Parse(data);
+
+            testCase.Name = jsonDocument.RootElement.GetProperty("name").GetString();
+            testCase.ExpectsFailure = jsonDocument.RootElement.TryGetProperty("expectsFailure", out var expectsFailure)
+                ? expectsFailure.GetString()
+                : null;
+            testCase.ParsingException = e;
+        }
+
+        testCase.Filename = Path.GetFileName(file);
+        testCase.FullPath = file;
+        testCase.Folder = folder;
+        testCase.RawJson = data;
+        return testCase;
+    }
 
     private void RunTestCase(string testName, string folder)
     {

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
@@ -1,10 +1,9 @@
-using System.Reflection;
 using System.Text.Json;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Tests.Helpers;
+using Altinn.App.Core.Tests.TestUtils;
 using FluentAssertions;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace Altinn.App.Core.Tests.LayoutExpressions;
 
@@ -12,113 +11,143 @@ public class TestFunctions
 {
     private readonly ITestOutputHelper _output;
 
+    private static readonly JsonSerializerOptions _jsonSerializerOptions =
+        new() { ReadCommentHandling = JsonCommentHandling.Skip, PropertyNamingPolicy = JsonNamingPolicy.CamelCase, };
+
     public TestFunctions(ITestOutputHelper output)
     {
         _output = output;
     }
 
+    public ExpressionTestCaseRoot LoadTestCase(string file, string folder)
+    {
+        ExpressionTestCaseRoot testCase = new();
+        var data = File.ReadAllText(Path.Join(folder, file));
+        try
+        {
+            testCase = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(data, _jsonSerializerOptions)!;
+        }
+        catch (Exception e)
+        {
+            using var jsonDocument = JsonDocument.Parse(data);
+
+            testCase.Name = jsonDocument.RootElement.GetProperty("name").GetString();
+            testCase.ExpectsFailure = jsonDocument.RootElement.TryGetProperty("expectsFailure", out var expectsFailure)
+                ? expectsFailure.GetString()
+                : null;
+            testCase.ParsingException = e;
+        }
+
+        testCase.Filename = Path.GetFileName(file);
+        testCase.FullPath = file;
+        testCase.Folder = folder;
+        testCase.RawJson = data;
+        return testCase;
+    }
+
     [Theory]
     [SharedTest("and")]
-    public void And_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void And_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("frontendSettings")]
-    public void FrontendSettings_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void FrontendSettings_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("component")]
-    public void Component_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void Component_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("commaContains")]
-    public void CommaContains_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void CommaContains_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("concat")]
-    public void Concat_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void Concat_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("contains")]
-    public void Contains_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void Contains_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("dataModel")]
-    public void DataModel_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void DataModel_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("endsWith")]
-    public void EndsWith_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void EndsWith_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("equals")]
-    public void Equals_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void Equals_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("greaterThan")]
-    public void GreaterThan_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void GreaterThan_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("greaterThanEq")]
-    public void GreaterThanEq_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void GreaterThanEq_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("if")]
-    public void If_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void If_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("not")]
-    public void Not_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void Not_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("notContains")]
-    public void NotContains_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void NotContains_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("instanceContext")]
-    public void InstanceContext_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void InstanceContext_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("lessThan")]
-    public void LessThan_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void LessThan_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("lessThanEq")]
-    public void LessThanEq_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void LessThanEq_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("notEquals")]
-    public void NotEquals_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void NotEquals_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("or")]
-    public void Or_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void Or_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("unknown")]
-    public void Unknown_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void Unknown_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("upperCase")]
-    public void UpperCase_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void UpperCase_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("lowerCase")]
-    public void LowerCase_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void LowerCase_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("startsWith")]
-    public void StartsWith_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void StartsWith_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("stringLength")]
-    public void StringLength_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void StringLength_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
     [Theory]
     [SharedTest("round")]
-    public void Round_Theory(ExpressionTestCaseRoot test) => RunTestCase(test);
+    public void Round_Theory(string testName, string folder) => RunTestCase(testName, folder);
 
-    private void RunTestCase(ExpressionTestCaseRoot test)
+    private void RunTestCase(string testName, string folder)
     {
+        var test = LoadTestCase(testName, folder);
         _output.WriteLine($"{test.Filename} in {test.Folder}");
         _output.WriteLine(test.RawJson);
         _output.WriteLine(test.FullPath);
@@ -208,51 +237,7 @@ public class TestFunctions
     }
 }
 
-public class SharedTestAttribute : DataAttribute
-{
-    private static readonly JsonSerializerOptions _jsonSerializerOptions =
-        new() { ReadCommentHandling = JsonCommentHandling.Skip, PropertyNamingPolicy = JsonNamingPolicy.CamelCase, };
-
-    private readonly string _folder;
-
-    public SharedTestAttribute(string folder)
-    {
-        _folder = folder;
-    }
-
-    public override IEnumerable<object[]> GetData(MethodInfo methodInfo)
-    {
-        var files = Directory.GetFiles(
-            Path.Join("LayoutExpressions", "CommonTests", "shared-tests", "functions", _folder)
-        );
-        foreach (var file in files)
-        {
-            ExpressionTestCaseRoot testCase = new();
-            var data = File.ReadAllText(file);
-            try
-            {
-                testCase = JsonSerializer.Deserialize<ExpressionTestCaseRoot>(data, _jsonSerializerOptions)!;
-            }
-            catch (Exception e)
-            {
-                using var jsonDocument = JsonDocument.Parse(data);
-
-                testCase.Name = jsonDocument.RootElement.GetProperty("name").GetString();
-                testCase.ExpectsFailure = jsonDocument.RootElement.TryGetProperty(
-                    "expectsFailure",
-                    out var expectsFailure
-                )
-                    ? expectsFailure.GetString()
-                    : null;
-                testCase.ParsingException = e;
-            }
-
-            testCase.Filename = Path.GetFileName(file);
-            testCase.FullPath = file;
-            testCase.Folder = _folder;
-            testCase.RawJson = data;
-
-            yield return new object[] { testCase };
-        }
-    }
-}
+public class SharedTestAttribute(string folder)
+    : FileNamesInFolderDataAttribute(
+        Path.Join("LayoutExpressions", "CommonTests", "shared-tests", "functions", folder)
+    ) { }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Tests.Helpers;
+using Altinn.App.Core.Tests.TestUtils;
 using FluentAssertions;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -21,9 +23,10 @@ public class TestInvalid
     }
 
     [Theory]
-    [SharedTestInvalid()]
-    public void Simple_Theory(InvalidTestCase testCase)
+    [FileNamesInFolderData(["LayoutExpressions", "CommonTests", "shared-tests", "invalid"])]
+    public void Simple_Theory(string testName, string folder)
     {
+        var testCase = LoadData(testName, folder);
         _output.WriteLine($"{testCase.Filename} in {testCase.Folder}");
         _output.WriteLine(testCase.RawJson);
         _output.WriteLine(testCase.FullPath);
@@ -44,28 +47,19 @@ public class TestInvalid
         };
         act.Should().Throw<Exception>().WithMessage(testCase.ExpectsFailure);
     }
-}
 
-public class SharedTestInvalidAttribute : DataAttribute
-{
-    public override IEnumerable<object[]> GetData(MethodInfo methodInfo)
+    private InvalidTestCase LoadData(string testName, string folder)
     {
-        var files = Directory.GetFiles(Path.Join("LayoutExpressions", "CommonTests", "shared-tests", "invalid"));
-        foreach (var file in files)
+        var data = File.ReadAllText(Path.Join(folder, testName));
+        using var document = JsonDocument.Parse(data);
+        return new InvalidTestCase()
         {
-            var data = File.ReadAllText(file);
-            using var document = JsonDocument.Parse(data);
-            var testCase = new InvalidTestCase()
-            {
-                Name = document.RootElement.GetProperty("name").GetString(),
-                ExpectsFailure = document.RootElement.GetProperty("expectsFailure").GetString(),
-                Filename = Path.GetFileName(file),
-                FullPath = file,
-                RawJson = data,
-            };
-
-            yield return new object[] { testCase };
-        }
+            Name = document.RootElement.GetProperty("name").GetString(),
+            ExpectsFailure = document.RootElement.GetProperty("expectsFailure").GetString(),
+            Filename = testName,
+            FullPath = folder,
+            RawJson = data,
+        };
     }
 }
 

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
@@ -48,7 +48,7 @@ public class TestInvalid
         act.Should().Throw<Exception>().WithMessage(testCase.ExpectsFailure);
     }
 
-    private InvalidTestCase LoadData(string testName, string folder)
+    private static InvalidTestCase LoadData(string testName, string folder)
     {
         var data = File.ReadAllText(Path.Join(folder, testName));
         using var document = JsonDocument.Parse(data);

--- a/test/Altinn.App.Core.Tests/TestUtils/FileNamesInFolderAttribute.cs
+++ b/test/Altinn.App.Core.Tests/TestUtils/FileNamesInFolderAttribute.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit.Sdk;
+
+namespace Altinn.App.Core.Tests.TestUtils;
+
+public class FileNamesInFolderDataAttribute(string folderName) : DataAttribute
+{
+    public FileNamesInFolderDataAttribute(string[] folderParts)
+        : this(Path.Join(folderParts)) { }
+
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+    {
+        var basePath = AltinnAppTestsBasePath();
+        var folder = Path.Join(basePath, folderName);
+        if (!Directory.Exists(folder))
+        {
+            throw new DirectoryNotFoundException($"Folder not found: {folder}");
+        }
+        return Directory
+            .GetFiles(folder)
+            .Select(fullPath =>
+                new object[]
+                {
+                    Path.GetFileName(fullPath),
+                    Path.GetDirectoryName(fullPath) ?? throw new Exception($"Folder not found for {fullPath}")
+                }
+            );
+    }
+
+    private static string AltinnAppTestsBasePath([CallerFilePath] string? callerFilePath = null)
+    {
+        if (callerFilePath is null)
+        {
+            throw new Exception("Caller path is null");
+        }
+        var testUtilsDirectoryPath = Path.GetDirectoryName(callerFilePath);
+        if (testUtilsDirectoryPath is null)
+        {
+            throw new Exception("Caller path is null");
+        }
+        var callerDirectoryPath = Path.GetDirectoryName(testUtilsDirectoryPath);
+        if (callerDirectoryPath is null)
+        {
+            throw new Exception("Caller path is null");
+        }
+
+        return callerDirectoryPath;
+    }
+}


### PR DESCRIPTION
Use simple types and delay loading of the actual files to when it runs to get exception at the correct test.

With the current setup with a big object as the test parameter, xUnit does not recognise the individual tests for a [Theory] so when you debug all the tests will run and trigger breakpoints in the other theories

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
