### PR TITLE
Fix process history with telemetry

### DIFF
--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -584,7 +584,7 @@ public class ProcessController : ControllerBase
     [HttpGet("history")]
     [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_READ)]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<ActionResult> GetProcessHistory(
+    public async Task<ActionResult<ProcessHistoryList>> GetProcessHistory(
         [FromRoute] int instanceOwnerPartyId,
         [FromRoute] Guid instanceGuid
     )

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.ProcessClient.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.ProcessClient.cs
@@ -7,10 +7,14 @@ partial class Telemetry
     internal Activity? StartGetProcessDefinitionActivity() =>
         ActivitySource.StartActivity("ProcessClient.GetProcessDefinition");
 
-    internal Activity? StartGetProcessHistoryActivity(string? instanceId, string? instanceOwnerPartyId)
+    internal Activity? StartGetProcessHistoryActivity(string? instanceGuid, string? instanceOwnerPartyId)
     {
         var activity = ActivitySource.StartActivity("ProcessClient.GetProcessHistory");
-        activity?.SetInstanceId(instanceId);
+        if (Guid.TryParse(instanceGuid, out Guid instanceId))
+        {
+            activity?.SetInstanceId(instanceId);
+        }
+
         activity?.SetInstanceOwnerPartyId(instanceOwnerPartyId);
         return activity;
     }

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -20,7 +21,9 @@ using Json.Pointer;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using Newtonsoft.Json;
 using Xunit.Abstractions;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Altinn.App.Api.Tests.Controllers;
 
@@ -592,6 +595,41 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         var nextResponseContent = await nextResponse.Content.ReadAsStringAsync();
         OutputHelper.WriteLine(nextResponseContent);
         nextResponse.Should().HaveStatusCode(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ProcessHistory_ShouldReturnProcessHistory()
+    {
+        var start = "2024-10-16T10:33:54.935732Z";
+        var processList = new ProcessHistoryList()
+        {
+            ProcessHistory = [new() { ElementId = "Task_1", Started = DateTime.Parse(start).ToUniversalTime(), }],
+        };
+        SendAsync = message =>
+        {
+            message
+                .RequestUri.PathAndQuery.Should()
+                .Be($"/storage/api/v1/instances/{InstanceOwnerPartyId}/{_instanceGuid}/process/history");
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(processList)),// Api uses Newtonsoft.Json
+                }
+            );
+        };
+        HttpClient client = GetRootedClient(Org, App, 1337, InstanceOwnerPartyId);
+        string url = $"/{Org}/{App}/instances/{InstanceOwnerPartyId}/{_instanceGuid}/process/history";
+
+        HttpResponseMessage response = await client.GetAsync(url);
+
+        var content = await response.Content.ReadAsStringAsync();
+        OutputHelper.WriteLine(content);
+        response.Should().HaveStatusCode(HttpStatusCode.OK);
+        content
+            .Should()
+            .Be(
+                $$"""{"processHistory":[{"eventType":null,"elementId":"Task_1","occured":null,"started":"{{start}}","ended":null,"performedBy":null}]}"""
+            );
     }
 
     //TODO: replace this assertion with a proper one once fluentassertions has a json compare feature scheduled for v7 https://github.com/fluentassertions/fluentassertions/issues/2205

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
@@ -607,13 +607,14 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         };
         SendAsync = message =>
         {
+            ArgumentNullException.ThrowIfNull(message.RequestUri);
             message
                 .RequestUri.PathAndQuery.Should()
                 .Be($"/storage/api/v1/instances/{InstanceOwnerPartyId}/{_instanceGuid}/process/history");
             return Task.FromResult(
                 new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent(JsonConvert.SerializeObject(processList)),// Api uses Newtonsoft.Json
+                    Content = new StringContent(JsonConvert.SerializeObject(processList)), // Api uses Newtonsoft.Json
                 }
             );
         };

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -3675,7 +3675,34 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessHistoryList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessHistoryList"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessHistoryList"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessHistoryList"
+                }
+              },
+              "text/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessHistoryList"
+                }
+              }
+            }
           }
         }
       }
@@ -6702,6 +6729,52 @@
           },
           "flowType": {
             "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProcessHistoryItem": {
+        "type": "object",
+        "properties": {
+          "eventType": {
+            "type": "string",
+            "nullable": true
+          },
+          "elementId": {
+            "type": "string",
+            "nullable": true
+          },
+          "occured": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "started": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ended": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "performedBy": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProcessHistoryList": {
+        "type": "object",
+        "properties": {
+          "processHistory": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProcessHistoryItem"
+            },
             "nullable": true
           }
         },

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -2245,6 +2245,22 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProcessHistoryList'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProcessHistoryList'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProcessHistoryList'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ProcessHistoryList'
+            text/xml:
+              schema:
+                $ref: '#/components/schemas/ProcessHistoryList'
   '/{org}/{app}/api/v1/profile/user':
     get:
       tags:
@@ -4287,6 +4303,40 @@ components:
           $ref: '#/components/schemas/ValidationStatus'
         flowType:
           type: string
+          nullable: true
+      additionalProperties: false
+    ProcessHistoryItem:
+      type: object
+      properties:
+        eventType:
+          type: string
+          nullable: true
+        elementId:
+          type: string
+          nullable: true
+        occured:
+          type: string
+          format: date-time
+          nullable: true
+        started:
+          type: string
+          format: date-time
+          nullable: true
+        ended:
+          type: string
+          format: date-time
+          nullable: true
+        performedBy:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ProcessHistoryList:
+      type: object
+      properties:
+        processHistory:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessHistoryItem'
           nullable: true
       additionalProperties: false
     ProcessNext:


### PR DESCRIPTION
The `Telemetry.StartGetProcessHistoryActivity` passed the InstanceGuid as string to SetInstance, when the full instance.Id was expected, resulting in an error on `instanceId.Split('/')[1]`

see https://altinn.slack.com/archives/C02EJ9HKQA3/p1729076638931259