### PR TITLE
Add an optional footer for the generated PDF

### DIFF
--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -4,6 +4,7 @@ using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Internal.Pdf;
 using Altinn.App.Core.Models.Pdf;
+using Altinn.Common.EFormidlingClient.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -52,12 +53,27 @@ public class PdfGeneratorClient : IPdfGeneratorClient
     /// <inheritdoc/>
     public async Task<Stream> GeneratePdf(Uri uri, CancellationToken ct)
     {
+        return await GeneratePdf(uri, null, ct);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Stream> GeneratePdf(Uri uri, string? FooterContent, CancellationToken ct)
+    {
         bool hasWaitForSelector = !string.IsNullOrWhiteSpace(_pdfGeneratorSettings.WaitForSelector);
+        bool footer = _pdfGeneratorSettings.Footer;
         PdfGeneratorRequest generatorRequest =
             new()
             {
                 Url = uri.AbsoluteUri,
-                WaitFor = hasWaitForSelector ? _pdfGeneratorSettings.WaitForSelector : _pdfGeneratorSettings.WaitForTime
+                WaitFor = hasWaitForSelector
+                    ? _pdfGeneratorSettings.WaitForSelector
+                    : _pdfGeneratorSettings.WaitForTime,
+                Options =
+                {
+                    HeaderTemplate = "<span/>",
+                    FooterTemplate = FooterContent ?? "<span/>",
+                    DisplayHeaderFooter = footer,
+                },
             };
 
         generatorRequest.Cookies.Add(

--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -60,7 +60,6 @@ public class PdfGeneratorClient : IPdfGeneratorClient
     public async Task<Stream> GeneratePdf(Uri uri, string? FooterContent, CancellationToken ct)
     {
         bool hasWaitForSelector = !string.IsNullOrWhiteSpace(_pdfGeneratorSettings.WaitForSelector);
-        bool displayFooter = _pdfGeneratorSettings.Footer;
         PdfGeneratorRequest generatorRequest =
             new()
             {
@@ -72,7 +71,7 @@ public class PdfGeneratorClient : IPdfGeneratorClient
                 {
                     HeaderTemplate = "<div/>",
                     FooterTemplate = FooterContent ?? "<div/>",
-                    DisplayHeaderFooter = displayFooter,
+                    DisplayHeaderFooter = FooterContent != null,
                 },
             };
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -56,7 +56,7 @@ public class PdfGeneratorClient : IPdfGeneratorClient
     }
 
     /// <inheritdoc/>
-    public async Task<Stream> GeneratePdf(Uri uri, string? FooterContent, CancellationToken ct)
+    public async Task<Stream> GeneratePdf(Uri uri, string? footerContent, CancellationToken ct)
     {
         bool hasWaitForSelector = !string.IsNullOrWhiteSpace(_pdfGeneratorSettings.WaitForSelector);
         PdfGeneratorRequest generatorRequest =
@@ -69,8 +69,8 @@ public class PdfGeneratorClient : IPdfGeneratorClient
                 Options =
                 {
                     HeaderTemplate = "<div/>",
-                    FooterTemplate = FooterContent ?? "<div/>",
-                    DisplayHeaderFooter = FooterContent != null,
+                    FooterTemplate = footerContent ?? "<div/>",
+                    DisplayHeaderFooter = footerContent != null,
                 },
             };
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -60,7 +60,7 @@ public class PdfGeneratorClient : IPdfGeneratorClient
     public async Task<Stream> GeneratePdf(Uri uri, string? FooterContent, CancellationToken ct)
     {
         bool hasWaitForSelector = !string.IsNullOrWhiteSpace(_pdfGeneratorSettings.WaitForSelector);
-        bool footer = _pdfGeneratorSettings.Footer;
+        bool displayFooter = _pdfGeneratorSettings.Footer;
         PdfGeneratorRequest generatorRequest =
             new()
             {
@@ -70,9 +70,9 @@ public class PdfGeneratorClient : IPdfGeneratorClient
                     : _pdfGeneratorSettings.WaitForTime,
                 Options =
                 {
-                    HeaderTemplate = "<span/>",
-                    FooterTemplate = FooterContent ?? "<span/>",
-                    DisplayHeaderFooter = footer,
+                    HeaderTemplate = "<div/>",
+                    FooterTemplate = FooterContent ?? "<div/>",
+                    DisplayHeaderFooter = displayFooter,
                 },
             };
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -4,7 +4,6 @@ using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Internal.Pdf;
 using Altinn.App.Core.Models.Pdf;
-using Altinn.Common.EFormidlingClient.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 

--- a/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
@@ -15,5 +15,5 @@ public interface IPdfGeneratorClient
     /// Generates a PDF.
     /// </summary>
     /// <returns>A stream with the binary content of the generated PDF with a footer</returns>
-    Task<Stream> GeneratePdf(Uri uri, string? FooterContent, CancellationToken ct);
+    Task<Stream> GeneratePdf(Uri uri, string? footerContent, CancellationToken ct);
 }

--- a/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs
@@ -10,4 +10,10 @@ public interface IPdfGeneratorClient
     /// </summary>
     /// <returns>A stream with the binary content of the generated PDF</returns>
     Task<Stream> GeneratePdf(Uri uri, CancellationToken ct);
+
+    /// <summary>
+    /// Generates a PDF.
+    /// </summary>
+    /// <returns>A stream with the binary content of the generated PDF with a footer</returns>
+    Task<Stream> GeneratePdf(Uri uri, string? FooterContent, CancellationToken ct);
 }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
@@ -28,5 +28,5 @@ public class PdfGeneratorSettings
     /// <summary>
     /// Shows a footer on each page in the PDF with the date, altinn-referance, page number and total pages.
     /// </summary>
-    public bool Footer { get; set; }
+    public bool DisplayFooter { get; set; }
 }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
@@ -24,4 +24,9 @@ public class PdfGeneratorSettings
     /// </summary>
     /// <remarks>This will be ignored if <see cref="WaitForSelector"/> has been assigned a value.</remarks>
     public int WaitForTime { get; set; } = 5000;
+
+    /// <summary>
+    /// Shows a footer on each page in the PDF with the date, altinn-referance, page number and total pages, or custom data.
+    /// </summary>
+    public bool Footer { get; set; }
 }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfGeneratorSettings.cs
@@ -26,7 +26,7 @@ public class PdfGeneratorSettings
     public int WaitForTime { get; set; } = 5000;
 
     /// <summary>
-    /// Shows a footer on each page in the PDF with the date, altinn-referance, page number and total pages, or custom data.
+    /// Shows a footer on each page in the PDF with the date, altinn-referance, page number and total pages.
     /// </summary>
     public bool Footer { get; set; }
 }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -36,7 +36,6 @@ public class PdfService : IPdfService
     private const string PdfElementType = "ref-data-as-pdf";
     private const string PdfContentType = "application/pdf";
 
-
     /// <summary>
     /// Initializes a new instance of the <see cref="PdfService"/> class.
     /// </summary>
@@ -239,10 +238,13 @@ public class PdfService : IPdfService
     private string GetFooterContent(Instance instance)
     {
         TimeZoneInfo timeZone = TimeZoneInfo.Utc;
-        try {
+        try
+        {
             // attempt to set timezone to norwegian
             timeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Oslo");
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             _logger.LogWarning($"Could not find timezone Europe/Oslo. Defaulting to UTC. {e.Message}");
         }
 

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Claims;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Extensions;
@@ -113,7 +114,9 @@ public class PdfService : IPdfService
 
         Uri uri = BuildUri(baseUrl, pagePath, language);
 
-        Stream pdfContent = await _pdfGeneratorClient.GeneratePdf(uri, ct);
+        string footerContent = GetFooterContent(instance);
+
+        Stream pdfContent = await _pdfGeneratorClient.GeneratePdf(uri, footerContent, ct);
 
         return pdfContent;
     }
@@ -224,5 +227,30 @@ public class PdfService : IPdfService
     {
         fileName = Uri.EscapeDataString(fileName.AsFileName(false));
         return fileName;
+    }
+
+    private string GetFooterContent(Instance instance)
+    {
+        string altinnReferenceId = instance.Id.Split("/")[1];
+        string dateGenerated = DateTimeOffset.UtcNow.ToString("g", new CultureInfo("nb-NO"));
+        string footerTemplate =
+            $@"<div style='font-family: Inter; font-size: 12px; width: 100%; display: flex; flex-direction: column; gap: 12px; padding: 0 70px 0 70px;'>
+                <span class='title'></span>
+                <div style='width: 100%; display: flex; flex-direction: row; align-items: center'>
+                    <div
+                        id='header-template'
+                        style='color: #F00; font-weight: 700; border: 1px solid #F00; padding: 7px 9px;'
+                    >
+                        <span>{dateGenerated} </span>
+                        <span>ID: {altinnReferenceId}</span>
+                    </div>
+                    <span style='margin-left: auto;'>
+                        <span class='pageNumber'></span>
+                        /
+                        <span class='totalPages'></span>
+                    </span>
+                </div>
+            </div>";
+        return footerTemplate;
     }
 }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -232,7 +232,6 @@ public class PdfService : IPdfService
 
     private static string GetFooterContent(Instance instance)
     {
-        // Convert to Norwegian timezone (Europe/Oslo)
         TimeZoneInfo norwegianTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Oslo");
         DateTimeOffset norwegianNow = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, norwegianTimeZone);
 

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -114,7 +114,7 @@ public class PdfService : IPdfService
 
         Uri uri = BuildUri(baseUrl, pagePath, language);
 
-        bool displayFooter = _pdfGeneratorSettings.Footer;
+        bool displayFooter = _pdfGeneratorSettings.DisplayFooter;
         string? footerContent = displayFooter ? GetFooterContent(instance) : null;
 
         Stream pdfContent = await _pdfGeneratorClient.GeneratePdf(uri, footerContent, ct);

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -243,7 +243,7 @@ public class PdfService : IPdfService
             // attempt to set timezone to norwegian
             timeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Oslo");
         }
-        catch (Exception e)
+        catch (TimeZoneNotFoundException e)
         {
             _logger.LogWarning($"Could not find timezone Europe/Oslo. Defaulting to UTC. {e.Message}");
         }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -114,7 +114,8 @@ public class PdfService : IPdfService
 
         Uri uri = BuildUri(baseUrl, pagePath, language);
 
-        string footerContent = GetFooterContent(instance);
+        bool displayFooter = _pdfGeneratorSettings.Footer;
+        string? footerContent = displayFooter ? GetFooterContent(instance) : null;
 
         Stream pdfContent = await _pdfGeneratorClient.GeneratePdf(uri, footerContent, ct);
 
@@ -229,10 +230,16 @@ public class PdfService : IPdfService
         return fileName;
     }
 
-    private string GetFooterContent(Instance instance)
+    private static string GetFooterContent(Instance instance)
     {
-        string altinnReferenceId = instance.Id.Split("/")[1];
-        string dateGenerated = DateTimeOffset.UtcNow.ToString("g", new CultureInfo("nb-NO"));
+        // Convert to Norwegian timezone (Europe/Oslo)
+        TimeZoneInfo norwegianTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Oslo");
+        DateTimeOffset norwegianNow = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, norwegianTimeZone);
+
+        string dateGenerated = norwegianNow.ToString("G", new CultureInfo("nb-NO"));
+
+        string altinnReferenceId = instance.Id.Split("/")[1].Split("-")[4];
+
         string footerTemplate =
             $@"<div style='font-family: Inter; font-size: 12px; width: 100%; display: flex; flex-direction: column; gap: 12px; padding: 0 70px 0 70px;'>
                 <span class='title'></span>

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -249,7 +249,7 @@ public class PdfService : IPdfService
                         style='color: #F00; font-weight: 700; border: 1px solid #F00; padding: 7px 9px;'
                     >
                         <span>{dateGenerated} </span>
-                        <span>ID: {altinnReferenceId}</span>
+                        <span>ID:{altinnReferenceId}</span>
                     </div>
                     <span style='margin-left: auto;'>
                         <span class='pageNumber'></span>

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -240,21 +240,21 @@ public class PdfService : IPdfService
         string altinnReferenceId = instance.Id.Split("/")[1].Split("-")[4];
 
         string footerTemplate =
-            $@"<div style='font-family: Inter; font-size: 12px; width: 100%; display: flex; flex-direction: column; gap: 12px; padding: 0 70px 0 70px;'>
-                <span class='title'></span>
-                <div style='width: 100%; display: flex; flex-direction: row; align-items: center'>
+            $@"<div style='font-family: Inter; font-size: 12px; width: 100%; display: flex; flex-direction: row; align-items: center; gap: 12px; padding: 0 70px 0 70px;'>
+                <div style='display: flex; flex-direction: row; width: 100%; align-items: center'>
+                    <span class='title'></span>
                     <div
                         id='header-template'
-                        style='color: #F00; font-weight: 700; border: 1px solid #F00; padding: 7px 9px;'
+                        style='color: #F00; font-weight: 700; border: 1px solid #F00; padding: 6px 8px; margin-left: auto;'
                     >
                         <span>{dateGenerated} </span>
                         <span>ID:{altinnReferenceId}</span>
                     </div>
-                    <span style='margin-left: auto;'>
-                        <span class='pageNumber'></span>
-                        /
-                        <span class='totalPages'></span>
-                    </span>
+                </div>
+                <div style='display: flex; flex-direction-row; align-items: center;'>
+                    <span class='pageNumber'></span>
+                    /
+                    <span class='totalPages'></span>
                 </div>
             </div>";
         return footerTemplate;

--- a/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequestOptions.cs
+++ b/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequestOptions.cs
@@ -11,6 +11,21 @@ internal class PdfGeneratorRequestOptions
     public bool DisplayHeaderFooter { get; set; } = false;
 
     /// <summary>
+    /// HTML template for the print header. Should be valid HTML with the following classes used to inject values into them:
+    ///  * `date` formatted print date
+    ///  * `title` document title
+    ///  * `url` document location
+    ///  * `pageNumber` current page number
+    ///  * `totalPages` total pages in the document
+    /// </summary>
+    public string HeaderTemplate { get; set; } = string.Empty;
+
+    /// <summary>
+    /// HTML template for the print footer. Has the same constraints and support for special classes as {@link PDFOptions.headerTemplate}.
+    /// </summary>
+    public string FooterTemplate { get; set; } = string.Empty;
+
+    /// <summary>
     /// Indicate wheter the background should be included.
     /// </summary>
     public bool PrintBackground { get; set; } = true;

--- a/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequestOptions.cs
+++ b/src/Altinn.App.Core/Models/Pdf/PdfGeneratorRequestOptions.cs
@@ -21,7 +21,7 @@ internal class PdfGeneratorRequestOptions
     public string HeaderTemplate { get; set; } = string.Empty;
 
     /// <summary>
-    /// HTML template for the print footer. Has the same constraints and support for special classes as {@link PDFOptions.headerTemplate}.
+    /// HTML template for the print footer. Has the same constraints and support for special classes as HeaderTemplate.
     /// </summary>
     public string FooterTemplate { get; set; } = string.Empty;
 

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
@@ -269,7 +269,9 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
     {
         var pdfMock = new Mock<IPdfGeneratorClient>(MockBehavior.Strict);
         using var pdfReturnStream = new MemoryStream();
-        pdfMock.Setup(p => p.GeneratePdf(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(pdfReturnStream);
+        pdfMock
+            .Setup(p => p.GeneratePdf(It.IsAny<Uri>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pdfReturnStream);
 
         // Setup test data
         string org = "tdd";

--- a/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
@@ -10,10 +10,12 @@ using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Internal.Pdf;
 using Altinn.App.Core.Internal.Profile;
 using Altinn.Platform.Storage.Interface.Models;
+using Castle.Core.Logging;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
@@ -41,6 +43,8 @@ public class PdfControllerTests
     private readonly IOptions<PdfGeneratorSettings> _pdfGeneratorSettingsOptions = Options.Create<PdfGeneratorSettings>(
         new() { }
     );
+
+    private readonly Mock<ILogger<PdfService>> _logger = new();
 
     public PdfControllerTests()
     {
@@ -92,7 +96,8 @@ public class PdfControllerTests
             _profile.Object,
             pdfGeneratorClient,
             _pdfGeneratorSettingsOptions,
-            generalSettingsOptions
+            generalSettingsOptions,
+            _logger.Object
         );
         var pdfController = new PdfController(
             _instanceClient.Object,
@@ -146,7 +151,8 @@ public class PdfControllerTests
             _profile.Object,
             pdfGeneratorClient,
             _pdfGeneratorSettingsOptions,
-            generalSettingsOptions
+            generalSettingsOptions,
+            _logger.Object
         );
         var pdfController = new PdfController(
             _instanceClient.Object,
@@ -225,7 +231,8 @@ public class PdfControllerTests
             _profile.Object,
             pdfGeneratorClient,
             _pdfGeneratorSettingsOptions,
-            generalSettingsOptions
+            generalSettingsOptions,
+            _logger.Object
         );
         var pdfController = new PdfController(
             _instanceClient.Object,
@@ -306,7 +313,8 @@ public class PdfControllerTests
             _profile.Object,
             pdfGeneratorClient,
             _pdfGeneratorSettingsOptions,
-            generalSettingsOptions
+            generalSettingsOptions,
+            _logger.Object
         );
         var pdfController = new PdfController(
             _instanceClient.Object,

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
@@ -341,7 +341,9 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
             );
         var pdfMock = new Mock<IPdfGeneratorClient>(MockBehavior.Strict);
         using var pdfReturnStream = new MemoryStream();
-        pdfMock.Setup(p => p.GeneratePdf(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(pdfReturnStream);
+        pdfMock
+            .Setup(p => p.GeneratePdf(It.IsAny<Uri>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pdfReturnStream);
         OverrideServicesForThisTest = (services) =>
         {
             services.AddSingleton(dataValidator.Object);
@@ -366,7 +368,9 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
     {
         var pdfMock = new Mock<IPdfGeneratorClient>(MockBehavior.Strict);
         using var pdfReturnStream = new MemoryStream();
-        pdfMock.Setup(p => p.GeneratePdf(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(pdfReturnStream);
+        pdfMock
+            .Setup(p => p.GeneratePdf(It.IsAny<Uri>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pdfReturnStream);
         OverrideServicesForThisTest = (services) =>
         {
             services.AddSingleton(pdfMock.Object);

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
@@ -14,8 +14,10 @@ using Altinn.App.PlatformServices.Tests.Mocks;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using AltinnCore.Authentication.Constants;
+using Castle.Core.Logging;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
@@ -42,6 +44,8 @@ public class PdfServiceTests
     private readonly IOptions<PlatformSettings> _platformSettingsOptions = Options.Create<PlatformSettings>(new() { });
 
     private readonly Mock<IUserTokenProvider> _userTokenProvider;
+
+    private readonly Mock<ILogger<PdfService>> _logger = new();
 
     public PdfServiceTests()
     {
@@ -400,6 +404,7 @@ public class PdfServiceTests
             pdfGeneratorClient?.Object ?? _pdfGeneratorClient.Object,
             pdfGeneratorSettingsOptions ?? _pdfGeneratorSettingsOptions,
             generalSettingsOptions ?? _generalSettingsOptions,
+            _logger.Object,
             telemetrySink?.Object
         );
     }

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
@@ -134,7 +134,9 @@ public class PdfServiceTests
     {
         // Arrange
         TelemetrySink telemetrySink = new();
-        _pdfGeneratorClient.Setup(s => s.GeneratePdf(It.IsAny<Uri>(), It.IsAny<CancellationToken>()));
+        _pdfGeneratorClient.Setup(s =>
+            s.GeneratePdf(It.IsAny<Uri>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())
+        );
         _generalSettingsOptions.Value.ExternalAppBaseUrl = "https://{org}.apps.{hostName}/{org}/{app}";
 
         var target = SetupPdfService(
@@ -164,6 +166,7 @@ public class PdfServiceTests
                         && u.AbsoluteUri.Contains(instance.AppId)
                         && u.AbsoluteUri.Contains(instance.Id)
                     ),
+                    It.Is<string?>(s => s == null),
                     It.IsAny<CancellationToken>()
                 ),
             Times.Once
@@ -189,7 +192,9 @@ public class PdfServiceTests
     public async Task GenerateAndStorePdf_with_generatedFrom()
     {
         // Arrange
-        _pdfGeneratorClient.Setup(s => s.GeneratePdf(It.IsAny<Uri>(), It.IsAny<CancellationToken>()));
+        _pdfGeneratorClient.Setup(s =>
+            s.GeneratePdf(It.IsAny<Uri>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())
+        );
 
         _generalSettingsOptions.Value.ExternalAppBaseUrl = "https://{org}.apps.{hostName}/{org}/{app}";
 
@@ -228,6 +233,7 @@ public class PdfServiceTests
                         && u.AbsoluteUri.Contains(instance.AppId)
                         && u.AbsoluteUri.Contains(instance.Id)
                     ),
+                    It.Is<string?>(s => s == null),
                     It.IsAny<CancellationToken>()
                 ),
             Times.Once


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds config for showing a footer at the bottom of the generated PDF pages.

<img width="716" alt="image" src="https://github.com/user-attachments/assets/feb44d4b-515c-4d4f-a115-583ca11229ae">


## Description
Adds a new property to `"PdfGeneratorSettings"` in `appsettings.json`: `"DisplayFooter"`.
The property is a boolean that, when true, adds a footer to each page of your generated PDF. The footer contains information about the title of the document, the date and time the pdf was generated, the altinn-reference-id, and the current and total page number.

## Related Issue(s)
- #787 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
