### PR TITLE
Unlock dataelements for a task if eFormidling service task fails

### DIFF
--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandler.cs
@@ -63,7 +63,16 @@ public class EndTaskEventHandler : IEndTaskEventHandler
             throw;
         }
 
-        await _eformidlingServiceTask.Execute(taskId, instance);
+        try
+        {
+            await _eformidlingServiceTask.Execute(taskId, instance);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error executing eFormidling service task. Unlocking data again.");
+            await _processTaskDataLocker.Unlock(taskId, instance);
+            throw;
+        }
     }
 
     /// <summary>

--- a/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/EventHandlers/ProcessTask/EndTaskEventHandlerTests.cs
@@ -106,6 +106,33 @@ public class EndTaskEventHandlerTests
     }
 
     [Fact]
+    public async Task Calls_unlock_if_eFormidling_fails()
+    {
+        EndTaskEventHandler eteh =
+            new(_processTaskDataLocker.Object, _processTaskFinisher.Object, ServiceTasks, _processTaskEnds, _logger);
+
+        var instance = new Instance() { Id = "1337/fa0678ad-960d-4307-aba2-ba29c9804c9d", AppId = "ttd/test", };
+
+        var taskId = "Task_1";
+        Mock<IProcessTask> mockProcessTask = new();
+
+        // Make PDF service task throw exception to simulate a failure situation.
+        _eformidlingServiceTask.Setup(x => x.Execute(It.IsAny<string>(), instance)).ThrowsAsync(new Exception());
+
+        // Expect exception to be thrown
+        await Assert.ThrowsAsync<Exception>(async () => await eteh.Execute(mockProcessTask.Object, taskId, instance));
+
+        // Assert normal flow until the exception is thrown
+        _processTaskDataLocker.Verify(p => p.Lock(taskId, instance));
+        _processTaskFinisher.Verify(p => p.Finalize(taskId, instance));
+        mockProcessTask.Verify(p => p.End(taskId, instance));
+        _pdfServiceTask.Verify(p => p.Execute(taskId, instance));
+
+        // Make sure unlock data is called
+        _processTaskDataLocker.Verify(p => p.Unlock(taskId, instance));
+    }
+
+    [Fact]
     public void Throws_If_Missing_Pdf_ServiceTask()
     {
         IServiceTask[] serviceTasks = [_eformidlingServiceTask.Object];


### PR DESCRIPTION
## Description
Just another failure condition the process engine doesn't handle at all. This isn't great, but it fixes 1 of the issues I've seen resulting in locked dataelements that users can't proceed from

## Related Issue(s)
- Support

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
