### PR TITLE
Handle invalid XML chars

### DIFF
--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -170,6 +170,8 @@ public static partial class ObjectUtils
         }
     }
 
+    // Regex copied from: https://stackoverflow.com/a/961504
+    // Which is based on spec: https://www.w3.org/TR/xml/#charsets
     [GeneratedRegex(
         @"(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\uFEFF\uFFFE\uFFFF]"
     )]

--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -154,7 +154,7 @@ public static partial class ObjectUtils
                         if (prop.SetMethod is not null)
                         {
                             // Remove invalid xml characters
-                            prop.SetValue(model, xmlRegex.Replace(s, "�"));
+                            prop.SetValue(model, xmlRegex.Replace(s, "\uFFFD")); // \uFFFD is the unicode replacement character �
                         }
                         else if (xmlRegex.IsMatch(s))
                         {

--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -147,17 +147,14 @@ public static partial class ObjectUtils
                     }
                     else
                     {
-                        var xmlRegex = XmlInvalidCharsRegex();
                         if (prop.SetMethod is not null)
                         {
+                            // If a property doesn't have a setter, it hopefully doesn't have user input,
+                            // and therefore it far less likely to have invalid XML chars. If that were the case
+                            // we will still just error out when serializing to XML
+
                             // Remove invalid xml characters
-                            prop.SetValue(model, xmlRegex.Replace(s, "\uFFFD")); // \uFFFD is the unicode replacement character �
-                        }
-                        else if (xmlRegex.IsMatch(s))
-                        {
-                            throw new InvalidOperationException(
-                                $"Property {prop.Name} of datamodel contains invalid xml characters"
-                            );
+                            prop.SetValue(model, XmlInvalidCharsRegex().Replace(s, "\uFFFD")); // \uFFFD is the unicode replacement character �
                         }
                     }
                 }

--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -140,13 +140,10 @@ public static partial class ObjectUtils
                 // Set string properties with [XmlText] attribute to null if they are empty or whitespace
                 if (value is string s)
                 {
-                    if (string.IsNullOrWhiteSpace(s))
+                    if (string.IsNullOrWhiteSpace(s) && prop.GetCustomAttribute<XmlTextAttribute>() is not null)
                     {
-                        if (prop.GetCustomAttribute<XmlTextAttribute>() is not null)
-                        {
-                            // Ensure empty strings are set to null
-                            prop.SetValue(model, null);
-                        }
+                        // Ensure empty strings are set to null
+                        prop.SetValue(model, null);
                     }
                     else
                     {

--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 
 namespace Altinn.App.Core.Helpers;
@@ -7,7 +8,7 @@ namespace Altinn.App.Core.Helpers;
 /// <summary>
 /// Utilities for working with model instances
 /// </summary>
-public static class ObjectUtils
+public static partial class ObjectUtils
 {
     /// <summary>
     /// Set empty Guid properties named "AltinnRowId" to a new random guid
@@ -137,14 +138,31 @@ public static class ObjectUtils
                 SetToDefaultIfShouldSerializeFalse(model, prop, methodInfos);
 
                 // Set string properties with [XmlText] attribute to null if they are empty or whitespace
-                if (
-                    value is string s
-                    && string.IsNullOrWhiteSpace(s)
-                    && prop.GetCustomAttribute<XmlTextAttribute>() is not null
-                )
+                if (value is string s)
                 {
-                    // Ensure empty strings are set to null
-                    prop.SetValue(model, null);
+                    if (string.IsNullOrWhiteSpace(s))
+                    {
+                        if (prop.GetCustomAttribute<XmlTextAttribute>() is not null)
+                        {
+                            // Ensure empty strings are set to null
+                            prop.SetValue(model, null);
+                        }
+                    }
+                    else
+                    {
+                        var xmlRegex = XmlInvalidCharsRegex();
+                        if (prop.SetMethod is not null)
+                        {
+                            // Remove invalid xml characters
+                            prop.SetValue(model, xmlRegex.Replace(s, "�"));
+                        }
+                        else if (xmlRegex.IsMatch(s))
+                        {
+                            throw new InvalidOperationException(
+                                $"Property {prop.Name} of datamodel contains invalid xml characters"
+                            );
+                        }
+                    }
                 }
 
                 // continue recursion over all properties that are NOT null or value types
@@ -154,6 +172,11 @@ public static class ObjectUtils
             }
         }
     }
+
+    [GeneratedRegex(
+        @"(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\uFEFF\uFFFE\uFFFF]"
+    )]
+    private static partial Regex XmlInvalidCharsRegex();
 
     private static void SetToDefaultIfShouldSerializeFalse(object model, PropertyInfo prop, MethodInfo[] methodInfos)
     {

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
@@ -90,7 +90,7 @@ public class ModelSerializationService
         using XmlWriter xmlWriter = XmlWriter.Create(memoryStream, xmlWriterSettings);
 
         XmlSerializer serializer = _xmlSerializer.GetSerializer(modelType);
-        serializer.Serialize(xmlWriter, model);
+        serializer.Serialize(xmlWriter, model); // TODO: sanitate
         return memoryStream.ToArray().AsMemory().RemoveBom();
     }
 

--- a/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
@@ -90,7 +90,7 @@ public class ModelSerializationService
         using XmlWriter xmlWriter = XmlWriter.Create(memoryStream, xmlWriterSettings);
 
         XmlSerializer serializer = _xmlSerializer.GetSerializer(modelType);
-        serializer.Serialize(xmlWriter, model); // TODO: sanitate
+        serializer.Serialize(xmlWriter, model);
         return memoryStream.ToArray().AsMemory().RemoveBom();
     }
 

--- a/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
@@ -135,8 +135,8 @@ public class ObjectUtils_XmlSerializationTests(ITestOutputHelper _output)
     [Fact]
     public void TestInvalidXmlCharsAreHandled()
     {
-        var input = "''";
-        var output = "'�'";
+        var input = "'\u0002'"; // Represents start of text (␂)
+        var output = "'\uFFFD'"; // Represents replacement character (�)
 
         var test = new YttersteObjekt { NormalString = input, };
 

--- a/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/ObjectUtils_XmlSerializationTests.cs
@@ -118,7 +118,7 @@ public class ObjectUtils_XmlSerializationTests(ITestOutputHelper _output)
             { "\n\n", null },
             { "\n\na", "\n\na" },
             { "a\n\n", "a\n\n" },
-            { "a\nb", "a\nb" }
+            { "a\nb", "a\nb" },
         };
 
     [Theory]
@@ -130,6 +130,19 @@ public class ObjectUtils_XmlSerializationTests(ITestOutputHelper _output)
         ObjectUtils.PrepareModelForXmlStorage(test);
 
         AssertObject(test, value, storedValue);
+    }
+
+    [Fact]
+    public void TestInvalidXmlCharsAreHandled()
+    {
+        var input = "''";
+        var output = "'�'";
+
+        var test = new YttersteObjekt { NormalString = input, };
+
+        ObjectUtils.PrepareModelForXmlStorage(test);
+
+        test.NormalString.Should().Be(output);
     }
 
     [Theory]


### PR DESCRIPTION
## Description
There are some characters, e.g. ASCII control characters, that aren't supported in XML strings. Options:

* Just remove unsupported characters
* Replace invalid XML characters with the `�` so that we still output a symbol (user can then deal with it)
* Validate (return validation issues)

## Related Issue(s)
- #833

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
