### PR TITLE
Include the full instance in single patch response

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -427,6 +427,7 @@ public class DataController : ControllerBase
                 {
                     ValidationIssues = newResponse.ValidationIssues.ToDictionary(d => d.Source, d => d.Issues),
                     NewDataModel = newResponse.NewDataModels.First(m => m.DataElementId == dataGuid).Data,
+                    Instance = newResponse.Instance,
                 }
             );
         }

--- a/src/Altinn.App.Api/Models/DataPatchResponse.cs
+++ b/src/Altinn.App.Api/Models/DataPatchResponse.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Models.Validation;
+using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Api.Models;
 
@@ -17,4 +18,9 @@ public class DataPatchResponse
     /// The current data model after the patch operation.
     /// </summary>
     public required object NewDataModel { get; init; }
+
+    /// <summary>
+    /// The instance object after patching. Used for frontend to detect added or removed data elements.
+    /// </summary>
+    public required Instance Instance { get; set; }
 }

--- a/src/Altinn.App.Api/Models/DataPatchResponse.cs
+++ b/src/Altinn.App.Api/Models/DataPatchResponse.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
@@ -12,15 +13,18 @@ public class DataPatchResponse
     /// <summary>
     /// The validation issues that were found during the patch operation.
     /// </summary>
+    [JsonPropertyName("validationIssues")]
     public required Dictionary<string, List<ValidationIssueWithSource>> ValidationIssues { get; init; }
 
     /// <summary>
     /// The current data model after the patch operation.
     /// </summary>
+    [JsonPropertyName("newDataModel")]
     public required object NewDataModel { get; init; }
 
     /// <summary>
     /// The instance object after patching. Used for frontend to detect added or removed data elements.
     /// </summary>
+    [JsonPropertyName("instance")]
     public required Instance Instance { get; set; }
 }

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -5719,6 +5719,7 @@
       },
       "DataPatchResponse": {
         "required": [
+          "instance",
           "newDataModel",
           "validationIssues"
         ],
@@ -5736,6 +5737,9 @@
           },
           "newDataModel": {
             "nullable": true
+          },
+          "instance": {
+            "$ref": "#/components/schemas/Instance"
           }
         },
         "additionalProperties": false

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -3574,6 +3574,7 @@ components:
       additionalProperties: false
     DataPatchResponse:
       required:
+        - instance
         - newDataModel
         - validationIssues
       type: object
@@ -3587,6 +3588,8 @@ components:
           nullable: true
         newDataModel:
           nullable: true
+        instance:
+          $ref: '#/components/schemas/Instance'
       additionalProperties: false
     DataPatchResponseMultiple:
       required:


### PR DESCRIPTION
Frontend uses the single PATCH endpoint when it can, so it also needs to get the instance object back in order to be able to add and remove data elements in `IDataWriteProcessor` with `IInstanceDataMutator`.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
