### PR TITLE
Chore/ensure enum serialization

### DIFF
--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.Data.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.Data.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Text.Json.Serialization;
 using Altinn.Platform.Storage.Interface.Models;
 using NetEscapades.EnumGenerators;
 using static Altinn.App.Core.Features.Telemetry.Data;
@@ -38,6 +39,7 @@ partial class Telemetry
         internal static readonly string MetricNameDataPatched = Metrics.CreateLibName("data_patched");
 
         [EnumExtensions]
+        [JsonConverter(typeof(JsonNumberEnumConverter<PatchResult>))]
         internal enum PatchResult
         {
             [Display(Name = "success")]

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.Maskinporten.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.Maskinporten.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Text.Json.Serialization;
 using NetEscapades.EnumGenerators;
 using static Altinn.App.Core.Features.Telemetry.Maskinporten;
 using Tag = System.Collections.Generic.KeyValuePair<string, object?>;
@@ -41,6 +42,7 @@ partial class Telemetry
         internal static readonly string MetricNameTokenRequest = Metrics.CreateLibName("maskinporten_token_requests");
 
         [EnumExtensions]
+        [JsonConverter(typeof(JsonNumberEnumConverter<RequestResult>))]
         internal enum RequestResult
         {
             [Display(Name = "cached")]

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.Notifications.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.Notifications.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Text.Json.Serialization;
 using NetEscapades.EnumGenerators;
 using static Altinn.App.Core.Features.Telemetry.Notifications;
 using Tag = System.Collections.Generic.KeyValuePair<string, object?>;
@@ -57,6 +58,7 @@ partial class Telemetry
         internal static readonly string MetricNameOrder = Metrics.CreateLibName("notification_orders");
 
         [EnumExtensions]
+        [JsonConverter(typeof(JsonNumberEnumConverter<OrderResult>))]
         internal enum OrderResult
         {
             [Display(Name = "success")]
@@ -67,6 +69,7 @@ partial class Telemetry
         }
 
         [EnumExtensions]
+        [JsonConverter(typeof(JsonNumberEnumConverter<OrderResult>))]
         internal enum OrderType
         {
             [Display(Name = "sms")]

--- a/src/Altinn.App.Core/Helpers/IDataModel.cs
+++ b/src/Altinn.App.Core/Helpers/IDataModel.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Altinn.App.Core.Helpers;
 
 /// <summary>
@@ -50,6 +52,7 @@ public interface IDataModelAccessor
 /// <summary>
 /// Option for how to handle row removal
 /// </summary>
+[JsonConverter(typeof(JsonNumberEnumConverter<RowRemovalOption>))]
 public enum RowRemovalOption
 {
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Patch/DataPatchError.cs
+++ b/src/Altinn.App.Core/Internal/Patch/DataPatchError.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Altinn.App.Core.Internal.Patch;
 
 /// <summary>
@@ -29,6 +31,7 @@ public class DataPatchError
 /// <summary>
 /// The type of error that occurred during a data patch operation.
 /// </summary>
+[JsonConverter(typeof(JsonNumberEnumConverter<DataPatchErrorType>))]
 public enum DataPatchErrorType
 {
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnAction.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnAction.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using System.Xml.Serialization;
 
 namespace Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
@@ -53,6 +54,7 @@ public class AltinnAction
 /// <summary>
 /// Defines the different types of actions
 /// </summary>
+[JsonConverter(typeof(JsonNumberEnumConverter<ActionType>))]
 public enum ActionType
 {
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Process/ProcessSequenceFlowType.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessSequenceFlowType.cs
@@ -1,8 +1,11 @@
+using System.Text.Json.Serialization;
+
 namespace Altinn.App.Core.Internal.Process;
 
 /// <summary>
 /// Defines the
 /// </summary>
+[JsonConverter(typeof(JsonNumberEnumConverter<ProcessSequenceFlowType>))]
 public enum ProcessSequenceFlowType
 {
     /// <summary>

--- a/src/Altinn.App.Core/Models/AppOption.cs
+++ b/src/Altinn.App.Core/Models/AppOption.cs
@@ -48,6 +48,7 @@ public class AppOption
 /// The type of the value for Json serialization
 /// Application developers must set this, if they want options that isn't strings.
 /// </summary>
+[JsonConverter(typeof(JsonNumberEnumConverter<AppOptionValueType>))]
 public enum AppOptionValueType
 {
     /// <summary>

--- a/src/Altinn.App.Core/Models/Expressions/ExpressionFunctionEnum.cs
+++ b/src/Altinn.App.Core/Models/Expressions/ExpressionFunctionEnum.cs
@@ -1,8 +1,11 @@
+using System.Text.Json.Serialization;
+
 namespace Altinn.App.Core.Models.Expressions;
 
 /// <summary>
 /// Enumeration for valid functions in Layout Expressions
 /// </summary>
+[JsonConverter(typeof(JsonNumberEnumConverter<ExpressionFunction>))]
 public enum ExpressionFunction
 {
     /// <summary>

--- a/src/Altinn.App.Core/Models/Process/ProcessChangeResult.cs
+++ b/src/Altinn.App.Core/Models/Process/ProcessChangeResult.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace Altinn.App.Core.Models.Process;
 
@@ -33,6 +34,7 @@ public class ProcessChangeResult
 /// <summary>
 /// Types of errors that can occur during a process change
 /// </summary>
+[JsonConverter(typeof(JsonNumberEnumConverter<ProcessErrorType>))]
 public enum ProcessErrorType
 {
     /// <summary>

--- a/src/Altinn.App.Core/Models/UserAction/UserActionResult.cs
+++ b/src/Altinn.App.Core/Models/UserAction/UserActionResult.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Altinn.App.Core.Models.Process;
 
 namespace Altinn.App.Core.Models.UserAction;
@@ -5,6 +6,7 @@ namespace Altinn.App.Core.Models.UserAction;
 /// <summary>
 /// Represents the result of a user action
 /// </summary>
+[JsonConverter(typeof(JsonNumberEnumConverter<ResultType>))]
 public enum ResultType
 {
     /// <summary>

--- a/src/Altinn.App.Core/Models/Validation/ValidationIssueSeverity.cs
+++ b/src/Altinn.App.Core/Models/Validation/ValidationIssueSeverity.cs
@@ -1,8 +1,11 @@
+using System.Text.Json.Serialization;
+
 namespace Altinn.App.Core.Models.Validation;
 
 /// <summary>
 /// Specifies the severity of a validation issue
 /// </summary>
+[JsonConverter(typeof(JsonNumberEnumConverter<ValidationIssueSeverity>))]
 public enum ValidationIssueSeverity
 {
     /// <summary>

--- a/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using System.Text.Json.Serialization;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Altinn.App.Core.Tests.Internal;
+
+public class EnumSerializationTests
+{
+    [Fact]
+    public void EnsureSerializationPolicyOnEnums()
+    {
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName.StartsWith("Altinn.App.Core"));
+        var enumTypes = GetEnumTypesFromAssemblies(assemblies);
+        var nonCompliantEnums = new List<string>();
+
+        foreach (var enumType in enumTypes)
+        {
+            var jsonConverterAttribute = enumType.GetCustomAttribute<JsonConverterAttribute>();
+            if (jsonConverterAttribute == null)
+            {
+                nonCompliantEnums.Add(enumType.FullName);
+            }
+        }
+
+        Assert.Empty(nonCompliantEnums);
+    }
+
+    private IEnumerable<Type> GetEnumTypesFromAssemblies(IEnumerable<Assembly> assemblies)
+    {
+        return assemblies
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(t => t.IsEnum && t.Namespace != null && t.Namespace.StartsWith("Altinn.App.Core"));
+    }
+}

--- a/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
@@ -10,7 +10,9 @@ public class EnumSerializationTests
     [Fact]
     public void EnsureSerializationPolicyOnEnums()
     {
-        var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName is not null && a.FullName.StartsWith("Altinn.App.Core"));
+        var assemblies = AppDomain
+            .CurrentDomain.GetAssemblies()
+            .Where(a => a.FullName is not null && a.FullName.StartsWith("Altinn.App.Core"));
         var enumTypes = GetEnumTypesFromAssemblies(assemblies);
         var nonCompliantEnums = new List<string>();
 
@@ -18,10 +20,10 @@ public class EnumSerializationTests
         {
             var jsonConverterAttribute = enumType.GetCustomAttribute<JsonConverterAttribute>();
             if (jsonConverterAttribute == null)
-                {
-                    string enumInfo = enumType.FullName ?? GetEnumInfo(enumType);
-                    nonCompliantEnums.Add(enumInfo);
-                }
+            {
+                string enumInfo = enumType.FullName ?? GetEnumInfo(enumType);
+                nonCompliantEnums.Add(enumInfo);
+            }
         }
 
         Assert.Empty(nonCompliantEnums);

--- a/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
@@ -37,7 +37,7 @@ public class EnumSerializationTests
         return $"{typeName} (in {namespaceName}, Assembly: {assemblyName})";
     }
 
-    private IEnumerable<Type> GetEnumTypesFromAssemblies(IEnumerable<Assembly> assemblies)
+    private static IEnumerable<Type> GetEnumTypesFromAssemblies(IEnumerable<Assembly> assemblies)
     {
         return assemblies
             .SelectMany(assembly => assembly.GetTypes())

--- a/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
@@ -1,7 +1,5 @@
 using System.Reflection;
 using System.Text.Json.Serialization;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace Altinn.App.Core.Tests.Internal;
 
@@ -19,7 +17,7 @@ public class EnumSerializationTests
         foreach (var enumType in enumTypes)
         {
             var jsonConverterAttribute = enumType.GetCustomAttribute<JsonConverterAttribute>();
-            if (jsonConverterAttribute == null)
+            if (jsonConverterAttribute is null)
             {
                 string enumInfo = enumType.FullName ?? GetEnumInfo(enumType);
                 nonCompliantEnums.Add(enumInfo);
@@ -41,6 +39,6 @@ public class EnumSerializationTests
     {
         return assemblies
             .SelectMany(assembly => assembly.GetTypes())
-            .Where(t => t.IsEnum && t.Namespace != null && t.Namespace.StartsWith("Altinn.App.Core"));
+            .Where(t => t.IsEnum && t.Namespace is not null && t.Namespace.StartsWith("Altinn.App.Core"));
     }
 }

--- a/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/EnumSerializationTests.cs
@@ -10,7 +10,7 @@ public class EnumSerializationTests
     [Fact]
     public void EnsureSerializationPolicyOnEnums()
     {
-        var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName.StartsWith("Altinn.App.Core"));
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName is not null && a.FullName.StartsWith("Altinn.App.Core"));
         var enumTypes = GetEnumTypesFromAssemblies(assemblies);
         var nonCompliantEnums = new List<string>();
 
@@ -18,12 +18,21 @@ public class EnumSerializationTests
         {
             var jsonConverterAttribute = enumType.GetCustomAttribute<JsonConverterAttribute>();
             if (jsonConverterAttribute == null)
-            {
-                nonCompliantEnums.Add(enumType.FullName);
-            }
+                {
+                    string enumInfo = enumType.FullName ?? GetEnumInfo(enumType);
+                    nonCompliantEnums.Add(enumInfo);
+                }
         }
 
         Assert.Empty(nonCompliantEnums);
+    }
+
+    private static string GetEnumInfo(Type enumType)
+    {
+        var assemblyName = enumType.Assembly.GetName().Name;
+        var namespaceName = enumType.Namespace ?? "<No Namespace>";
+        var typeName = enumType.Name;
+        return $"{typeName} (in {namespaceName}, Assembly: {assemblyName})";
     }
 
     private IEnumerable<Type> GetEnumTypesFromAssemblies(IEnumerable<Assembly> assemblies)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Find all enums in Altinn.App.Core which do not have JsonConverterAttribute.
Assume that they use the default serialization policy (number)
Add JsonNumberEnumConverter

## Related Issue(s)
- #729

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
