### PR TITLE
Remove default implementation from IDataWriteProcessor

### DIFF
--- a/src/Altinn.App.Core/Features/IDataWriteProcessor.cs
+++ b/src/Altinn.App.Core/Features/IDataWriteProcessor.cs
@@ -20,5 +20,5 @@ public interface IDataWriteProcessor
         string taskId,
         List<DataElementChange> changes,
         string? language
-    ) => Task.CompletedTask;
+    );
 }


### PR DESCRIPTION
Error when copying the method into a separate interface

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
