### PR TITLE
Payment: Add support for specifying payer details in OrderDetails

### DIFF
--- a/src/Altinn.App.Core/Features/Payment/Models/Address.cs
+++ b/src/Altinn.App.Core/Features/Payment/Models/Address.cs
@@ -31,7 +31,7 @@ public class Address
     public string? City { get; set; }
 
     /// <summary>
-    /// The country of the address.
+    /// The country of the address. What format this is expected in might differ between payment processors. For instance, Nets Easy requires 3-letter ISO 3166 country codes.
     /// </summary>
     public string? Country { get; set; }
 }

--- a/src/Altinn.App.Core/Features/Payment/Models/OrderDetails.cs
+++ b/src/Altinn.App.Core/Features/Payment/Models/OrderDetails.cs
@@ -16,6 +16,11 @@ public class OrderDetails
     public required PaymentReceiver Receiver { get; set; }
 
     /// <summary>
+    /// The party that will make the payment. How this is used/respected can vary between payment processors. Some payment processors might require this to be set.
+    /// </summary>
+    public Payer? Payer { get; set; }
+
+    /// <summary>
     /// Monetary unit of the prices in the order.
     /// </summary>
     public required string Currency { get; set; }

--- a/src/Altinn.App.Core/Features/Payment/Models/Payer.cs
+++ b/src/Altinn.App.Core/Features/Payment/Models/Payer.cs
@@ -6,12 +6,12 @@ namespace Altinn.App.Core.Features.Payment.Models;
 public class Payer
 {
     /// <summary>
-    /// If the payer is a private person, this property should be set.
+    /// If the payer is a private person, this property should be set. Do not set both this and <see cref="Company"/>.
     /// </summary>
     public PayerPrivatePerson? PrivatePerson { get; set; }
 
     /// <summary>
-    /// If the payer is a company, this property should be set.
+    /// If the payer is a company, this property should be set. Do not set both this and <see cref="PrivatePerson"/>.
     /// </summary>
     public PayerCompany? Company { get; set; }
 

--- a/src/Altinn.App.Core/Features/Payment/Processors/Nets/Models/NetsCheckout.cs
+++ b/src/Altinn.App.Core/Features/Payment/Processors/Nets/Models/NetsCheckout.cs
@@ -40,6 +40,12 @@ internal class NetsCheckout
     public string? CancelUrl { get; set; }
 
     /// <summary>
+    /// Contains information about the customer. If provided, this information will be used for initating the consumer data of the payment object.
+    /// See also the property merchantHandlesConsumerData which controls what fields to show on the checkout page.
+    /// </summary>
+    public NetsCheckoutConsumerDetails? Consumer { get; set; }
+
+    /// <summary>
     /// The URL to the terms and conditions of your webshop.
     /// Whitelist: “[&amp;]” =&gt; “”
     /// The following special characters are not supported: &lt;,&gt;,\,’,”,&amp;,\\

--- a/src/Altinn.App.Core/Features/Payment/Processors/Nets/Models/NetsCheckoutConsumerDetails.cs
+++ b/src/Altinn.App.Core/Features/Payment/Processors/Nets/Models/NetsCheckoutConsumerDetails.cs
@@ -1,0 +1,32 @@
+﻿namespace Altinn.App.Core.Features.Payment.Processors.Nets.Models;
+
+internal class NetsCheckoutConsumerDetails
+{
+    public string? Reference { get; set; }
+    public string? Email { get; set; }
+    public NetsAddress? ShippingAddress { get; set; }
+    public NetsAddress? BillingAddress { get; set; }
+    public NetsPhoneNumber? PhoneNumber { get; set; }
+    public NetsCheckoutPrivatePerson? PrivatePerson { get; set; }
+    public NetsCheckoutCompany? Company { get; set; }
+}
+
+/// <remarks>
+/// Warning: Nets Easy API reference has multiple variants of private person objects.
+/// This is used for create payment, while NetsPaymentFull uses a different object to represent a private person.
+/// </remarks>
+internal class NetsCheckoutPrivatePerson
+{
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+}
+
+/// <remarks>
+/// Warning: Nets Easy API reference has multiple variants of company objects.
+/// This is used for create payment, while NetsPaymentFull uses a different object to represent a private person.
+/// </remarks>
+internal class NetsCheckoutCompany
+{
+    public string? Name { get; set; }
+    public NetsCheckoutPrivatePerson? Contact { get; set; }
+}

--- a/src/Altinn.App.Core/Features/Payment/Processors/Nets/Models/README.md
+++ b/src/Altinn.App.Core/Features/Payment/Processors/Nets/Models/README.md
@@ -1,0 +1,21 @@
+﻿# API Models Information
+
+This folder has the C# models used for the Nets Easy API.
+
+## Overview
+
+These models were manually created based on the JSON examples in the Nets API documentation. Since they were written by
+hand, there might be some unintentional differences from the actual API objects.
+
+## API Reference
+
+The models are based on the following API documentation:
+
+- [Nets Easy Payment API](https://developer.nexigroup.com/nexi-checkout/en-EU/api/payment-v1/)
+
+## Notes
+
+- **Manual Creation**: Since these were manually created, there could be some mismatches between the models and the
+  actual API.
+- **Check for Updates**: Refer back to the official API docs for the most up-to-date information.
+

--- a/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsPaymentProcessor.cs
+++ b/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsPaymentProcessor.cs
@@ -6,7 +6,6 @@ using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
-using OrderDetails = Altinn.App.Core.Features.Payment.Models.OrderDetails;
 
 namespace Altinn.App.Core.Features.Payment.Processors.Nets;
 
@@ -82,6 +81,8 @@ internal class NetsPaymentProcessor : IPaymentProcessor
                 TermsUrl = _settings.TermsUrl,
                 ReturnUrl = altinnAppUrl,
                 CancelUrl = altinnAppUrl,
+                Consumer = NetsMapper.MapConsumerDetails(orderDetails.Payer),
+                MerchantHandlesConsumerData = orderDetails.Payer != null,
                 ConsumerType = new NetsConsumerType
                 {
                     SupportedTypes = NetsMapper.MapConsumerTypes(orderDetails.AllowedPayerTypes),

--- a/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsPaymentProcessor.cs
+++ b/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsPaymentProcessor.cs
@@ -154,9 +154,9 @@ internal class NetsPaymentProcessor : IPaymentProcessor
         PaymentStatus status = chargedAmount > 0 ? PaymentStatus.Paid : PaymentStatus.Created;
         NetsPaymentDetails? paymentPaymentDetails = payment.PaymentDetails;
 
-        var checkout =
+        NetsCheckoutUrls checkout =
             payment.Checkout ?? throw new PaymentException("Checkout information is missing in the response from Nets");
-        var checkoutUrl =
+        string checkoutUrl =
             checkout.Url ?? throw new PaymentException("Checkout URL is missing in the response from Nets");
 
         PaymentDetails paymentDetails =

--- a/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsPaymentProcessor.cs
+++ b/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsPaymentProcessor.cs
@@ -48,6 +48,13 @@ internal class NetsPaymentProcessor : IPaymentProcessor
         string baseUrl = _generalSettings.FormattedExternalAppBaseUrl(new AppIdentifier(instance));
         var altinnAppUrl = $"{baseUrl}#/instance/{instanceIdentifier}";
 
+        if (_settings.MerchantHandlesConsumerData == true && orderDetails.Payer is null)
+        {
+            throw new PaymentException(
+                "Payer is missing in orderDetails. MerchantHandlesConsumerData is set to true. Payer must be provided."
+            );
+        }
+
         var payment = new NetsCreatePayment()
         {
             Order = new NetsOrder
@@ -82,7 +89,7 @@ internal class NetsPaymentProcessor : IPaymentProcessor
                 ReturnUrl = altinnAppUrl,
                 CancelUrl = altinnAppUrl,
                 Consumer = NetsMapper.MapConsumerDetails(orderDetails.Payer),
-                MerchantHandlesConsumerData = orderDetails.Payer != null,
+                MerchantHandlesConsumerData = _settings.MerchantHandlesConsumerData ?? orderDetails.Payer is not null,
                 ConsumerType = new NetsConsumerType
                 {
                     SupportedTypes = NetsMapper.MapConsumerTypes(orderDetails.AllowedPayerTypes),

--- a/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsPaymentSettings.cs
+++ b/src/Altinn.App.Core/Features/Payment/Processors/Nets/NetsPaymentSettings.cs
@@ -29,4 +29,9 @@ public class NetsPaymentSettings
     /// If true, the name of the merchant will be shown to the user before they confirm the payment.
     /// </summary>
     public bool ShowMerchantName { get; set; } = true;
+
+    /// <summary>
+    /// Allows you to initiate the checkout with customer data so that your customer only need to provide payment details. If set to true, information about the paying party must be supplied.
+    /// </summary>
+    public bool? MerchantHandlesConsumerData { get; set; }
 }

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -5974,6 +5974,9 @@
           "receiver": {
             "$ref": "#/components/schemas/PaymentReceiver"
           },
+          "payer": {
+            "$ref": "#/components/schemas/Payer"
+          },
           "currency": {
             "type": "string",
             "nullable": true

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -3791,6 +3791,8 @@ components:
           nullable: true
         receiver:
           $ref: '#/components/schemas/PaymentReceiver'
+        payer:
+          $ref: '#/components/schemas/Payer'
         currency:
           type: string
           nullable: true

--- a/test/Altinn.App.Core.Tests/Features/Payment/Providers/Nets/NetsMapperTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Payment/Providers/Nets/NetsMapperTests.cs
@@ -94,6 +94,154 @@ public class NetsMapperTests
     }
 
     [Fact]
+    public void MapPayerDetails_ValidPayerCompany_ReturnsNetsConsumer()
+    {
+        // Arrange
+        var payer = new Payer
+        {
+            Company = new PayerCompany
+            {
+                Name = "Firmanavn",
+                ContactPerson = new PayerPrivatePerson
+                {
+                    FirstName = "Ola",
+                    LastName = "Normann",
+                    Email = "ola.normann@example.com",
+                    PhoneNumber = new PhoneNumber { Prefix = "+47", Number = "12345678" }
+                }
+            },
+            ShippingAddress = new Address
+            {
+                Name = "Ola Normann",
+                AddressLine1 = "Gate 1",
+                AddressLine2 = "Adresselinje 1",
+                PostalCode = "1234",
+                City = "By",
+                Country = "Land"
+            },
+            BillingAddress = new Address
+            {
+                Name = "Kari Normann",
+                AddressLine1 = "Gate 2",
+                AddressLine2 = "Adresselinje 2",
+                PostalCode = "5678",
+                City = "By",
+                Country = "Land"
+            }
+        };
+
+        // Act
+        NetsCheckoutConsumerDetails? result = NetsMapper.MapConsumerDetails(payer);
+
+        // Assert
+        result.Should().NotBeNull();
+
+        result!.Company.Should().NotBeNull();
+        result.Company!.Name.Should().Be("Firmanavn");
+        result.Company.Contact.Should().NotBeNull();
+        result.Company.Contact!.FirstName.Should().Be("Ola");
+        result.Company.Contact.LastName.Should().Be("Normann");
+        result.Email.Should().Be("ola.normann@example.com");
+        result.PhoneNumber.Should().NotBeNull();
+        result.PhoneNumber!.Prefix.Should().Be("+47");
+        result.PhoneNumber.Number.Should().Be("12345678");
+
+        result.PrivatePerson.Should().BeNull();
+
+        result.ShippingAddress.Should().NotBeNull();
+        result.ShippingAddress!.ReceiverLine.Should().Be("Ola Normann");
+        result.ShippingAddress.AddressLine1.Should().Be("Gate 1");
+        result.ShippingAddress.AddressLine2.Should().Be("Adresselinje 1");
+        result.ShippingAddress.PostalCode.Should().Be("1234");
+        result.ShippingAddress.City.Should().Be("By");
+        result.ShippingAddress.Country.Should().Be("Land");
+
+        result.BillingAddress.Should().NotBeNull();
+        result.BillingAddress!.ReceiverLine.Should().Be("Kari Normann");
+        result.BillingAddress.AddressLine1.Should().Be("Gate 2");
+        result.BillingAddress.AddressLine2.Should().Be("Adresselinje 2");
+        result.BillingAddress.PostalCode.Should().Be("5678");
+        result.BillingAddress.City.Should().Be("By");
+        result.BillingAddress.Country.Should().Be("Land");
+    }
+
+    [Fact]
+    public void MapPayerDetails_ValidPayerPrivatePerson_ReturnsNetsConsumer()
+    {
+        // Arrange
+        var payer = new Payer
+        {
+            PrivatePerson = new PayerPrivatePerson
+            {
+                FirstName = "Kari",
+                LastName = "Normann",
+                Email = "ola.normann@example.com",
+                PhoneNumber = new PhoneNumber { Prefix = "+47", Number = "87654321" }
+            },
+            ShippingAddress = new Address
+            {
+                Name = "Ola Normann",
+                AddressLine1 = "Gate 1",
+                AddressLine2 = "Adresselinje 1",
+                PostalCode = "1234",
+                City = "By",
+                Country = "Land"
+            },
+            BillingAddress = new Address
+            {
+                Name = "Kari Normann",
+                AddressLine1 = "Gate 2",
+                AddressLine2 = "Adresselinje 2",
+                PostalCode = "5678",
+                City = "By",
+                Country = "Land"
+            }
+        };
+
+        // Act
+        NetsCheckoutConsumerDetails? result = NetsMapper.MapConsumerDetails(payer);
+
+        // Assert
+        result.Should().NotBeNull();
+
+        result!.Company.Should().BeNull();
+
+        result.PrivatePerson.Should().NotBeNull();
+        result.PrivatePerson!.FirstName.Should().Be("Kari");
+        result.PrivatePerson.LastName.Should().Be("Normann");
+        result.Email.Should().Be("ola.normann@example.com");
+        result.PhoneNumber.Should().NotBeNull();
+        result.PhoneNumber!.Prefix.Should().Be("+47");
+        result.PhoneNumber.Number.Should().Be("87654321");
+
+        result.ShippingAddress.Should().NotBeNull();
+        result.ShippingAddress!.ReceiverLine.Should().Be("Ola Normann");
+        result.ShippingAddress.AddressLine1.Should().Be("Gate 1");
+        result.ShippingAddress.AddressLine2.Should().Be("Adresselinje 1");
+        result.ShippingAddress.PostalCode.Should().Be("1234");
+        result.ShippingAddress.City.Should().Be("By");
+        result.ShippingAddress.Country.Should().Be("Land");
+
+        result.BillingAddress.Should().NotBeNull();
+        result.BillingAddress!.ReceiverLine.Should().Be("Kari Normann");
+        result.BillingAddress.AddressLine1.Should().Be("Gate 2");
+        result.BillingAddress.AddressLine2.Should().Be("Adresselinje 2");
+        result.BillingAddress.PostalCode.Should().Be("5678");
+        result.BillingAddress.City.Should().Be("By");
+        result.BillingAddress.Country.Should().Be("Land");
+    }
+
+    [Fact]
+    public void MapPayerDetails_BothCompanyAndPrivatePersonIsSet_ThrowsArgumentException()
+    {
+        // Arrange
+        var payer = new Payer { Company = new PayerCompany(), PrivatePerson = new PayerPrivatePerson(), };
+
+        // Act & assert
+        Assert.Throws<ArgumentException>(() => NetsMapper.MapConsumerDetails(payer));
+    }
+
+    [Fact]
     public void MapConsumerTypes_ValidPayerTypes_ReturnsCorrectConsumerTypes()
     {
         // Arrange


### PR DESCRIPTION
Add support for specifying payer details in OrderDetails, allowing payment processors like Nets Easy to utilize the information when available.


## Related Issue(s)
- #716

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
