### PR TITLE
Run API tests in prod environment always

### DIFF
--- a/test/Altinn.App.Api.Tests/Program.cs
+++ b/test/Altinn.App.Api.Tests/Program.cs
@@ -18,6 +18,7 @@ using Altinn.App.Core.Internal.Registers;
 using AltinnCore.Authentication.JwtCookie;
 using App.IntegrationTests.Mocks.Services;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -33,7 +34,8 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(
     new WebApplicationOptions()
     {
         ApplicationName = "Altinn.App.Api.Tests",
-        WebRootPath = Path.Join(TestData.GetTestDataRootDirectory(), "apps", "tdd", "contributer-restriction")
+        WebRootPath = Path.Join(TestData.GetTestDataRootDirectory(), "apps", "tdd", "contributer-restriction"),
+        EnvironmentName = "Production",
     }
 );
 


### PR DESCRIPTION
## Description
@bjorntore and others reported the new manual instantiation tests (such as `InstationAllowedByOrg_Returns_Forbidden_For_user`) failed when running from Rider, but  succeeded under normal `dotnet test` as is done in CI.
Turns out Rider (and probably other IDEs) use `Development` environment as opposed to `Production` which is the default.
Setting in `Program.cs` the environment to always be `Production` will make things consistent

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
