### PR TITLE
Use dedicated data type for storing payment receipt pdf.

### DIFF
--- a/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnPaymentConfiguration.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnPaymentConfiguration.cs
@@ -15,16 +15,26 @@ public class AltinnPaymentConfiguration
     [XmlElement("paymentDataType", Namespace = "http://altinn.no/process")]
     public string? PaymentDataType { get; set; }
 
+    /// <summary>
+    /// Set what dataTypeId that should be used for storing the payment receipt pdf
+    /// </summary>
+    [XmlElement("paymentReceiptPdfDataType", Namespace = "http://altinn.no/process")]
+    public string? PaymentReceiptPdfDataType { get; set; }
+
     internal ValidAltinnPaymentConfiguration Validate()
     {
         List<string>? errorMessages = null;
 
-        var paymentDataType = PaymentDataType;
+        string? paymentDataType = PaymentDataType;
+        string? paymentReceiptPdfDataType = PaymentReceiptPdfDataType;
 
         if (paymentDataType.IsNullOrWhitespace(ref errorMessages, "PaymentDataType is missing."))
             ThrowApplicationConfigException(errorMessages);
 
-        return new ValidAltinnPaymentConfiguration(paymentDataType);
+        if (paymentReceiptPdfDataType.IsNullOrWhitespace(ref errorMessages, "PaymentReceiptPdfDataType is missing."))
+            ThrowApplicationConfigException(errorMessages);
+
+        return new ValidAltinnPaymentConfiguration(paymentDataType, paymentReceiptPdfDataType);
     }
 
     [DoesNotReturn]
@@ -36,7 +46,10 @@ public class AltinnPaymentConfiguration
     }
 }
 
-internal readonly record struct ValidAltinnPaymentConfiguration(string PaymentDataType);
+internal readonly record struct ValidAltinnPaymentConfiguration(
+    string PaymentDataType,
+    string PaymentReceiptPdfDataType
+);
 
 file static class ValidationExtensions
 {

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/PaymentProcessTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/PaymentProcessTask.cs
@@ -57,11 +57,11 @@ internal sealed class PaymentProcessTask : IProcessTask
 
         Stream pdfStream = await _pdfService.GeneratePdf(instance, taskId, CancellationToken.None);
 
-        var validatedPaymentConfiguration = paymentConfiguration.Validate();
+        ValidAltinnPaymentConfiguration validatedPaymentConfiguration = paymentConfiguration.Validate();
 
         await _dataClient.InsertBinaryData(
             instance.Id,
-            validatedPaymentConfiguration.PaymentDataType,
+            validatedPaymentConfiguration.PaymentReceiptPdfDataType,
             PdfContentType,
             ReceiptFileName,
             pdfStream,

--- a/test/Altinn.App.Core.Tests/Features/Action/TestData/payment-task-process.bpmn
+++ b/test/Altinn.App.Core.Tests/Features/Action/TestData/payment-task-process.bpmn
@@ -37,6 +37,7 @@
                     </altinn:actions>
                     <altinn:paymentConfig>
                         <altinn:paymentDataType>paymentInformation</altinn:paymentDataType>
+                        <altinn:paymentReceiptPdfDataType>paymentReceiptPdf</altinn:paymentReceiptPdfDataType>
                     </altinn:paymentConfig>
                 </altinn:taskExtension>
             </bpmn:extensionElements>

--- a/test/Altinn.App.Core.Tests/Features/Payment/AltinnPaymentConfigurationTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Payment/AltinnPaymentConfigurationTests.cs
@@ -19,14 +19,33 @@ public class AltinnPaymentConfigurationTests
         action.Should().Throw<ApplicationConfigException>();
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Validation_ThrowsException_When_PaymentReceiptPdfDataType_Is_Invalid(string? paymentReceiptPdfDataType)
+    {
+        AltinnPaymentConfiguration paymentConfiguration =
+            new() { PaymentDataType = "paymentDataType", PaymentReceiptPdfDataType = paymentReceiptPdfDataType };
+
+        var action = () => paymentConfiguration.Validate();
+
+        action.Should().Throw<ApplicationConfigException>();
+    }
+
     [Fact]
     public void Validation_Succeeds()
     {
         var paymentDataType = "paymentDataType";
-        AltinnPaymentConfiguration paymentConfiguration = new() { PaymentDataType = paymentDataType };
+        var paymentReceiptPdfDataType = "paymentReceiptPdfDataType";
+        AltinnPaymentConfiguration paymentConfiguration =
+            new() { PaymentDataType = paymentDataType, PaymentReceiptPdfDataType = paymentReceiptPdfDataType };
+
         paymentConfiguration.PaymentDataType.Should().Be(paymentDataType);
+        paymentConfiguration.PaymentReceiptPdfDataType.Should().Be(paymentReceiptPdfDataType);
 
         var validPaymentConfiguration = paymentConfiguration.Validate();
         validPaymentConfiguration.PaymentDataType.Should().Be(paymentDataType);
+        validPaymentConfiguration.PaymentReceiptPdfDataType.Should().Be(paymentReceiptPdfDataType);
     }
 }

--- a/test/Altinn.App.Core.Tests/Features/Payment/PaymentServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Payment/PaymentServiceTests.cs
@@ -425,7 +425,11 @@ public class PaymentServiceTests
         IPaymentProcessor[] paymentProcessors = [];
         var paymentService = new PaymentService(paymentProcessors, _dataService.Object, _logger.Object);
         Instance instance = CreateInstance();
-        var paymentConfiguration = new AltinnPaymentConfiguration { PaymentDataType = "paymentDataType" };
+        var paymentConfiguration = new AltinnPaymentConfiguration
+        {
+            PaymentDataType = "paymentDataType",
+            PaymentReceiptPdfDataType = "paymentReceiptPdfDataType"
+        };
 
         // Act
         Func<Task> act = async () =>
@@ -560,6 +564,10 @@ public class PaymentServiceTests
 
     private static ValidAltinnPaymentConfiguration CreatePaymentConfiguration()
     {
-        return new AltinnPaymentConfiguration { PaymentDataType = "paymentInformation" }.Validate();
+        return new AltinnPaymentConfiguration
+        {
+            PaymentDataType = "paymentInformation",
+            PaymentReceiptPdfDataType = "paymentReceiptPdf"
+        }.Validate();
     }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/PaymentProcessTaskTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/PaymentProcessTaskTests.cs
@@ -43,10 +43,7 @@ public class PaymentProcessTaskTests
             Instance instance = CreateInstance();
             string taskId = instance.Process.CurrentTask.ElementId;
 
-            var altinnTaskExtension = new AltinnTaskExtension
-            {
-                PaymentConfiguration = new AltinnPaymentConfiguration { PaymentDataType = "paymentDataType" }
-            };
+            var altinnTaskExtension = new AltinnTaskExtension { PaymentConfiguration = CreatePaymentConfiguration() };
 
             _processReaderMock.Setup(x => x.GetAltinnTaskExtension(It.IsAny<string>())).Returns(altinnTaskExtension);
 
@@ -65,10 +62,9 @@ public class PaymentProcessTaskTests
             Instance instance = CreateInstance();
             string taskId = instance.Process.CurrentTask.ElementId;
 
-            var altinnTaskExtension = new AltinnTaskExtension
-            {
-                PaymentConfiguration = new AltinnPaymentConfiguration { PaymentDataType = "paymentDataType" }
-            };
+            var altinnTaskExtension = new AltinnTaskExtension { PaymentConfiguration = CreatePaymentConfiguration() };
+            ValidAltinnPaymentConfiguration validPaymentConfiguration =
+                altinnTaskExtension.PaymentConfiguration.Validate();
 
             _processReaderMock.Setup(x => x.GetAltinnTaskExtension(It.IsAny<string>())).Returns(altinnTaskExtension);
 
@@ -84,7 +80,7 @@ public class PaymentProcessTaskTests
             _dataClientMock.Verify(x =>
                 x.InsertBinaryData(
                     instance.Id,
-                    altinnTaskExtension.PaymentConfiguration.PaymentDataType,
+                    validPaymentConfiguration.PaymentReceiptPdfDataType,
                     "application/pdf",
                     "Betalingskvittering.pdf",
                     It.IsAny<Stream>(),
@@ -99,10 +95,9 @@ public class PaymentProcessTaskTests
             Instance instance = CreateInstance();
             string taskId = instance.Process.CurrentTask.ElementId;
 
-            var altinnTaskExtension = new AltinnTaskExtension
-            {
-                PaymentConfiguration = new AltinnPaymentConfiguration { PaymentDataType = "paymentDataType" }
-            };
+            var altinnTaskExtension = new AltinnTaskExtension { PaymentConfiguration = CreatePaymentConfiguration() };
+            ValidAltinnPaymentConfiguration validPaymentConfiguration =
+                altinnTaskExtension.PaymentConfiguration.Validate();
 
             _processReaderMock.Setup(x => x.GetAltinnTaskExtension(It.IsAny<string>())).Returns(altinnTaskExtension);
 
@@ -116,7 +111,7 @@ public class PaymentProcessTaskTests
                 x =>
                     x.InsertBinaryData(
                         instance.Id,
-                        altinnTaskExtension.PaymentConfiguration.PaymentDataType,
+                        validPaymentConfiguration.PaymentReceiptPdfDataType,
                         "application/pdf",
                         "Betalingskvittering.pdf",
                         It.IsAny<Stream>(),
@@ -134,10 +129,7 @@ public class PaymentProcessTaskTests
             Instance instance = CreateInstance();
             string taskId = instance.Process.CurrentTask.ElementId;
 
-            var altinnTaskExtension = new AltinnTaskExtension
-            {
-                PaymentConfiguration = new AltinnPaymentConfiguration { PaymentDataType = "paymentDataType" }
-            };
+            var altinnTaskExtension = new AltinnTaskExtension { PaymentConfiguration = CreatePaymentConfiguration() };
 
             _processReaderMock.Setup(x => x.GetAltinnTaskExtension(It.IsAny<string>())).Returns(altinnTaskExtension);
 
@@ -184,12 +176,7 @@ public class PaymentProcessTaskTests
         {
             _processReaderMock
                 .Setup(pr => pr.GetAltinnTaskExtension(It.IsAny<string>()))
-                .Returns(
-                    new AltinnTaskExtension
-                    {
-                        PaymentConfiguration = new AltinnPaymentConfiguration { PaymentDataType = "paymentDataType" }
-                    }
-                );
+                .Returns(new AltinnTaskExtension { PaymentConfiguration = CreatePaymentConfiguration() });
 
             _paymentServiceMock
                 .Setup(ps => ps.IsPaymentCompleted(It.IsAny<Instance>(), It.IsAny<ValidAltinnPaymentConfiguration>()))
@@ -222,12 +209,7 @@ public class PaymentProcessTaskTests
         {
             _processReaderMock
                 .Setup(pr => pr.GetAltinnTaskExtension(It.IsAny<string>()))
-                .Returns(
-                    new AltinnTaskExtension
-                    {
-                        PaymentConfiguration = new AltinnPaymentConfiguration { PaymentDataType = "paymentDataType" }
-                    }
-                );
+                .Returns(new AltinnTaskExtension { PaymentConfiguration = CreatePaymentConfiguration() });
 
             Func<Task> act = async () => await _paymentProcessTask.Abandon("taskId", new Instance());
 
@@ -244,6 +226,15 @@ public class PaymentProcessTaskTests
                 {
                     CurrentTask = new ProcessElementInfo { AltinnTaskType = "payment", ElementId = "Task_1", },
                 },
+            };
+        }
+
+        private static AltinnPaymentConfiguration CreatePaymentConfiguration()
+        {
+            return new AltinnPaymentConfiguration
+            {
+                PaymentDataType = "paymentDataType",
+                PaymentReceiptPdfDataType = "paymentReceiptPdfDataType"
             };
         }
     }


### PR DESCRIPTION
We were using the same datatype that we use to store json-data about the payment to store the payment receipt pdf as well.
This is a bug, it should use a dedicated pdf data type.

Adding the possibility to tell the payment process step what datatype to use for this.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs/pull/1696) (if applicable)
