### PR TITLE
Remove unused property on DataPatchResult

### DIFF
--- a/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
+++ b/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
@@ -1,4 +1,3 @@
-using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
@@ -19,11 +18,6 @@ public class DataPatchResult
     /// The validation issues that were found during the patch operation.
     /// </summary>
     public required List<ValidationSourcePair> ValidationIssues { get; init; }
-
-    /// <summary>
-    /// The current data model after the patch operation.
-    /// </summary>
-    public required List<DataElementChange> ChangedDataElements { get; init; }
 
     /// <summary>
     /// Get updated data elements that have app logic in a dictionary with the data element id as key.

--- a/src/Altinn.App.Core/Internal/Patch/PatchService.cs
+++ b/src/Altinn.App.Core/Internal/Patch/PatchService.cs
@@ -197,7 +197,6 @@ internal class PatchService : IPatchService
         return new DataPatchResult
         {
             Instance = instance,
-            ChangedDataElements = changes,
             UpdatedData = updatedData,
             ValidationIssues = validationIssues,
         };

--- a/test/Altinn.App.Core.Tests/Internal/Patch/PatchServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Patch/PatchServiceTests.cs
@@ -174,13 +174,13 @@ public sealed class PatchServiceTests : IDisposable
         response.Ok.Should().NotBeNull();
         var res = response.Ok!;
         var change = res
-            .ChangedDataElements.Should()
+            .UpdatedData.Should()
             .ContainSingle()
             .Which.Should()
-            .BeOfType<DataElementChange>()
+            .BeOfType<DataPatchResult.DataModelPair>()
             .Which;
-        change.DataElement.Id.Should().Be(_dataGuid.ToString());
-        change.CurrentFormData.Should().BeOfType<MyModel>().Subject.Name.Should().Be("Test Testesen");
+        change.Identifier.Id.Should().Be(_dataGuid.ToString());
+        change.Data.Should().BeOfType<MyModel>().Subject.Name.Should().Be("Test Testesen");
         var validator = res.ValidationIssues.Should().ContainSingle().Which;
         validator.Source.Should().Be("formDataValidator");
         var issue = validator.Issues.Should().ContainSingle().Which;


### PR DESCRIPTION
Somehow I ended up storing the same information in two properties, which does not make much sense.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
