### PR TITLE
Intercepts unhandled exceptions, returns somewhat descriptive message to caller

### DIFF
--- a/src/Altinn.App.Api/Controllers/ExternalApiController.cs
+++ b/src/Altinn.App.Api/Controllers/ExternalApiController.cs
@@ -70,7 +70,17 @@ public class ExternalApiController : ControllerBase
             {
                 return StatusCode((int)ex.StatusCode.Value, ex.Message);
             }
-            return StatusCode((int)HttpStatusCode.InternalServerError, "An error occurred when calling external api.");
+            return StatusCode(
+                (int)HttpStatusCode.InternalServerError,
+                $"An error occurred when calling external api: {ex.Message}"
+            );
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(
+                (int)HttpStatusCode.InternalServerError,
+                $"An error occurred when calling external api: {ex.Message}"
+            );
         }
     }
 }


### PR DESCRIPTION
Minor adjustments to the error handling in `ExternalApiController`.

Catching unhandled errors and specifically returning a 500 status code to the caller, with what we know about the error; preventing exceptions from being automatically handled by the middleware.