### PR TITLE
Feat/679 named pdf

### DIFF
--- a/src/Altinn.App.Api/Controllers/OptionsController.cs
+++ b/src/Altinn.App.Api/Controllers/OptionsController.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features.Options;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -83,7 +84,7 @@ public class OptionsController : ControllerBase
         AppOptions appOptions = await _appOptionsService.GetOptionsAsync(
             instanceIdentifier,
             optionsId,
-            language ?? "nb",
+            language ?? LanguageConst.Bokmål,
             queryParams
         );
 

--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -78,6 +78,8 @@ public class PdfController : ControllerBase
             return NotFound();
         }
 
+        var t = HttpContext;
+
         var instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
         string? taskId = instance.Process?.CurrentTask?.ElementId;
         if (instance == null || taskId == null)

--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -78,8 +78,6 @@ public class PdfController : ControllerBase
             return NotFound();
         }
 
-        var t = HttpContext;
-
         var instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
         string? taskId = instance.Process?.CurrentTask?.ElementId;
         if (instance == null || taskId == null)

--- a/src/Altinn.App.Api/Controllers/TextsController.cs
+++ b/src/Altinn.App.Api/Controllers/TextsController.cs
@@ -1,4 +1,5 @@
 using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Language;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -40,9 +41,9 @@ public class TextsController : ControllerBase
 
         TextResource? textResource = await _appResources.GetTexts(org, app, language);
 
-        if (textResource == null && language != "nb")
+        if (textResource == null && language != LanguageConst.Bokmål)
         {
-            textResource = await _appResources.GetTexts(org, app, "nb");
+            textResource = await _appResources.GetTexts(org, app, LanguageConst.Bokmål);
         }
 
         if (textResource == null)

--- a/src/Altinn.App.Core/Internal/Language/LanguageConst.cs
+++ b/src/Altinn.App.Core/Internal/Language/LanguageConst.cs
@@ -1,0 +1,8 @@
+namespace Altinn.App.Core.Internal.Language;
+
+internal class LanguageConst
+{
+    internal static string Bokmål => "nb";
+    internal static string Nynorsk => "nn";
+    internal static string English => "en";
+}

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -1,10 +1,10 @@
-using System.Security.Claims;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers.Extensions;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Internal.Profile;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Profile.Models;
@@ -68,9 +68,10 @@ public class PdfService : IPdfService
     public async Task GenerateAndStorePdf(Instance instance, string taskId, CancellationToken ct)
     {
         using var activity = _telemetry?.StartGenerateAndStorePdfActivity(instance, taskId);
-        string language = GetOverriddenLanguage();
-        // Avoid a costly call if the language is allready overriden by the user
-        language = string.IsNullOrEmpty(language) ? await GetLanguage() : language;
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        var language = GetOverriddenLanguage(httpContext) ?? await GetLanguage(httpContext);
 
         var pdfContent = await GeneratePdfContent(instance, taskId, language, ct);
 
@@ -85,9 +86,10 @@ public class PdfService : IPdfService
     public async Task<Stream> GeneratePdf(Instance instance, string taskId, CancellationToken ct)
     {
         using var activity = _telemetry?.StartGeneratePdfActivity(instance, taskId);
-        var language = GetOverriddenLanguage();
-        // Avoid a costly call if the language is allready overriden by the user
-        language = string.IsNullOrEmpty(language) ? await GetLanguage() : language;
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        var language = GetOverriddenLanguage(httpContext) ?? await GetLanguage(httpContext);
 
         return await GeneratePdfContent(instance, taskId, language, ct);
     }
@@ -128,14 +130,18 @@ public class PdfService : IPdfService
         return new Uri(url);
     }
 
-    private async Task<string> GetLanguage()
+    internal async Task<string> GetLanguage(HttpContext? httpContext)
     {
-        string language = "nb";
-        ClaimsPrincipal? user = _httpContextAccessor.HttpContext?.User;
+        string language = LanguageConst.Bokmål;
 
-        int? userId = user.GetUserIdAsInt();
+        if (httpContext is null)
+        {
+            return language;
+        }
 
-        if (userId != null)
+        int? userId = httpContext.User.GetUserIdAsInt();
+
+        if (userId is not null)
         {
             UserProfile userProfile =
                 await _profileClient.GetUserProfile((int)userId)
@@ -150,33 +156,32 @@ public class PdfService : IPdfService
         return language;
     }
 
-    private string GetOverriddenLanguage()
+    internal static string? GetOverriddenLanguage(HttpContext? httpContext)
     {
-        // If the user has overridden the language from his profile by selecting a
-        // language directly in the form, then use the selected language.
-        if (_httpContextAccessor.HttpContext != null)
+        if (httpContext is null)
         {
-            StringValues queryLanguage;
-            bool hasQueryLanguage =
-                _httpContextAccessor.HttpContext.Request.Query.TryGetValue("language", out queryLanguage)
-                || _httpContextAccessor.HttpContext.Request.Query.TryGetValue("lang", out queryLanguage);
-            if (hasQueryLanguage)
-            {
-                return queryLanguage.ToString();
-            }
+            return null;
         }
 
-        return string.Empty;
+        if (
+            httpContext.Request.Query.TryGetValue("language", out StringValues queryLanguage)
+            || httpContext.Request.Query.TryGetValue("lang", out queryLanguage)
+        )
+        {
+            return queryLanguage.ToString();
+        }
+
+        return null;
     }
 
     private async Task<TextResource?> GetTextResource(string app, string org, string language)
     {
         TextResource? textResource = await _resourceService.GetTexts(org, app, language);
 
-        if (textResource == null && language != "nb")
+        if (textResource == null && language != LanguageConst.Bokmål)
         {
             // fallback to norwegian if texts does not exist
-            textResource = await _resourceService.GetTexts(org, app, "nb");
+            textResource = await _resourceService.GetTexts(org, app, LanguageConst.Bokmål);
         }
 
         return textResource;
@@ -189,7 +194,7 @@ public class PdfService : IPdfService
 
         fileName = $"{app}.pdf";
 
-        if (textResource == null)
+        if (textResource is null)
         {
             return GetValidFileName(fileName);
         }
@@ -202,7 +207,7 @@ public class PdfService : IPdfService
                 textResourceElement.Id.Equals("ServiceName", StringComparison.Ordinal)
             );
 
-        if (titleText != null && !string.IsNullOrEmpty(titleText.Value))
+        if (titleText is not null && !string.IsNullOrEmpty(titleText.Value))
         {
             fileName = titleText.Value + ".pdf";
         }

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -9,6 +9,7 @@ using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models;
 using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
@@ -38,9 +39,9 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
     private const string Org = "tdd";
     private const string App = "contributer-restriction";
     private const int InstanceOwnerPartyId = 500600;
-    private static readonly Guid InstanceGuid = new("0fc98a23-fe31-4ef5-8fb9-dd3f479354cd");
-    private static readonly string InstanceId = $"{InstanceOwnerPartyId}/{InstanceGuid}";
-    private static readonly Guid DataGuid = new("fc121812-0336-45fb-a75c-490df3ad5109");
+    private static readonly Guid _instanceGuid = new("0fc98a23-fe31-4ef5-8fb9-dd3f479354cd");
+    private static readonly string _instanceId = $"{InstanceOwnerPartyId}/{_instanceGuid}";
+    private static readonly Guid _dataGuid = new("fc121812-0336-45fb-a75c-490df3ad5109");
 
     // Define mocks
     private readonly Mock<IDataProcessor> _dataProcessorMock = new(MockBehavior.Strict);
@@ -56,8 +57,8 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
             services.AddSingleton(_dataProcessorMock.Object);
             services.AddSingleton(_formDataValidatorMock.Object);
         };
-        TestData.DeleteInstanceAndData(Org, App, InstanceOwnerPartyId, InstanceGuid);
-        TestData.PrepareInstance(Org, App, InstanceOwnerPartyId, InstanceGuid);
+        TestData.DeleteInstanceAndData(Org, App, InstanceOwnerPartyId, _instanceGuid);
+        TestData.PrepareInstance(Org, App, InstanceOwnerPartyId, _instanceGuid);
     }
 
     // Helper method to call the API
@@ -72,7 +73,7 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
         string? language = null
     )
     {
-        var url = $"/{Org}/{App}/instances/{InstanceId}/data/{DataGuid}";
+        var url = $"/{Org}/{App}/instances/{_instanceId}/data/{_dataGuid}";
         if (language is not null)
         {
             url += $"?language={language}";
@@ -136,7 +137,7 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
             p =>
                 p.ProcessDataWrite(
                     It.IsAny<Instance>(),
-                    It.Is<Guid>(dataId => dataId == DataGuid),
+                    It.Is<Guid>(dataId => dataId == _dataGuid),
                     It.IsAny<Skjema>(),
                     It.IsAny<Skjema?>(),
                     null
@@ -184,7 +185,7 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
             p =>
                 p.ProcessDataWrite(
                     It.IsAny<Instance>(),
-                    It.Is<Guid>(dataId => dataId == DataGuid),
+                    It.Is<Guid>(dataId => dataId == _dataGuid),
                     It.IsAny<Skjema>(),
                     It.IsAny<Skjema?>(),
                     null
@@ -295,7 +296,7 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
             p =>
                 p.ProcessDataWrite(
                     It.IsAny<Instance>(),
-                    It.Is<Guid>(dataId => dataId == DataGuid),
+                    It.Is<Guid>(dataId => dataId == _dataGuid),
                     It.Is<Skjema>(s => s.Melding!.NestedList!.Count == 1),
                     It.Is<Skjema?>(s => s!.Melding!.NestedList!.Count == 0),
                     null
@@ -669,7 +670,9 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
     public async Task DataReadChanges_IsPreservedWhenCallingPatch()
     {
         _dataProcessorMock
-            .Setup(p => p.ProcessDataRead(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<Skjema>(), "nn"))
+            .Setup(p =>
+                p.ProcessDataRead(It.IsAny<Instance>(), It.IsAny<Guid>(), It.IsAny<Skjema>(), LanguageConst.Nynorsk)
+            )
             .Returns(
                 (Instance instance, Guid dataGuid, Skjema skjema, string language) =>
                 {
@@ -695,7 +698,7 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
             .Verifiable(Times.Exactly(1));
 
         // call Read to get the data with changes to Melding.Random from ProcessDataRead
-        var url = $"/{Org}/{App}/instances/{InstanceId}/data/{DataGuid}?language=nn";
+        var url = $"/{Org}/{App}/instances/{_instanceId}/data/{_dataGuid}?language=nn";
         _outputHelper.WriteLine($"Calling GET {url}");
         using var httpClient = GetRootedClient(Org, App);
         string token = PrincipalUtil.GetToken(1337, null);
@@ -754,7 +757,7 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
             p =>
                 p.ProcessDataWrite(
                     It.IsAny<Instance>(),
-                    It.Is<Guid>(dataId => dataId == DataGuid),
+                    It.Is<Guid>(dataId => dataId == _dataGuid),
                     It.IsAny<Skjema>(),
                     It.IsAny<Skjema?>(),
                     "es"

--- a/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/OptionsControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -118,7 +119,7 @@ public class OptionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
 
         var headerValue = response.Headers.GetValues("Altinn-DownstreamParameters");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        headerValue.Should().NotContain("nb");
+        headerValue.Should().NotContain(LanguageConst.Bokmål);
     }
 
     [Fact]

--- a/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
@@ -6,6 +6,7 @@ using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Instances;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Internal.Pdf;
 using Altinn.App.Core.Internal.Profile;
 using Altinn.Platform.Storage.Interface.Models;
@@ -22,24 +23,24 @@ namespace Altinn.App.Api.Tests.Controllers;
 
 public class PdfControllerTests
 {
-    private readonly string org = "org";
-    private readonly string app = "app";
-    private readonly Guid instanceId = new Guid("e11e3e0b-a45c-48fb-a968-8d4ddf868c80");
-    private readonly int partyId = 12345;
-    private readonly string taskId = "Task_1";
+    private readonly string _org = "org";
+    private readonly string _app = "app";
+    private readonly Guid _instanceId = new("e11e3e0b-a45c-48fb-a968-8d4ddf868c80");
+    private readonly int _partyId = 12345;
+    private readonly string _taskId = "Task_1";
 
     private readonly Mock<IAppResources> _appResources = new();
     private readonly Mock<IDataClient> _dataClient = new();
     private readonly Mock<IProfileClient> _profile = new();
-    private readonly IOptions<PlatformSettings> _platformSettingsOptions =
-        Microsoft.Extensions.Options.Options.Create<PlatformSettings>(new() { });
+    private readonly IOptions<PlatformSettings> _platformSettingsOptions = Options.Create<PlatformSettings>(new() { });
     private readonly Mock<IInstanceClient> _instanceClient = new();
     private readonly Mock<IPdfFormatter> _pdfFormatter = new();
     private readonly Mock<IAppModel> _appModel = new();
     private readonly Mock<IUserTokenProvider> _userTokenProvider = new();
 
-    private readonly IOptions<PdfGeneratorSettings> _pdfGeneratorSettingsOptions =
-        Microsoft.Extensions.Options.Options.Create<PdfGeneratorSettings>(new() { });
+    private readonly IOptions<PdfGeneratorSettings> _pdfGeneratorSettingsOptions = Options.Create<PdfGeneratorSettings>(
+        new() { }
+    );
 
     public PdfControllerTests()
     {
@@ -49,10 +50,13 @@ public class PdfControllerTests
                 Task.FromResult(
                     new Instance()
                     {
-                        Org = org,
-                        AppId = $"{org}/{app}",
-                        Id = $"{partyId}/{instanceId}",
-                        Process = new ProcessState() { CurrentTask = new ProcessElementInfo() { ElementId = taskId, }, }
+                        Org = _org,
+                        AppId = $"{_org}/{_app}",
+                        Id = $"{_partyId}/{_instanceId}",
+                        Process = new ProcessState()
+                        {
+                            CurrentTask = new ProcessElementInfo() { ElementId = _taskId, },
+                        }
                     }
                 )
             );
@@ -64,12 +68,12 @@ public class PdfControllerTests
         var env = new Mock<IWebHostEnvironment>();
         env.Setup(a => a.EnvironmentName).Returns("Production");
 
-        IOptions<GeneralSettings> generalSettingsOptions = Microsoft.Extensions.Options.Options.Create<GeneralSettings>(
+        IOptions<GeneralSettings> generalSettingsOptions = Options.Create<GeneralSettings>(
             new() { HostName = "org.apps.altinn.no" }
         );
 
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        httpContextAccessor.Setup(x => x.HttpContext!.Request!.Query["lang"]).Returns("nb");
+        httpContextAccessor.Setup(x => x.HttpContext!.Request!.Query["lang"]).Returns(LanguageConst.Bokmål);
 
         var handler = new Mock<HttpMessageHandler>();
         var httpClient = new HttpClient(handler.Object);
@@ -100,7 +104,7 @@ public class PdfControllerTests
             pdfService
         );
 
-        var result = await pdfController.GetPdfPreview(org, app, partyId, instanceId);
+        var result = await pdfController.GetPdfPreview(_org, _app, _partyId, _instanceId);
 
         result.Should().BeOfType(typeof(NotFoundResult));
         handler
@@ -114,12 +118,12 @@ public class PdfControllerTests
         var env = new Mock<IWebHostEnvironment>();
         env.Setup(a => a.EnvironmentName).Returns("Development");
 
-        IOptions<GeneralSettings> generalSettingsOptions = Microsoft.Extensions.Options.Options.Create<GeneralSettings>(
+        IOptions<GeneralSettings> generalSettingsOptions = Options.Create<GeneralSettings>(
             new() { HostName = "local.altinn.cloud" }
         );
 
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        httpContextAccessor.Setup(x => x.HttpContext!.Request!.Query["lang"]).Returns("nb");
+        httpContextAccessor.Setup(x => x.HttpContext!.Request!.Query["lang"]).Returns(LanguageConst.Bokmål);
         string? frontendVersion = null;
         httpContextAccessor
             .Setup(x => x.HttpContext!.Request!.Cookies.TryGetValue("frontendVersion", out frontendVersion))
@@ -175,7 +179,7 @@ public class PdfControllerTests
                 )
                 .ReturnsAsync(mockResponse);
 
-            var result = await pdfController.GetPdfPreview(org, app, partyId, instanceId);
+            var result = await pdfController.GetPdfPreview(_org, _app, _partyId, _instanceId);
             result.Should().BeOfType(typeof(FileStreamResult));
         }
 
@@ -193,12 +197,12 @@ public class PdfControllerTests
         var env = new Mock<IWebHostEnvironment>();
         env.Setup(a => a.EnvironmentName).Returns("Development");
 
-        IOptions<GeneralSettings> generalSettingsOptions = Microsoft.Extensions.Options.Options.Create<GeneralSettings>(
+        IOptions<GeneralSettings> generalSettingsOptions = Options.Create<GeneralSettings>(
             new() { HostName = "local.altinn.cloud" }
         );
 
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        httpContextAccessor.Setup(x => x.HttpContext!.Request!.Query["lang"]).Returns("nb");
+        httpContextAccessor.Setup(x => x.HttpContext!.Request!.Query["lang"]).Returns(LanguageConst.Bokmål);
         string? frontendVersion = "https://altinncdn.no/toolkits/altinn-app-frontend/3/";
         httpContextAccessor
             .Setup(x => x.HttpContext!.Request!.Cookies.TryGetValue("frontendVersion", out frontendVersion))
@@ -254,7 +258,7 @@ public class PdfControllerTests
                 )
                 .ReturnsAsync(mockResponse);
 
-            var result = await pdfController.GetPdfPreview(org, app, partyId, instanceId);
+            var result = await pdfController.GetPdfPreview(_org, _app, _partyId, _instanceId);
             result.Should().BeOfType(typeof(FileStreamResult));
         }
 
@@ -274,12 +278,12 @@ public class PdfControllerTests
         var env = new Mock<IWebHostEnvironment>();
         env.Setup(a => a.EnvironmentName).Returns("Staging");
 
-        IOptions<GeneralSettings> generalSettingsOptions = Microsoft.Extensions.Options.Options.Create<GeneralSettings>(
+        IOptions<GeneralSettings> generalSettingsOptions = Options.Create<GeneralSettings>(
             new() { HostName = "org.apps.tt02.altinn.no" }
         );
 
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        httpContextAccessor.Setup(x => x.HttpContext!.Request!.Query["lang"]).Returns("nb");
+        httpContextAccessor.Setup(x => x.HttpContext!.Request!.Query["lang"]).Returns(LanguageConst.Bokmål);
         string? frontendVersion = "https://altinncdn.no/toolkits/altinn-app-frontend/3/";
         httpContextAccessor
             .Setup(x => x.HttpContext!.Request!.Cookies.TryGetValue("frontendVersion", out frontendVersion))
@@ -335,7 +339,7 @@ public class PdfControllerTests
                 )
                 .ReturnsAsync(mockResponse);
 
-            var result = await pdfController.GetPdfPreview(org, app, partyId, instanceId);
+            var result = await pdfController.GetPdfPreview(_org, _app, _partyId, _instanceId);
             result.Should().BeOfType(typeof(FileStreamResult));
         }
 

--- a/test/Altinn.App.Api.Tests/Controllers/TextsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/TextsControllerTests.cs
@@ -1,5 +1,7 @@
+using System.Drawing.Text;
 using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Language;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
@@ -15,7 +17,7 @@ public class TextsControllerTests
         // Arrange
         const string org = "ttd";
         const string app = "unit-app";
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         TextResource expected = new TextResource
         {
@@ -49,12 +51,12 @@ public class TextsControllerTests
         // Arrange
         const string org = "ttd";
         const string app = "unit-app";
-        const string language = "en";
+        string language = LanguageConst.English;
 
         TextResource expected = new TextResource
         {
             Id = "test",
-            Language = "nb",
+            Language = LanguageConst.Bokmål,
             Org = org,
             Resources = new List<TextResourceElement>
             {
@@ -64,7 +66,9 @@ public class TextsControllerTests
 
         var appResourceMock = new Mock<IAppResources>();
         appResourceMock.Setup(a => a.GetTexts(org, app, language)).Returns(Task.FromResult<TextResource?>(null));
-        appResourceMock.Setup(a => a.GetTexts(org, app, "nb")).Returns(Task.FromResult<TextResource?>(null));
+        appResourceMock
+            .Setup(a => a.GetTexts(org, app, LanguageConst.Bokmål))
+            .Returns(Task.FromResult<TextResource?>(null));
         // Act
         var controller = new TextsController(appResourceMock.Object);
         var result = await controller.Get(org, app, language);
@@ -74,7 +78,7 @@ public class TextsControllerTests
         result.Result.Should().BeOfType<NotFoundResult>();
         resultValue.Should().BeNull();
         appResourceMock.Verify(a => a.GetTexts(org, app, language), Times.Once);
-        appResourceMock.Verify(a => a.GetTexts(org, app, "nb"), Times.Once);
+        appResourceMock.Verify(a => a.GetTexts(org, app, LanguageConst.Bokmål), Times.Once);
         appResourceMock.VerifyNoOtherCalls();
     }
 

--- a/test/Altinn.App.Api.Tests/Controllers/TextsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/TextsControllerTests.cs
@@ -1,4 +1,3 @@
-using System.Drawing.Text;
 using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Language;

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
@@ -3,6 +3,7 @@ using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Instances;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Internal.Validation;
 using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Validation;
@@ -88,7 +89,7 @@ public class TestScenariosData : IEnumerable<object[]>
                         ValidationIssueCodes.DataElementCodes.DataElementValidatedAtWrongTask,
                         new Dictionary<string, Dictionary<string, string>>(),
                         null,
-                        "nb"
+                        LanguageConst.Bokmål
                     )
                 }
             },

--- a/test/Altinn.App.Core.Tests/DataLists/NullDataListProviderTest.cs
+++ b/test/Altinn.App.Core.Tests/DataLists/NullDataListProviderTest.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using Altinn.App.Core.Features.DataLists;
+using Altinn.App.Core.Internal.Language;
 using FluentAssertions;
 
 namespace Altinn.App.PlatformServices.Tests.DataLists;
@@ -12,7 +13,7 @@ public class NullDataListProviderTest
         var provider = new NullDataListProvider();
 
         provider.Id.Should().Be(string.Empty);
-        var list = await provider.GetDataListAsync("nb", new Dictionary<string, string>());
+        var list = await provider.GetDataListAsync(LanguageConst.Bokmål, new Dictionary<string, string>());
         list.ListItems.Should().BeNull();
     }
 }

--- a/test/Altinn.App.Core.Tests/DataLists/NullInstanceDataListProviderTest.cs
+++ b/test/Altinn.App.Core.Tests/DataLists/NullInstanceDataListProviderTest.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using Altinn.App.Core.Features.DataLists;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models;
 using FluentAssertions;
 
@@ -15,7 +16,7 @@ public class NullInstanceDataListProviderTest
         provider.Id.Should().Be(string.Empty);
         var options = await provider.GetInstanceDataListAsync(
             new InstanceIdentifier(12345, Guid.NewGuid()),
-            "nb",
+            LanguageConst.Bokmål,
             new Dictionary<string, string>()
         );
         options.ListItems.Should().BeNull();

--- a/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2OptionsCacheTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2OptionsCacheTests.cs
@@ -1,6 +1,7 @@
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Features.Options.Altinn2Provider;
+using Altinn.App.Core.Internal.Language;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -58,11 +59,11 @@ public class Altinn2OptionsCacheTests
             messageHandler.CallCounter.Should().Be(0);
             providers.Count().Should().Be(3);
             var optionsProvider = providers.Single(p => p.Id == "ASF_Land3");
-            await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>());
+            await optionsProvider.GetAppOptionsAsync(LanguageConst.Bokmål, new Dictionary<string, string>());
             await Task.Delay(5);
             messageHandler.CallCounter.Should().Be(1);
 
-            await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>());
+            await optionsProvider.GetAppOptionsAsync(LanguageConst.Bokmål, new Dictionary<string, string>());
             await Task.Delay(5);
             messageHandler.CallCounter.Should().Be(1);
         }
@@ -74,11 +75,11 @@ public class Altinn2OptionsCacheTests
             var messageHandler =
                 scope.ServiceProvider.GetRequiredService<Altinn2MetadataApiClientHttpMessageHandlerMoq>();
             var optionsProvider = providers.Single(p => p.Id == "ASF_Land3");
-            await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>());
+            await optionsProvider.GetAppOptionsAsync(LanguageConst.Bokmål, new Dictionary<string, string>());
             await Task.Delay(5);
             messageHandler.CallCounter.Should().Be(1);
 
-            await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>());
+            await optionsProvider.GetAppOptionsAsync(LanguageConst.Bokmål, new Dictionary<string, string>());
             await Task.Delay(5);
             messageHandler.CallCounter.Should().Be(1);
         }
@@ -90,12 +91,12 @@ public class Altinn2OptionsCacheTests
             var messageHandler =
                 scope.ServiceProvider.GetRequiredService<Altinn2MetadataApiClientHttpMessageHandlerMoq>();
             var optionsProvider = providers.Single(p => p.Id == "ASF_Fylker");
-            await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>());
+            await optionsProvider.GetAppOptionsAsync(LanguageConst.Bokmål, new Dictionary<string, string>());
             await Task.Delay(5);
             messageHandler.CallCounter.Should().Be(2);
 
             // Fetch the list in nynorsk and see that yeat another call is made
-            await optionsProvider.GetAppOptionsAsync("nn", new Dictionary<string, string>());
+            await optionsProvider.GetAppOptionsAsync(LanguageConst.Nynorsk, new Dictionary<string, string>());
             await Task.Delay(5);
             messageHandler.CallCounter.Should().Be(3);
         }

--- a/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2OptionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/Altinn2Provider/Altinn2OptionsTests.cs
@@ -1,6 +1,7 @@
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Options;
 using Altinn.App.Core.Features.Options.Altinn2Provider;
+using Altinn.App.Core.Internal.Language;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -62,7 +63,10 @@ public class Altinn2OptionsTests
             var providers = scope.ServiceProvider.GetRequiredService<IEnumerable<IAppOptionsProvider>>();
             providers.Count().Should().Be(1);
             var optionsProvider = providers.Single(p => p.Id == "ASF_Land1");
-            var landOptions = await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>());
+            var landOptions = await optionsProvider.GetAppOptionsAsync(
+                LanguageConst.Bokmål,
+                new Dictionary<string, string>()
+            );
             landOptions.Options.Should().HaveCountGreaterThan(4, "ASF_Land needs to have more than 4 countries");
             landOptions.Options.Should().Match(options => options.Any(o => o.Value == "NORGE"));
         }
@@ -85,7 +89,10 @@ public class Altinn2OptionsTests
             var providers = scope.ServiceProvider.GetRequiredService<IEnumerable<IAppOptionsProvider>>();
             providers.Count().Should().Be(1);
             var optionsProvider = providers.Single(p => p.Id == "ASF_Land1");
-            var landOptions = await optionsProvider.GetAppOptionsAsync("en", new Dictionary<string, string>());
+            var landOptions = await optionsProvider.GetAppOptionsAsync(
+                LanguageConst.English,
+                new Dictionary<string, string>()
+            );
             landOptions.Options.Should().HaveCountGreaterThan(4, "ASF_Land needs to have more than 4 countries");
             landOptions.Options.Should().Match(options => options.Any(o => o.Label == "NORWAY"));
         }
@@ -109,7 +116,10 @@ public class Altinn2OptionsTests
             var providers = scope.ServiceProvider.GetRequiredService<IEnumerable<IAppOptionsProvider>>();
             providers.Count().Should().Be(1);
             var optionsProvider = providers.Single(p => p.Id == "OnlyNorway");
-            var landOptions = await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>());
+            var landOptions = await optionsProvider.GetAppOptionsAsync(
+                LanguageConst.Bokmål,
+                new Dictionary<string, string>()
+            );
             landOptions.Options.Should().HaveCount(1, "We filter out only norway");
             landOptions.Options.Should().Match(options => options.Any(o => o.Value == "NORGE"));
         }
@@ -133,7 +143,10 @@ public class Altinn2OptionsTests
             var providers = scope.ServiceProvider.GetRequiredService<IEnumerable<IAppOptionsProvider>>();
             providers.Count().Should().Be(1);
             var optionsProvider = providers.Single(p => p.Id == "OnlyNorway");
-            var landOptions = await optionsProvider.GetAppOptionsAsync("nb", new Dictionary<string, string>());
+            var landOptions = await optionsProvider.GetAppOptionsAsync(
+                LanguageConst.Bokmål,
+                new Dictionary<string, string>()
+            );
             landOptions.Options.Should().HaveCount(1, "We filter out only norway");
             landOptions.Options.Should().Match(options => options.Any(o => o.Value == "NORGE"));
         }

--- a/test/Altinn.App.Core.Tests/Features/Options/AppOptionsFactoryTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/AppOptionsFactoryTests.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Options;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models;
 using FluentAssertions;
 using Moq;
@@ -98,7 +99,7 @@ public class AppOptionsFactoryTests
         IAppOptionsProvider optionsProvider = factory.GetOptionsProvider("Country");
 
         AppOptions options = await optionsProvider.GetAppOptionsAsync(
-            "nb",
+            LanguageConst.Bokmål,
             new Dictionary<string, string>() { { "key", "value" } }
         );
         options.Parameters.First(x => x.Key == "key").Value.Should().Be("value");

--- a/test/Altinn.App.Core.Tests/Features/Options/JoinedAppOptionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/JoinedAppOptionsTests.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Options;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,37 +16,32 @@ public class JoinedAppOptionsTests
     private readonly Mock<IAppOptionsFileHandler> _fileHandlerMock = new(MockBehavior.Strict);
     private readonly ServiceCollection _serviceCollection = new();
 
-    private const string Language = "nb";
-    private static readonly List<AppOption> AppOptionsCountries =
-        new()
-        {
-            new AppOption { Value = "no", Label = "Norway" },
-            new AppOption { Value = "se", Label = "Sweden" }
-        };
+    private string _language = LanguageConst.Bokmål;
+    private static readonly List<AppOption> _appOptionsCountries =
+    [
+        new AppOption { Value = "no", Label = "Norway" },
+        new AppOption { Value = "se", Label = "Sweden" }
+    ];
 
-    private static readonly List<AppOption> AppOptionsSentinel =
-        new()
-        {
-            new AppOption { Value = null, Label = "Sentinel" }
-        };
+    private static readonly List<AppOption> _appOptionsSentinel = [new AppOption { Value = null, Label = "Sentinel" }];
 
     public JoinedAppOptionsTests()
     {
         _countryAppOptionsMock.Setup(p => p.Id).Returns("country-no-sentinel");
         _countryAppOptionsMock
-            .Setup(p => p.GetAppOptionsAsync(Language, It.IsAny<Dictionary<string, string>>()))
+            .Setup(p => p.GetAppOptionsAsync(_language, It.IsAny<Dictionary<string, string>>()))
             .ReturnsAsync(
                 (string language, Dictionary<string, string> keyValuePairs) =>
-                    new AppOptions() { Options = AppOptionsCountries, Parameters = keyValuePairs.ToDictionary()!, }
+                    new AppOptions() { Options = _appOptionsCountries, Parameters = keyValuePairs.ToDictionary()!, }
             );
         _serviceCollection.AddSingleton(_countryAppOptionsMock.Object);
 
         _sentinelOptionsProviderMock.Setup(p => p.Id).Returns("sentinel");
         _sentinelOptionsProviderMock
-            .Setup(p => p.GetAppOptionsAsync(Language, It.IsAny<Dictionary<string, string>>()))
+            .Setup(p => p.GetAppOptionsAsync(_language, It.IsAny<Dictionary<string, string>>()))
             .ReturnsAsync(
                 (string language, Dictionary<string, string> keyValuePairs) =>
-                    new AppOptions() { Options = AppOptionsSentinel, Parameters = keyValuePairs.ToDictionary()!, }
+                    new AppOptions() { Options = _appOptionsSentinel, Parameters = keyValuePairs.ToDictionary()!, }
             );
         _serviceCollection.AddSingleton(_sentinelOptionsProviderMock.Object);
 
@@ -73,9 +69,9 @@ public class JoinedAppOptionsTests
 
         optionsProvider.Should().BeOfType<JoinedAppOptionsProvider>();
         optionsProvider.Id.Should().Be("country");
-        var appOptions = await optionsProvider.GetAppOptionsAsync(Language, new Dictionary<string, string>());
+        var appOptions = await optionsProvider.GetAppOptionsAsync(_language, new Dictionary<string, string>());
         appOptions.Options.Should().HaveCount(3);
-        appOptions.Options.Should().BeEquivalentTo(AppOptionsCountries.Concat(AppOptionsSentinel));
+        appOptions.Options.Should().BeEquivalentTo(_appOptionsCountries.Concat(_appOptionsSentinel));
 
         _neverUsedOptionsProviderMock.VerifyAll();
         _countryAppOptionsMock.VerifyAll();
@@ -90,9 +86,9 @@ public class JoinedAppOptionsTests
         using var sp = _serviceCollection.BuildServiceProvider();
         var appOptionsService = sp.GetRequiredService<AppOptionsService>();
 
-        var options = await appOptionsService.GetOptionsAsync("country", Language, new());
+        var options = await appOptionsService.GetOptionsAsync("country", _language, new());
 
-        options.Options.Should().BeEquivalentTo(AppOptionsCountries.Concat(AppOptionsSentinel));
+        options.Options.Should().BeEquivalentTo(_appOptionsCountries.Concat(_appOptionsSentinel));
 
         _neverUsedOptionsProviderMock.VerifyAll();
         _countryAppOptionsMock.VerifyAll();
@@ -109,12 +105,12 @@ public class JoinedAppOptionsTests
         var appOptionsService = sp.GetRequiredService<AppOptionsService>();
 
         // Fetch the country options (now without sentinel)
-        var options = await appOptionsService.GetOptionsAsync("country", Language, new());
-        options.Options.Should().BeEquivalentTo(AppOptionsCountries);
+        var options = await appOptionsService.GetOptionsAsync("country", _language, new());
+        options.Options.Should().BeEquivalentTo(_appOptionsCountries);
 
         // Fetch sentinel options to make verifications work
-        var sentinelOptions = await appOptionsService.GetOptionsAsync("sentinel", Language, new());
-        sentinelOptions.Options.Should().BeEquivalentTo(AppOptionsSentinel);
+        var sentinelOptions = await appOptionsService.GetOptionsAsync("sentinel", _language, new());
+        sentinelOptions.Options.Should().BeEquivalentTo(_appOptionsSentinel);
 
         _neverUsedOptionsProviderMock.VerifyAll();
         _countryAppOptionsMock.VerifyAll();
@@ -132,7 +128,7 @@ public class JoinedAppOptionsTests
 
         var parameters = new Dictionary<string, string> { { "key", "value" } };
 
-        var options = await appOptionsService.GetOptionsAsync("country", Language, parameters);
+        var options = await appOptionsService.GetOptionsAsync("country", _language, parameters);
 
         options
             .Parameters.Should()
@@ -154,7 +150,7 @@ public class JoinedAppOptionsTests
         using var sp = _serviceCollection.BuildServiceProvider();
         var appOptionsService = sp.GetRequiredService<AppOptionsService>();
 
-        var action = new Func<Task>(async () => await appOptionsService.GetOptionsAsync("country", Language, new()));
+        var action = new Func<Task>(async () => await appOptionsService.GetOptionsAsync("country", _language, new()));
         var exception = await action.Should().ThrowAsync<KeyNotFoundException>();
         exception.WithMessage("missing is not registrered as an app option");
 

--- a/test/Altinn.App.Core.Tests/Features/Options/JoinedAppOptionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/JoinedAppOptionsTests.cs
@@ -16,7 +16,7 @@ public class JoinedAppOptionsTests
     private readonly Mock<IAppOptionsFileHandler> _fileHandlerMock = new(MockBehavior.Strict);
     private readonly ServiceCollection _serviceCollection = new();
 
-    private string _language = LanguageConst.Bokmål;
+    private readonly string _language = LanguageConst.Bokmål;
     private static readonly List<AppOption> _appOptionsCountries =
     [
         new AppOption { Value = "no", Label = "Norway" },

--- a/test/Altinn.App.Core.Tests/Features/Options/NullInstanceAppOptionsProviderTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Options/NullInstanceAppOptionsProviderTests.cs
@@ -1,4 +1,5 @@
 using Altinn.App.Core.Features.Options;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models;
 using FluentAssertions;
 
@@ -14,7 +15,7 @@ public class NullInstanceAppOptionsProviderTests
         provider.Id.Should().Be(string.Empty);
         var options = await provider.GetInstanceAppOptionsAsync(
             new InstanceIdentifier(12345, Guid.NewGuid()),
-            "nb",
+            LanguageConst.Bokmål,
             new Dictionary<string, string>()
         );
         options.Options.Should().BeNull();

--- a/test/Altinn.App.Core.Tests/Features/Payment/PaymentServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Payment/PaymentServiceTests.cs
@@ -4,6 +4,7 @@ using Altinn.App.Core.Features.Payment.Models;
 using Altinn.App.Core.Features.Payment.Processors;
 using Altinn.App.Core.Features.Payment.Services;
 using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -40,7 +41,7 @@ public class PaymentServiceTests
         PaymentInformation paymentInformation = CreatePaymentInformation();
         PaymentDetails paymentDetails =
             paymentInformation.PaymentDetails ?? throw new NullReferenceException("PaymentDetails should not be null");
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _orderDetailsCalculator.Setup(p => p.CalculateOrderDetails(instance, language)).ReturnsAsync(orderDetails);
         _dataService
@@ -88,7 +89,7 @@ public class PaymentServiceTests
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
         ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _paymentProcessor.Setup(pp => pp.PaymentProcessorId).Returns(orderDetails.PaymentProcessorId);
 
@@ -124,7 +125,7 @@ public class PaymentServiceTests
     {
         Instance instance = CreateInstance();
         ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _dataService
             .Setup(ds => ds.GetByType<PaymentInformation>(It.IsAny<Instance>(), It.IsAny<string>()))
@@ -148,7 +149,7 @@ public class PaymentServiceTests
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
         ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _dataService
             .Setup(ds => ds.GetByType<PaymentInformation>(It.IsAny<Instance>(), It.IsAny<string>()))
@@ -173,7 +174,7 @@ public class PaymentServiceTests
         PaymentInformation paymentInformation = CreatePaymentInformation();
         PaymentDetails paymentDetails =
             paymentInformation.PaymentDetails ?? throw new NullReferenceException("PaymentDetails should not be null");
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _orderDetailsCalculator.Setup(p => p.CalculateOrderDetails(instance, language)).ReturnsAsync(orderDetails);
         _dataService
@@ -197,7 +198,7 @@ public class PaymentServiceTests
         Instance instance = CreateInstance();
         OrderDetails orderDetails = CreateOrderDetails();
         ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _orderDetailsCalculator.Setup(p => p.CalculateOrderDetails(instance, language)).ReturnsAsync(orderDetails);
 
@@ -226,7 +227,7 @@ public class PaymentServiceTests
         OrderDetails orderDetails = CreateOrderDetails();
         ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         PaymentInformation paymentInformation = CreatePaymentInformation();
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _orderDetailsCalculator.Setup(odc => odc.CalculateOrderDetails(instance, language)).ReturnsAsync(orderDetails);
 
@@ -260,7 +261,7 @@ public class PaymentServiceTests
         OrderDetails orderDetails = CreateOrderDetails();
         ValidAltinnPaymentConfiguration paymentConfiguration = CreatePaymentConfiguration();
         PaymentInformation paymentInformation = CreatePaymentInformation();
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _orderDetailsCalculator.Setup(p => p.CalculateOrderDetails(instance, language)).ReturnsAsync(orderDetails);
 
@@ -317,7 +318,7 @@ public class PaymentServiceTests
         PaymentInformation paymentInformation = CreatePaymentInformation();
         PaymentDetails paymentDetails =
             paymentInformation.PaymentDetails ?? throw new NullReferenceException("PaymentDetails should not be null");
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         paymentInformation.Status = PaymentStatus.Cancelled;
 
@@ -368,7 +369,7 @@ public class PaymentServiceTests
         PaymentInformation paymentInformation = CreatePaymentInformation();
         PaymentDetails paymentDetails =
             paymentInformation.PaymentDetails ?? throw new NullReferenceException("PaymentDetails should not be null");
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _orderDetailsCalculator.Setup(p => p.CalculateOrderDetails(instance, language)).ReturnsAsync(orderDetails);
         _dataService
@@ -408,7 +409,8 @@ public class PaymentServiceTests
         var paymentService = new PaymentService(paymentProcessors, _dataService.Object, _logger.Object);
 
         // Act
-        Func<Task> act = async () => await paymentService.StartPayment(instance, paymentConfiguration, "en");
+        Func<Task> act = async () =>
+            await paymentService.StartPayment(instance, paymentConfiguration, LanguageConst.English);
 
         // Assert
         await act.Should()
@@ -429,7 +431,11 @@ public class PaymentServiceTests
 
         // Act
         Func<Task> act = async () =>
-            await paymentService.CheckAndStorePaymentStatus(instance, paymentConfiguration.Validate(), "en");
+            await paymentService.CheckAndStorePaymentStatus(
+                instance,
+                paymentConfiguration.Validate(),
+                LanguageConst.English
+            );
 
         // Assert
         await act.Should()

--- a/test/Altinn.App.Core.Tests/Features/Payment/Providers/Nets/NetsPaymentProcessorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Payment/Providers/Nets/NetsPaymentProcessorTests.cs
@@ -3,6 +3,7 @@ using Altinn.App.Core.Features.Payment.Exceptions;
 using Altinn.App.Core.Features.Payment.Models;
 using Altinn.App.Core.Features.Payment.Processors.Nets;
 using Altinn.App.Core.Features.Payment.Processors.Nets.Models;
+using Altinn.App.Core.Internal.Language;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
@@ -59,7 +60,7 @@ public class NetsPaymentProcessorTests
             );
 
         // Act
-        PaymentDetails result = await _processor.StartPayment(instance, orderDetails, "nb");
+        PaymentDetails result = await _processor.StartPayment(instance, orderDetails, LanguageConst.Bokmål);
 
         // Assert
         Assert.NotNull(result);
@@ -116,7 +117,7 @@ public class NetsPaymentProcessorTests
             );
 
         // Act
-        PaymentDetails result = await _processor.StartPayment(instance, orderDetails, "nb");
+        PaymentDetails result = await _processor.StartPayment(instance, orderDetails, LanguageConst.Bokmål);
 
         // Assert
         result.Should().NotBeNull();
@@ -199,7 +200,7 @@ public class NetsPaymentProcessorTests
         Instance instance = CreateInstance();
         const string paymentReference = "12345";
         const decimal expectedTotalIncVat = 100;
-        const string language = "nb";
+        string language = LanguageConst.Bokmål;
 
         _netsClientMock
             .Setup(x => x.RetrievePayment(paymentReference))

--- a/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
@@ -15,8 +15,8 @@ namespace Altinn.App.Core.Tests.Implementation;
 
 public class AppResourcesSITests
 {
-    private readonly string appBasePath = Path.Combine("Implementation", "TestData") + Path.DirectorySeparatorChar;
-    private readonly TelemetrySink telemetry = new();
+    private readonly string _appBasePath = Path.Combine("Implementation", "TestData") + Path.DirectorySeparatorChar;
+    private readonly TelemetrySink _telemetry = new();
 
     [Fact]
     public void GetApplication_desrializes_file_from_disk()
@@ -29,7 +29,7 @@ public class AppResourcesSITests
             appMetadata,
             null,
             new NullLogger<AppResourcesSI>(),
-            telemetry.Object
+            _telemetry.Object
         );
         Application expected = new Application()
         {
@@ -80,7 +80,7 @@ public class AppResourcesSITests
             appMetadata,
             null,
             new NullLogger<AppResourcesSI>(),
-            telemetry.Object
+            _telemetry.Object
         );
         Application expected = new Application()
         {
@@ -137,7 +137,7 @@ public class AppResourcesSITests
             appMetadata,
             null,
             new NullLogger<AppResourcesSI>(),
-            telemetry.Object
+            _telemetry.Object
         );
         Application expected = new Application()
         {
@@ -192,7 +192,7 @@ public class AppResourcesSITests
             appMetadata,
             null,
             new NullLogger<AppResourcesSI>(),
-            telemetry.Object
+            _telemetry.Object
         );
         Assert.Throws<ApplicationConfigException>(() => appResources.GetApplication());
     }
@@ -208,7 +208,7 @@ public class AppResourcesSITests
             appMetadata,
             null,
             new NullLogger<AppResourcesSI>(),
-            telemetry.Object
+            _telemetry.Object
         );
         Assert.Throws<ApplicationConfigException>(() => appResources.GetApplication());
     }
@@ -224,7 +224,7 @@ public class AppResourcesSITests
             appMetadata,
             null,
             new NullLogger<AppResourcesSI>(),
-            telemetry.Object
+            _telemetry.Object
         );
         string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine + "<root>policy</root>";
         var actual = appResources.GetApplicationXACMLPolicy();
@@ -242,7 +242,7 @@ public class AppResourcesSITests
             appMetadata,
             null,
             new NullLogger<AppResourcesSI>(),
-            telemetry.Object
+            _telemetry.Object
         );
         var actual = appResources.GetApplicationXACMLPolicy();
         actual.Should().BeNull();
@@ -259,7 +259,7 @@ public class AppResourcesSITests
             appMetadata,
             null,
             new NullLogger<AppResourcesSI>(),
-            telemetry.Object
+            _telemetry.Object
         );
         string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine + "<root>process</root>";
         var actual = appResources.GetApplicationBPMNProcess();
@@ -277,7 +277,7 @@ public class AppResourcesSITests
             appMetadata,
             null,
             new NullLogger<AppResourcesSI>(),
-            telemetry.Object
+            _telemetry.Object
         );
         var actual = appResources.GetApplicationBPMNProcess();
         actual.Should().BeNull();
@@ -292,7 +292,7 @@ public class AppResourcesSITests
     {
         AppSettings appSettings = new AppSettings()
         {
-            AppBasePath = appBasePath,
+            AppBasePath = _appBasePath,
             ConfigurationFolder = subfolder + Path.DirectorySeparatorChar,
             AuthorizationFolder = string.Empty,
             ProcessFolder = string.Empty,

--- a/test/Altinn.App.Core.Tests/Implementation/TextClientTest.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/TextClientTest.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Text;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Infrastructure.Clients.Storage;
+using Altinn.App.Core.Internal.Language;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
@@ -17,34 +18,34 @@ namespace Altinn.App.PlatformServices.Tests.Implementation;
 
 public class TextClientTest
 {
-    private readonly Mock<IOptions<PlatformSettings>> platformSettingsOptions;
-    private readonly Mock<IOptions<AppSettings>> appSettingsOptions;
-    private readonly Mock<HttpMessageHandler> handlerMock;
-    private readonly Mock<IHttpContextAccessor> contextAccessor;
-    private readonly Mock<ILogger<TextClient>> logger;
-    private readonly IMemoryCache memoryCache;
+    private readonly Mock<IOptions<PlatformSettings>> _platformSettingsOptions;
+    private readonly Mock<IOptions<AppSettings>> _appSettingsOptions;
+    private readonly Mock<HttpMessageHandler> _handlerMock;
+    private readonly Mock<IHttpContextAccessor> _contextAccessor;
+    private readonly Mock<ILogger<TextClient>> _logger;
+    private readonly IMemoryCache _memoryCache;
 
     public TextClientTest()
     {
-        platformSettingsOptions = new Mock<IOptions<PlatformSettings>>();
-        appSettingsOptions = new Mock<IOptions<AppSettings>>();
-        handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        contextAccessor = new Mock<IHttpContextAccessor>();
-        logger = new Mock<ILogger<TextClient>>();
+        _platformSettingsOptions = new Mock<IOptions<PlatformSettings>>();
+        _appSettingsOptions = new Mock<IOptions<AppSettings>>();
+        _handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        _contextAccessor = new Mock<IHttpContextAccessor>();
+        _logger = new Mock<ILogger<TextClient>>();
 
         var services = new ServiceCollection();
         services.AddMemoryCache();
         var serviceProvider = services.BuildServiceProvider();
 
-        memoryCache = serviceProvider.GetService<IMemoryCache>();
+        _memoryCache = serviceProvider.GetService<IMemoryCache>();
     }
 
     [Fact]
     public async Task GetAppTextNb_SuccessfulCallToStorage()
     {
         // Arrange
-        memoryCache.Remove("org-app-nb");
-        TextResource texts = new TextResource { Language = "nb" };
+        _memoryCache.Remove("org-app-nb");
+        TextResource texts = new TextResource { Language = LanguageConst.Bokmål };
 
         HttpResponseMessage httpResponseMessage = new HttpResponseMessage
         {
@@ -53,41 +54,41 @@ public class TextClientTest
         };
 
         InitializeMocks(httpResponseMessage, "texts");
-        HttpClient httpClient = new HttpClient(handlerMock.Object);
+        HttpClient httpClient = new HttpClient(_handlerMock.Object);
         TextClient target = new TextClient(
-            appSettingsOptions.Object,
-            platformSettingsOptions.Object,
-            logger.Object,
-            contextAccessor.Object,
+            _appSettingsOptions.Object,
+            _platformSettingsOptions.Object,
+            _logger.Object,
+            _contextAccessor.Object,
             httpClient,
-            memoryCache
+            _memoryCache
         );
 
         // Act
         await target.GetText("org", "app", "nb");
 
         // Assert
-        handlerMock.VerifyAll();
+        _handlerMock.VerifyAll();
     }
 
     [Fact]
     public async Task GetAppTextNb_TextSuccessfullyRetrievedFromCache()
     {
         // Arrange
-        memoryCache.Remove("org-app-nb");
-        TextResource texts = new TextResource { Language = "nb" };
-        memoryCache.Set("org-app-nb", texts);
+        _memoryCache.Remove("org-app-nb");
+        TextResource texts = new TextResource { Language = LanguageConst.Bokmål };
+        _memoryCache.Set("org-app-nb", texts);
 
         InitializeMocks(new HttpResponseMessage(), "texts");
 
-        HttpClient httpClient = new HttpClient(handlerMock.Object);
+        HttpClient httpClient = new HttpClient(_handlerMock.Object);
         TextClient target = new TextClient(
-            appSettingsOptions.Object,
-            platformSettingsOptions.Object,
-            logger.Object,
-            contextAccessor.Object,
+            _appSettingsOptions.Object,
+            _platformSettingsOptions.Object,
+            _logger.Object,
+            _contextAccessor.Object,
             httpClient,
-            memoryCache
+            _memoryCache
         );
 
         // Act
@@ -101,7 +102,7 @@ public class TextClientTest
     public async Task GetAppTextNb_StorageReturnsError()
     {
         // Arrange
-        memoryCache.Remove("org-app-nb");
+        _memoryCache.Remove("org-app-nb");
 
         HttpResponseMessage httpResponseMessage = new HttpResponseMessage
         {
@@ -109,14 +110,14 @@ public class TextClientTest
         };
 
         InitializeMocks(httpResponseMessage, "texts");
-        HttpClient httpClient = new HttpClient(handlerMock.Object);
+        HttpClient httpClient = new HttpClient(_handlerMock.Object);
         TextClient target = new TextClient(
-            appSettingsOptions.Object,
-            platformSettingsOptions.Object,
-            logger.Object,
-            contextAccessor.Object,
+            _appSettingsOptions.Object,
+            _platformSettingsOptions.Object,
+            _logger.Object,
+            _contextAccessor.Object,
             httpClient,
-            memoryCache
+            _memoryCache
         );
 
         // Act
@@ -133,14 +134,14 @@ public class TextClientTest
             ApiStorageEndpoint = "http://localhost",
             SubscriptionKey = "key"
         };
-        platformSettingsOptions.Setup(s => s.Value).Returns(platformSettings);
+        _platformSettingsOptions.Setup(s => s.Value).Returns(platformSettings);
 
         AppSettings appSettings = new AppSettings { RuntimeCookieName = "AltinnStudioRuntime" };
-        appSettingsOptions.Setup(s => s.Value).Returns(appSettings);
+        _appSettingsOptions.Setup(s => s.Value).Returns(appSettings);
 
-        contextAccessor.Setup(s => s.HttpContext).Returns(new DefaultHttpContext());
+        _contextAccessor.Setup(s => s.HttpContext).Returns(new DefaultHttpContext());
 
-        handlerMock
+        _handlerMock
             .Protected()
             .Setup<Task<HttpResponseMessage>>(
                 "SendAsync",

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Security.Claims;
 using Altinn.App.Common.Tests;
 using Altinn.App.Core.Configuration;
-using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Infrastructure.Clients.Pdf;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Auth;
@@ -300,13 +299,14 @@ public class PdfServiceTests
     public async Task GetLanguage_UserProfileIsNull_ShouldThrow()
     {
         // Arrange
-        var userId = 123; // Example user ID
-        var claims = new List<Claim> { new(AltinnCoreClaimTypes.UserId, userId.ToString()) };
+        var userId = 123;
 
-        var identity = new ClaimsIdentity(claims, "TestAuthType");
-        var claimsPrincipal = new ClaimsPrincipal(identity);
-
-        var httpContext = new DefaultHttpContext { User = claimsPrincipal };
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(
+                new ClaimsIdentity([new(AltinnCoreClaimTypes.UserId, userId.ToString())], "TestAuthType")
+            )
+        };
 
         _profile.Setup(s => s.GetUserProfile(It.IsAny<int>())).Returns(Task.FromResult<UserProfile?>(null));
 

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
@@ -5,6 +5,7 @@ using Altinn.App.Core.Infrastructure.Clients.Pdf;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Internal.Pdf;
 using Altinn.App.Core.Internal.Profile;
 using Altinn.App.PlatformServices.Tests.Helpers;
@@ -26,14 +27,15 @@ public class PdfServiceTests
     private readonly Mock<IHttpContextAccessor> _httpContextAccessor = new();
     private readonly Mock<IPdfGeneratorClient> _pdfGeneratorClient = new();
     private readonly Mock<IProfileClient> _profile = new();
-    private readonly IOptions<PdfGeneratorSettings> _pdfGeneratorSettingsOptions =
-        Microsoft.Extensions.Options.Options.Create<PdfGeneratorSettings>(new() { });
+    private readonly IOptions<PdfGeneratorSettings> _pdfGeneratorSettingsOptions = Options.Create<PdfGeneratorSettings>(
+        new() { }
+    );
 
-    private readonly IOptions<GeneralSettings> _generalSettingsOptions =
-        Microsoft.Extensions.Options.Options.Create<GeneralSettings>(new() { HostName = HostName });
+    private readonly IOptions<GeneralSettings> _generalSettingsOptions = Options.Create<GeneralSettings>(
+        new() { HostName = HostName }
+    );
 
-    private readonly IOptions<PlatformSettings> _platformSettingsOptions =
-        Microsoft.Extensions.Options.Options.Create<PlatformSettings>(new() { });
+    private readonly IOptions<PlatformSettings> _platformSettingsOptions = Options.Create<PlatformSettings>(new() { });
 
     private readonly Mock<IUserTokenProvider> _userTokenProvider;
 
@@ -42,9 +44,9 @@ public class PdfServiceTests
         var resource = new TextResource()
         {
             Id = "digdir-not-really-an-app-nb",
-            Language = "nb",
+            Language = LanguageConst.Bokmål,
             Org = "digdir",
-            Resources = new List<TextResourceElement>()
+            Resources = []
         };
         _appResources
             .Setup(s => s.GetTexts(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
@@ -278,9 +278,24 @@ public class PdfServiceTests
     public async Task GetLanguage_NoLanguageInUserPreference_ShouldReturnBokmål()
     {
         // Arrange
+        var profileMock = new Mock<IProfileClient>();
+        profileMock
+            .Setup(s => s.GetUserProfile(It.IsAny<int>()))
+            .Returns(
+                Task.FromResult<UserProfile?>(
+                    new UserProfile
+                    {
+                        UserId = 123,
+                        ProfileSettingPreference = new ProfileSettingPreference
+                        {
+                            /* No language preference set*/
+                        }
+                    }
+                )
+            );
         var user = new ClaimsPrincipal(new ClaimsIdentity([new(AltinnCoreClaimTypes.UserId, "123")], "TestAuthType"));
 
-        var target = SetupPdfService();
+        var target = SetupPdfService(profile: profileMock);
 
         // Act
         var language = await target.GetLanguage(user);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactorings: 

- Add languageConst to avoid "magic strings"
- Change GetLanguage and GetOverridenLanguage in PdfService to not deal with the entire HttpContext directly. Input param is the part they are concerned with. Would like to not have http context bleed into the service layer at all, but that would be a breaking change.

## Related Issue(s)
- #679 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
