### PR TITLE
Upgrade `Altinn.ApiClients.Maskinporten` to v8 to fix 'test' environment validation

### DIFF
--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -10,7 +10,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="7.1.0" />
+    <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="8.0.1" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.5" />
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.3.3" />
     <PackageReference Include="Altinn.Common.PEP" Version="4.0.0" />


### PR DESCRIPTION
## Description
Users can't use `test` environment of Maskinporten since this library got support for it in v8. v9 can't be taken right now since it would break some apps. Related comment: https://github.com/Altinn/app-lib-dotnet/pull/507#issuecomment-2111117892


## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
