### PR TITLE
Add draft support for adding/removing/modifying other data elements in dataProcessWrite

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -577,23 +577,21 @@ public class DataController : ControllerBase
 
             if (res.Success)
             {
+                // TODO: handle added and deleted data elements
                 foreach (var change in res.Ok.ChangedDataElements)
                 {
-                    if (change.HasAppLogic)
-                    {
-                        await UpdateDataValuesOnInstance(instance, change.DataElement.DataType, change.CurrentValue);
-                        await UpdatePresentationTextsOnInstance(
-                            instance,
-                            change.DataElement.DataType,
-                            change.CurrentValue
-                        );
-                    }
+                    await UpdateDataValuesOnInstance(instance, change.DataElement.DataType, change.CurrentFormData);
+                    await UpdatePresentationTextsOnInstance(
+                        instance,
+                        change.DataElement.DataType,
+                        change.CurrentFormData
+                    );
                 }
 
                 return Ok(
                     new DataPatchResponseMultiple()
                     {
-                        NewDataModels = res.Ok.GetUpdatedData(),
+                        NewDataModels = res.Ok.UpdatedData,
                         ValidationIssues = res.Ok.ValidationIssues
                     }
                 );

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -455,6 +455,7 @@ public class DataController : ControllerBase
     [ProducesResponseType(typeof(DataPatchResponse), 200)]
     [ProducesResponseType(typeof(ProblemDetails), 409)]
     [ProducesResponseType(typeof(ProblemDetails), 422)]
+    [Obsolete("Use PatchFormDataMultiple instead")]
     public async Task<ActionResult<DataPatchResponse>> PatchFormData(
         [FromRoute] string org,
         [FromRoute] string app,
@@ -478,8 +479,8 @@ public class DataController : ControllerBase
             return Ok(
                 new DataPatchResponse()
                 {
-                    ValidationIssues = newResponse.ValidationIssues,
-                    NewDataModel = newResponse.NewDataModels[dataGuid],
+                    ValidationIssues = newResponse.ValidationIssues.ToDictionary(d => d.Source, d => d.Issues),
+                    NewDataModel = newResponse.NewDataModels.First(m => m.Id == dataGuid).Data,
                 }
             );
         }
@@ -592,7 +593,12 @@ public class DataController : ControllerBase
                     new DataPatchResponseMultiple()
                     {
                         Instance = res.Ok.Instance,
-                        NewDataModels = res.Ok.UpdatedData,
+                        NewDataModels = res
+                            .Ok.UpdatedData.Select(d => new DataPatchResponseMultiple.DataModelPairResponse(
+                                d.Id.Guid,
+                                d.Data
+                            ))
+                            .ToList(),
                         ValidationIssues = res.Ok.ValidationIssues
                     }
                 );

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -595,7 +595,7 @@ public class DataController : ControllerBase
                         Instance = res.Ok.Instance,
                         NewDataModels = res
                             .Ok.UpdatedData.Select(d => new DataPatchResponseMultiple.DataModelPairResponse(
-                                d.Id.Guid,
+                                d.Identifier.Guid,
                                 d.Data
                             ))
                             .ToList(),

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -591,6 +591,7 @@ public class DataController : ControllerBase
                 return Ok(
                     new DataPatchResponseMultiple()
                     {
+                        Instance = res.Ok.Instance,
                         NewDataModels = res.Ok.UpdatedData,
                         ValidationIssues = res.Ok.ValidationIssues
                     }

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -4,8 +4,8 @@ using Altinn.App.Api.Infrastructure.Filters;
 using Altinn.App.Api.Models;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
-using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Process;
@@ -43,7 +43,7 @@ public class ProcessController : ControllerBase
     private readonly IProcessReader _processReader;
     private readonly IDataClient _dataClient;
     private readonly IAppMetadata _appMetadata;
-    private readonly IAppModel _appModel;
+    private readonly ModelSerializationService _modelSerialization;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProcessController"/>
@@ -58,7 +58,7 @@ public class ProcessController : ControllerBase
         IProcessEngine processEngine,
         IDataClient dataClient,
         IAppMetadata appMetadata,
-        IAppModel appModel
+        ModelSerializationService modelSerialization
     )
     {
         _logger = logger;
@@ -70,7 +70,7 @@ public class ProcessController : ControllerBase
         _processEngine = processEngine;
         _dataClient = dataClient;
         _appMetadata = appMetadata;
-        _appModel = appModel;
+        _modelSerialization = modelSerialization;
     }
 
     /// <summary>
@@ -249,10 +249,10 @@ public class ProcessController : ControllerBase
         string? language
     )
     {
-        var dataAcceesor = new CachedInstanceDataAccessor(instance, _dataClient, _appMetadata, _appModel);
+        var dataAccessor = new CachedInstanceDataAccessor(instance, _dataClient, _appMetadata, _modelSerialization);
         var validationIssues = await _validationService.ValidateInstanceAtTask(
             instance,
-            dataAcceesor,
+            dataAccessor,
             currentTaskId, // run full validation
             ignoredValidators: null,
             onlyIncrementalValidators: null,

--- a/src/Altinn.App.Api/Controllers/ValidateController.cs
+++ b/src/Altinn.App.Api/Controllers/ValidateController.cs
@@ -1,6 +1,6 @@
 using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
-using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Validation;
@@ -20,7 +20,7 @@ public class ValidateController : ControllerBase
 {
     private readonly IInstanceClient _instanceClient;
     private readonly IDataClient _dataClient;
-    private readonly IAppModel _appModel;
+    private readonly ModelSerializationService _modelSerialization;
     private readonly IAppMetadata _appMetadata;
     private readonly IValidationService _validationService;
 
@@ -32,14 +32,14 @@ public class ValidateController : ControllerBase
         IValidationService validationService,
         IAppMetadata appMetadata,
         IDataClient dataClient,
-        IAppModel appModel
+        ModelSerializationService modelSerialization
     )
     {
         _instanceClient = instanceClient;
         _validationService = validationService;
         _appMetadata = appMetadata;
         _dataClient = dataClient;
-        _appModel = appModel;
+        _modelSerialization = modelSerialization;
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ public class ValidateController : ControllerBase
 
         try
         {
-            var dataAccessor = new CachedInstanceDataAccessor(instance, _dataClient, _appMetadata, _appModel);
+            var dataAccessor = new CachedInstanceDataAccessor(instance, _dataClient, _appMetadata, _modelSerialization);
             var ignoredSources = ignoredValidators?.Split(',').ToList();
             List<ValidationIssueWithSource> messages = await _validationService.ValidateInstanceAtTask(
                 instance,
@@ -155,7 +155,7 @@ public class ValidateController : ControllerBase
             throw new ValidationException("Unknown element type.");
         }
 
-        var dataAccessor = new CachedInstanceDataAccessor(instance, _dataClient, _appMetadata, _appModel);
+        var dataAccessor = new CachedInstanceDataAccessor(instance, _dataClient, _appMetadata, _modelSerialization);
 
         // Run validations for all data elements, but only return the issues for the specific data element
         var issues = await _validationService.ValidateInstanceAtTask(

--- a/src/Altinn.App.Api/Models/DataPatchResponseMultiple.cs
+++ b/src/Altinn.App.Api/Models/DataPatchResponseMultiple.cs
@@ -12,12 +12,19 @@ public class DataPatchResponseMultiple
     /// <summary>
     /// The validation issues that were found during the patch operation.
     /// </summary>
-    public required Dictionary<string, List<ValidationIssueWithSource>> ValidationIssues { get; init; }
+    public required List<ValidationSourcePair> ValidationIssues { get; init; }
 
     /// <summary>
     /// The current data in all data models updated by the patch operation.
     /// </summary>
-    public required Dictionary<Guid, object> NewDataModels { get; init; }
+    public required List<DataModelPairResponse> NewDataModels { get; init; }
+
+    /// <summary>
+    /// Pair of Guid and data object.
+    /// </summary>
+    /// <param name="Id">The guid of the DataElement</param>
+    /// <param name="Data">The form data of the data element</param>
+    public record DataModelPairResponse(Guid Id, object Data);
 
     /// <summary>
     /// The instance with updated dataElement list.

--- a/src/Altinn.App.Api/Models/DataPatchResponseMultiple.cs
+++ b/src/Altinn.App.Api/Models/DataPatchResponseMultiple.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Models.Validation;
+using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Api.Models;
 
@@ -17,4 +18,9 @@ public class DataPatchResponseMultiple
     /// The current data in all data models updated by the patch operation.
     /// </summary>
     public required Dictionary<Guid, object> NewDataModels { get; init; }
+
+    /// <summary>
+    /// The instance with updated dataElement list.
+    /// </summary>
+    public required Instance Instance { get; init; }
 }

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Altinn.App.Core.Features.Payment.Services;
 using Altinn.App.Core.Features.Pdf;
 using Altinn.App.Core.Features.Validation;
 using Altinn.App.Core.Features.Validation.Default;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Implementation;
 using Altinn.App.Core.Infrastructure.Clients.Authentication;
 using Altinn.App.Core.Infrastructure.Clients.Authorization;
@@ -179,6 +180,7 @@ public static class ServiceCollectionExtensions
         services.Configure<AccessTokenSettings>(configuration.GetSection("AccessTokenSettings"));
         services.Configure<FrontEndSettings>(configuration.GetSection(nameof(FrontEndSettings)));
         services.Configure<PdfGeneratorSettings>(configuration.GetSection(nameof(PdfGeneratorSettings)));
+        services.AddSingleton<ModelSerializationService>();
 
         AddAppOptions(services);
         AddExternalApis(services);

--- a/src/Altinn.App.Core/Features/IDataProcessor.cs
+++ b/src/Altinn.App.Core/Features/IDataProcessor.cs
@@ -25,4 +25,11 @@ public interface IDataProcessor
     /// <param name="previousData">The previous data model (for running comparisons)</param>
     /// <param name="language">The currently selected language of the user (if available)</param>
     public Task ProcessDataWrite(Instance instance, Guid? dataId, object data, object? previousData, string? language);
+
+    public Task ProcessDataWrite(
+        IInstanceDataAccessor instanceDataAccessor,
+        string taskId,
+        List<DataElementChange> changes,
+        string? language
+    ) => Task.CompletedTask;
 }

--- a/src/Altinn.App.Core/Features/IDataProcessor.cs
+++ b/src/Altinn.App.Core/Features/IDataProcessor.cs
@@ -25,11 +25,4 @@ public interface IDataProcessor
     /// <param name="previousData">The previous data model (for running comparisons)</param>
     /// <param name="language">The currently selected language of the user (if available)</param>
     public Task ProcessDataWrite(Instance instance, Guid? dataId, object data, object? previousData, string? language);
-
-    public Task ProcessDataWrite(
-        IInstanceDataAccessor instanceDataAccessor,
-        string taskId,
-        List<DataElementChange> changes,
-        string? language
-    ) => Task.CompletedTask;
 }

--- a/src/Altinn.App.Core/Features/IDataWriteProcessor.cs
+++ b/src/Altinn.App.Core/Features/IDataWriteProcessor.cs
@@ -1,0 +1,24 @@
+namespace Altinn.App.Core.Features;
+
+/// <summary>
+/// This interface defines how you can make changes to the data model on every write operation from frontend.
+/// </summary>
+public interface IDataWriteProcessor
+{
+    /// <summary>
+    /// Is called to run custom calculation events defined by app developer when data is written to app.
+    /// </summary>
+    /// <remarks>
+    /// Make changes directly to the changes[].CurrentFormData object, or fetch other data elements from the instanceDataMutator.
+    /// </remarks>
+    /// <param name="instanceDataMutator">Object to fetch data elements not included in changes</param>
+    /// <param name="taskId">The current task ID</param>
+    /// <param name="changes">List of changes that are included in this request(might not include changes to extra data models from previous )</param>
+    /// <param name="language">The currently active language or null</param>
+    Task ProcessDataWrite(
+        IInstanceDataMutator instanceDataMutator,
+        string taskId,
+        List<DataElementChange> changes,
+        string? language
+    ) => Task.CompletedTask;
+}

--- a/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
@@ -32,4 +32,28 @@ public interface IInstanceDataAccessor
     /// </summary>
     /// <throws>Throws an InvalidOperationException if the data element is not found on the instance</throws>
     DataElement GetDataElement(DataElementId dataElementId);
+
+    /// <summary>
+    /// Add a new data element with app logic to the instance of this accessor
+    /// </summary>
+    /// <remarks>
+    /// Serialization of data is done immediately, so the data object should be in a valid state.
+    /// </remarks>
+    /// <throws>Throws an InvalidOperationException if the dataType is not found in applicationmetadata</throws>
+    void AddFormDataElement(string dataType, object data);
+
+    /// <summary>
+    /// Add a new data element without app logic to the instance.
+    /// </summary>
+    /// <remarks>
+    /// Saving to storage is not done until the instance is saved, so mutations to data might or might not be sendt to storage.
+    /// </remarks>
+    void AddAttachmentDataElement(string dataType, string contentType, string? filename, ReadOnlyMemory<byte> bytes);
+
+    /// <summary>
+    /// Remove a data element from the instance.
+    ///
+    /// Actual removal from storage is not done until the instance is saved.
+    /// </summary>
+    void RemoveDataElement(DataElementId dataElementId);
 }

--- a/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
@@ -32,28 +32,4 @@ public interface IInstanceDataAccessor
     /// </summary>
     /// <throws>Throws an InvalidOperationException if the data element is not found on the instance</throws>
     DataElement GetDataElement(DataElementId dataElementId);
-
-    /// <summary>
-    /// Add a new data element with app logic to the instance of this accessor
-    /// </summary>
-    /// <remarks>
-    /// Serialization of data is done immediately, so the data object should be in a valid state.
-    /// </remarks>
-    /// <throws>Throws an InvalidOperationException if the dataType is not found in applicationmetadata</throws>
-    void AddFormDataElement(string dataType, object data);
-
-    /// <summary>
-    /// Add a new data element without app logic to the instance.
-    /// </summary>
-    /// <remarks>
-    /// Saving to storage is not done until the instance is saved, so mutations to data might or might not be sendt to storage.
-    /// </remarks>
-    void AddAttachmentDataElement(string dataType, string contentType, string? filename, ReadOnlyMemory<byte> bytes);
-
-    /// <summary>
-    /// Remove a data element from the instance.
-    ///
-    /// Actual removal from storage is not done until the instance is saved.
-    /// </summary>
-    void RemoveDataElement(DataElementId dataElementId);
 }

--- a/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
@@ -16,11 +16,20 @@ public interface IInstanceDataAccessor
     /// <summary>
     /// Get the actual data represented in the data element.
     /// </summary>
-    /// <returns>The deserialized data model for this data element or a stream for binary elements</returns>
-    Task<object> GetData(DataElementId dataElementId);
+    /// <returns>The deserialized data model for this data element or an exception for non-form data elements</returns>
+    Task<object> GetFormData(DataElementId dataElementId);
 
     /// <summary>
-    /// Get actual data represented, when there should only be a single element of this type.
+    /// Gets the raw binary data from a DataElement.
+    /// </summary>´
+    /// <remarks>Form data elements (with appLogic) will get json serialized UTF-8</remarks>
+    /// <throws>Throws an InvalidOperationException if the data element is not found on the instance</throws>
+    /// <returns></returns>
+    Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementId dataElementId);
+
+    /// <summary>
+    /// Get a data element from an instance by id,
     /// </summary>
-    Task<object?> GetSingleDataByType(string dataType);
+    /// <throws>Throws an InvalidOperationException if the data element is not found on the instance</throws>
+    DataElement GetDataElement(DataElementId dataElementId);
 }

--- a/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
@@ -17,7 +17,7 @@ public interface IInstanceDataAccessor
     /// Get the actual data represented in the data element.
     /// </summary>
     /// <returns>The deserialized data model for this data element or an exception for non-form data elements</returns>
-    Task<object> GetFormData(DataElementId dataElementId);
+    Task<object> GetFormData(DataElementIdentifier dataElementIdentifier);
 
     /// <summary>
     /// Gets the raw binary data from a DataElement.
@@ -25,11 +25,11 @@ public interface IInstanceDataAccessor
     /// <remarks>Form data elements (with appLogic) will get json serialized UTF-8</remarks>
     /// <throws>Throws an InvalidOperationException if the data element is not found on the instance</throws>
     /// <returns></returns>
-    Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementId dataElementId);
+    Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier);
 
     /// <summary>
     /// Get a data element from an instance by id,
     /// </summary>
     /// <throws>Throws an InvalidOperationException if the data element is not found on the instance</throws>
-    DataElement GetDataElement(DataElementId dataElementId);
+    DataElement GetDataElement(DataElementIdentifier dataElementIdentifier);
 }

--- a/src/Altinn.App.Core/Features/IInstanceDataMutator.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataMutator.cs
@@ -1,0 +1,34 @@
+using Altinn.App.Core.Models;
+
+namespace Altinn.App.Core.Features;
+
+/// <summary>
+/// Extension of the IInstanceDataAccessor that allows for adding and removing data elements,
+/// and also indicate that it is OK to mutate the models
+/// </summary>
+public interface IInstanceDataMutator : IInstanceDataAccessor
+{
+    /// <summary>
+    /// Add a new data element with app logic to the instance of this accessor
+    /// </summary>
+    /// <remarks>
+    /// Serialization of data is done immediately, so the data object should be in a valid state.
+    /// </remarks>
+    /// <throws>Throws an InvalidOperationException if the dataType is not found in applicationmetadata</throws>
+    void AddFormDataElement(string dataType, object model);
+
+    /// <summary>
+    /// Add a new data element without app logic to the instance.
+    /// </summary>
+    /// <remarks>
+    /// Saving to storage is not done until the instance is saved, so mutations to data might or might not be sendt to storage.
+    /// </remarks>
+    void AddAttachmentDataElement(string dataType, string contentType, string? filename, ReadOnlyMemory<byte> bytes);
+
+    /// <summary>
+    /// Remove a data element from the instance.
+    ///
+    /// Actual removal from storage is not done until the instance is saved.
+    /// </summary>
+    void RemoveDataElement(DataElementId dataElementId);
+}

--- a/src/Altinn.App.Core/Features/IInstanceDataMutator.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataMutator.cs
@@ -30,5 +30,5 @@ public interface IInstanceDataMutator : IInstanceDataAccessor
     ///
     /// Actual removal from storage is not done until the instance is saved.
     /// </summary>
-    void RemoveDataElement(DataElementId dataElementId);
+    void RemoveDataElement(DataElementIdentifier dataElementIdentifier);
 }

--- a/src/Altinn.App.Core/Features/IValidator.cs
+++ b/src/Altinn.App.Core/Features/IValidator.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -68,49 +68,17 @@ public interface IValidator
 public class DataElementChange
 {
     /// <summary>
-    /// If the data element has app logic you can expect <see cref="CurrentValue"/> and <see cref="PreviousValue"/> to be available
-    /// </summary>
-    [MemberNotNullWhen(true, nameof(CurrentValue), nameof(PreviousValue))]
-    public required bool HasAppLogic { get; init; }
-
-    /// <summary>
     /// The data element the change is related to
     /// </summary>
-    public required DataElement DataElement { get; init; }
-
-    /// <summary>
-    /// The type of change that has occurred
-    /// </summary>
-    public required DataElementChangeType ChangeType { get; init; }
+    public required DataElementId DataElement { get; init; }
 
     /// <summary>
     /// The state of the data element before the change
     /// </summary>
-    public required object? PreviousValue { get; init; }
+    public required object PreviousFormData { get; init; }
 
     /// <summary>
     /// The state of the data element after the change
     /// </summary>
-    public required object? CurrentValue { get; init; }
-}
-
-/// <summary>
-/// Enum specifying the type of changes that can occur to a data element
-/// </summary>
-public enum DataElementChangeType
-{
-    /// <summary>
-    /// The data element has appLogic and was updated
-    /// </summary>
-    Update,
-
-    /// <summary>
-    /// The data element was added
-    /// </summary>
-    Add,
-
-    /// <summary>
-    /// The data element was removed
-    /// </summary>
-    Delete,
+    public required object CurrentFormData { get; init; }
 }

--- a/src/Altinn.App.Core/Features/IValidator.cs
+++ b/src/Altinn.App.Core/Features/IValidator.cs
@@ -1,4 +1,3 @@
-using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -12,7 +11,15 @@ public interface IValidator
     /// <summary>
     /// The task id for the task that the validator is associated with or "*" if the validator should run for all tasks.
     /// </summary>
+    /// <remarks>Ignored if <see cref="ShouldRunForTask"/> is implemented</remarks>
     public string TaskId { get; }
+
+    /// <summary>
+    /// Check if this validator should run for the given task
+    ///
+    /// Default implementations check <see cref="TaskId"/>
+    /// </summary>
+    public bool ShouldRunForTask(string taskId) => TaskId == "*" || TaskId == taskId;
 
     /// <summary>
     /// Unique string that identifies the source of the validation issues from this validator
@@ -65,12 +72,12 @@ public interface IValidator
 /// <summary>
 /// Represents a change in a data element with current and previous deserialized data
 /// </summary>
-public class DataElementChange
+public sealed class DataElementChange
 {
     /// <summary>
     /// The data element the change is related to
     /// </summary>
-    public required DataElementId DataElement { get; init; }
+    public required DataElement DataElement { get; init; }
 
     /// <summary>
     /// The state of the data element before the change
@@ -81,4 +88,14 @@ public class DataElementChange
     /// The state of the data element after the change
     /// </summary>
     public required object CurrentFormData { get; init; }
+
+    /// <summary>
+    /// The binary representation (for storage) of the data element before changes
+    /// </summary>
+    public ReadOnlyMemory<byte>? PreviousBinaryData { get; init; }
+
+    /// <summary>
+    /// The binary representation (for storage) of the data element after changes
+    /// </summary>
+    public ReadOnlyMemory<byte>? CurrentBinaryData { get; init; }
 }

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.Data.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.Data.cs
@@ -38,6 +38,12 @@ partial class Telemetry
         return activity;
     }
 
+    internal Activity? StartDataProcessWriteActivity(IDataWriteProcessor dataProcessor)
+    {
+        var activity = ActivitySource.StartActivity($"{Prefix}.ProcessWrite.{dataProcessor.GetType().Name}");
+        return activity;
+    }
+
     internal static class Data
     {
         internal const string Prefix = "Data";

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.ModelSerialization.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.ModelSerialization.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+
+namespace Altinn.App.Core.Features;
+
+partial class Telemetry
+{
+    internal Activity? StartSerializeToXmlActivity(Type typeToSerialize)
+    {
+        var activity = ActivitySource.StartActivity("SerializationService.SerializeXml");
+        activity?.SetTag("Type", typeToSerialize.FullName);
+        return activity;
+    }
+
+    internal Activity? StartSerializeToJsonActivity(Type typeToSerialize)
+    {
+        var activity = ActivitySource.StartActivity("SerializationService.SerializeXml");
+        activity?.SetTag("Type", typeToSerialize.FullName);
+        return activity;
+    }
+
+    internal Activity? StartDeserializeFromXmlActivity(Type typeToDeserialize)
+    {
+        var activity = ActivitySource.StartActivity("SerializationService.DeserializeXml");
+        activity?.SetTag("Type", typeToDeserialize.FullName);
+        return activity;
+    }
+
+    internal Activity? StartDeserializeFromJsonActivity(Type typeToDeserialize)
+    {
+        var activity = ActivitySource.StartActivity("SerializationService.DeserializeJson");
+        activity?.SetTag("Type", typeToDeserialize.FullName);
+        return activity;
+    }
+}

--- a/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
@@ -115,17 +115,21 @@ public class ExpressionValidator : IValidator
 
         var validationIssues = new List<ValidationIssue>();
         var expressionValidations = ParseExpressionValidationConfig(validationConfig.RootElement, _logger);
-        DataElementId dataElementId = dataElement;
+        DataElementIdentifier dataElementIdentifier = dataElement;
         foreach (var validationObject in expressionValidations)
         {
-            var baseField = new DataReference() { Field = validationObject.Key, DataElementId = dataElementId };
+            var baseField = new DataReference()
+            {
+                Field = validationObject.Key,
+                DataElementIdentifier = dataElementIdentifier
+            };
             var resolvedFields = await evaluatorState.GetResolvedKeys(baseField);
             var validations = validationObject.Value;
             foreach (var resolvedField in resolvedFields)
             {
                 if (
                     hiddenFields.Exists(d =>
-                        d.DataElementId == dataElementId
+                        d.DataElementIdentifier == dataElementIdentifier
                         && resolvedField.Field.StartsWith(d.Field, StringComparison.InvariantCulture)
                     )
                 )
@@ -136,7 +140,7 @@ public class ExpressionValidator : IValidator
                     component: null,
                     rowIndices: DataModel.GetRowIndices(resolvedField.Field),
                     rowLength: null,
-                    dataElementId: resolvedField.DataElementId
+                    dataElementIdentifier: resolvedField.DataElementIdentifier
                 );
                 var positionalArguments = new object[] { resolvedField };
                 foreach (var validation in validations)
@@ -184,7 +188,7 @@ public class ExpressionValidator : IValidator
                     var validationIssue = new ValidationIssue
                     {
                         Field = resolvedField.Field,
-                        DataElementId = resolvedField.DataElementId.Id.ToString(),
+                        DataElementId = resolvedField.DataElementIdentifier.Id.ToString(),
                         Severity = validation.Severity ?? ValidationIssueSeverity.Error,
                         CustomTextKey = validation.Message,
                         Code = validation.Message,

--- a/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
@@ -40,8 +40,15 @@ public class ExpressionValidator : IValidator
         _appMetadata = appMetadata;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// We implement <see cref="ShouldRunForTask"/> instead
+    /// </summary>
     public string TaskId => "*";
+
+    /// <summary>
+    /// Only run for tasks that specifies a layout set
+    /// </summary>
+    public bool ShouldRunForTask(string taskId) => GetDataTypesWithExpressionsForTask(taskId).Any();
 
     /// <summary>
     /// This validator has the code "Expression" and this is known by the frontend, who may request this validator to not run for incremental validation.
@@ -66,19 +73,22 @@ public class ExpressionValidator : IValidator
         string? language
     )
     {
-        var dataTypes = (await _appMetadata.GetApplicationMetadata()).DataTypes;
-        var formDataElementsForTask = instance
-            .Data.Where(d =>
-            {
-                var dataType = dataTypes.Find(dt => dt.Id == d.DataType);
-                return dataType != null && dataType.TaskId == taskId;
-            })
-            .ToList();
         var validationIssues = new List<ValidationIssue>();
-        foreach (var dataElement in formDataElementsForTask)
+        foreach (var (dataType, validationConfig) in GetDataTypesWithExpressionsForTask(taskId))
         {
-            var issues = await ValidateFormData(instance, dataElement, instanceDataAccessor, taskId, language);
-            validationIssues.AddRange(issues);
+            var formDataElementsForTask = instance.Data.Where(d => d.DataType == dataType.Id);
+            foreach (var dataElement in formDataElementsForTask)
+            {
+                var issues = await ValidateFormData(
+                    instance,
+                    dataElement,
+                    instanceDataAccessor,
+                    validationConfig,
+                    taskId,
+                    language
+                );
+                validationIssues.AddRange(issues);
+            }
         }
 
         return validationIssues;
@@ -88,17 +98,11 @@ public class ExpressionValidator : IValidator
         Instance instance,
         DataElement dataElement,
         IInstanceDataAccessor dataAccessor,
+        string rawValidationConfig,
         string taskId,
         string? language
     )
     {
-        var rawValidationConfig = _appResourceService.GetValidationConfiguration(dataElement.DataType);
-        if (rawValidationConfig == null)
-        {
-            // No validation configuration exists for this data type
-            return new List<ValidationIssue>();
-        }
-
         using var validationConfig = JsonDocument.Parse(rawValidationConfig);
 
         var evaluatorState = await _layoutEvaluatorStateInitializer.Init(
@@ -424,5 +428,20 @@ public class ExpressionValidator : IValidator
             }
         }
         return expressionValidations;
+    }
+
+    private IEnumerable<KeyValuePair<DataType, string>> GetDataTypesWithExpressionsForTask(string taskId)
+    {
+        var appMetadata = _appMetadata.GetApplicationMetadata().Result;
+        foreach (
+            var dataType in appMetadata.DataTypes.Where(dt => dt.TaskId == taskId && dt.AppLogic?.ClassRef is not null)
+        )
+        {
+            var validationConfig = _appResourceService.GetValidationConfiguration(dataType.Id);
+            if (validationConfig != null)
+            {
+                yield return KeyValuePair.Create(dataType, validationConfig);
+            }
+        }
     }
 }

--- a/src/Altinn.App.Core/Features/Validation/Default/LegacyIInstanceValidatorFormDataValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/LegacyIInstanceValidatorFormDataValidator.cs
@@ -59,10 +59,13 @@ public class LegacyIInstanceValidatorFormDataValidator : IValidator
     {
         var issues = new List<ValidationIssue>();
         var appMetadata = await _appMetadata.GetApplicationMetadata();
-        var dataTypes = appMetadata.DataTypes.Where(d => d.TaskId == taskId).Select(d => d.Id).ToList();
+        var dataTypes = appMetadata
+            .DataTypes.Where(d => d.TaskId == taskId && d.AppLogic?.ClassRef != null)
+            .Select(d => d.Id)
+            .ToList();
         foreach (var dataElement in instance.Data.Where(d => dataTypes.Contains(d.DataType)))
         {
-            var data = await instanceDataAccessor.GetData(dataElement);
+            var data = await instanceDataAccessor.GetFormData(dataElement);
             var modelState = new ModelStateDictionary();
             await _instanceValidator.ValidateData(data, modelState);
             issues.AddRange(

--- a/src/Altinn.App.Core/Features/Validation/Default/RequiredValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/RequiredValidator.cs
@@ -1,3 +1,4 @@
+using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
@@ -10,19 +11,30 @@ namespace Altinn.App.Core.Features.Validation.Default;
 public class RequiredLayoutValidator : IValidator
 {
     private readonly ILayoutEvaluatorStateInitializer _layoutEvaluatorStateInitializer;
+    private readonly IAppResources _appResources;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequiredLayoutValidator"/> class.
     /// </summary>
-    public RequiredLayoutValidator(ILayoutEvaluatorStateInitializer layoutEvaluatorStateInitializer)
+    public RequiredLayoutValidator(
+        ILayoutEvaluatorStateInitializer layoutEvaluatorStateInitializer,
+        IAppResources appResources
+    )
     {
         _layoutEvaluatorStateInitializer = layoutEvaluatorStateInitializer;
+        _appResources = appResources;
     }
 
     /// <summary>
-    /// Run for all tasks
+    /// We implement <see cref="ShouldRunForTask"/> instead
     /// </summary>
     public string TaskId => "*";
+
+    /// <summary>
+    /// Only run for tasks that specifies a layout set
+    /// </summary>
+    public bool ShouldRunForTask(string taskId) =>
+        _appResources.GetLayoutSet()?.Sets.SelectMany(s => s.Tasks ?? []).Any(t => t == taskId) ?? false;
 
     /// <summary>
     /// This validator has the code "Required" and this is known by the frontend, who may request this validator to not run for incremental validation.

--- a/src/Altinn.App.Core/Features/Validation/Wrappers/FormDataValidatorWrapper.cs
+++ b/src/Altinn.App.Core/Features/Validation/Wrappers/FormDataValidatorWrapper.cs
@@ -42,7 +42,7 @@ internal class FormDataValidatorWrapper : IValidator
                 continue;
             }
 
-            var data = await instanceDataAccessor.GetData(dataElement);
+            var data = await instanceDataAccessor.GetFormData(dataElement);
             var dataElementValidationResult = await _formDataValidator.ValidateFormData(
                 instance,
                 dataElement,
@@ -70,11 +70,8 @@ internal class FormDataValidatorWrapper : IValidator
             foreach (var change in changes)
             {
                 if (
-                    change.HasAppLogic
-                    && (
-                        _formDataValidator.DataType == "*" || _formDataValidator.DataType == change.DataElement.DataType
-                    )
-                    && _formDataValidator.HasRelevantChanges(change.CurrentValue, change.PreviousValue)
+                    (_formDataValidator.DataType == "*" || _formDataValidator.DataType == change.DataElement.DataType)
+                    && _formDataValidator.HasRelevantChanges(change.CurrentFormData, change.PreviousFormData)
                 )
                 {
                     return Task.FromResult(true);

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModel.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModel.cs
@@ -52,7 +52,7 @@ public class DataModel
     {
         if (key.DataType == null)
         {
-            return (defaultDataElementId, await _dataAccessor.GetData(defaultDataElementId));
+            return (defaultDataElementId, await _dataAccessor.GetFormData(defaultDataElementId));
         }
 
         if (_dataIdsByType.TryGetValue(key.DataType, out var dataElementId))
@@ -63,7 +63,7 @@ public class DataModel
                     $"{key.DataType} has maxCount different from 1 in applicationmetadata.json or don't have a classRef in appLogic"
                 );
             }
-            return (dataElementId.Value, await _dataAccessor.GetData(dataElementId.Value));
+            return (dataElementId.Value, await _dataAccessor.GetFormData(dataElementId.Value));
         }
 
         throw new InvalidOperationException(
@@ -109,7 +109,7 @@ public class DataModel
     /// </example>
     public async Task<DataReference[]> GetResolvedKeys(DataReference reference)
     {
-        var model = await _dataAccessor.GetData(reference.DataElementId);
+        var model = await _dataAccessor.GetFormData(reference.DataElementId);
         var modelWrapper = new DataModelWrapper(model);
         return modelWrapper
             .GetResolvedKeys(reference.Field)
@@ -156,7 +156,7 @@ public class DataModel
     /// </summary>
     public async Task RemoveField(DataReference reference, RowRemovalOption rowRemovalOption)
     {
-        var serviceModel = await _dataAccessor.GetData(reference.DataElementId);
+        var serviceModel = await _dataAccessor.GetFormData(reference.DataElementId);
         if (serviceModel is null)
         {
             throw new DataModelException(

--- a/src/Altinn.App.Core/Helpers/MemoryAsStream.cs
+++ b/src/Altinn.App.Core/Helpers/MemoryAsStream.cs
@@ -1,0 +1,57 @@
+namespace Altinn.App.Core.Helpers;
+
+internal class MemoryAsStream : Stream
+{
+    private readonly ReadOnlyMemory<byte> _memory;
+
+    public MemoryAsStream(ReadOnlyMemory<byte> memory)
+    {
+        _memory = memory;
+    }
+
+    public override void Flush() { }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        count = (int)Math.Min(count, Length - Position);
+        if (count > 0)
+        {
+            var toCopy = _memory.Span.Slice((int)Position, count);
+            toCopy.CopyTo(buffer.AsSpan(offset));
+            Position += count;
+            return count;
+        }
+
+        return 0;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        Position = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => Position + offset,
+            SeekOrigin.End => Length + offset, // Assume offset is negative
+            _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, "SeekOrigin not supported")
+        };
+        // Validate position?
+
+        return Position;
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => true;
+    public override bool CanWrite => false;
+    public override long Length => _memory.Length;
+    public override long Position { get; set; }
+}

--- a/src/Altinn.App.Core/Helpers/MemoryAsStream.cs
+++ b/src/Altinn.App.Core/Helpers/MemoryAsStream.cs
@@ -1,5 +1,8 @@
 namespace Altinn.App.Core.Helpers;
 
+/// <summary>
+/// A read only stream that can be used to pass <see cref="ReadOnlyMemory{T}"/> to a function that request a Stream without any copying.
+/// </summary>
 internal class MemoryAsStream : Stream
 {
     private readonly ReadOnlyMemory<byte> _memory;

--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -73,10 +73,13 @@ public static class ObjectUtils
     /// <summary>
     /// Xml serialization-deserialization does not preserve all properties, and we sometimes need
     /// to know how it looks when it comes back from storage.
+    /// </summary>
+    /// <remarks>
     /// * Recursively initialize all <see cref="List{T}"/> properties on the object that are currently null
     /// * Ensure that all string properties with `[XmlTextAttribute]` that are empty or whitespace are set to null
     /// * If a class has `[XmlTextAttribute]` and no value, set the parent property to null (if the other properties has [BindNever] attribute)
-    /// </summary>
+    /// * If a property has a `ShouldSerialize{PropertyName}` method that returns false, set the property to default value
+    /// </remarks>
     /// <param name="model">The object to mutate</param>
     /// <param name="depth">Remaining recursion depth. To prevent infinite recursion we stop prepeation after this depth. (default matches json serialization)</param>
     public static void PrepareModelForXmlStorage(object model, int depth = 64)

--- a/src/Altinn.App.Core/Helpers/RemoveBomExtentions.cs
+++ b/src/Altinn.App.Core/Helpers/RemoveBomExtentions.cs
@@ -6,10 +6,37 @@ internal static class RemoveBomExtentions
 
     internal static ReadOnlySpan<byte> RemoveBom(this byte[] bytes)
     {
+        return RemoveBom((ReadOnlySpan<byte>)bytes);
+    }
+
+    internal static ReadOnlySpan<byte> RemoveBom(this ReadOnlySpan<byte> bytes)
+    {
         // Remove UTF8 BOM (if present)
-        if (bytes.AsSpan().StartsWith(_utf8bom))
+        if (bytes.StartsWith(_utf8bom))
         {
-            return bytes.AsSpan().Slice(_utf8bom.Length);
+            return bytes.Slice(_utf8bom.Length);
+        }
+
+        return bytes;
+    }
+
+    internal static ReadOnlyMemory<byte> RemoveBom(this ReadOnlyMemory<byte> bytes)
+    {
+        // Remove UTF8 BOM (if present)
+        if (bytes.Span.StartsWith(_utf8bom))
+        {
+            return bytes.Slice(_utf8bom.Length);
+        }
+
+        return bytes;
+    }
+
+    internal static Memory<byte> RemoveBom(this Memory<byte> bytes)
+    {
+        // Remove UTF8 BOM (if present)
+        if (bytes.Span.StartsWith(_utf8bom))
+        {
+            return bytes.Slice(_utf8bom.Length);
         }
 
         return bytes;

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
@@ -10,7 +10,7 @@ namespace Altinn.App.Core.Helpers.Serialization;
 /// Represents logic to deserialize a stream of data to an instance of the given type
 /// </summary>
 // [Obsolete(
-//     "This class is deprecated and will be removed in a v9. Use Altinn.App.PlatformServices.Helpers.Serialization.ModelSerializationSerivce from dependency injection instead."
+//     "This class is deprecated and will be removed in a v9. Use Altinn.App.Core.Helpers.Serialization.ModelSerializationSerivce from dependency injection instead."
 // )]
 public class ModelDeserializer
 {

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelDeserializer.cs
@@ -9,6 +9,9 @@ namespace Altinn.App.Core.Helpers.Serialization;
 /// <summary>
 /// Represents logic to deserialize a stream of data to an instance of the given type
 /// </summary>
+// [Obsolete(
+//     "This class is deprecated and will be removed in a v9. Use Altinn.App.PlatformServices.Helpers.Serialization.ModelSerializationSerivce from dependency injection instead."
+// )]
 public class ModelDeserializer
 {
     private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
@@ -88,12 +88,7 @@ public class ModelSerializationService
 
         XmlSerializer serializer = _xmlSerializer.GetSerializer(modelType);
         serializer.Serialize(xmlWriter, model);
-        if (!memoryStream.TryGetBuffer(out var segment))
-        {
-            throw new InvalidOperationException("Failed to get buffer from memory stream");
-        }
-
-        return segment.AsMemory().RemoveBom();
+        return memoryStream.ToArray().AsMemory().RemoveBom();
     }
 
     /// <summary>
@@ -161,11 +156,8 @@ public class ModelSerializationService
     }
 
     /// <summary>
-    ///
+    /// Deserialize utf8 encoded xml data to a model of the specified type
     /// </summary>
-    /// <param name="data"></param>
-    /// <param name="modelType"></param>
-    /// <returns></returns>
     public object DeserializeXml(ReadOnlySpan<byte> data, Type modelType)
     {
         using var activity = _telemetry?.StartDeserializeFromXmlActivity(modelType);

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
@@ -1,0 +1,267 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using System.Xml;
+using System.Xml.Serialization;
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Internal.AppModel;
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.Core.Helpers.Serialization;
+
+/// <summary>
+/// DI registered service for centralizing (de)serialization logic for data models
+/// </summary>
+public class ModelSerializationService
+{
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
+    private static readonly XmlSerializerCache _xmlSerializer = new();
+
+    private readonly Telemetry? _telemetry;
+    private readonly IAppModel _appModel;
+
+    /// <summary>
+    /// Constructor for the ModelDeserializerService
+    /// </summary>
+    public ModelSerializationService(IAppModel appModel, Telemetry? telemetry = null)
+    {
+        _appModel = appModel;
+        _telemetry = telemetry;
+    }
+
+    /// <summary>
+    /// Deserialize binary data from storage to a model of the classRef specified in the dataType
+    /// </summary>
+    /// <param name="data">The binary data</param>
+    /// <param name="dataType">The data type used to get content type and the classRef for the object to be returned</param>
+    /// <returns>The model specified in </returns>
+    public object DeserializeFromStorage(ReadOnlySpan<byte> data, DataType dataType)
+    {
+        var type = GetModelTypeForDataType(dataType);
+
+        // TODO: support sending json to storage based on dataType.ContentTypes
+        return DeserializeXml(data, type);
+    }
+
+    /// <summary>
+    /// Serialize an object to binary data for storage, respecting classRef and content type in dataType
+    /// </summary>
+    /// <param name="model">The object to serialize (must match the classRef in DataType)</param>
+    /// <param name="dataType">The data type</param>
+    /// <returns>the binary data and the content type (currently only application/xml, but likely also json in the future)</returns>
+    /// <exception cref="InvalidOperationException">If the classRef in dataType does not match type of the model</exception>
+    public (ReadOnlyMemory<byte> data, string contentType) SerializeToStorage(object model, DataType dataType)
+    {
+        var type = GetModelTypeForDataType(dataType);
+        if (type != model.GetType())
+        {
+            throw new InvalidOperationException(
+                $"DataType {dataType.Id} expects {type.FullName}, found {model.GetType().FullName}"
+            );
+        }
+
+        //TODO: support sending json to storage based on dataType.ContentTypes
+        return (SerializeToXml(model), "application/xml");
+    }
+
+    /// <summary>
+    /// Serialize an object to xml
+    /// </summary>
+    /// <param name="model">The object to serialize</param>
+    /// <returns>The bytes of the serialized xml in UTF8 encoding</returns>
+    public ReadOnlyMemory<byte> SerializeToXml(object model)
+    {
+        var modelType = model.GetType();
+        using var activity = _telemetry?.StartSerializeToXmlActivity(modelType);
+
+        // Ensure that model is mutated in the same way it would be when deserialized from storage
+        // (evaluate ShouldSerialize* methods, set empty strings to null, etc.)
+        ObjectUtils.PrepareModelForXmlStorage(model);
+
+        XmlWriterSettings xmlWriterSettings = new XmlWriterSettings()
+        {
+            Encoding = new UTF8Encoding(false),
+            NewLineHandling = NewLineHandling.None,
+        };
+        using var memoryStream = new MemoryStream();
+        XmlWriter xmlWriter = XmlWriter.Create(memoryStream, xmlWriterSettings);
+
+        XmlSerializer serializer = _xmlSerializer.GetSerializer(modelType);
+        serializer.Serialize(xmlWriter, model);
+        if (!memoryStream.TryGetBuffer(out var segment))
+        {
+            throw new InvalidOperationException("Failed to get buffer from memory stream");
+        }
+
+        return segment.AsMemory().RemoveBom();
+    }
+
+    /// <summary>
+    /// Serialize an object to json
+    /// </summary>
+    /// <param name="model">The object to serialize</param>
+    /// <returns>the serialized UTF8 encoded bytes</returns>
+    public ReadOnlyMemory<byte> SerializeToJson(object model)
+    {
+        var modelType = model.GetType();
+        using var span = _telemetry?.StartSerializeToJsonActivity(modelType);
+        var json = JsonSerializer.SerializeToUtf8Bytes(model, modelType, _jsonSerializerOptions);
+        return json;
+    }
+
+    // public async Task<ServiceResult<object, ProblemDetails>> DeserializeSingleFromRequest(
+    //     Stream body,
+    //     string? contentType,
+    //     DataType dataType
+    // )
+    // {
+    //     using var memoryStream = new MemoryStream();
+    //     await body.CopyToAsync(memoryStream);
+    //     if (!memoryStream.TryGetBuffer(out var segment))
+    //     {
+    //         throw new InvalidOperationException("Failed to get buffer from memory stream");
+    //     }
+    //
+    //     var modelType = GetModelTypeForDataType(dataType);
+    //     object model;
+    //     if (contentType?.Contains("application/xml") ?? true) // default to xml if no content type is provided
+    //     {
+    //         model = DeserializeXml(segment, modelType);
+    //     }
+    //     else if (contentType.Contains("application/json"))
+    //     {
+    //         model = DeserializeJson(segment, modelType);
+    //     }
+    //     else
+    //     {
+    //         return new ProblemDetails()
+    //         {
+    //             Title = "Unsupported content type",
+    //             Detail = $"Content type {contentType} is not supported for deserialization",
+    //             Status = StatusCodes.Status415UnsupportedMediaType,
+    //         };
+    //     }
+    //
+    //     return model;
+    // }
+
+    /// <summary>
+    /// Deserialize utf8 encoded json data to a model of the specified type
+    ///
+    /// Basically just JsonSerializer.Deserialize, but with a telemetry activity and BOM removal
+    /// </summary>
+    /// <param name="data">The binary UTF8 encoded json</param>
+    /// <param name="modelType">The target type for deserialization</param>
+    /// <returns>The deserialized object</returns>
+    public object DeserializeJson(ReadOnlySpan<byte> data, Type modelType)
+    {
+        using var activity = _telemetry?.StartDeserializeFromJsonActivity(modelType);
+        return JsonSerializer.Deserialize(data.RemoveBom(), modelType, _jsonSerializerOptions)
+            ?? throw new JsonException("Json deserialization returned null");
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="data"></param>
+    /// <param name="modelType"></param>
+    /// <returns></returns>
+    public object DeserializeXml(ReadOnlySpan<byte> data, Type modelType)
+    {
+        using var activity = _telemetry?.StartDeserializeFromXmlActivity(modelType);
+        // convert to UTF16 string as it seems to be preferred by the XmlTextReader
+        // and aligns with previous implementation
+        string streamContent = Encoding.UTF8.GetString(data.RemoveBom());
+        if (string.IsNullOrWhiteSpace(streamContent))
+        {
+            throw new Exception("No XML content read from stream");
+        }
+        try
+        {
+            using XmlTextReader xmlTextReader = new XmlTextReader(new StringReader(streamContent));
+            XmlSerializer serializer = _xmlSerializer.GetSerializer(modelType);
+
+            return serializer.Deserialize(xmlTextReader)
+                ?? throw new InvalidOperationException("Deserialization returned null");
+        }
+        catch (InvalidOperationException)
+        {
+            using XmlTextReader xmlTextReader = new XmlTextReader(new StringReader(streamContent));
+            XmlSerializer serializer = _xmlSerializer.GetSerializerIgnoreNamespace(modelType);
+
+            return serializer.Deserialize(xmlTextReader)
+                ?? throw new InvalidOperationException("Deserialization returned null");
+        }
+    }
+
+    private Type GetModelTypeForDataType(DataType dataType)
+    {
+        if (dataType.AppLogic?.ClassRef is not { } classRef)
+        {
+            throw new InvalidOperationException(
+                $"Data type {dataType.Id} does not have a appLogic.classRef in application metadata"
+            );
+        }
+
+        var type = _appModel.GetModelType(classRef);
+        return type;
+    }
+
+    /// <summary>
+    /// XmlSerializer instances should be cached to avoid the overhead of creating them repeatedly.
+    ///
+    /// We cache two types of XmlSerializers:
+    /// 1. XmlSerializer: The default serializer for a given model type.
+    /// 2. XmlSerializer: A serializer that ignores the namespace of the XML, so we can deserialize XML without a namespace declaration.
+    /// </summary>
+    private class XmlSerializerCache
+    {
+        private readonly ConcurrentDictionary<Type, XmlSerializer> _xmlSerializers = new();
+        private readonly ConcurrentDictionary<Type, XmlSerializer> _xmlSerializersWithOverride = new();
+
+        /// <summary>
+        /// Get a cached XmlSerializer for the given model type.
+        /// </summary>
+        public XmlSerializer GetSerializer(Type modelType)
+        {
+            return _xmlSerializers.GetOrAdd(modelType, t => new XmlSerializer(t));
+        }
+
+        /// <summary>
+        /// Get a cached XmlSerializer for the given model type, that ignores the namespace of the XML.
+        /// </summary>
+        public XmlSerializer GetSerializerIgnoreNamespace(Type modelType)
+        {
+            return _xmlSerializersWithOverride.GetOrAdd(
+                modelType,
+                t =>
+                {
+                    // In this backup try block we assume that the modelType has declared a namespace,
+                    // but that the XML is without any namespace declaration.
+                    string elementName = GetRootElementName(modelType);
+
+                    XmlAttributeOverrides attributeOverrides = new XmlAttributeOverrides();
+                    XmlAttributes attributes = new XmlAttributes();
+                    attributes.XmlRoot = new XmlRootAttribute(elementName);
+                    attributeOverrides.Add(modelType, attributes);
+                    return new XmlSerializer(t, attributeOverrides);
+                }
+            );
+        }
+
+        private static string GetRootElementName(Type modelType)
+        {
+            Attribute[] attributes = Attribute.GetCustomAttributes(modelType);
+
+            foreach (var attribute in attributes)
+            {
+                if (attribute is XmlRootAttribute xmlRootAttribute)
+                {
+                    return xmlRootAttribute.ElementName;
+                }
+            }
+
+            return modelType.Name;
+        }
+    }
+}

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -317,17 +317,23 @@ public class AppResourcesSI : IAppResources
     }
 
     /// <inheritdoc />
-    public LayoutModel GetLayoutModelForTask(string taskId)
+    public LayoutModel? GetLayoutModelForTask(string taskId)
     {
         using var activity = _telemetry?.StartGetLayoutModelActivity();
-        var layoutSets = GetLayoutSet() ?? throw new InvalidOperationException("no layout sets found");
+        var layoutSets = GetLayoutSet();
+        if (layoutSets is null)
+        {
+            return null;
+        }
         var dataTypes = _appMetadata.GetApplicationMetadata().Result.DataTypes;
 
         var layouts = layoutSets.Sets.Select(set => LoadLayout(set, dataTypes)).ToList();
 
-        var layoutSet =
-            GetLayoutSetForTask(taskId)
-            ?? throw new InvalidOperationException("No layout set found for task " + taskId);
+        var layoutSet = GetLayoutSetForTask(taskId);
+        if (layoutSet is null)
+        {
+            return null;
+        }
 
         return new LayoutModel(layouts, layoutSet);
     }

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
@@ -2,14 +2,13 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
-using System.Xml;
-using System.Xml.Serialization;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Models;
@@ -29,6 +28,8 @@ public class DataClient : IDataClient
     private readonly PlatformSettings _platformSettings;
     private readonly ILogger _logger;
     private readonly IUserTokenProvider _userTokenProvider;
+    private readonly IAppMetadata _appMetadata;
+    private readonly ModelSerializationService _modelSerializationService;
     private readonly Telemetry? _telemetry;
     private readonly HttpClient _client;
 
@@ -39,12 +40,16 @@ public class DataClient : IDataClient
     /// <param name="logger">the logger</param>
     /// <param name="httpClient">A HttpClient from the built in HttpClient factory.</param>
     /// <param name="userTokenProvider">Service to obtain json web token</param>
+    /// <param name="appMetadata"></param>
+    /// <param name="modelSerializationService"></param>
     /// <param name="telemetry">Telemetry for traces and metrics.</param>
     public DataClient(
         IOptions<PlatformSettings> platformSettings,
         ILogger<DataClient> logger,
         HttpClient httpClient,
         IUserTokenProvider userTokenProvider,
+        IAppMetadata appMetadata,
+        ModelSerializationService modelSerializationService,
         Telemetry? telemetry = null
     )
     {
@@ -57,6 +62,8 @@ public class DataClient : IDataClient
         httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
         _client = httpClient;
         _userTokenProvider = userTokenProvider;
+        _appMetadata = appMetadata;
+        _modelSerializationService = modelSerializationService;
         _telemetry = telemetry;
     }
 
@@ -70,6 +77,7 @@ public class DataClient : IDataClient
         int instanceOwnerPartyId,
         string dataType
     )
+        where T : notnull
     {
         using var activity = _telemetry?.StartInsertFormDataActivity(instanceGuid, instanceOwnerPartyId);
         Instance instance = new() { Id = $"{instanceOwnerPartyId}/{instanceGuid}", };
@@ -77,18 +85,26 @@ public class DataClient : IDataClient
     }
 
     /// <inheritdoc />
-    public async Task<DataElement> InsertFormData<T>(Instance instance, string dataType, T dataToSerialize, Type type)
+    public async Task<DataElement> InsertFormData<T>(
+        Instance instance,
+        string dataTypeString,
+        T dataToSerialize,
+        Type type
+    )
+        where T : notnull
     {
         using var activity = _telemetry?.StartInsertFormDataActivity(instance);
-        string apiUrl = $"instances/{instance.Id}/data?dataType={dataType}";
+        string apiUrl = $"instances/{instance.Id}/data?dataType={dataTypeString}";
         string token = _userTokenProvider.GetUserToken();
-        DataElement dataElement;
 
-        using MemoryStream stream = new MemoryStream();
-        Serialize(dataToSerialize, type, stream);
+        var application = await _appMetadata.GetApplicationMetadata();
+        var dataType =
+            application.DataTypes.Find(d => d.Id == dataTypeString)
+            ?? throw new InvalidOperationException($"Data type {dataTypeString} not found in applicationmetadata.json");
 
-        stream.Position = 0;
-        StreamContent streamContent = new StreamContent(stream);
+        var (data, contentType) = _modelSerializationService.SerializeToStorage(dataToSerialize, dataType);
+
+        StreamContent streamContent = new StreamContent(new MemoryAsStream(data));
         streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/xml");
         HttpResponseMessage response = await _client.PostAsync(token, apiUrl, streamContent);
 
@@ -96,7 +112,7 @@ public class DataClient : IDataClient
         {
             string instanceData = await response.Content.ReadAsStringAsync();
             // ! TODO: this null-forgiving operator should be fixed/removed for the next major release
-            dataElement = JsonConvert.DeserializeObject<DataElement>(instanceData)!;
+            var dataElement = JsonConvert.DeserializeObject<DataElement>(instanceData)!;
 
             return dataElement;
         }
@@ -120,19 +136,20 @@ public class DataClient : IDataClient
         int instanceOwnerPartyId,
         Guid dataId
     )
+        where T : notnull
     {
         using var activity = _telemetry?.StartUpdateDataActivity(instanceGuid, instanceOwnerPartyId);
         string instanceIdentifier = $"{instanceOwnerPartyId}/{instanceGuid}";
         string apiUrl = $"instances/{instanceIdentifier}/data/{dataId}";
         string token = _userTokenProvider.GetUserToken();
 
-        using MemoryStream stream = new MemoryStream();
+        //TODO: this method does not get enough information to know the content type from the DataType
+        //      if we start to support more than XML
+        var serializedBytes = _modelSerializationService.SerializeToXml(dataToSerialize);
+        var contentType = "application/xml";
 
-        Serialize(dataToSerialize, type, stream);
-
-        stream.Position = 0;
-        StreamContent streamContent = new StreamContent(stream);
-        streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/xml");
+        StreamContent streamContent = new StreamContent(new MemoryAsStream(serializedBytes));
+        streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
 
         HttpResponseMessage response = await _client.PutAsync(token, apiUrl, streamContent);
 
@@ -145,24 +162,6 @@ public class DataClient : IDataClient
         }
 
         throw await PlatformHttpException.CreateAsync(response);
-    }
-
-    // Serializing using XmlWriter with UTF8 Encoding without generating BOM
-    // to avoid issue introduced with .Net when MS introduced BOM by default
-    // when serializing ref. https://github.com/dotnet/runtime/issues/63585
-    // Will be fixed with  https://github.com/dotnet/runtime/pull/75637
-    internal static void Serialize<T>(T dataToSerialize, Type type, Stream targetStream)
-    {
-        XmlWriterSettings xmlWriterSettings = new XmlWriterSettings()
-        {
-            Encoding = new UTF8Encoding(false),
-            NewLineHandling = NewLineHandling.None,
-        };
-        XmlWriter xmlWriter = XmlWriter.Create(targetStream, xmlWriterSettings);
-
-        XmlSerializer serializer = new(type);
-
-        serializer.Serialize(xmlWriter, dataToSerialize);
     }
 
     /// <inheritdoc />
@@ -214,20 +213,44 @@ public class DataClient : IDataClient
         HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
         if (response.IsSuccessStatusCode)
         {
-            using Stream stream = await response.Content.ReadAsStreamAsync();
-            ModelDeserializer deserializer = new ModelDeserializer(_logger, type);
-            object? model = await deserializer.DeserializeAsync(stream, "application/xml");
+            var bytes = await response.Content.ReadAsByteArrayAsync();
 
-            if (deserializer.Error != null || model is null)
+            try
             {
-                _logger.LogError($"Cannot deserialize XML form data read from storage: {deserializer.Error}");
-                throw new ServiceException(
-                    HttpStatusCode.Conflict,
-                    $"Cannot deserialize XML form data from storage {deserializer.Error}"
-                );
+                //TODO: this method does not get enough information to know the content type from the DataType
+                //      if we start to support more than XML
+                return _modelSerializationService.DeserializeXml(bytes, type);
             }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error deserializing form data");
+                throw new ServiceException(HttpStatusCode.Conflict, "Error deserializing form data", e);
+            }
+        }
 
-            return model;
+        throw await PlatformHttpException.CreateAsync(response);
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]> GetDataBytes(
+        string org,
+        string app,
+        int instanceOwnerPartyId,
+        Guid instanceGuid,
+        Guid dataId
+    )
+    {
+        using var activity = _telemetry?.StartGetBinaryDataActivity(instanceGuid, instanceOwnerPartyId);
+        string instanceIdentifier = $"{instanceOwnerPartyId}/{instanceGuid}";
+        string apiUrl = $"instances/{instanceIdentifier}/data/{dataId}";
+
+        string token = _userTokenProvider.GetUserToken();
+
+        HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return await response.Content.ReadAsByteArrayAsync();
         }
 
         throw await PlatformHttpException.CreateAsync(response);
@@ -464,7 +487,7 @@ public class DataClient : IDataClient
     public async Task<DataElement> UpdateBinaryData(
         InstanceIdentifier instanceIdentifier,
         string? contentType,
-        string filename,
+        string? filename,
         Guid dataGuid,
         Stream stream
     )
@@ -475,11 +498,15 @@ public class DataClient : IDataClient
         StreamContent content = new StreamContent(stream);
         ArgumentNullException.ThrowIfNull(contentType);
         content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
-        content.Headers.ContentDisposition = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
+        if (!string.IsNullOrEmpty(filename))
         {
-            FileName = filename,
-            FileNameStar = filename
-        };
+            content.Headers.ContentDisposition = new ContentDispositionHeaderValue(DispositionTypeNames.Attachment)
+            {
+                FileName = filename,
+                FileNameStar = filename
+            };
+        }
+
         HttpResponseMessage response = await _client.PutAsync(token, apiUrl, content);
         _logger.LogInformation("Update binary data result: {ResultCode}", response.StatusCode);
         if (response.IsSuccessStatusCode)

--- a/src/Altinn.App.Core/Internal/App/IAppResources.cs
+++ b/src/Altinn.App.Core/Internal/App/IAppResources.cs
@@ -128,7 +128,7 @@ public interface IAppResources
     /// <summary>
     /// Gets the full layout model for the task
     /// </summary>
-    LayoutModel GetLayoutModelForTask(string taskId);
+    LayoutModel? GetLayoutModelForTask(string taskId);
 
     /// <summary>
     /// Gets the full layout model for the optional set

--- a/src/Altinn.App.Core/Internal/Data/IDataClient.cs
+++ b/src/Altinn.App.Core/Internal/Data/IDataClient.cs
@@ -28,30 +28,33 @@ public interface IDataClient
         string app,
         int instanceOwnerPartyId,
         string dataType
-    );
+    )
+        where T : notnull;
 
     /// <summary>
     /// Stores the form
     /// </summary>
     /// <typeparam name="T">The model type</typeparam>
     /// <param name="instance">The instance that the data element belongs to</param>
-    /// <param name="dataType">The data type with requirements</param>
+    /// <param name="dataTypeString">The data type with requirements</param>
     /// <param name="dataToSerialize">The data element instance</param>
     /// <param name="type">The class type describing the data</param>
     /// <returns>The data element metadata</returns>
-    Task<DataElement> InsertFormData<T>(Instance instance, string dataType, T dataToSerialize, Type type);
+    Task<DataElement> InsertFormData<T>(Instance instance, string dataTypeString, T dataToSerialize, Type type)
+        where T : notnull;
 
     /// <summary>
     /// updates the form data
     /// </summary>
     /// <typeparam name="T">The type</typeparam>
     /// <param name="dataToSerialize">The form data to serialize</param>
-    /// <param name="instanceGuid">The instanceid</param>
+    /// <param name="instanceGuid">The instance id</param>
     /// <param name="type">The type for serialization</param>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="app">Application identifier which is unique within an organisation.</param>
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
     /// <param name="dataId">the data id</param>
+    //TODO: [Obsolete in v9 in favour of a version that gets the dataType so we can support json and xml]
     Task<DataElement> UpdateData<T>(
         T dataToSerialize,
         Guid instanceGuid,
@@ -60,12 +63,13 @@ public interface IDataClient
         string app,
         int instanceOwnerPartyId,
         Guid dataId
-    );
+    )
+        where T : notnull;
 
     /// <summary>
     /// Gets the form data
     /// </summary>
-    /// <param name="instanceGuid">The instanceid</param>
+    /// <param name="instanceGuid">The instance id</param>
     /// <param name="type">The type for serialization</param>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="app">Application identifier which is unique within an organisation.</param>
@@ -86,9 +90,20 @@ public interface IDataClient
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="app">Application identifier which is unique within an organisation.</param>
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
-    /// <param name="instanceGuid">The instanceid</param>
+    /// <param name="instanceGuid">The instance id</param>
     /// <param name="dataId">the data id</param>
     Task<Stream> GetBinaryData(string org, string app, int instanceOwnerPartyId, Guid instanceGuid, Guid dataId);
+
+    /// <summary>
+    /// Similar to GetBinaryData, but returns a HttpResponseMessage instead of a cached stream
+    /// </summary>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataId">the data id</param>
+    /// <returns>The raw HttpResponseMessage from the call to platform</returns>
+    Task<byte[]> GetDataBytes(string org, string app, int instanceOwnerPartyId, Guid instanceGuid, Guid dataId);
 
     /// <summary>
     /// Method that gets metadata on form attachments ordered by attachmentType
@@ -180,7 +195,7 @@ public interface IDataClient
     Task<DataElement> UpdateBinaryData(
         InstanceIdentifier instanceIdentifier,
         string? contentType,
-        string filename,
+        string? filename,
         Guid dataGuid,
         Stream stream
     );

--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -111,7 +111,7 @@ public static class ExpressionEvaluator
         {
             return await DataModel(
                 new ModelBinding() { Field = dataReference.Field },
-                dataReference.DataElementId,
+                dataReference.DataElementIdentifier,
                 context.RowIndices,
                 state
             );
@@ -127,17 +127,17 @@ public static class ExpressionEvaluator
                     $"""Expected ["dataModel", ...] to have 1-2 argument(s), got {args.Length}"""
                 )
         };
-        return await DataModel(key, context.DataElementId, context.RowIndices, state);
+        return await DataModel(key, context.DataElementIdentifier, context.RowIndices, state);
     }
 
     private static async Task<object?> DataModel(
         ModelBinding key,
-        DataElementId defaultDataElementId,
+        DataElementIdentifier defaultDataElementIdentifier,
         int[]? indexes,
         LayoutEvaluatorState state
     )
     {
-        var data = await state.GetModelData(key, defaultDataElementId, indexes);
+        var data = await state.GetModelData(key, defaultDataElementIdentifier, indexes);
 
         // Only allow IConvertible types to be returned from data model
         // Objects and arrays should return null
@@ -182,7 +182,7 @@ public static class ExpressionEvaluator
             return null;
         }
 
-        return await DataModel(binding, context.DataElementId, context.RowIndices, state);
+        return await DataModel(binding, context.DataElementIdentifier, context.RowIndices, state);
     }
 
     private static string? Concat(object?[] args)

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluator.cs
@@ -79,7 +79,7 @@ public static class LayoutEvaluator
                 var rowIndices = context.RowIndices?.Append(index).ToArray() ?? [index];
                 var indexedBinding = await state.AddInidicies(
                     repGroup.DataModelBindings["group"],
-                    context.DataElementId,
+                    context.DataElementIdentifier,
                     rowIndices
                 );
 
@@ -166,7 +166,7 @@ public static class LayoutEvaluator
             {
                 foreach (var (bindingName, binding) in context.Component.DataModelBindings)
                 {
-                    var value = await state.GetModelData(binding, context.DataElementId, context.RowIndices);
+                    var value = await state.GetModelData(binding, context.DataElementIdentifier, context.RowIndices);
                     if (value is null)
                     {
                         var field = await state.AddInidicies(binding, context);
@@ -174,7 +174,7 @@ public static class LayoutEvaluator
                             new ValidationIssue()
                             {
                                 Severity = ValidationIssueSeverity.Error,
-                                DataElementId = field.DataElementId.ToString(),
+                                DataElementId = field.DataElementIdentifier.ToString(),
                                 Field = field.Field,
                                 Description =
                                     $"{field.Field} is required in component with id {context.Component.LayoutId}.{context.Component.PageId}.{context.Component.Id} for binding {bindingName}",

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -140,9 +140,13 @@ public class LayoutEvaluatorState
     /// <summary>
     /// Get field from dataModel with key and context
     /// </summary>
-    public async Task<object?> GetModelData(ModelBinding key, DataElementId defaultDataElementId, int[]? indexes)
+    public async Task<object?> GetModelData(
+        ModelBinding key,
+        DataElementIdentifier defaultDataElementIdentifier,
+        int[]? indexes
+    )
     {
-        return await _dataModel.GetModelData(key, defaultDataElementId, indexes);
+        return await _dataModel.GetModelData(key, defaultDataElementIdentifier, indexes);
     }
 
     /// <summary>
@@ -205,21 +209,25 @@ public class LayoutEvaluatorState
     /// </example>
     public async Task<DataReference> AddInidicies(ModelBinding binding, ComponentContext context)
     {
-        return await _dataModel.AddIndexes(binding, context.DataElementId, context.RowIndices);
+        return await _dataModel.AddIndexes(binding, context.DataElementIdentifier, context.RowIndices);
     }
 
     /// <summary>
     /// Return a full dataModelBiding from a context aware binding by adding indexes
     /// </summary>
-    public async Task<DataReference> AddInidicies(ModelBinding binding, DataElementId dataElementId, int[]? indexes)
+    public async Task<DataReference> AddInidicies(
+        ModelBinding binding,
+        DataElementIdentifier dataElementIdentifier,
+        int[]? indexes
+    )
     {
-        return await _dataModel.AddIndexes(binding, dataElementId, indexes);
+        return await _dataModel.AddIndexes(binding, dataElementIdentifier, indexes);
     }
 
     /// <summary>
     /// This is the wrong abstraction, but used in tests that work
     /// </summary>
-    internal DataElementId GetDefaultDataElementId()
+    internal DataElementIdentifier GetDefaultDataElementId()
     {
         return _componentModel?.GetDefaultDataElementId(_instanceContext)
             ?? throw new InvalidOperationException("Component model not loaded");

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -82,7 +82,7 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
         }
 
         // Not implemented
-        public void AddFormDataElement(string dataType, object data)
+        public void AddFormDataElement(string dataType, object model)
         {
             throw new NotImplementedException(
                 "The obsolete LayoutEvaluatorStateInitializer.Init method does not support adding data elements"

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -52,9 +52,9 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
 
         public Instance Instance { get; }
 
-        public Task<object> GetFormData(DataElementId dataElementId)
+        public Task<object> GetFormData(DataElementIdentifier dataElementIdentifier)
         {
-            if (dataElementId != _dataElement)
+            if (dataElementIdentifier != _dataElement)
             {
                 return Task.FromException<object>(
                     new InvalidOperationException(
@@ -65,14 +65,14 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
             return Task.FromResult(_data);
         }
 
-        public Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementId dataElementId)
+        public Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier)
         {
             return Task.FromException<ReadOnlyMemory<byte>>(new NotImplementedException());
         }
 
-        public DataElement GetDataElement(DataElementId dataElementId)
+        public DataElement GetDataElement(DataElementIdentifier dataElementIdentifier)
         {
-            if (dataElementId != _dataElement)
+            if (dataElementIdentifier != _dataElement)
             {
                 throw new InvalidOperationException(
                     "Use the new ILayoutEvaluatorStateInitializer interface to support multiple data models and subforms"
@@ -102,7 +102,7 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
         }
 
         // Not implemented
-        public void RemoveDataElement(DataElementId dataElementId)
+        public void RemoveDataElement(DataElementIdentifier dataElementIdentifier)
         {
             throw new NotImplementedException(
                 "The obsolete LayoutEvaluatorStateInitializer.Init method does not support removing data elements"

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -80,6 +80,34 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
             }
             return _dataElement;
         }
+
+        // Not implemented
+        public void AddFormDataElement(string dataType, object data)
+        {
+            throw new NotImplementedException(
+                "The obsolete LayoutEvaluatorStateInitializer.Init method does not support adding data elements"
+            );
+        }
+
+        public void AddAttachmentDataElement(
+            string dataType,
+            string contentType,
+            string? filename,
+            ReadOnlyMemory<byte> data
+        )
+        {
+            throw new NotImplementedException(
+                "The obsolete LayoutEvaluatorStateInitializer.Init method does not support adding data elements"
+            );
+        }
+
+        // Not implemented
+        public void RemoveDataElement(DataElementId dataElementId)
+        {
+            throw new NotImplementedException(
+                "The obsolete LayoutEvaluatorStateInitializer.Init method does not support removing data elements"
+            );
+        }
     }
 
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -52,7 +52,7 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
 
         public Instance Instance { get; }
 
-        public Task<object> GetData(DataElementId dataElementId)
+        public Task<object> GetFormData(DataElementId dataElementId)
         {
             if (dataElementId != _dataElement)
             {
@@ -65,15 +65,20 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
             return Task.FromResult(_data);
         }
 
-        public Task<object?> GetSingleDataByType(string dataType)
+        public Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementId dataElementId)
         {
-            if (_dataElement.DataType != dataType)
+            return Task.FromException<ReadOnlyMemory<byte>>(new NotImplementedException());
+        }
+
+        public DataElement GetDataElement(DataElementId dataElementId)
+        {
+            if (dataElementId != _dataElement)
             {
-                return Task.FromException<object?>(
-                    new InvalidOperationException("Data type does not match the data element")
+                throw new InvalidOperationException(
+                    "Use the new ILayoutEvaluatorStateInitializer interface to support multiple data models and subforms"
                 );
             }
-            return Task.FromResult<object?>(_data);
+            return _dataElement;
         }
     }
 

--- a/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
+++ b/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Models.Validation;
+using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Patch;
 
@@ -8,6 +9,11 @@ namespace Altinn.App.Core.Internal.Patch;
 /// </summary>
 public class DataPatchResult
 {
+    /// <summary>
+    /// The updated instance after the patch and dataProcessing operations.
+    /// </summary>
+    public required Instance Instance { get; set; }
+
     /// <summary>
     /// The validation issues that were found during the patch operation.
     /// </summary>

--- a/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
+++ b/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
@@ -33,7 +33,7 @@ public class DataPatchResult
     /// <summary>
     /// Store a pair with Id and Data
     /// </summary>
-    /// <param name="Id">The data element id</param>
+    /// <param name="Identifier">The data element id</param>
     /// <param name="Data">The deserialized data</param>
-    public record DataModelPair(DataElementId Id, object Data);
+    public record DataModelPair(DataElementIdentifier Identifier, object Data);
 }

--- a/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
+++ b/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
@@ -1,4 +1,5 @@
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -17,7 +18,7 @@ public class DataPatchResult
     /// <summary>
     /// The validation issues that were found during the patch operation.
     /// </summary>
-    public required Dictionary<string, List<ValidationIssueWithSource>> ValidationIssues { get; init; }
+    public required List<ValidationSourcePair> ValidationIssues { get; init; }
 
     /// <summary>
     /// The current data model after the patch operation.
@@ -27,5 +28,12 @@ public class DataPatchResult
     /// <summary>
     /// Get updated data elements that have app logic in a dictionary with the data element id as key.
     /// </summary>
-    public required Dictionary<Guid, object> UpdatedData { get; init; }
+    public required List<DataModelPair> UpdatedData { get; init; }
+
+    /// <summary>
+    /// Store a pair with Id and Data
+    /// </summary>
+    /// <param name="Id">The data element id</param>
+    /// <param name="Data">The deserialized data</param>
+    public record DataModelPair(DataElementId Id, object Data);
 }

--- a/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
+++ b/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
@@ -21,15 +21,5 @@ public class DataPatchResult
     /// <summary>
     /// Get updated data elements that have app logic in a dictionary with the data element id as key.
     /// </summary>
-    public Dictionary<Guid, object> GetUpdatedData()
-    {
-        return ChangedDataElements
-            .Where(d => d.HasAppLogic)
-            .ToDictionary(
-                d => Guid.Parse(d.DataElement.Id),
-                d =>
-                    d.CurrentValue
-                    ?? throw new InvalidOperationException("Data element has app logic but no current value")
-            );
-    }
+    public required Dictionary<Guid, object> UpdatedData { get; init; }
 }

--- a/src/Altinn.App.Core/Internal/Patch/PatchService.cs
+++ b/src/Altinn.App.Core/Internal/Patch/PatchService.cs
@@ -2,9 +2,8 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Features;
-using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
-using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Validation;
 using Altinn.App.Core.Models;
@@ -21,7 +20,7 @@ internal class PatchService : IPatchService
 {
     private readonly IAppMetadata _appMetadata;
     private readonly IDataClient _dataClient;
-    private readonly IAppModel _appModel;
+    private readonly ModelSerializationService _modelSerializationService;
     private readonly Telemetry? _telemetry;
     private readonly IValidationService _validationService;
     private readonly IEnumerable<IDataProcessor> _dataProcessors;
@@ -37,7 +36,7 @@ internal class PatchService : IPatchService
         IDataClient dataClient,
         IValidationService validationService,
         IEnumerable<IDataProcessor> dataProcessors,
-        IAppModel appModel,
+        ModelSerializationService modelSerializationService,
         Telemetry? telemetry = null
     )
     {
@@ -45,7 +44,7 @@ internal class PatchService : IPatchService
         _dataClient = dataClient;
         _validationService = validationService;
         _dataProcessors = dataProcessors;
-        _appModel = appModel;
+        _modelSerializationService = modelSerializationService;
         _telemetry = telemetry;
     }
 
@@ -62,22 +61,30 @@ internal class PatchService : IPatchService
         InstanceIdentifier instanceIdentifier = new(instance);
         AppIdentifier appIdentifier = (await _appMetadata.GetApplicationMetadata()).AppIdentifier;
 
-        var dataAccessor = new CachedInstanceDataAccessor(instance, _dataClient, _appMetadata, _appModel);
-        var changes = new List<DataElementChange>();
+        var dataAccessor = new CachedInstanceDataAccessor(
+            instance,
+            _dataClient,
+            _appMetadata,
+            _modelSerializationService
+        );
 
-        foreach (var (dataElementId, jsonPatch) in patches)
+        List<DataElementChange> changesAfterPatch = new();
+
+        foreach (var (dataElementGuid, jsonPatch) in patches)
         {
-            var dataElement = instance.Data.Find(d => d.Id == dataElementId.ToString());
+            var dataElement = instance.Data.Find(d => d.Id == dataElementGuid.ToString());
+
             if (dataElement is null)
             {
                 return new DataPatchError()
                 {
                     Title = "Unknown data element to patch",
-                    Detail = $"Data element with id {dataElementId} not found in instance",
+                    Detail = $"Data element with id {dataElementGuid} not found in instance",
                 };
             }
+            DataElementId dataElementId = dataElement;
 
-            var oldModel = await dataAccessor.GetData(dataElement);
+            var oldModel = await dataAccessor.GetFormData(dataElementId); // TODO: Fetch data in parallel
             var oldModelNode = JsonSerializer.SerializeToNode(oldModel);
             var patchResult = jsonPatch.Apply(oldModelNode);
 
@@ -110,14 +117,34 @@ internal class PatchService : IPatchService
                 };
             }
             var newModel = newModelResult.Ok;
+            // Reset dataAccessor to provide the patched model.
+            dataAccessor.SetFormData(dataElement, newModel);
 
-            foreach (var dataProcessor in _dataProcessors)
+            changesAfterPatch.Add(
+                new DataElementChange
+                {
+                    DataElement = dataElementId,
+                    PreviousFormData = oldModel,
+                    CurrentFormData = newModel
+                }
+            );
+        }
+
+        foreach (var dataProcessor in _dataProcessors)
+        {
+            foreach (var change in changesAfterPatch)
             {
                 using var processWriteActivity = _telemetry?.StartDataProcessWriteActivity(dataProcessor);
                 try
                 {
                     // TODO: Create new dataProcessor interface that takes multiple models at the same time.
-                    await dataProcessor.ProcessDataWrite(instance, dataElementId, newModel, oldModel, language);
+                    await dataProcessor.ProcessDataWrite(
+                        instance,
+                        change.DataElement.Guid,
+                        change.CurrentFormData,
+                        change.PreviousFormData,
+                        language
+                    );
                 }
                 catch (Exception e)
                 {
@@ -125,33 +152,14 @@ internal class PatchService : IPatchService
                     throw;
                 }
             }
-            ObjectUtils.InitializeAltinnRowId(newModel);
-            ObjectUtils.PrepareModelForXmlStorage(newModel);
-            changes.Add(
-                new DataElementChange
-                {
-                    HasAppLogic = true,
-                    ChangeType = DataElementChangeType.Update,
-                    DataElement = dataElement,
-                    PreviousValue = oldModel,
-                    CurrentValue = newModel,
-                }
-            );
-
-            // save form data to storage
-            await _dataClient.UpdateData(
-                newModel,
-                instanceIdentifier.InstanceGuid,
-                newModel.GetType(),
-                appIdentifier.Org,
-                appIdentifier.App,
-                instanceIdentifier.InstanceOwnerPartyId,
-                dataElementId
-            );
-
-            // Ensure that validation runs on the modified model.
-            dataAccessor.Set(dataElement, newModel);
         }
+
+        // Get all changes to data elements by comparing the serialized values
+        var changes = dataAccessor.GetDataElementChanges();
+        // Start saving changes in parallel with validation
+        Task saveChanges = dataAccessor.SaveChanges(changes, initializeRowId: true);
+        // Update instance data to reflect the changes and save created data elements
+        await dataAccessor.UpdateInstanceData();
 
         var validationIssues = await _validationService.ValidateIncrementalFormData(
             instance,
@@ -162,7 +170,37 @@ internal class PatchService : IPatchService
             language
         );
 
-        return new DataPatchResult { ChangedDataElements = changes, ValidationIssues = validationIssues };
+        // don't await saving until validation is done, so that they run in parallel
+        await saveChanges;
+
+        if (true) // TODO: only run in development mode
+        {
+            // Ensure that validation did not change the data elements
+            dataAccessor.VerifyDataElementsUnchanged();
+        }
+
+        var updatedData = changes.ToDictionary(
+            d => d.DataElement.Guid,
+            d =>
+                d.CurrentFormData
+                ?? throw new InvalidOperationException("Data element has app logic but no current value")
+        );
+        // Ensure that all data elements that were patched are included in the updated data
+        // (even if they were not changed or the change was reverted by dataProcessor)
+        foreach (var patchedElementGuid in patches.Keys.Where(g => !updatedData.ContainsKey(g)))
+        {
+            var dataElement =
+                instance.Data.Find(d => d.Id == patchedElementGuid.ToString())
+                ?? throw new InvalidOperationException("Data element not found in instance");
+            updatedData.Add(patchedElementGuid, dataAccessor.GetFormData(dataElement));
+        }
+
+        return new DataPatchResult
+        {
+            ChangedDataElements = changes,
+            UpdatedData = updatedData,
+            ValidationIssues = validationIssues,
+        };
     }
 
     private static ServiceResult<object, string> DeserializeModel(Type type, JsonNode? patchResult)

--- a/src/Altinn.App.Core/Internal/Patch/PatchService.cs
+++ b/src/Altinn.App.Core/Internal/Patch/PatchService.cs
@@ -88,9 +88,9 @@ internal class PatchService : IPatchService
                 };
             }
 
-            DataElementId dataElementId = dataElement;
+            DataElementIdentifier dataElementIdentifier = dataElement;
 
-            var oldModel = await dataAccessor.GetFormData(dataElementId); // TODO: Fetch data in parallel
+            var oldModel = await dataAccessor.GetFormData(dataElementIdentifier); // TODO: Fetch data in parallel
             var oldModelNode = JsonSerializer.SerializeToNode(oldModel);
             var patchResult = jsonPatch.Apply(oldModelNode);
 
@@ -133,7 +133,7 @@ internal class PatchService : IPatchService
                     DataElement = dataElement,
                     PreviousFormData = oldModel,
                     CurrentFormData = newModel,
-                    PreviousBinaryData = await dataAccessor.GetBinaryData(dataElementId),
+                    PreviousBinaryData = await dataAccessor.GetBinaryData(dataElementIdentifier),
                     CurrentBinaryData = null,
                 }
             );

--- a/src/Altinn.App.Core/Internal/Patch/PatchService.cs
+++ b/src/Altinn.App.Core/Internal/Patch/PatchService.cs
@@ -152,6 +152,14 @@ internal class PatchService : IPatchService
                     throw;
                 }
             }
+
+            // TODO: add new method to IDataProcessor that takes multiple models at the same time
+            await dataProcessor.ProcessDataWrite(
+                dataAccessor,
+                instance.Process.CurrentTask.ElementId,
+                changesAfterPatch,
+                language
+            );
         }
 
         // Get all changes to data elements by comparing the serialized values
@@ -197,6 +205,7 @@ internal class PatchService : IPatchService
 
         return new DataPatchResult
         {
+            Instance = instance,
             ChangedDataElements = changes,
             UpdatedData = updatedData,
             ValidationIssues = validationIssues,

--- a/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
+++ b/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
@@ -89,7 +89,8 @@ public class ExpressionsExclusiveGateway : IProcessExclusiveGateway
                 dataTypeId = layoutSet?.DataType;
             }
             var expression = GetExpressionFromCondition(sequenceFlow.ConditionExpression);
-            DataElementId dataElement = instance.Data.Find(d => d.DataType == dataTypeId) ?? new DataElementId();
+            DataElementIdentifier dataElement =
+                instance.Data.Find(d => d.DataType == dataTypeId) ?? new DataElementIdentifier();
 
             var componentContext = new ComponentContext(
                 component: null,

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
@@ -4,6 +4,9 @@ using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Action;
 using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.App.Core.Internal.Process.Elements.Base;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
@@ -29,18 +32,13 @@ public class ProcessEngine : IProcessEngine
     private readonly UserActionService _userActionService;
     private readonly Telemetry? _telemetry;
     private readonly IProcessTaskCleaner _processTaskCleaner;
+    private readonly IDataClient _dataClient;
+    private readonly ModelSerializationService _modelSerialization;
+    private readonly IAppMetadata _appMetadata;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProcessEngine"/> class
     /// </summary>
-    /// <param name="processReader">Process reader service</param>
-    /// <param name="profileClient">The profile service</param>
-    /// <param name="processNavigator">The process navigator</param>
-    /// <param name="processEventsDelegator">The process events delegator</param>
-    /// <param name="processEventDispatcher">The process event dispatcher</param>
-    /// <param name="processTaskCleaner">The process task cleaner</param>
-    /// <param name="userActionService">The action handler factory</param>
-    /// <param name="telemetry">The telemetry service</param>
     public ProcessEngine(
         IProcessReader processReader,
         IProfileClient profileClient,
@@ -49,6 +47,9 @@ public class ProcessEngine : IProcessEngine
         IProcessEventDispatcher processEventDispatcher,
         IProcessTaskCleaner processTaskCleaner,
         UserActionService userActionService,
+        IDataClient dataClient,
+        ModelSerializationService modelSerialization,
+        IAppMetadata appMetadata,
         Telemetry? telemetry = null
     )
     {
@@ -59,6 +60,9 @@ public class ProcessEngine : IProcessEngine
         _processEventDispatcher = processEventDispatcher;
         _processTaskCleaner = processTaskCleaner;
         _userActionService = userActionService;
+        _dataClient = dataClient;
+        _modelSerialization = modelSerialization;
+        _appMetadata = appMetadata;
         _telemetry = telemetry;
     }
 
@@ -163,10 +167,16 @@ public class ProcessEngine : IProcessEngine
 
         int? userId = request.User.GetUserIdAsInt();
         IUserAction? actionHandler = _userActionService.GetActionHandler(request.Action);
+        var cachedDataMutator = new CachedInstanceDataAccessor(
+            instance,
+            _dataClient,
+            _appMetadata,
+            _modelSerialization
+        );
 
         UserActionResult actionResult = actionHandler is null
             ? UserActionResult.SuccessResult()
-            : await actionHandler.HandleAction(new UserActionContext(request.Instance, userId));
+            : await actionHandler.HandleAction(new UserActionContext(cachedDataMutator, userId));
 
         if (actionResult.ResultType != ResultType.Success)
         {
@@ -179,6 +189,10 @@ public class ProcessEngine : IProcessEngine
             activity?.SetProcessChangeResult(result);
             return result;
         }
+
+        var changes = cachedDataMutator.GetDataElementChanges(initializeAltinnRowId: false);
+        await cachedDataMutator.UpdateInstanceData();
+        await cachedDataMutator.SaveChanges(changes);
 
         ProcessStateChange? nextResult = await HandleMoveToNext(instance, request.User, request.Action);
 

--- a/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
@@ -1,6 +1,6 @@
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
-using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.App.Core.Internal.Process.Elements.Base;
@@ -20,7 +20,7 @@ public class ProcessNavigator : IProcessNavigator
     private readonly ILogger<ProcessNavigator> _logger;
     private readonly IDataClient _dataClient;
     private readonly IAppMetadata _appMetadata;
-    private readonly IAppModel _appModel;
+    private readonly ModelSerializationService _modelSerialization;
 
     /// <summary>
     /// Initialize a new instance of <see cref="ProcessNavigator"/>
@@ -31,7 +31,7 @@ public class ProcessNavigator : IProcessNavigator
         ILogger<ProcessNavigator> logger,
         IDataClient dataClient,
         IAppMetadata appMetadata,
-        IAppModel appModel
+        ModelSerializationService modelSerialization
     )
     {
         _processReader = processReader;
@@ -39,7 +39,7 @@ public class ProcessNavigator : IProcessNavigator
         _logger = logger;
         _dataClient = dataClient;
         _appMetadata = appMetadata;
-        _appModel = appModel;
+        _modelSerialization = modelSerialization;
     }
 
     /// <inheritdoc/>
@@ -114,7 +114,7 @@ public class ProcessNavigator : IProcessNavigator
                     instance,
                     _dataClient,
                     _appMetadata,
-                    _appModel
+                    _modelSerialization
                 );
                 filteredList = await gatewayFilter.FilterAsync(
                     outgoingFlows,

--- a/src/Altinn.App.Core/Internal/Validation/IValidationService.cs
+++ b/src/Altinn.App.Core/Internal/Validation/IValidationService.cs
@@ -16,7 +16,7 @@ public interface IValidationService
     /// <param name="dataAccessor">Accessor for instance data to be validated</param>
     /// <param name="taskId">The task to run validations for (overriding instance.Process?.CurrentTask?.ElementId)</param>
     /// <param name="ignoredValidators">List of <see cref="IValidator.ValidationSource"/> to ignore</param>
-    /// <param name="onlyIncrementalValidators"></param>
+    /// <param name="onlyIncrementalValidators">only run validators that implements incremental validation</param>
     /// <param name="language">The language to run validations in</param>
     /// <returns>List of validation issues for this data element</returns>
     Task<List<ValidationIssueWithSource>> ValidateInstanceAtTask(

--- a/src/Altinn.App.Core/Internal/Validation/IValidationService.cs
+++ b/src/Altinn.App.Core/Internal/Validation/IValidationService.cs
@@ -39,7 +39,7 @@ public interface IValidationService
     /// <param name="ignoredValidators">List of <see cref="IValidator.ValidationSource"/> to ignore</param>
     /// <param name="language">The language to run validations in</param>
     /// <returns>Dictionary where the key is the <see cref="IValidator.ValidationSource"/> and the value is the list of issues this validator produces</returns>
-    public Task<Dictionary<string, List<ValidationIssueWithSource>>> ValidateIncrementalFormData(
+    public Task<List<ValidationSourcePair>> ValidateIncrementalFormData(
         Instance instance,
         IInstanceDataAccessor dataAccessor,
         string taskId,

--- a/src/Altinn.App.Core/Internal/Validation/IValidatorFactory.cs
+++ b/src/Altinn.App.Core/Internal/Validation/IValidatorFactory.cs
@@ -58,6 +58,11 @@ public class ValidatorFactory : IValidatorFactory
         _appMetadata = appMetadata;
     }
 
+    private IEnumerable<IValidator> GetIValidators(string taskId)
+    {
+        return _validators.Where(v => v.ShouldRunForTask(taskId));
+    }
+
     private IEnumerable<ITaskValidator> GetTaskValidators(string taskId)
     {
         return _taskValidators.Where(tv => tv.TaskId == "*" || tv.TaskId == taskId);
@@ -121,7 +126,7 @@ public class ValidatorFactory : IValidatorFactory
     {
         var validators = new List<IValidator>();
         // add new style validators
-        validators.AddRange(_validators);
+        validators.AddRange(GetIValidators(taskId));
         // add legacy task validators, data element validators and form data validators
         validators.AddRange(GetTaskValidators(taskId).Select(tv => new TaskValidatorWrapper(tv)));
         var dataTypes = _appMetadata.GetApplicationMetadata().Result.DataTypes;

--- a/src/Altinn.App.Core/Models/DataElementId.cs
+++ b/src/Altinn.App.Core/Models/DataElementId.cs
@@ -5,11 +5,66 @@ namespace Altinn.App.Core.Models;
 /// <summary>
 /// Wrapper type for a <see cref="DataElement.Id"/>
 /// </summary>
-/// <param name="Guid">The guid as a Guid</param>
-/// <param name="Id">The guid ID as string</param>
-/// <param name="DataType">The data type id from app metadata</param>
-public readonly record struct DataElementId(Guid Guid, string Id, string DataType)
+public readonly struct DataElementId : IEquatable<DataElementId>
 {
+    /// <summary>
+    /// The backing field for the parsed guid that identifies a <see cref="DataElement"/>
+    /// </summary>
+    public Guid Guid { get; }
+
+    /// <summary>
+    /// The backing field for the string containing a guid that identifies a <see cref="DataElement"/>
+    /// </summary>
+    public string Id { get; }
+
+    private DataElementId(Guid guid, string id)
+    {
+        Guid = guid;
+        Id = id;
+    }
+
+    /// <summary>
+    /// Implicit conversion to allow DataElements to be used as DataElementIds
+    /// </summary>
+    public static implicit operator DataElementId(DataElement dataElement) =>
+        new(Guid.Parse(dataElement.Id), dataElement.Id);
+
+    /// <summary>
+    /// Make the implicit conversion from string (containing a valid guid) to DataElementIdentifier work
+    /// </summary>
+    public static explicit operator DataElementId(string id) => new(Guid.Parse(id), id);
+
+    /// <summary>
+    /// Make the implicit conversion from guid to DataElementIdentifier work
+    /// </summary>
+    public static explicit operator DataElementId(Guid guid) => new(guid, guid.ToString());
+
+    /// <summary>
+    /// Make the ToString method return the ID
+    /// </summary>
+    public override string ToString()
+    {
+        return Id;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is DataElementId other && Equals(other);
+    }
+
+    /// <inheritdoc />
+    public static bool operator ==(DataElementId left, DataElementId right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <inheritdoc />
+    public static bool operator !=(DataElementId left, DataElementId right)
+    {
+        return !left.Equals(right);
+    }
+
     /// <summary>
     /// Override equality to only compare the guid
     /// </summary>
@@ -24,19 +79,5 @@ public readonly record struct DataElementId(Guid Guid, string Id, string DataTyp
     public override int GetHashCode()
     {
         return Guid.GetHashCode();
-    }
-
-    /// <summary>
-    /// Implicit conversion to allow DataElements to be used as DataElementIds
-    /// </summary>
-    public static implicit operator DataElementId(DataElement dataElement) =>
-        new(Guid.Parse(dataElement.Id), dataElement.Id, dataElement.DataType);
-
-    /// <summary>
-    /// Make the ToString method return the ID
-    /// </summary>
-    public override string ToString()
-    {
-        return Id;
     }
 }

--- a/src/Altinn.App.Core/Models/DataElementId.cs
+++ b/src/Altinn.App.Core/Models/DataElementId.cs
@@ -5,19 +5,38 @@ namespace Altinn.App.Core.Models;
 /// <summary>
 /// Wrapper type for a <see cref="DataElement.Id"/>
 /// </summary>
-/// <param name="Id">The guid ID</param>
-public readonly record struct DataElementId(Guid Id)
+/// <param name="Guid">The guid as a Guid</param>
+/// <param name="Id">The guid ID as string</param>
+/// <param name="DataType">The data type id from app metadata</param>
+public readonly record struct DataElementId(Guid Guid, string Id, string DataType)
 {
+    /// <summary>
+    /// Override equality to only compare the guid
+    /// </summary>
+    public bool Equals(DataElementId other)
+    {
+        return Guid.Equals(other.Guid);
+    }
+
+    /// <summary>
+    /// Override equality to only compare the guid
+    /// </summary>
+    public override int GetHashCode()
+    {
+        return Guid.GetHashCode();
+    }
+
     /// <summary>
     /// Implicit conversion to allow DataElements to be used as DataElementIds
     /// </summary>
-    public static implicit operator DataElementId(DataElement dataElement) => new(Guid.Parse(dataElement.Id));
+    public static implicit operator DataElementId(DataElement dataElement) =>
+        new(Guid.Parse(dataElement.Id), dataElement.Id, dataElement.DataType);
 
     /// <summary>
     /// Make the ToString method return the ID
     /// </summary>
     public override string ToString()
     {
-        return Id.ToString();
+        return Id;
     }
 }

--- a/src/Altinn.App.Core/Models/DataElementIdentifier.cs
+++ b/src/Altinn.App.Core/Models/DataElementIdentifier.cs
@@ -3,9 +3,9 @@ using Altinn.Platform.Storage.Interface.Models;
 namespace Altinn.App.Core.Models;
 
 /// <summary>
-/// Wrapper type for a <see cref="DataElement.Id"/>
+/// Wrapper type for a <see cref="DataElement.Id"/> as Guid and string
 /// </summary>
-public readonly struct DataElementId : IEquatable<DataElementId>
+public readonly struct DataElementIdentifier : IEquatable<DataElementIdentifier>
 {
     /// <summary>
     /// The backing field for the parsed guid that identifies a <see cref="DataElement"/>
@@ -17,7 +17,7 @@ public readonly struct DataElementId : IEquatable<DataElementId>
     /// </summary>
     public string Id { get; }
 
-    private DataElementId(Guid guid, string id)
+    private DataElementIdentifier(Guid guid, string id)
     {
         Guid = guid;
         Id = id;
@@ -26,18 +26,18 @@ public readonly struct DataElementId : IEquatable<DataElementId>
     /// <summary>
     /// Implicit conversion to allow DataElements to be used as DataElementIds
     /// </summary>
-    public static implicit operator DataElementId(DataElement dataElement) =>
+    public static implicit operator DataElementIdentifier(DataElement dataElement) =>
         new(Guid.Parse(dataElement.Id), dataElement.Id);
 
     /// <summary>
     /// Make the implicit conversion from string (containing a valid guid) to DataElementIdentifier work
     /// </summary>
-    public static explicit operator DataElementId(string id) => new(Guid.Parse(id), id);
+    public static explicit operator DataElementIdentifier(string id) => new(Guid.Parse(id), id);
 
     /// <summary>
     /// Make the implicit conversion from guid to DataElementIdentifier work
     /// </summary>
-    public static explicit operator DataElementId(Guid guid) => new(guid, guid.ToString());
+    public static explicit operator DataElementIdentifier(Guid guid) => new(guid, guid.ToString());
 
     /// <summary>
     /// Make the ToString method return the ID
@@ -50,17 +50,21 @@ public readonly struct DataElementId : IEquatable<DataElementId>
     /// <inheritdoc />
     public override bool Equals(object? obj)
     {
-        return obj is DataElementId other && Equals(other);
+        return obj is DataElementIdentifier other && Equals(other);
     }
 
-    /// <inheritdoc />
-    public static bool operator ==(DataElementId left, DataElementId right)
+    /// <summary>
+    /// Override as in a record type
+    /// </summary>
+    public static bool operator ==(DataElementIdentifier left, DataElementIdentifier right)
     {
         return left.Equals(right);
     }
 
-    /// <inheritdoc />
-    public static bool operator !=(DataElementId left, DataElementId right)
+    /// <summary>
+    /// Override as in a record type
+    /// </summary>
+    public static bool operator !=(DataElementIdentifier left, DataElementIdentifier right)
     {
         return !left.Equals(right);
     }
@@ -68,7 +72,7 @@ public readonly struct DataElementId : IEquatable<DataElementId>
     /// <summary>
     /// Override equality to only compare the guid
     /// </summary>
-    public bool Equals(DataElementId other)
+    public bool Equals(DataElementIdentifier other)
     {
         return Guid.Equals(other.Guid);
     }

--- a/src/Altinn.App.Core/Models/Expressions/ComponentContext.cs
+++ b/src/Altinn.App.Core/Models/Expressions/ComponentContext.cs
@@ -19,11 +19,11 @@ public sealed class ComponentContext
         BaseComponent? component,
         int[]? rowIndices,
         int? rowLength,
-        DataElementId dataElementId,
+        DataElementIdentifier dataElementIdentifier,
         IEnumerable<ComponentContext>? childContexts = null
     )
     {
-        DataElementId = dataElementId;
+        DataElementIdentifier = dataElementIdentifier;
         Component = component;
         RowIndices = rowIndices;
         _rowLength = rowLength;
@@ -95,7 +95,7 @@ public sealed class ComponentContext
                 Component,
                 rowIndices,
                 rowLength: hiddenRows.Length,
-                dataElementId: DataElementId,
+                dataElementIdentifier: DataElementIdentifier,
                 childContexts: childContexts
             );
             var rowHidden = await ExpressionEvaluator.EvaluateBooleanExpression(state, rowContext, "hiddenRow", false);
@@ -121,7 +121,7 @@ public sealed class ComponentContext
     /// <summary>
     /// The Id of the default data element in this context
     /// </summary>
-    public DataElementId DataElementId { get; }
+    public DataElementIdentifier DataElementIdentifier { get; }
 
     /// <summary>
     /// Get all children and children of children of this componentContext (not including this)

--- a/src/Altinn.App.Core/Models/Layout/DataReference.cs
+++ b/src/Altinn.App.Core/Models/Layout/DataReference.cs
@@ -13,5 +13,5 @@ public record struct DataReference
     /// <summary>
     /// The Id of the data element that the field is referencing
     /// </summary>
-    public required DataElementId DataElementId { get; init; }
+    public required DataElementIdentifier DataElementIdentifier { get; init; }
 }

--- a/src/Altinn.App.Core/Models/Layout/LayoutSetComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/LayoutSetComponent.cs
@@ -50,9 +50,9 @@ public record LayoutSetComponent
     public IEnumerable<PageComponent> Pages => _pages;
 
     /// <summary>
-    /// Get the <see cref="DataElementId"/> of the <see cref="DataElement"/> that is default for this layout
+    /// Get the <see cref="DataElementIdentifier"/> of the <see cref="DataElement"/> that is default for this layout
     /// </summary>
-    public DataElementId GetDefaultDataElementId(Instance instance)
+    public DataElementIdentifier GetDefaultDataElementId(Instance instance)
     {
         var dataType = DefaultDataType.Id;
         return instance.Data.Find(d => d.DataType == dataType)

--- a/src/Altinn.App.Core/Models/UserAction/UserActionContext.cs
+++ b/src/Altinn.App.Core/Models/UserAction/UserActionContext.cs
@@ -1,3 +1,4 @@
+using Altinn.App.Core.Features;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Models.UserAction;
@@ -10,11 +11,36 @@ public class UserActionContext
     /// <summary>
     /// Creates a new instance of the <see cref="UserActionContext"/> class
     /// </summary>
+    /// <param name="dataMutator">The instance the action is performed on</param>
+    /// <param name="userId">The user performing the action</param>
+    /// <param name="buttonId">The id of the button that triggered the action (optional)</param>
+    /// <param name="actionMetadata"></param>
+    /// <param name="language">The currently used language by the user (or null if not available)</param>
+    public UserActionContext(
+        IInstanceDataMutator dataMutator,
+        int? userId,
+        string? buttonId = null,
+        Dictionary<string, string>? actionMetadata = null,
+        string? language = null
+    )
+    {
+        Instance = dataMutator.Instance;
+        DataMutator = dataMutator;
+        UserId = userId;
+        ButtonId = buttonId;
+        ActionMetadata = actionMetadata ?? new Dictionary<string, string>();
+        Language = language;
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="UserActionContext"/> class
+    /// </summary>
     /// <param name="instance">The instance the action is performed on</param>
     /// <param name="userId">The user performing the action</param>
     /// <param name="buttonId">The id of the button that triggered the action (optional)</param>
     /// <param name="actionMetadata"></param>
     /// <param name="language">The currently used language by the user (or null if not available)</param>
+    [Obsolete("Use the constructor with IInstanceDataAccessor instead")]
     public UserActionContext(
         Instance instance,
         int? userId,
@@ -24,6 +50,8 @@ public class UserActionContext
     )
     {
         Instance = instance;
+        // ! TODO: Deprecated constructor, remove in v9
+        DataMutator = null!;
         UserId = userId;
         ButtonId = buttonId;
         ActionMetadata = actionMetadata ?? new Dictionary<string, string>();
@@ -34,6 +62,11 @@ public class UserActionContext
     /// The instance the action is performed on
     /// </summary>
     public Instance Instance { get; }
+
+    /// <summary>
+    /// Access dataElements through this accessor to ensure that changes gets saved in storage and returned to frontend
+    /// </summary>
+    public IInstanceDataAccessor DataMutator { get; }
 
     /// <summary>
     /// The user performing the action

--- a/src/Altinn.App.Core/Models/UserAction/UserActionResult.cs
+++ b/src/Altinn.App.Core/Models/UserAction/UserActionResult.cs
@@ -26,7 +26,7 @@ public enum ResultType
 /// <summary>
 /// Represents the result of a user action
 /// </summary>
-public class UserActionResult
+public sealed class UserActionResult
 {
     /// <summary>
     /// Gets or sets a value indicating whether the user action was a success

--- a/src/Altinn.App.Core/Models/Validation/ValidationIssueWithSource.cs
+++ b/src/Altinn.App.Core/Models/Validation/ValidationIssueWithSource.cs
@@ -99,3 +99,10 @@ public class ValidationIssueWithSource
     [JsonPropertyName("customTextParams")]
     public List<string>? CustomTextParams { get; set; }
 }
+
+/// <summary>
+/// API responses that returns validation issues grouped by source, typically return a list of these.
+/// </summary>
+/// <param name="Source">The <see cref="IValidator.ValidationSource"/> for the Validator that created theese issues</param>
+/// <param name="Issues">List of issues</param>
+public record ValidationSourcePair(string Source, List<ValidationIssueWithSource> Issues);

--- a/src/Altinn.App.Core/Models/Validation/ValidationIssueWithSource.cs
+++ b/src/Altinn.App.Core/Models/Validation/ValidationIssueWithSource.cs
@@ -77,7 +77,7 @@ public class ValidationIssueWithSource
     /// Weather the issue is from a validator that correctly implements <see cref="IValidator.HasRelevantChanges"/>.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    [JsonPropertyName("NoIncrementalUpdates")]
+    [JsonPropertyName("noIncrementalUpdates")]
     public bool NoIncrementalUpdates { get; set; }
 
     /// <summary>

--- a/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
@@ -17,8 +17,13 @@ namespace Altinn.App.Api.Tests.Controllers;
 
 public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
 {
+    private readonly ITestOutputHelper _outputHelper;
+
     public ActionsControllerTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper) { }
+        : base(factory, outputHelper)
+    {
+        _outputHelper = outputHelper;
+    }
 
     [Fact]
     public async Task Perform_returns_403_if_user_not_authorized()
@@ -189,7 +194,8 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         var content = await response.Content.ReadAsStringAsync();
         var expectedString = """
             {
-              "updatedDataModels": null,
+              "updatedDataModels": {},
+              "updatedValidationIssues": {},
               "clientActions": [
                 {
                   "id": "nextPage",
@@ -333,8 +339,10 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
     }
 
     //TODO: replace this assertion with a proper one once fluentassertions has a json compare feature scheduled for v7 https://github.com/fluentassertions/fluentassertions/issues/2205
-    private static void CompareResult<T>(string expectedString, string actualString)
+    private void CompareResult<T>(string expectedString, string actualString)
     {
+        _outputHelper.WriteLine($"Expected: {expectedString}");
+        _outputHelper.WriteLine($"Actual: {actualString}");
         T? expected = JsonSerializer.Deserialize<T>(expectedString);
         T? actual = JsonSerializer.Deserialize<T>(actualString);
         actual.Should().BeEquivalentTo(expected);

--- a/test/Altinn.App.Api.Tests/Controllers/DataControllerPatchTests.InvalidTestValue_ReturnsConflict.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/DataControllerPatchTests.InvalidTestValue_ReturnsConflict.verified.txt
@@ -63,6 +63,15 @@
       ],
       IdFormat: W3C,
       Kind: Server
+    },
+    {
+      ActivityName: SerializationService.DeserializeXml,
+      Tags: [
+        {
+          Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
+        }
+      ],
+      IdFormat: W3C
     }
   ],
   Metrics: []

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -979,16 +979,20 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
             .Setup(fdv => fdv.HasRelevantChanges(It.IsAny<object>(), It.IsAny<object>()))
             .Returns(true);
 
-        var patch = new JsonPatch(
-            PatchOperation.Replace(JsonPointer.Create("melding", "name"), JsonNode.Parse("\"Ola Olsen\""))
-        );
+        var path = JsonPointer.Create("melding", "name");
+        var patch = new JsonPatch(PatchOperation.Replace(path, JsonNode.Parse("\"Ola Olsen\"")));
 
         var (_, _, parsedResponse1) = await CallPatchApi<DataPatchResponse>(patch, ["ignored"], HttpStatusCode.OK);
 
         // Verify that no issues from the ignored validator are present
         parsedResponse1.ValidationIssues.Should().NotContainKey("ignored");
 
-        var (_, _, parsedResponse2) = await CallPatchApi<DataPatchResponse>(patch, null, HttpStatusCode.OK);
+        var patch2 = new JsonPatch(
+            PatchOperation.Test(path, JsonNode.Parse("\"Ola Olsen\"")),
+            PatchOperation.Replace(path, JsonNode.Parse("\"Ola Nielsen\""))
+        );
+
+        var (_, _, parsedResponse2) = await CallPatchApi<DataPatchResponse>(patch2, null, HttpStatusCode.OK);
 
         // Verify that issues from the ignored validator are present
         parsedResponse2

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
@@ -110,6 +110,15 @@
       IdFormat: W3C
     },
     {
+      ActivityName: SerializationService.DeserializeXml,
+      Tags: [
+        {
+          Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
+        }
+      ],
+      IdFormat: W3C
+    },
+    {
       ActivityName: Validation.RunValidator,
       Tags: [
         {

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
@@ -13,6 +13,14 @@
       IdFormat: W3C
     },
     {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C
+    },
+    {
       ActivityName: ApplicationMetadata.Service.GetLayoutSets,
       IdFormat: W3C
     },
@@ -26,6 +34,18 @@
     },
     {
       ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
       IdFormat: W3C
     },
     {
@@ -129,21 +149,6 @@
         },
         {
           validator.type: RequiredLayoutValidator
-        }
-      ],
-      IdFormat: W3C
-    },
-    {
-      ActivityName: Validation.RunValidator,
-      Tags: [
-        {
-          validation.issue_count: 0
-        },
-        {
-          validator.source: Expression
-        },
-        {
-          validator.type: ExpressionValidator
         }
       ],
       IdFormat: W3C

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -205,6 +205,24 @@
       IdFormat: W3C
     },
     {
+      ActivityName: SerializationService.DeserializeXml,
+      Tags: [
+        {
+          Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
+        }
+      ],
+      IdFormat: W3C
+    },
+    {
+      ActivityName: SerializationService.DeserializeXml,
+      Tags: [
+        {
+          Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
+        }
+      ],
+      IdFormat: W3C
+    },
+    {
       ActivityName: Validation.RunValidator,
       Tags: [
         {

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -13,6 +13,14 @@
       IdFormat: W3C
     },
     {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C
+    },
+    {
       ActivityName: ApplicationMetadata.Service.GetLayoutSets,
       IdFormat: W3C
     },
@@ -26,6 +34,18 @@
     },
     {
       ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
       IdFormat: W3C
     },
     {
@@ -233,21 +253,6 @@
         },
         {
           validator.type: RequiredLayoutValidator
-        }
-      ],
-      IdFormat: W3C
-    },
-    {
-      ActivityName: Validation.RunValidator,
-      Tags: [
-        {
-          validation.issue_count: 0
-        },
-        {
-          validator.source: Expression
-        },
-        {
-          validator.type: ExpressionValidator
         }
       ],
       IdFormat: W3C

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateControllerTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;
@@ -45,13 +46,7 @@ public class ValidateControllerTests
             .Returns(Task.FromResult<Instance>(null!));
 
         // Act
-        var validateController = new ValidateController(
-            _instanceMock.Object,
-            _validationMock.Object,
-            _appMetadataMock.Object,
-            _dataClientMock.Object,
-            _appModelMock.Object
-        );
+        var validateController = GetValidateController();
         var result = await validateController.ValidateInstance(Org, App, InstanceOwnerPartyId, _instanceId);
 
         // Assert
@@ -71,13 +66,7 @@ public class ValidateControllerTests
             .Returns(Task.FromResult<Instance>(instance));
 
         // Act
-        var validateController = new ValidateController(
-            _instanceMock.Object,
-            _validationMock.Object,
-            _appMetadataMock.Object,
-            _dataClientMock.Object,
-            _appModelMock.Object
-        );
+        var validateController = GetValidateController();
 
         // Assert
         var exception = await Assert.ThrowsAsync<ValidationException>(
@@ -101,13 +90,7 @@ public class ValidateControllerTests
             .Returns(Task.FromResult<Instance>(instance));
 
         // Act
-        var validateController = new ValidateController(
-            _instanceMock.Object,
-            _validationMock.Object,
-            _appMetadataMock.Object,
-            _dataClientMock.Object,
-            _appModelMock.Object
-        );
+        var validateController = GetValidateController();
 
         // Assert
         var exception = await Assert.ThrowsAsync<ValidationException>(
@@ -155,13 +138,7 @@ public class ValidateControllerTests
             .ReturnsAsync(validationResult);
 
         // Act
-        var validateController = new ValidateController(
-            _instanceMock.Object,
-            _validationMock.Object,
-            _appMetadataMock.Object,
-            _dataClientMock.Object,
-            _appModelMock.Object
-        );
+        var validateController = GetValidateController();
         var result = await validateController.ValidateInstance(Org, App, InstanceOwnerPartyId, _instanceId);
 
         // Assert
@@ -195,13 +172,7 @@ public class ValidateControllerTests
             .Throws(exception);
 
         // Act
-        var validateController = new ValidateController(
-            _instanceMock.Object,
-            _validationMock.Object,
-            _appMetadataMock.Object,
-            _dataClientMock.Object,
-            _appModelMock.Object
-        );
+        var validateController = GetValidateController();
         var result = await validateController.ValidateInstance(Org, App, InstanceOwnerPartyId, _instanceId);
 
         // Assert
@@ -235,18 +206,23 @@ public class ValidateControllerTests
             .Throws(exception);
 
         // Act
-        var validateController = new ValidateController(
-            _instanceMock.Object,
-            _validationMock.Object,
-            _appMetadataMock.Object,
-            _dataClientMock.Object,
-            _appModelMock.Object
-        );
+        var validateController = GetValidateController();
 
         // Assert
         var thrownException = await Assert.ThrowsAsync<PlatformHttpException>(
             () => validateController.ValidateInstance(Org, App, InstanceOwnerPartyId, _instanceId)
         );
         Assert.Equal(exception, thrownException);
+    }
+
+    private ValidateController GetValidateController()
+    {
+        return new ValidateController(
+            _instanceMock.Object,
+            _validationMock.Object,
+            _appMetadataMock.Object,
+            _dataClientMock.Object,
+            new ModelSerializationService(_appModelMock.Object)
+        );
     }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;
@@ -203,7 +204,7 @@ public class ValidationControllerValidateDataTests
             _validationMock.Object,
             _appMetadataMock.Object,
             _dataClientMock.Object,
-            _appModelMock.Object
+            new ModelSerializationService(_appModelMock.Object)
         );
 
         // Act and Assert

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -5728,6 +5728,7 @@
       },
       "DataPatchResponseMultiple": {
         "required": [
+          "instance",
           "newDataModels",
           "validationIssues"
         ],
@@ -5747,6 +5748,9 @@
             "type": "object",
             "additionalProperties": { },
             "nullable": true
+          },
+          "instance": {
+            "$ref": "#/components/schemas/Instance"
           }
         },
         "additionalProperties": false

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -1134,7 +1134,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       },
       "delete": {
         "tags": [
@@ -5659,6 +5660,19 @@
         },
         "additionalProperties": false
       },
+      "DataModelPairResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "data": {
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "DataPatchRequest": {
         "required": [
           "ignoredValidators",
@@ -5735,18 +5749,17 @@
         "type": "object",
         "properties": {
           "validationIssues": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ValidationIssueWithSource"
-              }
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationSourcePair"
             },
             "nullable": true
           },
           "newDataModels": {
-            "type": "object",
-            "additionalProperties": { },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataModelPairResponse"
+            },
             "nullable": true
           },
           "instance": {
@@ -7057,6 +7070,23 @@
             "type": "array",
             "items": {
               "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValidationSourcePair": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string",
+            "nullable": true
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationIssueWithSource"
             },
             "nullable": true
           }

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -7042,7 +7042,7 @@
             "type": "string",
             "nullable": true
           },
-          "NoIncrementalUpdates": {
+          "noIncrementalUpdates": {
             "type": "boolean"
           },
           "customTextKey": {

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -690,6 +690,7 @@ paths:
             text/xml:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+      deprecated: true
     delete:
       tags:
         - Data
@@ -3531,6 +3532,15 @@ components:
           type: string
           nullable: true
       additionalProperties: false
+    DataModelPairResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        data:
+          nullable: true
+      additionalProperties: false
     DataPatchRequest:
       required:
         - ignoredValidators
@@ -3586,15 +3596,14 @@ components:
       type: object
       properties:
         validationIssues:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/ValidationIssueWithSource'
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationSourcePair'
           nullable: true
         newDataModels:
-          type: object
-          additionalProperties: { }
+          type: array
+          items:
+            $ref: '#/components/schemas/DataModelPairResponse'
           nullable: true
         instance:
           $ref: '#/components/schemas/Instance'
@@ -4545,6 +4554,18 @@ components:
           type: array
           items:
             type: string
+          nullable: true
+      additionalProperties: false
+    ValidationSourcePair:
+      type: object
+      properties:
+        source:
+          type: string
+          nullable: true
+        issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationIssueWithSource'
           nullable: true
       additionalProperties: false
     ValidationStatus:

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -3580,6 +3580,7 @@ components:
       additionalProperties: false
     DataPatchResponseMultiple:
       required:
+        - instance
         - newDataModels
         - validationIssues
       type: object
@@ -3595,6 +3596,8 @@ components:
           type: object
           additionalProperties: { }
           nullable: true
+        instance:
+          $ref: '#/components/schemas/Instance'
       additionalProperties: false
     DataType:
       type: object

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -4533,7 +4533,7 @@ components:
         source:
           type: string
           nullable: true
-        NoIncrementalUpdates:
+        noIncrementalUpdates:
           type: boolean
         customTextKey:
           type: string

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -85,16 +85,17 @@ public class ExpressionValidatorTests
                 init.Init(It.IsAny<IInstanceDataAccessor>(), "Task_1", It.IsAny<string?>(), It.IsAny<string?>())
             )
             .ReturnsAsync(evaluatorState);
-        _appResources
-            .Setup(ar => ar.GetValidationConfiguration("default"))
-            .Returns(JsonSerializer.Serialize(testCase.ValidationConfig));
-        _appResources
-            .Setup(ar => ar.GetLayoutSetForTask(null!))
-            .Returns(new LayoutSet() { Id = "layout", DataType = "default", });
 
         var dataAccessor = new InstanceDataAccessorFake(instance) { { dataElement, dataModel } };
 
-        var validationIssues = await _validator.ValidateFormData(instance, dataElement, dataAccessor, "Task_1", null);
+        var validationIssues = await _validator.ValidateFormData(
+            instance,
+            dataElement,
+            dataAccessor,
+            JsonSerializer.Serialize(testCase.ValidationConfig),
+            "Task_1",
+            null
+        );
 
         var result = validationIssues.Select(i => new
         {

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/LegacyIValidationFormDataTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/LegacyIValidationFormDataTests.cs
@@ -26,7 +26,12 @@ public class LegacyIValidationFormDataTests
         Title = new LanguageString() { { "nb", "test" } },
         DataTypes = new List<DataType>()
         {
-            new DataType() { Id = "test", TaskId = "Task_1" },
+            new DataType()
+            {
+                Id = "test",
+                TaskId = "Task_1",
+                AppLogic = new() { ClassRef = typeof(TestModel).FullName }
+            },
         },
     };
 
@@ -58,12 +63,12 @@ public class LegacyIValidationFormDataTests
     public async Task ValidateFormData_WithErrors()
     {
         // Arrange
-        var data = new object();
+        var data = new TestModel();
 
         _instanceValidator
-            .Setup(iv => iv.ValidateData(It.IsAny<object>(), It.IsAny<ModelStateDictionary>()))
+            .Setup(iv => iv.ValidateData(It.IsAny<TestModel>(), It.IsAny<ModelStateDictionary>()))
             .Returns(
-                (object _, ModelStateDictionary modelState) =>
+                (TestModel _, ModelStateDictionary modelState) =>
                 {
                     modelState.AddModelError("test", "test");
                     modelState.AddModelError("ddd", "*FIXED*test");
@@ -72,7 +77,7 @@ public class LegacyIValidationFormDataTests
             )
             .Verifiable(Times.Once);
 
-        _instanceDataAccessor.Setup(ida => ida.GetData(_dataElement)).ReturnsAsync(data);
+        _instanceDataAccessor.Setup(ida => ida.GetFormData(_dataElement)).ReturnsAsync(data);
 
         // Act
         var result = await _validator.Validate(_instance, _instanceDataAccessor.Object, "Task_1", null);
@@ -151,7 +156,7 @@ public class LegacyIValidationFormDataTests
                 }
             )
             .Verifiable(Times.Once);
-        _instanceDataAccessor.Setup(ida => ida.GetData(_dataElement)).ReturnsAsync(data).Verifiable(Times.Once);
+        _instanceDataAccessor.Setup(ida => ida.GetFormData(_dataElement)).ReturnsAsync(data).Verifiable(Times.Once);
 
         // Act
         var result = await _validator.Validate(_instance, _instanceDataAccessor.Object, "Task_1", null);

--- a/test/Altinn.App.Core.Tests/Features/Validators/LegacyValidationServiceTests/ValidationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/LegacyValidationServiceTests/ValidationServiceTests.cs
@@ -226,9 +226,14 @@ public sealed class ValidationServiceTests : IDisposable
             .Verifiable(hasRelevantChanges is null ? Times.Never : Times.AtLeastOnce);
     }
 
-    private void SourcePropertyIsSet(Dictionary<string, List<ValidationIssueWithSource>> result)
+    private void SourcePropertyIsSet(List<ValidationSourcePair> result)
     {
-        Assert.All(result.Values, SourcePropertyIsSet);
+        var issues = result.SelectMany(p => p.Issues).ToArray();
+        if (issues.Length == 0)
+        {
+            return;
+        }
+        issues.Should().AllSatisfy(i => i.Source.Should().NotBeNull());
     }
 
     private void SourcePropertyIsSet(List<ValidationIssueWithSource> result)
@@ -326,7 +331,7 @@ public sealed class ValidationServiceTests : IDisposable
             DefaultLanguage
         );
 
-        result.Should().ContainKey("specificValidator").WhoseValue.Should().HaveCount(0);
+        result.Should().ContainSingle(p => p.Source == "specificValidator").Which.Issues.Should().HaveCount(0);
         result.Should().HaveCount(1);
         SourcePropertyIsSet(result);
     }
@@ -382,15 +387,15 @@ public sealed class ValidationServiceTests : IDisposable
         );
         resultData
             .Should()
-            .ContainKey("specificValidator")
-            .WhoseValue.Should()
+            .ContainSingle(p => p.Source == "specificValidator")
+            .Which.Issues.Should()
             .ContainSingle()
             .Which.CustomTextKey.Should()
             .Be("NameNotOla");
         resultData
             .Should()
-            .ContainKey("alwaysUsedValidator")
-            .WhoseValue.Should()
+            .ContainSingle(p => p.Source == "alwaysUsedValidator")
+            .Which.Issues.Should()
             .ContainSingle()
             .Which.CustomTextKey.Should()
             .Be("AlwaysNameNotOla");

--- a/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.GenericFormDataValidator_serviceModelIsString_CallsValidatorFunctionForIncremental.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.GenericFormDataValidator_serviceModelIsString_CallsValidatorFunctionForIncremental.verified.txt
@@ -51,16 +51,19 @@
     ],
     Metrics: []
   },
-  issues: {
-    Altinn.App.Core.Tests.Features.Validators.ValidationServiceTests+GenericValidatorFake-default: [
-      {
-        Severity: Error,
-        DataElementId: DataElementId_0,
-        Code: TestCode,
-        Description: Test error,
-        Source: Altinn.App.Core.Tests.Features.Validators.ValidationServiceTests+GenericValidatorFake-default,
-        NoIncrementalUpdates: false
-      }
-    ]
-  }
+  issues: [
+    {
+      Source: Altinn.App.Core.Tests.Features.Validators.ValidationServiceTests+GenericValidatorFake-default,
+      Issues: [
+        {
+          Severity: Error,
+          DataElementId: DataElementId_0,
+          Code: TestCode,
+          Description: Test error,
+          Source: Altinn.App.Core.Tests.Features.Validators.ValidationServiceTests+GenericValidatorFake-default,
+          NoIncrementalUpdates: false
+        }
+      ]
+    }
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.cs
@@ -359,19 +359,15 @@ public class ValidationServiceTests : IAsyncLifetime
             {
                 new DataElementChange()
                 {
-                    HasAppLogic = true,
-                    ChangeType = DataElementChangeType.Update,
                     DataElement = dataElement,
-                    CurrentValue = "currentValue",
-                    PreviousValue = "previousValue"
+                    CurrentFormData = "currentValue",
+                    PreviousFormData = "previousValue"
                 },
                 new DataElementChange()
                 {
-                    HasAppLogic = true,
-                    ChangeType = DataElementChangeType.Update,
                     DataElement = dataElementNoValidation,
-                    CurrentValue = "currentValue",
-                    PreviousValue = "previousValue"
+                    CurrentFormData = "currentValue",
+                    PreviousFormData = "previousValue"
                 }
             };
 

--- a/test/Altinn.App.Core.Tests/Helpers/MemoryAsStreamTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/MemoryAsStreamTests.cs
@@ -1,0 +1,114 @@
+using Altinn.App.Core.Helpers;
+using FluentAssertions;
+
+namespace Altinn.App.Core.Tests.Helpers;
+
+public class MemoryAsStreamTests
+{
+    private static byte[] _byteSequence = GenerateNonRepeatingByteArray();
+
+    /// <summary>
+    /// For testing <see cref="MemoryAsStream"/> class we need to handle a sequence of bytes where errors are
+    /// easy to spot. This method generates a sequence of bytes where no 2 byte pairs repeat, which is useful
+    /// to find errors in the implementation of <see cref="MemoryAsStream"/>.
+    /// </summary>
+    /// <returns>Sequence of bytes where no 2 byte pairs repeat</returns>
+    private static byte[] GenerateNonRepeatingByteArray()
+    {
+        int byteCount = 256;
+        int sequenceLength = 65_537;
+        byte[] result = new byte[sequenceLength];
+
+        // Start with the first byte being 0
+        result[0] = 0;
+
+        // Initialize counters to represent the current pair
+        byte nextByte = 1; // Start with the second byte being 1
+
+        // Generate the sequence by sliding over the pairs
+        for (int i = 1; i < sequenceLength; i++)
+        {
+            result[i] = nextByte;
+
+            // Slide the window: move the current byte to the next byte
+            byte currentByte = nextByte;
+
+            // Determine the next byte (wrap around to avoid repeating pairs)
+            nextByte = (byte)((nextByte + 1) % byteCount);
+
+            // Ensure we don't repeat consecutive pairs
+            if (i > 1 && result[i - 1] == currentByte && result[i] == nextByte)
+            {
+                // Adjust the next byte to avoid consecutive pair repetition
+                nextByte = (byte)((nextByte + 1) % byteCount);
+            }
+        }
+
+        return result;
+    }
+
+    [Fact]
+    public void Read_WithValidInput_ShouldReadBytes()
+    {
+        // Arrange
+        byte[] bytes = _byteSequence;
+        MemoryAsStream stream = new MemoryAsStream(bytes);
+        byte[] buffer = new byte[bytes.Length];
+
+        // Act
+        int bytesRead = stream.Read(buffer, 0, buffer.Length);
+
+        // Assert
+        Assert.Equal(bytes.Length, bytesRead);
+        Assert.Equal(bytes, buffer);
+    }
+
+    [Fact]
+    public void Read_ChunkedReads_ShouldReadBytesInChunks()
+    {
+        // Arrange
+        byte[] bytes = _byteSequence;
+        MemoryAsStream stream = new MemoryAsStream(bytes);
+        int bytesRead = 0;
+
+        // Act
+        using var chunkedReader = new BinaryReader(stream);
+        do
+        {
+            byte read = chunkedReader.ReadByte();
+            bytes[bytesRead].Should().Be(read, $"Mismatch at position {bytesRead}");
+        } while (++bytesRead < bytes.Length);
+    }
+
+    [Theory]
+    // Comment out a few cases to reduce the number of tests
+    [InlineData(2)]
+    // [InlineData(3)]
+    // [InlineData(5)]
+    [InlineData(7)]
+    // [InlineData(11)]
+    [InlineData(13)]
+    // [InlineData(17)]
+    // [InlineData(19)]
+    [InlineData(23)]
+    public void Read_WithChunkSize_ShouldReadBytesInChunks(int chunkSize)
+    {
+        // Arrange
+        byte[] bytes = _byteSequence;
+        MemoryAsStream stream = new MemoryAsStream(bytes);
+        byte[] buffer = new byte[chunkSize];
+        int bytesRead = 0;
+
+        // Act
+        while (bytesRead < bytes.Length)
+        {
+            int read = stream.Read(buffer, 0, buffer.Length);
+            read.Should().BeLessOrEqualTo(chunkSize);
+            for (int i = 0; i < read; i++)
+            {
+                bytes[bytesRead].Should().Be(buffer[i], $"Mismatch at position {bytesRead}");
+                bytesRead++;
+            }
+        }
+    }
+}

--- a/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
@@ -134,29 +134,29 @@ public class ObjectUtils_XmlSerializationTests(ITestOutputHelper _output)
 
     [Theory]
     [MemberData(nameof(StringTests))]
-    public async Task TestSerializeDeserializeAsStorage(string? value, string? storedValue)
+    public void TestSerializeDeserializeAsStorage(string? value, string? storedValue)
     {
         var test = CreateObject(value);
 
         // Serialize and deserialize twice to ensure that all changes in serialization is applied
-        var testResult = await SerializeDeserialize(test);
-        testResult = await SerializeDeserialize(testResult);
+        var testResult = SerializeDeserialize(test);
+        testResult = SerializeDeserialize(testResult);
 
         AssertObject(testResult, value, storedValue);
     }
 
-    private async Task<YttersteObjekt> SerializeDeserialize(YttersteObjekt test)
+    private YttersteObjekt SerializeDeserialize(YttersteObjekt test)
     {
         // Serialize
         using var serializationStream = new MemoryStream();
-        DataClient.Serialize<YttersteObjekt>(test, typeof(YttersteObjekt), serializationStream);
+        var modelSerializer = new ModelSerializationService(null!);
+        var serialized = modelSerializer.SerializeToXml(test);
 
         serializationStream.Seek(0, SeekOrigin.Begin);
-        _output.WriteLine(Encoding.UTF8.GetString(serializationStream.ToArray()));
+        _output.WriteLine(Encoding.UTF8.GetString(serialized.Span));
 
         // Deserialize
-        ModelDeserializer serializer = new ModelDeserializer(_loggerMock.Object, typeof(YttersteObjekt));
-        var deserialized = await serializer.DeserializeAsync(serializationStream, "application/xml");
+        var deserialized = modelSerializer.DeserializeXml(serialized.Span, typeof(YttersteObjekt));
         var testResult = deserialized.Should().BeOfType<YttersteObjekt>().Which;
 
         return testResult;
@@ -267,13 +267,13 @@ public class ObjectUtils_XmlSerializationTests(ITestOutputHelper _output)
 
     [Theory]
     [MemberData(nameof(DecimalTests))]
-    public async Task TestSerializeDeserializeAsStorage_Decimal(decimal? value)
+    public void TestSerializeDeserializeAsStorage_Decimal(decimal? value)
     {
         var test = CreateObject(value);
 
         // Serialize and deserialize twice to ensure that all changes in serialization is applied
-        var testResult = await SerializeDeserialize(test);
-        testResult = await SerializeDeserialize(testResult);
+        var testResult = SerializeDeserialize(test);
+        testResult = SerializeDeserialize(testResult);
 
         AssertObject(testResult, value);
     }

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
@@ -5,7 +5,9 @@ using System.Text;
 using Altinn.App.Common.Tests;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Infrastructure.Clients.Storage;
+using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Models;
 using Altinn.App.Core.Tests.Infrastructure.Clients.Storage.TestData;
@@ -24,6 +26,7 @@ public class DataClientTests
 {
     private readonly Mock<IOptions<PlatformSettings>> platformSettingsOptions;
     private readonly Mock<IUserTokenProvider> userTokenProvide;
+    private readonly Mock<IAppModel> _appModelMock = new(MockBehavior.Strict);
     private readonly ILogger<DataClient> logger;
     private readonly string apiStorageEndpoint = "https://local.platform.altinn.no/api/storage/";
 
@@ -646,7 +649,12 @@ public class DataClientTests
     [Fact]
     public async Task UpdateData_throws_error_if_serilization_fails()
     {
-        object exampleModel = new ExampleModel() { Name = "Test", Age = 22 };
+        object exampleModel = new ExampleModel()
+        {
+            Name = "Test",
+            Age = 22,
+            ShouldError = true
+        };
         var instanceIdentifier = new InstanceIdentifier("501337/d3f3250d-705c-4683-a215-e05ebcbe6071");
         var dataGuid = new Guid("67a5ef12-6e38-41f8-8b42-f91249ebcec0");
         int invocations = 0;
@@ -843,6 +851,8 @@ public class DataClientTests
             logger,
             new HttpClient(delegatingHandlerStub),
             userTokenProvide.Object,
+            null!,
+            new ModelSerializationService(_appModelMock.Object),
             telemetrySink?.Object
         );
     }

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Reflection;
 using System.Text;
 using Altinn.App.Common.Tests;
 using Altinn.App.Core.Configuration;
@@ -666,7 +667,7 @@ public class DataClientTests
                 return new HttpResponseMessage() { StatusCode = HttpStatusCode.OK };
             }
         );
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<TargetInvocationException>(
             async () =>
                 await dataClient.UpdateData(
                     exampleModel,

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/TestData/ExampleModel.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/TestData/ExampleModel.cs
@@ -15,4 +15,12 @@ public class ExampleModel
     /// The age
     /// </summary>
     public int Age { get; set; } = 0;
+
+    public bool ShouldError { get; set; } = false;
+
+    public string Error
+    {
+        get { return ShouldError ? throw new Exception() : string.Empty; }
+        set { }
+    }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task.verified.txt
@@ -2,10 +2,20 @@
   Activities: [
     {
       ActivityName: Process.HandleEvents,
+      Tags: [
+        {
+          instance.guid: Guid_1
+        }
+      ],
       IdFormat: W3C
     },
     {
       ActivityName: Process.Start,
+      Tags: [
+        {
+          instance.guid: Guid_1
+        }
+      ],
       IdFormat: W3C,
       Status: Ok,
       Events: [
@@ -32,6 +42,11 @@
     },
     {
       ActivityName: Process.StoreEvents,
+      Tags: [
+        {
+          instance.guid: Guid_1
+        }
+      ],
       IdFormat: W3C
     }
   ],

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -1,8 +1,13 @@
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
 using Altinn.App.Common.Tests;
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Action;
+using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.AppModel;
+using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Process;
 using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
@@ -17,26 +22,29 @@ using AltinnCore.Authentication.Constants;
 using FluentAssertions;
 using Moq;
 using Newtonsoft.Json;
+using Xunit.Abstractions;
 
 namespace Altinn.App.Core.Tests.Internal.Process;
 
 public sealed class ProcessEngineTest : IDisposable
 {
-    private Mock<IProcessReader> _processReaderMock;
-    private readonly Mock<IProfileClient> _profileMock;
-    private readonly Mock<IProcessNavigator> _processNavigatorMock;
-    private readonly Mock<IProcessEventHandlerDelegator> _processEventHandlingDelegatorMock;
-    private readonly Mock<IProcessEventDispatcher> _processEventDispatcherMock;
-    private readonly Mock<IProcessTaskCleaner> _processTaskCleanerMock;
+    private readonly ITestOutputHelper _output;
+    private static readonly int _instanceOwnerPartyId = 1337;
+    private static readonly Guid _instanceGuid = new("00000000-DEAD-BABE-0000-001230000000");
+    private static readonly string _instanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}";
+    private readonly Mock<IProcessReader> _processReaderMock = new();
+    private readonly Mock<IProfileClient> _profileMock = new(MockBehavior.Strict);
+    private readonly Mock<IProcessNavigator> _processNavigatorMock = new(MockBehavior.Strict);
+    private readonly Mock<IProcessEventHandlerDelegator> _processEventHandlingDelegatorMock = new();
+    private readonly Mock<IProcessEventDispatcher> _processEventDispatcherMock = new();
+    private readonly Mock<IProcessTaskCleaner> _processTaskCleanerMock = new();
+    private readonly Mock<IDataClient> _dataClientMock = new(MockBehavior.Strict);
+    private readonly Mock<IAppModel> _appModelMock = new(MockBehavior.Strict);
+    private readonly Mock<IAppMetadata> _appMetadataMock = new(MockBehavior.Strict);
 
-    public ProcessEngineTest()
+    public ProcessEngineTest(ITestOutputHelper output)
     {
-        _processReaderMock = new();
-        _profileMock = new();
-        _processNavigatorMock = new();
-        _processEventHandlingDelegatorMock = new();
-        _processEventDispatcherMock = new();
-        _processTaskCleanerMock = new();
+        _output = output;
     }
 
     [Fact]
@@ -45,6 +53,8 @@ public sealed class ProcessEngineTest : IDisposable
         ProcessEngine processEngine = GetProcessEngine();
         Instance instance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             Process = new ProcessState() { CurrentTask = new ProcessElementInfo() { ElementId = "Task_1" } }
         };
         ProcessStartRequest processStartRequest = new ProcessStartRequest() { Instance = instance };
@@ -57,10 +67,9 @@ public sealed class ProcessEngineTest : IDisposable
     [Fact]
     public async Task StartProcess_returns_unsuccessful_when_no_matching_startevent_found()
     {
-        Mock<IProcessReader> processReaderMock = new();
-        processReaderMock.Setup(r => r.GetStartEventIds()).Returns(new List<string>() { "StartEvent_1" });
-        ProcessEngine processEngine = GetProcessEngine(processReaderMock);
-        Instance instance = new Instance();
+        _processReaderMock.Setup(r => r.GetStartEventIds()).Returns(new List<string>() { "StartEvent_1" });
+        ProcessEngine processEngine = GetProcessEngine(setupProcessReaderMock: false);
+        Instance instance = new Instance() { Id = _instanceId, AppId = "org/app", };
         ProcessStartRequest processStartRequest = new ProcessStartRequest()
         {
             Instance = instance,
@@ -77,7 +86,12 @@ public sealed class ProcessEngineTest : IDisposable
     public async Task StartProcess_starts_process_and_moves_to_first_task_without_event_dispatch_when_dryrun()
     {
         ProcessEngine processEngine = GetProcessEngine();
-        Instance instance = new Instance() { InstanceOwner = new InstanceOwner() { PartyId = "1337" } };
+        Instance instance = new Instance()
+        {
+            Id = _instanceId,
+            AppId = "org/app",
+            InstanceOwner = new InstanceOwner() { PartyId = "1337" }
+        };
         ClaimsPrincipal user =
             new(
                 new ClaimsIdentity(
@@ -104,7 +118,13 @@ public sealed class ProcessEngineTest : IDisposable
     {
         TelemetrySink telemetrySink = new();
         ProcessEngine processEngine = GetProcessEngine(telemetrySink: telemetrySink);
-        Instance instance = new Instance() { InstanceOwner = new InstanceOwner() { PartyId = "1337" } };
+        Instance instance = new Instance()
+        {
+            Id = _instanceId,
+            AppId = "org/app",
+            InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
+        };
         ClaimsPrincipal user =
             new(
                 new ClaimsIdentity(
@@ -126,7 +146,10 @@ public sealed class ProcessEngineTest : IDisposable
         _processNavigatorMock.Verify(n => n.GetNextTask(It.IsAny<Instance>(), "StartEvent_1", null), Times.Once);
         var expectedInstance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 CurrentTask = new ProcessElementInfo()
@@ -144,6 +167,7 @@ public sealed class ProcessEngineTest : IDisposable
         {
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_StartEvent.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -165,6 +189,7 @@ public sealed class ProcessEngineTest : IDisposable
             },
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_StartTask.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -212,7 +237,13 @@ public sealed class ProcessEngineTest : IDisposable
     public async Task StartProcess_starts_process_and_moves_to_first_task_with_prefill()
     {
         ProcessEngine processEngine = GetProcessEngine();
-        Instance instance = new Instance() { InstanceOwner = new InstanceOwner() { PartyId = "1337" } };
+        Instance instance = new Instance()
+        {
+            Id = _instanceId,
+            AppId = "org/app",
+            InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
+        };
         ClaimsPrincipal user =
             new(
                 new ClaimsIdentity(
@@ -240,7 +271,10 @@ public sealed class ProcessEngineTest : IDisposable
         _processNavigatorMock.Verify(n => n.GetNextTask(It.IsAny<Instance>(), "StartEvent_1", null), Times.Once);
         var expectedInstance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 CurrentTask = new ProcessElementInfo()
@@ -258,6 +292,7 @@ public sealed class ProcessEngineTest : IDisposable
         {
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_StartEvent.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -279,6 +314,7 @@ public sealed class ProcessEngineTest : IDisposable
             },
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_StartTask.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -324,7 +360,12 @@ public sealed class ProcessEngineTest : IDisposable
     public async Task Next_returns_unsuccessful_when_process_null()
     {
         ProcessEngine processEngine = GetProcessEngine();
-        Instance instance = new Instance() { Process = null };
+        Instance instance = new Instance()
+        {
+            Id = _instanceId,
+            AppId = "org/app",
+            Process = null
+        };
         ProcessNextRequest processNextRequest = new ProcessNextRequest() { Instance = instance };
         ProcessChangeResult result = await processEngine.Next(processNextRequest);
         result.Success.Should().BeFalse();
@@ -336,7 +377,12 @@ public sealed class ProcessEngineTest : IDisposable
     public async Task Next_returns_unsuccessful_when_process_currenttask_null()
     {
         ProcessEngine processEngine = GetProcessEngine();
-        Instance instance = new Instance() { Process = new ProcessState() { CurrentTask = null } };
+        Instance instance = new Instance()
+        {
+            Id = _instanceId,
+            AppId = "org/app",
+            Process = new ProcessState() { CurrentTask = null }
+        };
         ProcessNextRequest processNextRequest = new ProcessNextRequest() { Instance = instance };
         ProcessChangeResult result = await processEngine.Next(processNextRequest);
         result.Success.Should().BeFalse();
@@ -349,7 +395,10 @@ public sealed class ProcessEngineTest : IDisposable
     {
         var expectedInstance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 CurrentTask = null,
@@ -367,10 +416,16 @@ public sealed class ProcessEngineTest : IDisposable
                     errorType: ProcessErrorType.Unauthorized
                 )
             );
-        ProcessEngine processEngine = GetProcessEngine(null, expectedInstance, [userActionMock.Object]);
+        ProcessEngine processEngine = GetProcessEngine(
+            updatedInstance: expectedInstance,
+            userActions: [userActionMock.Object]
+        );
         Instance instance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 StartEvent = "StartEvent_1",
@@ -402,7 +457,10 @@ public sealed class ProcessEngineTest : IDisposable
     {
         var expectedInstance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 CurrentTask = new ProcessElementInfo()
@@ -416,10 +474,13 @@ public sealed class ProcessEngineTest : IDisposable
                 StartEvent = "StartEvent_1"
             }
         };
-        ProcessEngine processEngine = GetProcessEngine(null, expectedInstance);
+        ProcessEngine processEngine = GetProcessEngine(updatedInstance: expectedInstance);
         Instance instance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 StartEvent = "StartEvent_1",
@@ -459,6 +520,7 @@ public sealed class ProcessEngineTest : IDisposable
         {
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_EndTask.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -481,6 +543,7 @@ public sealed class ProcessEngineTest : IDisposable
             },
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_StartTask.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -541,7 +604,10 @@ public sealed class ProcessEngineTest : IDisposable
     {
         var expectedInstance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 CurrentTask = new ProcessElementInfo()
@@ -555,10 +621,13 @@ public sealed class ProcessEngineTest : IDisposable
                 StartEvent = "StartEvent_1"
             }
         };
-        ProcessEngine processEngine = GetProcessEngine(null, expectedInstance);
+        ProcessEngine processEngine = GetProcessEngine(updatedInstance: expectedInstance);
         Instance instance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 StartEvent = "StartEvent_1",
@@ -599,6 +668,7 @@ public sealed class ProcessEngineTest : IDisposable
         {
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_AbandonTask.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -621,6 +691,7 @@ public sealed class ProcessEngineTest : IDisposable
             },
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_StartTask.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -681,7 +752,10 @@ public sealed class ProcessEngineTest : IDisposable
     {
         var expectedInstance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 CurrentTask = null,
@@ -689,10 +763,13 @@ public sealed class ProcessEngineTest : IDisposable
                 EndEvent = "EndEvent_1"
             }
         };
-        ProcessEngine processEngine = GetProcessEngine(null, expectedInstance);
+        ProcessEngine processEngine = GetProcessEngine(updatedInstance: expectedInstance);
         Instance instance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 StartEvent = "StartEvent_1",
@@ -727,6 +804,7 @@ public sealed class ProcessEngineTest : IDisposable
         {
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_EndTask.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -749,6 +827,7 @@ public sealed class ProcessEngineTest : IDisposable
             },
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_EndEvent.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -766,6 +845,7 @@ public sealed class ProcessEngineTest : IDisposable
             },
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.Submited.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -820,7 +900,10 @@ public sealed class ProcessEngineTest : IDisposable
     {
         Instance instance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 StartEvent = "StartEvent_1",
@@ -835,8 +918,11 @@ public sealed class ProcessEngineTest : IDisposable
         };
         Instance updatedInstance = new Instance()
         {
+            Id = _instanceId,
+            AppId = "org/app",
             Org = "ttd",
             InstanceOwner = new InstanceOwner() { PartyId = "1337" },
+            Data = [],
             Process = new ProcessState()
             {
                 StartEvent = "StartEvent_1",
@@ -854,6 +940,7 @@ public sealed class ProcessEngineTest : IDisposable
         {
             new()
             {
+                InstanceId = $"{_instanceOwnerPartyId}/{_instanceGuid}",
                 EventType = InstanceEventType.process_AbandonTask.ToString(),
                 InstanceOwnerPartyId = "1337",
                 User = new()
@@ -875,7 +962,7 @@ public sealed class ProcessEngineTest : IDisposable
                 }
             }
         };
-        ProcessEngine processEngine = GetProcessEngine(null, updatedInstance);
+        ProcessEngine processEngine = GetProcessEngine(updatedInstance: updatedInstance);
         ProcessStartRequest processStartRequest = new ProcessStartRequest() { Instance = instance, Prefill = prefill, };
         Instance result = await processEngine.HandleEventsAndUpdateStorage(
             processStartRequest.Instance,
@@ -902,15 +989,14 @@ public sealed class ProcessEngineTest : IDisposable
     }
 
     private ProcessEngine GetProcessEngine(
-        Mock<IProcessReader>? processReaderMock = null,
+        bool setupProcessReaderMock = true,
         Instance? updatedInstance = null,
         List<IUserAction>? userActions = null,
         TelemetrySink? telemetrySink = null
     )
     {
-        if (processReaderMock == null)
+        if (setupProcessReaderMock)
         {
-            _processReaderMock = new();
             _processReaderMock.Setup(r => r.GetStartEventIds()).Returns(new List<string>() { "StartEvent_1" });
             _processReaderMock.Setup(r => r.IsProcessTask("StartEvent_1")).Returns(false);
             _processReaderMock.Setup(r => r.IsEndEvent("Task_1")).Returns(false);
@@ -919,10 +1005,6 @@ public sealed class ProcessEngineTest : IDisposable
             _processReaderMock.Setup(r => r.IsProcessTask("EndEvent_1")).Returns(false);
             _processReaderMock.Setup(r => r.IsEndEvent("EndEvent_1")).Returns(true);
             _processReaderMock.Setup(r => r.IsProcessTask("EndEvent_1")).Returns(false);
-        }
-        else
-        {
-            _processReaderMock = processReaderMock;
         }
 
         _profileMock
@@ -987,6 +1069,9 @@ public sealed class ProcessEngineTest : IDisposable
             _processEventDispatcherMock.Object,
             _processTaskCleanerMock.Object,
             new UserActionService(userActions ?? []),
+            _dataClientMock.Object,
+            new ModelSerializationService(_appModelMock.Object, telemetrySink?.Object),
+            _appMetadataMock.Object,
             telemetrySink?.Object
         );
     }
@@ -1000,7 +1085,7 @@ public sealed class ProcessEngineTest : IDisposable
         _processEventDispatcherMock.VerifyNoOtherCalls();
     }
 
-    private static bool CompareInstance(Instance expected, Instance actual)
+    private bool CompareInstance(Instance expected, Instance actual)
     {
         expected.Process.Started = actual.Process.Started;
         expected.Process.Ended = actual.Process.Ended;
@@ -1012,7 +1097,7 @@ public sealed class ProcessEngineTest : IDisposable
         return JsonCompare(expected, actual);
     }
 
-    private static bool CompareInstanceEvents(List<InstanceEvent> expected, List<InstanceEvent> actual)
+    private bool CompareInstanceEvents(List<InstanceEvent> expected, List<InstanceEvent> actual)
     {
         for (int i = 0; i < expected.Count; i++)
         {
@@ -1028,7 +1113,7 @@ public sealed class ProcessEngineTest : IDisposable
         return JsonCompare(expected, actual);
     }
 
-    public static bool JsonCompare(object? expected, object? actual)
+    private bool JsonCompare(object? expected, object? actual)
     {
         if (ReferenceEquals(expected, actual))
         {
@@ -1047,6 +1132,11 @@ public sealed class ProcessEngineTest : IDisposable
 
         var expectedJson = JsonConvert.SerializeObject(expected);
         var actualJson = JsonConvert.SerializeObject(actual);
+        _output.WriteLine("Expected:");
+        _output.WriteLine(expectedJson);
+        _output.WriteLine("Actual:");
+        _output.WriteLine(actualJson);
+        _output.WriteLine("");
 
         var jsonCompare = expectedJson == actualJson;
         if (jsonCompare == false)

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
@@ -1,4 +1,5 @@
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;
@@ -277,7 +278,7 @@ public class ProcessNavigatorTests
             new NullLogger<ProcessNavigator>(),
             _dataClient.Object,
             _appMetadata.Object,
-            _appModel.Object
+            new ModelSerializationService(_appModel.Object)
         );
     }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizerTests.cs
@@ -1,4 +1,5 @@
 using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;
@@ -26,7 +27,7 @@ public class ProcessTaskFinalizerTests
         _processTaskFinalizer = new ProcessTaskFinalizer(
             _appMetadataMock.Object,
             _dataClientMock.Object,
-            _appModelMock.Object,
+            new ModelSerializationService(_appModelMock.Object),
             _layoutEvaluatorStateInitializerMock.Object,
             _appSettings
         );

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/SubForm/SubFormTests.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/SubForm/SubFormTests.cs
@@ -246,6 +246,22 @@ public class SubFormTests : IClassFixture<DataAnnotationsTestFixture>
         _appResourcesMock
             .Setup(ar => ar.GetLayoutModelForTask(TaskId))
             .Returns(new LayoutModel([_mainLayoutComponent, _subLayoutComponent], null));
+        _appResourcesMock
+            .Setup(ar => ar.GetLayoutSet())
+            .Returns(
+                new LayoutSets()
+                {
+                    Sets =
+                    [
+                        new LayoutSet()
+                        {
+                            Id = "layoutId",
+                            Tasks = [TaskId],
+                            DataType = DefaultDataType
+                        }
+                    ]
+                }
+            );
         _httpContextAccessorMock.SetupGet(hca => hca.HttpContext).Returns(new DefaultHttpContext());
     }
 

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test1/RunTest1.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test1/RunTest1.cs
@@ -55,12 +55,12 @@ public class RunTest1
                     new DataReference()
                     {
                         Field = "some.data.binding3",
-                        DataElementId = state.GetDefaultDataElementId()
+                        DataElementIdentifier = state.GetDefaultDataElementId()
                     },
                     new DataReference()
                     {
                         Field = "some.data.binding2",
-                        DataElementId = state.GetDefaultDataElementId()
+                        DataElementIdentifier = state.GetDefaultDataElementId()
                     }
                 ]
             );

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/RunTest2.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/RunTest2.cs
@@ -53,32 +53,32 @@ public class RunTest2
                     new DataReference
                     {
                         Field = "some.data[0].binding",
-                        DataElementId = state.GetDefaultDataElementId()
+                        DataElementIdentifier = state.GetDefaultDataElementId()
                     },
                     new DataReference()
                     {
                         Field = "some.data[0].binding2",
-                        DataElementId = state.GetDefaultDataElementId()
+                        DataElementIdentifier = state.GetDefaultDataElementId()
                     },
                     new DataReference
                     {
                         Field = "some.data[0].binding3",
-                        DataElementId = state.GetDefaultDataElementId()
+                        DataElementIdentifier = state.GetDefaultDataElementId()
                     },
                     new DataReference
                     {
                         Field = "some.data[1].binding",
-                        DataElementId = state.GetDefaultDataElementId()
+                        DataElementIdentifier = state.GetDefaultDataElementId()
                     },
                     new DataReference
                     {
                         Field = "some.data[1].binding2",
-                        DataElementId = state.GetDefaultDataElementId()
+                        DataElementIdentifier = state.GetDefaultDataElementId()
                     },
                     new DataReference
                     {
                         Field = "some.data[1].binding3",
-                        DataElementId = state.GetDefaultDataElementId()
+                        DataElementIdentifier = state.GetDefaultDataElementId()
                     }
                 ]
             );
@@ -124,7 +124,7 @@ public class RunTest2
                     new DataReference()
                     {
                         Field = "some.data[1].binding2",
-                        DataElementId = state.GetDefaultDataElementId()
+                        DataElementIdentifier = state.GetDefaultDataElementId()
                     }
                 ]
             );

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test3/RunTest3.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test3/RunTest3.cs
@@ -55,7 +55,13 @@ public class RunTest3
         hidden
             .Should()
             .BeEquivalentTo(
-                [new DataReference() { Field = "some.data[2]", DataElementId = state.GetDefaultDataElementId() }]
+                [
+                    new DataReference()
+                    {
+                        Field = "some.data[2]",
+                        DataElementIdentifier = state.GetDefaultDataElementId()
+                    }
+                ]
             );
 
         // Verify before removing data
@@ -116,7 +122,13 @@ public class RunTest3
         hidden
             .Should()
             .BeEquivalentTo(
-                [new DataReference() { Field = "some.data[2]", DataElementId = state.GetDefaultDataElementId() }]
+                [
+                    new DataReference()
+                    {
+                        Field = "some.data[2]",
+                        DataElementIdentifier = state.GetDefaultDataElementId()
+                    }
+                ]
             );
 
         // Verify before removing data

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
@@ -93,7 +93,7 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
         throw new NotImplementedException();
     }
 
-    public void AddFormDataElement(string dataType, object data)
+    public void AddFormDataElement(string dataType, object model)
     {
         throw new NotImplementedException();
     }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
@@ -25,7 +25,7 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
         Instance.Data ??= new();
     }
 
-    private readonly Dictionary<DataElementId, object> _dataById = new();
+    private readonly Dictionary<DataElementIdentifier, object> _dataById = new();
     private readonly Dictionary<string, object> _dataByType = new();
     private readonly List<KeyValuePair<DataElement, object>> _data = new();
 
@@ -78,17 +78,17 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
 
     public Instance Instance { get; }
 
-    public Task<object> GetFormData(DataElementId dataElementId)
+    public Task<object> GetFormData(DataElementIdentifier dataElementIdentifier)
     {
-        return Task.FromResult(_dataById[dataElementId]);
+        return Task.FromResult(_dataById[dataElementIdentifier]);
     }
 
-    public Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementId dataElementId)
+    public Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier)
     {
         throw new NotImplementedException();
     }
 
-    public DataElement GetDataElement(DataElementId dataElementId)
+    public DataElement GetDataElement(DataElementIdentifier dataElementIdentifier)
     {
         throw new NotImplementedException();
     }
@@ -108,7 +108,7 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
         throw new NotImplementedException();
     }
 
-    public void RemoveDataElement(DataElementId dataElementId)
+    public void RemoveDataElement(DataElementIdentifier dataElementIdentifier)
     {
         throw new NotImplementedException();
     }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
@@ -93,6 +93,26 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
         throw new NotImplementedException();
     }
 
+    public void AddFormDataElement(string dataType, object data)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void AddAttachmentDataElement(
+        string dataType,
+        string contentType,
+        string? filename,
+        ReadOnlyMemory<byte> data
+    )
+    {
+        throw new NotImplementedException();
+    }
+
+    public void RemoveDataElement(DataElementId dataElementId)
+    {
+        throw new NotImplementedException();
+    }
+
     public IEnumerator<KeyValuePair<DataElement?, object>> GetEnumerator()
     {
         // We implement IEnumerable so that we can use the collection initializer syntax, but we also store the elements for debugger visualization

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
@@ -78,14 +78,19 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
 
     public Instance Instance { get; }
 
-    public Task<object> GetData(DataElementId dataElementId)
+    public Task<object> GetFormData(DataElementId dataElementId)
     {
         return Task.FromResult(_dataById[dataElementId]);
     }
 
-    public Task<object?> GetSingleDataByType(string dataType)
+    public Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementId dataElementId)
     {
-        return Task.FromResult(_dataByType.GetValueOrDefault(dataType));
+        throw new NotImplementedException();
+    }
+
+    public DataElement GetDataElement(DataElementId dataElementId)
+    {
+        throw new NotImplementedException();
     }
 
     public IEnumerator<KeyValuePair<DataElement?, object>> GetEnumerator()


### PR DESCRIPTION
The main goal is to add a method to `IDataProcessor` that takes an `IInstanceDataAccessor` and a list of changes and to add methods to `IInstanceDataAccessor` to add and remove data elements.


## Major refactorings
- New service `ModelSerializationService` to handle (de)serialisation of json and xml with convenience methods `*Storage` that looks in applicationmetadata 
- Extend `IInstanceDataAccessor` with methods to add and remove data elements from the instance
    - These are currently lazy, which means that they return void, and updating storage is deferred till after data processing is complete
- Extend `CachedInstanceDataAccessor` with functionality to ensure that nothing has been changed, after a certain point. This is used so that after data processing we can save to storage in parallel with validation without having to worry about validators mutating the models undetected.
- `DataElementId` was previously intended to be a thin wrapper around `System.Guid`, to communicate that this isn't just any guid, but a Guid from a specific database column. Every time I created one it was from a `DataElement`, and it was often required to get the data type, so I added fields to avoid lookups. Now it is more of an Immutable DataElement. Not sure everybody loves that development.
- `DataClient` uses the new `ModelSerializationService` and `IDataClient` gets a new `GetDataBytes` to argument the old `GetBinaryData` for those who want a clean `byte[]` that isn't wrapped in a `Stream`.

## Open questions
- New `IDataProcessing` interface, or just extend the existing with a new method. What to call the new one in that case?
- I got some help from ChatGPT to write `MemoryAsStream` in order to be able to pass `ReadOnlyMemory<byte>` to functions that expects a stream. I also found an alternative in [Windows Developer Toolkit](https://learn.microsoft.com/en-us/dotnet/api/microsoft.toolkit.highperformance.extensions.readonlymemoryextensions.asstream?view=win-comm-toolkit-dotnet-6.1). I'm not sure it is worth including a full toolkit for 14 effective lines of code.

## Remaining updates to make old code conform to new patterns
- Deprecate `ModelDeserializer` and use `ModelSerializationService` everywhere.
- Use `IInstanceDataAccessor` instead of `IDataClient` in more places where it makes sense to use the new data-processing interface
    - Instance creation
    - Data POST
    - Data PUT
    - Simpler detection for action implementations
    - Run new data-processing method on file/attachment upload
    

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/776

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
