### PR TITLE
Run analyzers that sonar cloud runs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -111,7 +111,7 @@ csharp_style_namespace_declarations = file_scoped:error
 dotnet_diagnostic.IDE1006.severity = error
 
 # Unused usings
-dotnet_diagnostic.IDE0005.severity = suggestion
+dotnet_diagnostic.IDE0005.severity = warning
 
 # CA1848: Use the LoggerMessage delegates
 dotnet_diagnostic.CA1848.severity = none
@@ -123,7 +123,10 @@ dotnet_diagnostic.CA1727.severity = suggestion
 dotnet_diagnostic.CA2254.severity = none
 
 # CA1822: Mark members as static
-dotnet_diagnostic.CA1822.severity = suggestion
+dotnet_diagnostic.CA1822.severity = warning
+
+# IDE0052: Remove unread private members
+dotnet_diagnostic.IDE0052.severity = warning
 
 # IDE0080: Remove unnecessary suppression operator
 dotnet_diagnostic.IDE0080.severity = error
@@ -145,6 +148,9 @@ dotnet_diagnostic.CA2201.severity = suggestion
 # CA1720: Identifier contains type name
 # TODO: fixing this would be breaking
 dotnet_diagnostic.CA1720.severity = suggestion
+
+# CA1816: Call GC.SuppressFinalize correctly
+dotnet_diagnostic.CA1816.severity = warning
 
 [Program.cs]
 dotnet_diagnostic.CA1050.severity = none

--- a/src/Altinn.App.Api/Controllers/ProfileController.cs
+++ b/src/Altinn.App.Api/Controllers/ProfileController.cs
@@ -14,15 +14,13 @@ namespace Altinn.App.Api.Controllers;
 public class ProfileController : Controller
 {
     private readonly IProfileClient _profileClient;
-    private readonly ILogger _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProfileController"/> class
     /// </summary>
-    public ProfileController(IProfileClient profileClient, ILogger<ProfileController> logger)
+    public ProfileController(IProfileClient profileClient)
     {
         _profileClient = profileClient;
-        _logger = logger;
     }
 
     /// <summary>

--- a/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
@@ -1,6 +1,4 @@
 using Altinn.App.Core.Extensions;
-using Altinn.App.Core.Features.Maskinporten;
-using Altinn.App.Core.Features.Maskinporten.Models;
 using Microsoft.Extensions.FileProviders;
 
 namespace Altinn.App.Api.Extensions;

--- a/src/Altinn.App.Core/Features/Maskinporten/Converters/JsonWebKeyConverter.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/Converters/JsonWebKeyConverter.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Altinn.App.Core.Features.Maskinporten.Exceptions;
 using Altinn.App.Core.Features.Maskinporten.Models;
 using Microsoft.IdentityModel.Tokens;

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.Validation.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.Validation.cs
@@ -6,7 +6,7 @@ namespace Altinn.App.Core.Features;
 
 partial class Telemetry
 {
-    private void InitValidation(InitContext context) { }
+    private static void InitValidation(InitContext context) { }
 
     internal Activity? StartValidateInstanceAtTaskActivity(Instance instance, string taskId)
     {

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModel.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModel.cs
@@ -44,7 +44,12 @@ public class DataModel : IDataModelAccessor
         return null;
     }
 
-    private object? GetModelDataRecursive(string[] keys, int index, object currentModel, ReadOnlySpan<int> indicies)
+    private static object? GetModelDataRecursive(
+        string[] keys,
+        int index,
+        object currentModel,
+        ReadOnlySpan<int> indicies
+    )
     {
         if (index == keys.Length)
         {
@@ -404,7 +409,7 @@ public class DataModel : IDataModelAccessor
         return VerifyKeyRecursive(key.Split('.'), 0, _serviceModel.GetType());
     }
 
-    private bool VerifyKeyRecursive(string[] keys, int index, Type currentModel)
+    private static bool VerifyKeyRecursive(string[] keys, int index, Type currentModel)
     {
         if (index == keys.Length)
         {

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -8,7 +8,6 @@ using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Layout;
 using Altinn.App.Core.Models.Layout.Components;
 using Altinn.Platform.Storage.Interface.Models;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -30,7 +29,6 @@ public class AppResourcesSI : IAppResources
 
     private readonly AppSettings _settings;
     private readonly IAppMetadata _appMetadata;
-    private readonly IWebHostEnvironment _hostingEnvironment;
     private readonly ILogger _logger;
     private readonly Telemetry? _telemetry;
 
@@ -39,20 +37,17 @@ public class AppResourcesSI : IAppResources
     /// </summary>
     /// <param name="settings">The app repository settings.</param>
     /// <param name="appMetadata">App metadata service</param>
-    /// <param name="hostingEnvironment">The hosting environment</param>
     /// <param name="logger">A logger from the built in logger factory.</param>
     /// <param name="telemetry">Telemetry for traces and metrics.</param>
     public AppResourcesSI(
         IOptions<AppSettings> settings,
         IAppMetadata appMetadata,
-        IWebHostEnvironment hostingEnvironment,
         ILogger<AppResourcesSI> logger,
         Telemetry? telemetry = null
     )
     {
         _settings = settings.Value;
         _appMetadata = appMetadata;
-        _hostingEnvironment = hostingEnvironment;
         _logger = logger;
         _telemetry = telemetry;
     }
@@ -403,7 +398,7 @@ public class AppResourcesSI : IAppResources
         return ReadFileByte(filename);
     }
 
-    private byte[] ReadFileByte(string fileName)
+    private static byte[] ReadFileByte(string fileName)
     {
         byte[]? filedata = null;
         if (File.Exists(fileName))
@@ -416,7 +411,7 @@ public class AppResourcesSI : IAppResources
 #nullable restore
     }
 
-    private byte[] ReadFileContentsFromLegalPath(string legalPath, string filePath)
+    private static byte[] ReadFileContentsFromLegalPath(string legalPath, string filePath)
     {
         var fullFileName = legalPath + filePath;
         if (!PathHelper.ValidateLegalFilePath(legalPath, fullFileName))

--- a/src/Altinn.App.Core/Implementation/PrefillSI.cs
+++ b/src/Altinn.App.Core/Implementation/PrefillSI.cs
@@ -313,7 +313,7 @@ public class PrefillSI : IPrefill
         }
     }
 
-    private Dictionary<string, string> SwapKeyValuesForPrefill(Dictionary<string, string> externalPrefil)
+    private static Dictionary<string, string> SwapKeyValuesForPrefill(Dictionary<string, string> externalPrefil)
     {
         return externalPrefil.ToDictionary(x => x.Value, x => x.Key);
     }

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsSubscriptionClient.cs
@@ -17,7 +17,6 @@ public class EventsSubscriptionClient : IEventsSubscription
 {
     private static readonly JsonSerializerOptions _jsonSerializerOptions = new() { PropertyNameCaseInsensitive = true };
 
-    private readonly PlatformSettings _platformSettings;
     private readonly GeneralSettings _generalSettings;
     private readonly HttpClient _client;
     private readonly IEventSecretCodeProvider _secretCodeProvider;
@@ -34,7 +33,6 @@ public class EventsSubscriptionClient : IEventsSubscription
         ILogger<EventsSubscriptionClient> logger
     )
     {
-        _platformSettings = platformSettings.Value;
         _generalSettings = generalSettings.Value;
         httpClient.BaseAddress = new Uri(platformSettings.Value.ApiEventsEndpoint);
         httpClient.DefaultRequestHeaders.Add(General.SubscriptionKeyHeaderName, platformSettings.Value.SubscriptionKey);

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
@@ -81,7 +81,7 @@ public class PersonClient : IPersonClient
         request.Headers.Add("Authorization", "Bearer " + _userTokenProvider.GetUserToken());
     }
 
-    private async Task<Person?> ReadResponse(HttpResponseMessage response, CancellationToken ct)
+    private static async Task<Person?> ReadResponse(HttpResponseMessage response, CancellationToken ct)
     {
         if (response.StatusCode == HttpStatusCode.OK)
         {

--- a/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
@@ -1,8 +1,6 @@
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
-using Altinn.App.Core.Implementation;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Altinn.App.Core.Internal.Language;
@@ -16,23 +14,16 @@ public class ApplicationLanguage : IApplicationLanguage
         new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
     private readonly AppSettings _settings;
-    private readonly ILogger _logger;
     private readonly Telemetry? _telemetry;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ApplicationLanguage"/> class.
     /// </summary>
     /// <param name="settings">The app repository settings.</param>
-    /// <param name="logger">A logger from the built in logger factory.</param>
     /// <param name="telemetry">Telemetry for traces and metrics.</param>
-    public ApplicationLanguage(
-        IOptions<AppSettings> settings,
-        ILogger<AppResourcesSI> logger,
-        Telemetry? telemetry = null
-    )
+    public ApplicationLanguage(IOptions<AppSettings> settings, Telemetry? telemetry = null)
     {
         _settings = settings.Value;
-        _logger = logger;
         _telemetry = telemetry;
     }
 

--- a/src/Altinn.App.Core/Internal/Patch/IPatchService.cs
+++ b/src/Altinn.App.Core/Internal/Patch/IPatchService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Nodes;
 using Altinn.App.Core.Models.Result;
 using Altinn.Platform.Storage.Interface.Models;
 using Json.Patch;

--- a/src/Altinn.App.Core/Models/Layout/PageComponentConverter.cs
+++ b/src/Altinn.App.Core/Models/Layout/PageComponentConverter.cs
@@ -48,7 +48,7 @@ public class PageComponentConverter : JsonConverter<PageComponent>
     /// <summary>
     /// Similar to read, but not nullable, and no pageName hack.
     /// </summary>
-    public PageComponent ReadNotNull(ref Utf8JsonReader reader, string pageName, JsonSerializerOptions options)
+    public static PageComponent ReadNotNull(ref Utf8JsonReader reader, string pageName, JsonSerializerOptions options)
     {
         if (reader.TokenType != JsonTokenType.StartObject)
         {
@@ -87,7 +87,7 @@ public class PageComponentConverter : JsonConverter<PageComponent>
         return page;
     }
 
-    private PageComponent ReadData(ref Utf8JsonReader reader, string pageName, JsonSerializerOptions options)
+    private static PageComponent ReadData(ref Utf8JsonReader reader, string pageName, JsonSerializerOptions options)
     {
         if (reader.TokenType != JsonTokenType.StartObject)
         {
@@ -156,10 +156,11 @@ public class PageComponentConverter : JsonConverter<PageComponent>
         return new PageComponent(pageName, layout, componentLookup, hidden, required, readOnly, additionalProperties);
     }
 
-    private (List<BaseComponent>, Dictionary<string, BaseComponent>, Dictionary<string, GroupComponent>) ReadLayout(
-        ref Utf8JsonReader reader,
-        JsonSerializerOptions options
-    )
+    private static (
+        List<BaseComponent>,
+        Dictionary<string, BaseComponent>,
+        Dictionary<string, GroupComponent>
+    ) ReadLayout(ref Utf8JsonReader reader, JsonSerializerOptions options)
     {
         if (reader.TokenType != JsonTokenType.StartArray)
         {
@@ -248,7 +249,7 @@ public class PageComponentConverter : JsonConverter<PageComponent>
         }
     }
 
-    private BaseComponent ReadComponent(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    private static BaseComponent ReadComponent(ref Utf8JsonReader reader, JsonSerializerOptions options)
     {
         if (reader.TokenType != JsonTokenType.StartObject)
         {

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstance.cs
@@ -82,7 +82,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         readDataElementResponseParsed.Melding!.Name.Should().Be(testName);
     }
 
-    private async Task<Instance> CreateInstanceSimplified(
+    private static async Task<Instance> CreateInstanceSimplified(
         string org,
         string app,
         int instanceOwnerPartyId,

--- a/test/Altinn.App.Api.Tests/Helpers/StartupHelperTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/StartupHelperTests.cs
@@ -34,7 +34,7 @@ public class StartupHelperTests
     public void IncludeXmlComments_discards_exceptions()
     {
         var testDouble = new SwaggerIncludeXmlCommentsTestDouble();
-        StartupHelper.IncludeXmlComments(testDouble.IncludeXmlCommentsFailingTestDouble);
+        StartupHelper.IncludeXmlComments(SwaggerIncludeXmlCommentsTestDouble.IncludeXmlCommentsFailingTestDouble);
         testDouble.GetStrings().Should().HaveCount(0);
         testDouble.GetBools().Should().HaveCount(0);
     }

--- a/test/Altinn.App.Api.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/test/Altinn.App.Api.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -344,7 +344,7 @@ public class TelemetryConfigurationTests
         Assert.Equal(timeoutToUse, options.ExportTimeoutMilliseconds);
     }
 
-    private Sampler GetSampler(TracerProvider provider)
+    private static Sampler GetSampler(TracerProvider provider)
     {
         var property =
             provider.GetType().GetProperty("Sampler", BindingFlags.Instance | BindingFlags.NonPublic)

--- a/test/Altinn.App.Api.Tests/TestStubs/SwaggerIncludeXmlCommentsTestDouble.cs
+++ b/test/Altinn.App.Api.Tests/TestStubs/SwaggerIncludeXmlCommentsTestDouble.cs
@@ -12,7 +12,7 @@ public class SwaggerIncludeXmlCommentsTestDouble
         _bools.Add(b);
     }
 
-    public void IncludeXmlCommentsFailingTestDouble(string s, bool b)
+    public static void IncludeXmlCommentsFailingTestDouble(string s, bool b)
     {
         throw new Exception("xUnit expected exception");
     }

--- a/test/Altinn.App.Common.Tests/TelemetrySink.cs
+++ b/test/Altinn.App.Common.Tests/TelemetrySink.cs
@@ -77,10 +77,10 @@ public sealed record TelemetrySink : IDisposable
 
     public TelemetrySnapshot GetSnapshot() => new(CapturedActivities, CapturedMetrics);
 
-    public TelemetrySnapshot GetSnapshot(Activity activity) =>
+    public static TelemetrySnapshot GetSnapshot(Activity activity) =>
         new([activity], new Dictionary<string, IReadOnlyList<MetricMeasurement>>());
 
-    public TelemetrySnapshot GetSnapshot(IEnumerable<Activity> activities) =>
+    public static TelemetrySnapshot GetSnapshot(IEnumerable<Activity> activities) =>
         new(activities, new Dictionary<string, IReadOnlyList<MetricMeasurement>>());
 
     public async Task Snapshot(

--- a/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
@@ -296,7 +296,7 @@ public class SigningUserActionTests
         );
     }
 
-    private bool AssertSigningContextAsExpected(SignatureContext s1, SignatureContext s2)
+    private static bool AssertSigningContextAsExpected(SignatureContext s1, SignatureContext s2)
     {
         s1.Should().BeEquivalentTo(s2);
         return true;

--- a/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
@@ -14,7 +14,7 @@ using Moq;
 
 namespace Altinn.App.Core.Tests.Features.Action;
 
-public class UniqueSignatureAuthorizerTests : IDisposable
+public sealed class UniqueSignatureAuthorizerTests : IDisposable
 {
     private readonly Mock<IProcessReader> _processReaderMock;
     private readonly Mock<IInstanceClient> _instanceClientMock;

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/DataAnnotationValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/DataAnnotationValidatorTests.cs
@@ -13,7 +13,7 @@ using Moq;
 
 namespace Altinn.App.Core.Tests.Features.Validators.Default;
 
-public class DataAnnotationValidatorTests : IClassFixture<DataAnnotationsTestFixture>
+public sealed class DataAnnotationValidatorTests : IClassFixture<DataAnnotationsTestFixture>
 {
     private readonly DataAnnotationValidator _validator;
 
@@ -168,7 +168,7 @@ public class DataAnnotationValidatorTests : IClassFixture<DataAnnotationsTestFix
 ///
 /// A full WebApplicationFactory seemed a little overkill, so we just use a WebApplicationBuilder.
 /// </summary>
-public class DataAnnotationsTestFixture : IAsyncDisposable
+public sealed class DataAnnotationsTestFixture : IAsyncDisposable
 {
     public const string DataType = "test";
 

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -48,7 +48,7 @@ public class ExpressionValidatorTests
     private static readonly JsonSerializerOptions _jsonSerializerOptions =
         new() { ReadCommentHandling = JsonCommentHandling.Skip, PropertyNamingPolicy = JsonNamingPolicy.CamelCase, };
 
-    public ExpressionValidationTestModel LoadData(string fileName, string folder)
+    public static ExpressionValidationTestModel LoadData(string fileName, string folder)
     {
         var data = File.ReadAllText(Path.Join(folder, fileName));
         return JsonSerializer.Deserialize<ExpressionValidationTestModel>(data, _jsonSerializerOptions)!;

--- a/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.cs
@@ -15,7 +15,7 @@ using Moq;
 
 namespace Altinn.App.Core.Tests.Features.Validators;
 
-public class ValidationServiceTests : IDisposable
+public sealed class ValidationServiceTests : IDisposable
 {
     private class MyModel
     {
@@ -127,13 +127,17 @@ public class ValidationServiceTests : IDisposable
         SetupFormDataValidatorType(_formDataValidatorAlwaysMock, "*", "alwaysUsedValidator");
     }
 
-    private void SetupTaskValidatorType(Mock<ITaskValidator> taskValidatorMock, string taskId, string validationSource)
+    private static void SetupTaskValidatorType(
+        Mock<ITaskValidator> taskValidatorMock,
+        string taskId,
+        string validationSource
+    )
     {
         taskValidatorMock.Setup(v => v.TaskId).Returns(taskId);
         taskValidatorMock.Setup(v => v.ValidationSource).Returns(validationSource);
     }
 
-    private void SetupTaskValidatorReturn(
+    private static void SetupTaskValidatorReturn(
         Mock<ITaskValidator> taskValidatorMock,
         List<ValidationIssue> validationIssues,
         Times? times = default
@@ -145,7 +149,7 @@ public class ValidationServiceTests : IDisposable
             .Verifiable(times ?? Times.Once());
     }
 
-    private void SetupDataElementValidatorType(
+    private static void SetupDataElementValidatorType(
         Mock<IDataElementValidator> taskValidatorMock,
         string dataType,
         string validationSource
@@ -155,7 +159,7 @@ public class ValidationServiceTests : IDisposable
         taskValidatorMock.Setup(v => v.ValidationSource).Returns(validationSource);
     }
 
-    private void SetupDataElementValidatorReturn(
+    private static void SetupDataElementValidatorReturn(
         Mock<IDataElementValidator> dataElementValidatorMock,
         List<ValidationIssue> validationIssues,
         Times? times = default
@@ -167,7 +171,7 @@ public class ValidationServiceTests : IDisposable
             .Verifiable(times ?? Times.Once());
     }
 
-    private void SetupFormDataValidatorType(
+    private static void SetupFormDataValidatorType(
         Mock<IFormDataValidator> formDataValidatorMock,
         string dataType,
         string validationSource
@@ -180,7 +184,7 @@ public class ValidationServiceTests : IDisposable
         formDataValidatorMock.Setup(v => v.ValidationSource).Returns(validationSource);
     }
 
-    private void SetupFormDataValidatorReturn(
+    private static void SetupFormDataValidatorReturn(
         Mock<IFormDataValidator> formDataValidatorMock,
         bool? hasRelevantChanges,
         Func<MyModel, List<ValidationIssue>> func,

--- a/test/Altinn.App.Core.Tests/Helpers/JsonDataModel.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/JsonDataModel.cs
@@ -35,7 +35,12 @@ public class JsonDataModel : IDataModelAccessor
         return GetModelDataRecursive(key.Split('.'), 0, _modelRoot, indicies);
     }
 
-    private object? GetModelDataRecursive(string[] keys, int index, JsonNode? currentModel, ReadOnlySpan<int> indicies)
+    private static object? GetModelDataRecursive(
+        string[] keys,
+        int index,
+        JsonNode? currentModel,
+        ReadOnlySpan<int> indicies
+    )
     {
         if (currentModel is null)
         {
@@ -114,7 +119,12 @@ public class JsonDataModel : IDataModelAccessor
         return GetModelDataCountRecurs(key.Split('.'), 0, _modelRoot, indicies);
     }
 
-    private int? GetModelDataCountRecurs(string[] keys, int index, JsonNode? currentModel, ReadOnlySpan<int> indicies)
+    private static int? GetModelDataCountRecurs(
+        string[] keys,
+        int index,
+        JsonNode? currentModel,
+        ReadOnlySpan<int> indicies
+    )
     {
         if (index == keys.Length || currentModel is null)
         {

--- a/test/Altinn.App.Core.Tests/Helpers/JsonHelperTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/JsonHelperTests.cs
@@ -13,7 +13,7 @@ public class JsonHelperTests
     /// <summary>
     /// Helper method to setup and get the dictionary of the diffs
     /// </summary>
-    public async Task<Dictionary<string, object?>?> DoTest<TModel>(
+    public static async Task<Dictionary<string, object?>?> DoTest<TModel>(
         TModel model,
         Func<TModel, bool> processDataWriteImpl
     )

--- a/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -15,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace Altinn.App.Core.Tests.Helpers;
 
+[SuppressMessage("Performance", "CA1822:Mark members as static")]
 public class ObjectUtils_XmlSerializationTests(ITestOutputHelper _output)
 {
     private readonly Mock<ILogger> _loggerMock = new();

--- a/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
@@ -26,8 +26,7 @@ public class AppResourcesSITests
         AppSettings appSettings = GetAppSettings("AppMetadata", "default.applicationmetadata.json");
         var settings = Options.Create(appSettings);
         IAppMetadata appMetadata = SetupAppMetadata(Options.Create(appSettings));
-        AppResourcesSI appResources =
-            new(settings, appMetadata, null, new NullLogger<AppResourcesSI>(), _telemetry.Object);
+        AppResourcesSI appResources = new(settings, appMetadata, new NullLogger<AppResourcesSI>(), _telemetry.Object);
         Application expected =
             new()
             {
@@ -73,8 +72,7 @@ public class AppResourcesSITests
         AppSettings appSettings = GetAppSettings("AppMetadata", "no-on-entry.applicationmetadata.json");
         var settings = Options.Create(appSettings);
         IAppMetadata appMetadata = SetupAppMetadata(Options.Create(appSettings));
-        AppResourcesSI appResources =
-            new(settings, appMetadata, null, new NullLogger<AppResourcesSI>(), _telemetry.Object);
+        AppResourcesSI appResources = new(settings, appMetadata, new NullLogger<AppResourcesSI>(), _telemetry.Object);
         Application expected = new Application()
         {
             Id = "tdd/bestilling",
@@ -122,8 +120,7 @@ public class AppResourcesSITests
             .ReturnsAsync(new Dictionary<string, bool>() { { "footer", true } });
         var settings = Options.Create(appSettings);
         IAppMetadata appMetadata = SetupAppMetadata(Options.Create(appSettings), appFeaturesMock.Object);
-        AppResourcesSI appResources =
-            new(settings, appMetadata, null, new NullLogger<AppResourcesSI>(), _telemetry.Object);
+        AppResourcesSI appResources = new(settings, appMetadata, new NullLogger<AppResourcesSI>(), _telemetry.Object);
         Application expected =
             new()
             {
@@ -176,7 +173,6 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -192,7 +188,6 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -208,7 +203,6 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -226,7 +220,6 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -243,7 +236,6 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -261,7 +253,6 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );

--- a/test/Altinn.App.Core.Tests/Implementation/InstanceClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/InstanceClientTests.cs
@@ -17,7 +17,7 @@ using Newtonsoft.Json;
 
 namespace Altinn.App.PlatformServices.Tests.Implementation;
 
-public class InstanceClientTests : IDisposable
+public sealed class InstanceClientTests : IDisposable
 {
     private readonly Mock<IOptions<PlatformSettings>> platformSettingsOptions;
     private readonly Mock<IOptionsMonitor<AppSettings>> appSettingsOptions;

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Profile/ProfileClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Profile/ProfileClientTests.cs
@@ -27,7 +27,7 @@ public class ProfileClientTests
         public ValueTask DisposeAsync() => ServiceProvider.DisposeAsync();
     }
 
-    private Fixture BuildFixture(Func<UserProfile?>? userProfileFactory = null)
+    private static Fixture BuildFixture(Func<UserProfile?>? userProfileFactory = null)
     {
         var services = new ServiceCollection();
 

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
@@ -847,7 +847,7 @@ public class DataClientTests
         );
     }
 
-    private void AssertHttpRequest(
+    private static void AssertHttpRequest(
         HttpRequestMessage actual,
         Uri expectedUri,
         HttpMethod method,

--- a/test/Altinn.App.Core.Tests/Internal/Patch/PatchServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Patch/PatchServiceTests.cs
@@ -18,7 +18,7 @@ using DataType = Altinn.Platform.Storage.Interface.Models.DataType;
 
 namespace Altinn.App.Core.Tests.Internal.Patch;
 
-public class PatchServiceTests : IDisposable
+public sealed class PatchServiceTests : IDisposable
 {
     // Test data
     private static readonly Guid DataGuid = new("12345678-1234-1234-1234-123456789123");

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json;
 
 namespace Altinn.App.Core.Tests.Internal.Process;
 
-public class ProcessEngineTest : IDisposable
+public sealed class ProcessEngineTest : IDisposable
 {
     private Mock<IProcessReader> _processReaderMock;
     private readonly Mock<IProfileClient> _profileMock;

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/LayoutModelConverterFromObject.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/LayoutModelConverterFromObject.cs
@@ -45,9 +45,8 @@ public class LayoutModelConverterFromObject : JsonConverter<LayoutModel>
             reader.Read();
 
             PageComponentConverter.SetAsyncLocalPageName(pageName);
-            var converter = new PageComponentConverter();
 
-            componentModel.Pages[pageName] = converter.ReadNotNull(ref reader, pageName, options);
+            componentModel.Pages[pageName] = PageComponentConverter.ReadNotNull(ref reader, pageName, options);
         }
 
         return componentModel;

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
@@ -220,6 +220,7 @@ public class TestFunctions
         // This is just a way to ensure that all folders have test methods associcated.
         var jsonTestFolders = Directory
             .GetDirectories(Path.Join("LayoutExpressions", "CommonTests", "shared-tests", "functions"))
+            .Where(d => Directory.GetFiles(d).Length > 0)
             .Select(d => Path.GetFileName(d))
             .OrderBy(s => s)
             .ToArray();
@@ -232,10 +233,9 @@ public class TestFunctions
             )
             .OrderBy(s => s)
             .OfType<string>()
+            .OrderBy(d => d)
             .ToArray();
-        testMethods
-            .Should()
-            .BeEquivalentTo(jsonTestFolders, "Shared test folders should have a corresponding test method");
+        testMethods.Should().Equal(jsonTestFolders, "Shared test folders should have a corresponding test method");
     }
 }
 

--- a/test/Altinn.App.Core.Tests/Models/PageComponentConverterTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/PageComponentConverterTests.cs
@@ -37,13 +37,13 @@ public class PageComponentConverterTests
         }
     }
 
-    private PageComponentConverterTestModel LoadData(string fileName, string folder)
+    private static PageComponentConverterTestModel LoadData(string fileName, string folder)
     {
         var data = File.ReadAllText(Path.Join(folder, fileName));
         return JsonSerializer.Deserialize<PageComponentConverterTestModel>(data, _jsonSerializerOptions)!;
     }
 
-    private HierarchyTestModel[] GenerateTestHierarchy(GroupComponent group)
+    private static HierarchyTestModel[] GenerateTestHierarchy(GroupComponent group)
     {
         var children = new List<HierarchyTestModel>();
         foreach (var child in group.Children)


### PR DESCRIPTION
This enables analysers that Sonar Cloud runs so that they can be caught in local development instead of the slow cycle of getting an issue in sonar cloud.

This is part of #730, because I changed these to warning in `.editorconfig` because it made the sonar cloud issues easier to find. I think this could be reviewed separately.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
