### PR TITLE
Make IProcessEventHandlerDelegator transient to reverse breaking behavior change from v8.1

### DIFF
--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -325,7 +325,7 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient<IProcessEngine, ProcessEngine>();
         services.TryAddTransient<IProcessNavigator, ProcessNavigator>();
         services.TryAddSingleton<IProcessReader, ProcessReader>();
-        services.TryAddSingleton<IProcessEventHandlerDelegator, ProcessEventHandlingDelegator>();
+        services.TryAddTransient<IProcessEventHandlerDelegator, ProcessEventHandlingDelegator>();
         services.TryAddTransient<IProcessEventDispatcher, ProcessEventDispatcher>();
         services.AddTransient<IProcessExclusiveGateway, ExpressionsExclusiveGateway>();
         services.TryAddTransient<ExclusiveGatewayFactory>();


### PR DESCRIPTION
## Description
In the internal process engine refactoring of v8.1.0 we released a slight behavioral change:

### Before v8.1.0

| Request controller | `IProcessEngine` | `IProcessEventDispatcher` | `ITaskEvents` | `IInstantiationProcessor` |
|--------------------|------------------|---------------------------|---------------|---------------------------|
| `Scoped`           | `Transient`      | `Transient`               | `Transient`   | User controlled           |

### After v8.1.0

| Request controller | `IProcessEngine` | `IProcessEventHandlerDelegator` | `IStartTaskEventHandler` | `IProcessTaskInitializer` | `IInstantiationProcessor` |
|--------------------|------------------|---------------------------------|--------------------------|---------------------------|---------------------------|
| `Scoped`           | `Transient`      | `Singleton`                     | `Transient`              | `Transient`               | User controlled           |


Since `IProcessEventHandlerDelegator` became singleton. Downstream dependencies (e.g. `IInstantiationProcessor`) became singleton. If we add the delegator as `Transient` instead, it should take us back to the original behavior.

## Related Issue(s)
- N/A - no public issue

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
