### PR TITLE
Return 400 on wrong external api client id

### DIFF
--- a/src/Altinn.App.Api/Controllers/ExternalApiController.cs
+++ b/src/Altinn.App.Api/Controllers/ExternalApiController.cs
@@ -57,8 +57,8 @@ public class ExternalApiController : ControllerBase
 
             if (!wasExternalApiFound)
             {
-                _logger.LogWarning("External api not found.");
-                return NotFound("External api not found.");
+                _logger.LogWarning("External api with id '{ExternalApiId}' not found.", externalApiId);
+                return BadRequest($"External api with id '{externalApiId}' not found.");
             }
 
             return Ok(externalApiData);

--- a/test/Altinn.App.Api.Tests/Controllers/ExternalApiControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ExternalApiControllerTests.cs
@@ -61,10 +61,10 @@ public class ExternalApiControllerTests
         var result = await controller.Get(1, Guid.NewGuid(), externalApiId, queryParams);
 
         // Assert
-        result.Should().BeOfType<NotFoundObjectResult>();
-        var objectResult = result as NotFoundObjectResult;
-        objectResult?.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
-        objectResult?.Value.Should().Be("External api not found.");
+        result.Should().BeOfType<BadRequestObjectResult>();
+        var objectResult = result as BadRequestObjectResult;
+        objectResult?.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);
+        objectResult?.Value.Should().Be($"External api with id '{externalApiId}' not found.");
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changing http status code to return 400 instead of 404 when supplied external api client id does not correspond to an existing implementation of `IExternalApiClient`.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
