### PR TITLE
Fix NullReferenceException when using a gateway before instance is created

### DIFF
--- a/src/Altinn.App.Core/Internal/Data/CachedInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Internal/Data/CachedInstanceDataAccessor.cs
@@ -18,8 +18,6 @@ namespace Altinn.App.Core.Internal.Data;
 internal sealed class CachedInstanceDataAccessor : IInstanceDataMutator
 {
     // DataClient needs a few arguments to fetch data
-    private readonly string _org;
-    private readonly string _app;
     private readonly Guid _instanceGuid;
     private readonly int _instanceOwnerPartyId;
 
@@ -60,12 +58,13 @@ internal sealed class CachedInstanceDataAccessor : IInstanceDataMutator
         ModelSerializationService modelSerializationService
     )
     {
-        var splitApp = instance.AppId.Split("/");
-        _org = splitApp[0];
-        _app = splitApp[1];
-        var splitId = instance.Id.Split("/");
-        _instanceOwnerPartyId = int.Parse(splitId[0], CultureInfo.InvariantCulture);
-        _instanceGuid = Guid.Parse(splitId[1]);
+        if (instance.Id is not null)
+        {
+            var splitId = instance.Id.Split("/");
+            _instanceOwnerPartyId = int.Parse(splitId[0], CultureInfo.InvariantCulture);
+            _instanceGuid = Guid.Parse(splitId[1]);
+        }
+
         Instance = instance;
         _dataClient = dataClient;
         _appMetadata = appMetadata;
@@ -93,18 +92,22 @@ internal sealed class CachedInstanceDataAccessor : IInstanceDataMutator
     }
 
     /// <inheritdoc />
-    public async Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier) =>
-        await _binaryCache.GetOrCreate(
+    public async Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier)
+    {
+        var appMetadata = await _appMetadata.GetApplicationMetadata();
+
+        return await _binaryCache.GetOrCreate(
             dataElementIdentifier,
             async () =>
                 await _dataClient.GetDataBytes(
-                    _org,
-                    _app,
+                    appMetadata.AppIdentifier.Org,
+                    appMetadata.AppIdentifier.App,
                     _instanceOwnerPartyId,
                     _instanceGuid,
                     dataElementIdentifier.Guid
                 )
         );
+    }
 
     /// <inheritdoc />
     public DataElement GetDataElement(DataElementIdentifier dataElementIdentifier)
@@ -258,14 +261,16 @@ internal sealed class CachedInstanceDataAccessor : IInstanceDataMutator
             tasks.Add(InsertBinaryData());
         }
 
+        var appMetadata = await _appMetadata.GetApplicationMetadata();
+
         // Delete data elements
         foreach (var dataElementId in _dataElementsToDelete)
         {
             async Task DeleteData()
             {
                 await _dataClient.DeleteData(
-                    _org,
-                    _app,
+                    appMetadata.AppIdentifier.Org,
+                    appMetadata.AppIdentifier.App,
                     _instanceOwnerPartyId,
                     _instanceGuid,
                     dataElementId.Guid,

--- a/src/Altinn.App.Core/Internal/Data/CachedInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Internal/Data/CachedInstanceDataAccessor.cs
@@ -94,6 +94,11 @@ internal sealed class CachedInstanceDataAccessor : IInstanceDataMutator
     /// <inheritdoc />
     public async Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier)
     {
+        if (_instanceOwnerPartyId == 0 || _instanceGuid == Guid.Empty)
+        {
+            throw new InvalidOperationException("Cannot access instance data before it has been created");
+        }
+
         var appMetadata = await _appMetadata.GetApplicationMetadata();
 
         return await _binaryCache.GetOrCreate(
@@ -233,6 +238,11 @@ internal sealed class CachedInstanceDataAccessor : IInstanceDataMutator
 
     internal async Task UpdateInstanceData(List<DataElementChange> changes)
     {
+        if (_instanceOwnerPartyId == 0 || _instanceGuid == Guid.Empty)
+        {
+            throw new InvalidOperationException("Cannot access instance data before it has been created");
+        }
+
         var tasks = new List<Task>();
         ConcurrentBag<DataElement> createdDataElements = new();
         // We need to create data elements here, so that we can set them correctly on the instance

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -13,6 +13,7 @@ using Altinn.App.Core.Internal.Process;
 using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.App.Core.Internal.Profile;
+using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Process;
 using Altinn.App.Core.Models.UserAction;
 using Altinn.Platform.Profile.Models;
@@ -457,6 +458,7 @@ public sealed class ProcessEngineTest : IDisposable
     [Fact]
     public async Task Next_moves_instance_to_next_task_and_produces_instanceevents()
     {
+        _appMetadataMock.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(new ApplicationMetadata("org/app"));
         var expectedInstance = new Instance()
         {
             Id = _instanceId,
@@ -604,6 +606,7 @@ public sealed class ProcessEngineTest : IDisposable
     [Fact]
     public async Task Next_moves_instance_to_next_task_and_produces_abandon_instanceevent_when_action_reject()
     {
+        _appMetadataMock.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(new ApplicationMetadata("org/app"));
         var expectedInstance = new Instance()
         {
             Id = _instanceId,
@@ -752,6 +755,7 @@ public sealed class ProcessEngineTest : IDisposable
     [Fact]
     public async Task Next_moves_instance_to_end_event_and_ends_proces()
     {
+        _appMetadataMock.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(new ApplicationMetadata("org/app"));
         var expectedInstance = new Instance()
         {
             Id = _instanceId,

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizerTests.cs
@@ -70,6 +70,7 @@ public class ProcessTaskFinalizerTests
         await _processTaskFinalizer.Finalize(instance.Process.CurrentTask.ElementId, instance);
 
         // Assert
-        _appMetadataMock.Verify(x => x.GetApplicationMetadata(), Times.Once);
+        // Called once in Finalize and once in CachedInstanceDataAccessor.UpdateInstanceData
+        _appMetadataMock.Verify(x => x.GetApplicationMetadata(), Times.Exactly(2));
     }
 }


### PR DESCRIPTION
A fix that allows instantiation of `CachedInstanceDataAccessor` when the instance hasn't been created yet. The purpose of this is to allow a `IProcessExclusiveGateway` implementation to run directly after the start event.

## Description

The problem initially was that the app and org was derived from `instance.AppId`, but because the instance was not created yet, a null reference exception was thrown when trying to Split on it. 

Because `CachedInstanceDataAccessor` already had a dependency on `IAppMetadata`, I changed to using that instead.

I was thinking about changing the signature of `CachedInstanceDataAccessor.ctor` to accept the `ApplicationMetadata` directly instead of the `IAppMetadata`. This is because `IAppMetadata` is used only to retrieve the `ApplicationMetadata` through `IAppMetadata.GetApplicationMetadata` anyways. If this seems like a reasonable change, I can make a new commit with this change. One of the reasons I was thinking about this is because of how the verification in `ProcessTaskFinalizerTests.cs` is done. That test probably shouldn't need to know that `IAppMetadata.GetApplicationMetadata` is invoked inside `CachedInstanceDataAccessor`(?).

Another issue that arised was that the `instance.Id` will be null in this case. A null check sufficed to allow the creation of `CachedInstanceDataAccessor` regardless.

Finally, I couldn't find any test class where the `CachedInstanceDataAccessor` is  tested itself. Do you want me to write a test for this fix, and if so, where should I put it?

## Related Issue(s)
N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
