### PR TITLE
392: Fix response of PUT user-defined-metadata.

### DIFF
--- a/src/Altinn.App.Api/Controllers/UserDefinedMetadataController.cs
+++ b/src/Altinn.App.Api/Controllers/UserDefinedMetadataController.cs
@@ -151,7 +151,10 @@ public class UserDefinedMetadataController : ControllerBase
         dataElement.UserDefinedMetadata = userDefinedMetadataDto.UserDefinedMetadata;
         dataElement = await _dataClient.Update(instance, dataElement);
 
-        return Ok(dataElement.UserDefinedMetadata);
+        UserDefinedMetadataDto responseUserDefinedMetadataDto =
+            new() { UserDefinedMetadata = dataElement.UserDefinedMetadata };
+
+        return responseUserDefinedMetadataDto;
     }
 
     private static List<string> FindNotAllowedKeys(


### PR DESCRIPTION
The actual return value of the PUT user-defined-metadata endpoint was different than what the openapi spec stated. Now it will be the same as the GET endpoint.

## Related Issue(s)
- #392 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
