### PR TITLE
Add extension method for optionally adding key vault …

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -24,6 +24,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0"/>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Altinn.App.Core\Altinn.App.Core.csproj" />

--- a/src/Altinn.App.Api/Extensions/HostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/HostBuilderExtensions.cs
@@ -14,7 +14,7 @@ public static class HostBuilderExtensions
     /// <remarks>Use </remarks>
     /// <param name="builder"></param>
     /// <exception cref="ApplicationConfigException"></exception>
-    public static void AddKeyVaultAsConfigProvider(this IHostApplicationBuilder builder)
+    public static void AddAzureKeyVaultAsConfigProvider(this IHostApplicationBuilder builder)
     {
         IConfigurationManager configuration = builder.Configuration;
         IConfigurationSection section = configuration.GetSection("kvSetting");

--- a/src/Altinn.App.Api/Extensions/HostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/HostBuilderExtensions.cs
@@ -11,36 +11,34 @@ public static class HostBuilderExtensions
     /// <summary>
     /// Add KeyVault as a configuration provider. Requires that the kvSetting section is present in the configuration and throws an exception if not. See documentation for secret handling in Altinn apps.
     /// </summary>
+    /// <remarks>Use </remarks>
     /// <param name="builder"></param>
     /// <exception cref="ApplicationConfigException"></exception>
-    public static void AddKeyVaultAsConfigProvider(IHostBuilder builder)
+    public static void AddKeyVaultAsConfigProvider(this IHostApplicationBuilder builder)
     {
-        builder.ConfigureAppConfiguration(
-            (context, configuration) =>
-            {
-                IConfigurationSection section = context.Configuration.GetSection("kvSetting");
-                var keyVaultUri = section.GetValue<string>("SecretUri");
-                var clientId = section.GetValue<string>("ClientId");
-                var clientSecret = section.GetValue<string>("ClientSecret");
-                var tenantId = section.GetValue<string>("TenantId");
+        IConfigurationManager configuration = builder.Configuration;
+        IConfigurationSection section = configuration.GetSection("kvSetting");
 
-                if (
-                    string.IsNullOrWhiteSpace(keyVaultUri)
-                    || string.IsNullOrWhiteSpace(clientId)
-                    || string.IsNullOrWhiteSpace(clientSecret)
-                    || string.IsNullOrWhiteSpace(tenantId)
-                )
-                {
-                    throw new ApplicationConfigException(
-                        "Attempted to add KeyVault as a configuration provider, but the required settings for authenticating with KeyVault are missing. Please check the configuration."
-                    );
-                }
+        var keyVaultUri = section.GetValue<string>("SecretUri");
+        var clientId = section.GetValue<string>("ClientId");
+        var clientSecret = section.GetValue<string>("ClientSecret");
+        var tenantId = section.GetValue<string>("TenantId");
 
-                configuration.AddAzureKeyVault(
-                    new Uri(keyVaultUri),
-                    new ClientSecretCredential(tenantId, clientId, clientSecret)
-                );
-            }
+        if (
+            string.IsNullOrWhiteSpace(keyVaultUri)
+            || string.IsNullOrWhiteSpace(clientId)
+            || string.IsNullOrWhiteSpace(clientSecret)
+            || string.IsNullOrWhiteSpace(tenantId)
+        )
+        {
+            throw new ApplicationConfigException(
+                "Attempted to add KeyVault as a configuration provider, but the required settings for authenticating with KeyVault are missing. Please check the configuration."
+            );
+        }
+
+        builder.Configuration.AddAzureKeyVault(
+            new Uri(keyVaultUri),
+            new ClientSecretCredential(tenantId, clientId, clientSecret)
         );
     }
 }

--- a/src/Altinn.App.Api/Extensions/HostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/HostBuilderExtensions.cs
@@ -1,0 +1,46 @@
+﻿using Altinn.App.Core.Internal.App;
+using Azure.Identity;
+
+namespace Altinn.App.Api.Extensions;
+
+/// <summary>
+/// Class for defining extensions to IHostBuilder for AltinnApps
+/// </summary>
+public static class HostBuilderExtensions
+{
+    /// <summary>
+    /// Add KeyVault as a configuration provider. Requires that the kvSetting section is present in the configuration and throws an exception if not. See documentation for secret handling in Altinn apps.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <exception cref="ApplicationConfigException"></exception>
+    public static void AddKeyVaultAsConfigProvider(IHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration(
+            (context, configuration) =>
+            {
+                IConfigurationSection section = context.Configuration.GetSection("kvSetting");
+                var keyVaultUri = section.GetValue<string>("SecretUri");
+                var clientId = section.GetValue<string>("ClientId");
+                var clientSecret = section.GetValue<string>("ClientSecret");
+                var tenantId = section.GetValue<string>("TenantId");
+
+                if (
+                    string.IsNullOrWhiteSpace(keyVaultUri)
+                    || string.IsNullOrWhiteSpace(clientId)
+                    || string.IsNullOrWhiteSpace(clientSecret)
+                    || string.IsNullOrWhiteSpace(tenantId)
+                )
+                {
+                    throw new ApplicationConfigException(
+                        "Attempted to add KeyVault as a configuration provider, but the required settings for authenticating with KeyVault are missing. Please check the configuration."
+                    );
+                }
+
+                configuration.AddAzureKeyVault(
+                    new Uri(keyVaultUri),
+                    new ClientSecretCredential(tenantId, clientId, clientSecret)
+                );
+            }
+        );
+    }
+}

--- a/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
@@ -1,8 +1,4 @@
 using Altinn.App.Core.Extensions;
-using Altinn.App.Core.Internal.App;
-using AltinnCore.Authentication.Constants;
-using Azure.Identity;
-using Azure.Security.KeyVault.Secrets;
 
 namespace Altinn.App.Api.Extensions;
 

--- a/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
@@ -35,45 +35,4 @@ public static class WebHostBuilderExtensions
             }
         );
     }
-
-    /// <summary>
-    /// Add KeyVault as a configuration provider. Requires that the kvSetting section is present in the configuration and throws an exception if not. See documentation for secret handling in Altinn apps.
-    /// </summary>
-    /// <param name="builder"></param>
-    public static void AddKeyVaultAsConfigProvider(this IWebHostBuilder builder)
-    {
-        builder.ConfigureAppConfiguration(
-            (_, configBuilder) =>
-            {
-                IConfiguration stageOneConfig = configBuilder.Build();
-                var keyVaultSettings = new KeyVaultSettings();
-                stageOneConfig.GetSection("kvSetting").Bind(keyVaultSettings);
-
-                if (
-                    string.IsNullOrEmpty(keyVaultSettings.ClientId)
-                    || string.IsNullOrEmpty(keyVaultSettings.TenantId)
-                    || string.IsNullOrEmpty(keyVaultSettings.ClientSecret)
-                    || string.IsNullOrEmpty(keyVaultSettings.SecretUri)
-                )
-                {
-                    throw new ApplicationConfigException(
-                        "Attempted to add KeyVault as a configuration provider, but the required settings for authenticating with KeyVault are missing. Please check the configuration."
-                    );
-                }
-
-                var clientSecretCredential = new ClientSecretCredential(
-                    keyVaultSettings.TenantId,
-                    keyVaultSettings.ClientId,
-                    keyVaultSettings.ClientSecret
-                );
-
-                var secretClient = new SecretClient(new Uri(keyVaultSettings.SecretUri), clientSecretCredential);
-
-                configBuilder.AddAzureKeyVault(
-                    secretClient,
-                    new Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager()
-                );
-            }
-        );
-    }
 }

--- a/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
@@ -1,4 +1,8 @@
 using Altinn.App.Core.Extensions;
+using Altinn.App.Core.Internal.App;
+using AltinnCore.Authentication.Constants;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
 
 namespace Altinn.App.Api.Extensions;
 
@@ -28,6 +32,47 @@ public static class WebHostBuilderExtensions
 
                 configBuilder.AddInMemoryCollection(config);
                 configBuilder.LoadAppConfig(args);
+            }
+        );
+    }
+
+    /// <summary>
+    /// Add KeyVault as a configuration provider. Requires that the kvSetting section is present in the configuration and throws an exception if not. See documentation for secret handling in Altinn apps.
+    /// </summary>
+    /// <param name="builder"></param>
+    public static void AddKeyVaultAsConfigProvider(this IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration(
+            (_, configBuilder) =>
+            {
+                IConfiguration stageOneConfig = configBuilder.Build();
+                var keyVaultSettings = new KeyVaultSettings();
+                stageOneConfig.GetSection("kvSetting").Bind(keyVaultSettings);
+
+                if (
+                    string.IsNullOrEmpty(keyVaultSettings.ClientId)
+                    || string.IsNullOrEmpty(keyVaultSettings.TenantId)
+                    || string.IsNullOrEmpty(keyVaultSettings.ClientSecret)
+                    || string.IsNullOrEmpty(keyVaultSettings.SecretUri)
+                )
+                {
+                    throw new ApplicationConfigException(
+                        "Attempted to add KeyVault as a configuration provider, but the required settings for authenticating with KeyVault are missing. Please check the configuration."
+                    );
+                }
+
+                var clientSecretCredential = new ClientSecretCredential(
+                    keyVaultSettings.TenantId,
+                    keyVaultSettings.ClientId,
+                    keyVaultSettings.ClientSecret
+                );
+
+                var secretClient = new SecretClient(new Uri(keyVaultSettings.SecretUri), clientSecretCredential);
+
+                configBuilder.AddAzureKeyVault(
+                    secretClient,
+                    new Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager()
+                );
             }
         );
     }


### PR DESCRIPTION
Add extension method for optionally adding key vault as a configuration provider.

Do you think it's correct to add it in the API project, or should I put it in Core?
Should I unit test this on any level? Tips on a good way to do it?

We are most probably going to add key vault as a configuration provider by default in next major version. This can be removed then.

## Related Issue(s)
- #703 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs/pull/1708) (if applicable)
