### PR TITLE
Make sure exception is thrown when an exclusive gateway fails to return a valid path in the process engine

### DIFF
--- a/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
@@ -306,7 +306,11 @@ public class ProcessEngine : IProcessEngine
         }
 
         // ending process if next element is end event
-        var nextElementId = nextElement?.Id;
+        if (nextElement is null)
+        {
+            throw new Exception("Next process element was unexpectedly null");
+        }
+        var nextElementId = nextElement.Id;
         if (_processReader.IsEndEvent(nextElementId))
         {
             using var activity = _telemetry?.StartProcessEndActivity(instance);
@@ -324,11 +328,6 @@ public class ProcessEngine : IProcessEngine
         }
         else if (_processReader.IsProcessTask(nextElementId))
         {
-            if (nextElement is null)
-            {
-                throw new Exception("Next process element was unexpectedly null");
-            }
-
             var task = nextElement as ProcessTask;
             currentState.CurrentTask = new ProcessElementInfo
             {

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
@@ -308,7 +308,7 @@ public class ProcessEngine : IProcessEngine
         // ending process if next element is end event
         if (nextElement is null)
         {
-            throw new Exception("Next process element was unexpectedly null");
+            throw new ProcessException("Next process element was unexpectedly null");
         }
         var nextElementId = nextElement.Id;
         if (_processReader.IsEndEvent(nextElementId))

--- a/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
@@ -103,6 +103,12 @@ public class ProcessNavigator : IProcessNavigator
                     };
 
                 filteredList = await gatewayFilter.FilterAsync(outgoingFlows, instance, gatewayInformation);
+                if (filteredList.Count != 1)
+                {
+                    throw new ProcessException(
+                        $"Exclusive gateway {gatewayFilter.GatewayId} returned {filteredList.Count} flows. Expected 1"
+                    );
+                }
             }
             var defaultSequenceFlow = filteredList.Find(s => s.Id == gateway.Default);
             if (defaultSequenceFlow != null)

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
@@ -3,6 +3,7 @@ using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Process;
 using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.App.Core.Internal.Process.Elements.Base;
+using Altinn.App.Core.Models.Process;
 using Altinn.App.Core.Tests.Internal.Process.TestUtils;
 using Altinn.App.PlatformServices.Tests.Internal.Process.StubGatewayFilters;
 using Altinn.Platform.Storage.Interface.Models;
@@ -16,10 +17,7 @@ public class ProcessNavigatorTests
     [Fact]
     public async Task GetNextTask_returns_next_element_if_no_gateway()
     {
-        IProcessNavigator processNavigator = SetupProcessNavigator(
-            "simple-linear.bpmn",
-            new List<IProcessExclusiveGateway>()
-        );
+        IProcessNavigator processNavigator = SetupProcessNavigator("simple-linear.bpmn", []);
         ProcessElement nextElements = await processNavigator.GetNextTask(new Instance(), "Task1", null);
         nextElements
             .Should()
@@ -39,12 +37,58 @@ public class ProcessNavigatorTests
     }
 
     [Fact]
+    public async Task GetNextTask_single_sign_to_process_end()
+    {
+        var processFile = "with-double-sign.bpmn";
+        IProcessNavigator processNavigator = SetupProcessNavigator(processFile, [new SingleSignGateway()]);
+        ProcessElement nextElements = await processNavigator.GetNextTask(new Instance(), "Task_Sign1", "sign");
+        nextElements.Id.Should().Be("EndEvent_1");
+    }
+
+    private sealed class SingleSignGateway : IProcessExclusiveGateway
+    {
+        public string GatewayId => "AltinnExpressionsExclusiveGateway";
+
+        public Task<List<SequenceFlow>> FilterAsync(
+            List<SequenceFlow> outgoingFlows,
+            Instance instance,
+            ProcessGatewayInformation processGatewayInformation
+        )
+        {
+            return Task.FromResult(
+                outgoingFlows.Where(f => f.Id == "Flow_sign1_sign" || f.Id == "Flow_SingleSign").ToList()
+            );
+        }
+    }
+
+    [Fact]
+    public async Task GetNextTask_exclusive_gateway_zero_paths_should_fail()
+    {
+        var processFile = "with-double-sign.bpmn";
+        IProcessNavigator processNavigator = SetupProcessNavigator(processFile, [new ZeroPathsGateway()]);
+        await Assert.ThrowsAsync<ProcessException>(
+            async () => await processNavigator.GetNextTask(new Instance(), "Task_Sign1", "sign")
+        );
+    }
+
+    private sealed class ZeroPathsGateway : IProcessExclusiveGateway
+    {
+        public string GatewayId => "AltinnExpressionsExclusiveGateway";
+
+        public Task<List<SequenceFlow>> FilterAsync(
+            List<SequenceFlow> outgoingFlows,
+            Instance instance,
+            ProcessGatewayInformation processGatewayInformation
+        )
+        {
+            return Task.FromResult(new List<SequenceFlow>());
+        }
+    }
+
+    [Fact]
     public async Task NextFollowAndFilterGateways_returns_empty_list_if_no_outgoing_flows()
     {
-        IProcessNavigator processNavigator = SetupProcessNavigator(
-            "simple-linear.bpmn",
-            new List<IProcessExclusiveGateway>()
-        );
+        IProcessNavigator processNavigator = SetupProcessNavigator("simple-linear.bpmn", []);
         ProcessElement nextElements = await processNavigator.GetNextTask(new Instance(), "EndEvent", null);
         nextElements.Should().BeNull();
     }
@@ -52,10 +96,7 @@ public class ProcessNavigatorTests
     [Fact]
     public async Task GetNextTask_returns_default_if_no_filtering_is_implemented_and_default_set()
     {
-        IProcessNavigator processNavigator = SetupProcessNavigator(
-            "simple-gateway-default.bpmn",
-            new List<IProcessExclusiveGateway>()
-        );
+        IProcessNavigator processNavigator = SetupProcessNavigator("simple-gateway-default.bpmn", []);
         ProcessElement nextElements = await processNavigator.GetNextTask(new Instance(), "Task1", null);
         nextElements
             .Should()
@@ -83,7 +124,7 @@ public class ProcessNavigatorTests
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-gateway-with-join-gateway.bpmn",
-            new List<IProcessExclusiveGateway>() { new DataValuesFilter("Gateway1", "choose") }
+            [new DataValuesFilter("Gateway1", "choose")]
         );
         Instance i = new Instance() { DataValues = new Dictionary<string, string>() { { "choose", "Flow3" } } };
 

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
@@ -190,7 +190,7 @@ public class ProcessNavigatorTests
     }
 
     [Fact]
-    public async Task GetNextTask_runs_custom_filter_and_returns_empty_list_if_all_filtered_out()
+    public async Task GetNextTask_runs_custom_filter_and_throws_exception_when_no_paths_are_found()
     {
         IProcessNavigator processNavigator = SetupProcessNavigator(
             "simple-gateway-with-join-gateway.bpmn",
@@ -205,8 +205,7 @@ public class ProcessNavigatorTests
             DataValues = new Dictionary<string, string>() { { "choose1", "Flow4" }, { "choose2", "Bar" } }
         };
 
-        ProcessElement nextElements = await processNavigator.GetNextTask(i, "Task1", null);
-        nextElements.Should().BeNull();
+        await Assert.ThrowsAsync<ProcessException>(async () => await processNavigator.GetNextTask(i, "Task1", null));
     }
 
     [Fact]

--- a/test/Altinn.App.Core.Tests/Internal/Process/TestData/with-double-sign.bpmn
+++ b/test/Altinn.App.Core.Tests/Internal/Process/TestData/with-double-sign.bpmn
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bpmn:definitions id="Altinn_SingleDataTask_Process_Definition" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:altinn="http://altinn.no/process" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="SingleDataTask" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_start</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_Form" name="Utfylling">
+      <bpmn:incoming>Flow_start</bpmn:incoming>
+      <bpmn:incoming>Flow_sign1_reject</bpmn:incoming>
+      <bpmn:incoming>Flow_edit</bpmn:incoming>
+      <bpmn:outgoing>Flow_form</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>data</altinn:taskType>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:task id="Task_Sign1" name="Signering1">
+      <bpmn:incoming>Flow_form</bpmn:incoming>
+      <bpmn:outgoing>Flow_sign1</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>signing</altinn:taskType>
+          <altinn:actions>
+            <altinn:action>sign</altinn:action>
+            <altinn:action>reject</altinn:action>
+          </altinn:actions>
+          <altinn:signatureConfig>
+            <altinn:dataTypesToSign>
+              <altinn:dataType>KRT-1008-2_M</altinn:dataType>
+              <altinn:dataType>ref-data-as-pdf</altinn:dataType>
+            </altinn:dataTypesToSign>
+            <altinn:signatureDataType>signature1</altinn:signatureDataType>
+          </altinn:signatureConfig>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="Gateway_Sign1">
+      <bpmn:incoming>Flow_sign1</bpmn:incoming>
+      <bpmn:outgoing>Flow_sign1_sign</bpmn:outgoing>
+      <bpmn:outgoing>Flow_sign1_reject</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <altinn:gatewayExtension>
+          <altinn:connectedDataTypeId>KRT-1008-2_M</altinn:connectedDataTypeId>
+        </altinn:gatewayExtension>
+      </bpmn:extensionElements>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_DoubleSign">
+      <bpmn:incoming>Flow_sign1_sign</bpmn:incoming>
+      <bpmn:outgoing>Flow_DoubleSign</bpmn:outgoing>
+      <bpmn:outgoing>Flow_SingleSign</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <altinn:gatewayExtension>
+          <altinn:connectedDataTypeId>KRT-1008-2_M</altinn:connectedDataTypeId>
+        </altinn:gatewayExtension>
+      </bpmn:extensionElements>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Task_Sign2" name="Signering2">
+      <bpmn:incoming>Flow_DoubleSign</bpmn:incoming>
+      <bpmn:outgoing>Flow_sign2</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>signing</altinn:taskType>
+          <altinn:actions>
+            <altinn:action>sign</altinn:action>
+            <altinn:action>reject</altinn:action>
+          </altinn:actions>
+          <altinn:signatureConfig>
+            <altinn:dataTypesToSign>
+              <altinn:dataType>KRT-1008-2_M</altinn:dataType>
+              <altinn:dataType>ref-data-as-pdf</altinn:dataType>
+              <altinn:dataType>signature1</altinn:dataType>
+            </altinn:dataTypesToSign>
+            <altinn:signatureDataType>signature2</altinn:signatureDataType>
+          </altinn:signatureConfig>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:task id="Task_Reject" name="Reject">
+      <bpmn:incoming>Flow_sign2_reject</bpmn:incoming>
+      <bpmn:outgoing>Flow_edit</bpmn:outgoing>
+      <bpmn:extensionElements>
+        <altinn:taskExtension>
+          <altinn:taskType>signing</altinn:taskType>
+          <altinn:actions>
+            <altinn:action>reject</altinn:action>
+          </altinn:actions>
+        </altinn:taskExtension>
+      </bpmn:extensionElements>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="Gateway_Sign2">
+      <bpmn:incoming>Flow_sign2</bpmn:incoming>
+      <bpmn:outgoing>Flow_sign2_sign</bpmn:outgoing>
+      <bpmn:outgoing>Flow_sign2_reject</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_SingleSign</bpmn:incoming>
+      <bpmn:incoming>Flow_sign2_sign</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_start" sourceRef="StartEvent_1" targetRef="Task_Form" />
+    <bpmn:sequenceFlow id="Flow_form" sourceRef="Task_Form" targetRef="Task_Sign1" />
+    <bpmn:sequenceFlow id="Flow_sign1" sourceRef="Task_Sign1" targetRef="Gateway_Sign1" />
+    <bpmn:sequenceFlow id="Flow_sign1_reject" sourceRef="Gateway_Sign1" targetRef="Task_Form">
+      <bpmn:conditionExpression>["equals", ["gatewayAction"], "reject"]</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_sign1_sign" sourceRef="Gateway_Sign1" targetRef="Gateway_DoubleSign">
+      <bpmn:conditionExpression>["equals", ["gatewayAction"], "sign"]</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_DoubleSign" sourceRef="Gateway_DoubleSign" targetRef="Task_Sign2">
+      <bpmn:conditionExpression>["equals", ["dataModel", "model.ShouldDoubleSign"], true]</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_SingleSign" sourceRef="Gateway_DoubleSign" targetRef="EndEvent_1">
+      <bpmn:conditionExpression>["equals", ["dataModel", "model.ShouldDoubleSign"], false]</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_sign2" sourceRef="Task_Sign2" targetRef="Gateway_Sign2" />
+    <bpmn:sequenceFlow id="Flow_sign2_reject" sourceRef="Gateway_Sign2" targetRef="Task_Reject">
+      <bpmn:conditionExpression>["equals", ["gatewayAction"], "reject"]</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_sign2_sign" sourceRef="Gateway_Sign2" targetRef="EndEvent_1">
+      <bpmn:conditionExpression>["equals", ["gatewayAction"], "sign"]</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_edit" sourceRef="Task_Reject" targetRef="Task_Form" />
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
## Description
A hard to diagnose bug occurred where due to a logic error in bpmn `conditionExpressions` there were some `process/next` invocations that returned the same task (which happens any time `GetNextTask` returns null).

* Exclusive gateways should only return 1 path AFAICT
* When `GetNextTask` resolves to null, we need to handle it in some way (is this always a logic error on the part of the app bpmn?)

## Related Issue(s)
- Lots

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
