### PR TITLE
Add error handling logic for profile lookups with user ID 0, improve telemetry

### DIFF
--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.UserHelper.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.UserHelper.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics;
+
+namespace Altinn.App.Core.Features;
+
+partial class Telemetry
+{
+    internal Activity? StartGetUserContextActivity() => ActivitySource.StartActivity("UserHelper.GetUserContext");
+}

--- a/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Profile/ProfileClient.cs
@@ -84,6 +84,12 @@ public class ProfileClient : IProfileClient
         using var activity = _telemetry?.StartGetUserProfileActivity(userId);
         UserProfile? userProfile = null;
 
+        if (userId == default)
+        {
+            _logger.LogError("Tried to get user profile with 0 as user ID");
+            return null;
+        }
+
         string endpointUrl = $"users/{userId}";
         string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
 


### PR DESCRIPTION
## Description
There is a bug where we ask for the profile of user ID 0 sometimes (e.g. in `AuthorizationController.GetCurrentParty`).
I don't understand why this happens yet, but maybe a good first step is to handle the error condition and add some telemetry.
In a trace where this happened, only authenticationlevel was set and it was set to `0`. I think enabling OTel would help debugging here

`UserHelper` is used by a lot of user code (even the constructor directly), but I don't think we consider this a breaking change when the added argument in optional

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
