### PR TITLE
Handle integer values in equals expression

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -511,6 +511,10 @@ public static class ExpressionEvaluator
         {
             return doubvalue.ToString(CultureInfo.InvariantCulture);
         }
+        else if (value is int intvalue)
+        {
+            return intvalue.ToString(CultureInfo.InvariantCulture);
+        }
 
         //TODO: consider accepting more types that might be used in model (eg Datetime)
         throw new NotImplementedException();

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/stringLength/length-equals.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/stringLength/length-equals.json
@@ -1,0 +1,5 @@
+{
+    "name": "Two strings of equal length should be equal according to equals expression",
+    "expression": ["equals", ["stringLength", "Hello"], ["stringLength", "World"]],
+    "expects": true
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The equals expression did was not implemented for integer value inputs. This means you could not compare the output of `stringLength` for equality. This PR simply adds a case for handling integers.

There is a shared test for `equals` that tests equality between integers; however, json numbers are converted to double when parsing so the type in C# is not actually an integer, so this was not actually covered in tests. I added a new shared test that tests the `equals` expression on the result of two `stringLength`-expressions to cover this.

## Related Issue(s)
- https://altinn.slack.com/archives/C02EJ9HKQA3/p1722849166690299

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
