### PR TITLE
Implement IInstanceDataMutator.AbandonAllChanges

### DIFF
--- a/src/Altinn.App.Api/Controllers/ActionsController.cs
+++ b/src/Altinn.App.Api/Controllers/ActionsController.cs
@@ -172,6 +172,13 @@ public class ActionsController : ControllerBase
             );
         }
 
+        if (dataMutator.AbandonIssues.Count > 0)
+        {
+            throw new NotImplementedException(
+                "return an error response from UserActions instead of abandoning the dataMutator"
+            );
+        }
+
         var changes = dataMutator.GetDataElementChanges(initializeAltinnRowId: true);
 
         await dataMutator.UpdateInstanceData(changes);

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -297,11 +297,60 @@ public class DataController : ControllerBase
             }
             else
             {
-                var createBinaryResult = await CreateBinaryData(dataMutator, dataType);
-                if (!createBinaryResult.Success)
+                (bool validationRestrictionSuccess, List<ValidationIssue> errors) =
+                    DataRestrictionValidation.CompliesWithDataRestrictions(Request, dataType);
+
+                if (!validationRestrictionSuccess)
                 {
-                    return createBinaryResult.Error;
+                    var issuesWithSource = errors
+                        .Select(e => ValidationIssueWithSource.FromIssue(e, "DataRestrictionValidation", false))
+                        .ToList();
+                    return new DataPostErrorResponse("Common checks failed", issuesWithSource);
                 }
+
+                if (Request.ContentType is null)
+                {
+                    return new ProblemDetails()
+                    {
+                        Title = "Missing content type",
+                        Detail = "The request is missing a content type header.",
+                        Status = (int)HttpStatusCode.BadRequest,
+                    };
+                }
+
+                var (bytes, actualLength) = await Request.ReadBodyAsByteArrayAsync(dataType.MaxSize * 1024 * 1024);
+                if (bytes is null)
+                {
+                    return new ProblemDetails()
+                    {
+                        Title = "Request too large",
+                        Detail =
+                            $"The request body is too large. The content length is {actualLength} bytes, which exceeds the limit of {dataType.MaxSize} MB",
+                        Status = (int)HttpStatusCode.RequestEntityTooLarge,
+                    };
+                }
+
+                if (bytes.Length is 0)
+                {
+                    return new ProblemDetails()
+                    {
+                        Title = "Invalid data",
+                        Detail = "Invalid data provided. Error: The file is zero bytes.",
+                        Status = (int)HttpStatusCode.BadRequest,
+                    };
+                }
+
+                bool parseSuccess = Request.Headers.TryGetValue("Content-Disposition", out StringValues headerValues);
+                string? filename = parseSuccess ? DataRestrictionValidation.GetFileNameFromHeader(headerValues) : null;
+
+                var analysisAndValidationProblem = await RunFileAnalysisAndValidation(dataType, bytes, filename);
+                if (analysisAndValidationProblem != null)
+                {
+                    return analysisAndValidationProblem;
+                }
+
+                //schedule the binary data element to be created
+                dataMutator.AddBinaryDataElement(dataType.Id, Request.ContentType, filename, bytes);
             }
 
             var initialChanges = dataMutator.GetDataElementChanges(initializeAltinnRowId: true);
@@ -309,13 +358,6 @@ public class DataController : ControllerBase
             {
                 throw new InvalidOperationException("Expected exactly one change in initialChanges");
             }
-
-            // Mutates initialChanges and to add DataElement Type = Created
-            await dataMutator.UpdateInstanceData(initialChanges);
-
-            var newDataElement =
-                change.DataElement
-                ?? throw new InvalidOperationException("DataElement not set in dataMutator.UpdateInstanceData");
 
             await _patchService.RunDataProcessors(
                 dataMutator,
@@ -346,16 +388,13 @@ public class DataController : ControllerBase
             await saveTask;
             SelfLinkHelper.SetInstanceAppSelfLinks(instance, Request);
 
+            var newDataElement =
+                change.DataElement ?? throw new InvalidOperationException("The change was not updated while saving");
             return new DataPostResponse
             {
                 Instance = instance,
                 NewDataElementId = Guid.Parse(newDataElement.Id),
-                NewDataModels = finalChanges
-                    .FormDataChanges.Select(formDataChange => new DataModelPairResponse(
-                        formDataChange.DataElementIdentifier.Guid,
-                        formDataChange.CurrentFormData
-                    ))
-                    .ToList(),
+                NewDataModels = GetNewDataModels(finalChanges),
                 ValidationIssues = validationIssues,
             };
         }
@@ -370,63 +409,16 @@ public class DataController : ControllerBase
         }
     }
 
-    private async Task<ServiceResult<BinaryDataChange, ProblemDetails>> CreateBinaryData(
-        InstanceDataUnitOfWork dataMutator,
-        DataType dataTypeFromMetadata
-    )
+    private static List<DataModelPairResponse> GetNewDataModels(DataElementChanges finalChanges)
     {
-        (bool validationRestrictionSuccess, List<ValidationIssue> errors) =
-            DataRestrictionValidation.CompliesWithDataRestrictions(Request, dataTypeFromMetadata);
-
-        if (!validationRestrictionSuccess)
-        {
-            var issuesWithSource = errors
-                .Select(e => ValidationIssueWithSource.FromIssue(e, "DataRestrictionValidation", false))
-                .ToList();
-            return new DataPostErrorResponse("Common checks failed", issuesWithSource);
-        }
-
-        if (Request.ContentType is null)
-        {
-            return new ProblemDetails()
-            {
-                Title = "Missing content type",
-                Detail = "The request is missing a content type header.",
-                Status = (int)HttpStatusCode.BadRequest,
-            };
-        }
-
-        var (bytes, actualLength) = await Request.ReadBodyAsByteArrayAsync(dataTypeFromMetadata.MaxSize * 1024 * 1024);
-        if (bytes is null)
-        {
-            return new ProblemDetails()
-            {
-                Title = "Request too large",
-                Detail =
-                    $"The request body is too large. The content length is {actualLength} bytes, which exceeds the limit of {dataTypeFromMetadata.MaxSize} MB",
-                Status = (int)HttpStatusCode.RequestEntityTooLarge,
-            };
-        }
-        if (bytes.Length is 0)
-        {
-            return new ProblemDetails()
-            {
-                Title = "Invalid data",
-                Detail = "Invalid data provided. Error: The file is zero bytes.",
-                Status = (int)HttpStatusCode.BadRequest,
-            };
-        }
-
-        bool parseSuccess = Request.Headers.TryGetValue("Content-Disposition", out StringValues headerValues);
-        string? filename = parseSuccess ? DataRestrictionValidation.GetFileNameFromHeader(headerValues) : null;
-
-        var analysisAndValidationProblem = await RunFileAnalysisAndValidation(dataTypeFromMetadata, bytes, filename);
-        if (analysisAndValidationProblem != null)
-        {
-            return analysisAndValidationProblem;
-        }
-
-        return dataMutator.AddBinaryDataElement(dataTypeFromMetadata.Id, Request.ContentType, filename, bytes);
+        // Return currentFormData for form data changes that are created or updated
+        return finalChanges
+            .FormDataChanges.Where(c => c.Type != ChangeType.Deleted)
+            .Select(formDataChange => new DataModelPairResponse(
+                formDataChange.DataElementIdentifier.Guid,
+                formDataChange.CurrentFormData
+            ))
+            .ToList();
     }
 
     private async Task<ProblemDetails?> RunFileAnalysisAndValidation(
@@ -726,9 +718,7 @@ public class DataController : ControllerBase
                     new DataPatchResponseMultiple()
                     {
                         Instance = res.Ok.Instance,
-                        NewDataModels = res
-                            .Ok.UpdatedData.Select(d => new DataModelPairResponse(d.Identifier.Guid, d.Data))
-                            .ToList(),
+                        NewDataModels = GetNewDataModels(res.Ok.FormDataChanges),
                         ValidationIssues = res.Ok.ValidationIssues
                     }
                 );
@@ -753,16 +743,18 @@ public class DataController : ControllerBase
     /// <param name="instanceOwnerPartyId">unique id of the party that is the owner of the instance</param>
     /// <param name="instanceGuid">unique id to identify the instance</param>
     /// <param name="dataGuid">unique id to identify the data element to update</param>
+    /// <param name="ignoredValidators">comma separated string of validators to ignore</param>
     /// <param name="language">The currently active language</param>
     /// <returns>The updated data element.</returns>
     [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_WRITE)]
     [HttpDelete("{dataGuid:guid}")]
-    public async Task<ActionResult> Delete(
+    public async Task<ActionResult<DataPostResponse>> Delete(
         [FromRoute] string org,
         [FromRoute] string app,
         [FromRoute] int instanceOwnerPartyId,
         [FromRoute] Guid instanceGuid,
         [FromRoute] Guid dataGuid,
+        [FromQuery] string? ignoredValidators = null,
         [FromQuery] string? language = null
     )
     {
@@ -803,7 +795,27 @@ public class DataController : ControllerBase
             await dataMutator.UpdateInstanceData(changes);
             await dataMutator.SaveChanges(changes);
 
-            return Ok();
+            List<ValidationSourcePair> validationIssues = [];
+            if (ignoredValidators is not null)
+            {
+                var ignoredValidatorsList = ignoredValidators.Split(',').Where(v => !string.IsNullOrEmpty(v)).ToList();
+                validationIssues = await _patchService.RunIncrementalValidation(
+                    dataMutator,
+                    instance.Process.CurrentTask.ElementId,
+                    changes,
+                    ignoredValidatorsList,
+                    language
+                );
+            }
+
+            return Ok(
+                new DataDeleteResponse()
+                {
+                    Instance = instance,
+                    ValidationIssues = validationIssues,
+                    NewDataModels = GetNewDataModels(changes),
+                }
+            );
         }
         catch (PlatformHttpException e)
         {

--- a/src/Altinn.App.Api/Models/DataDeleteResponse.cs
+++ b/src/Altinn.App.Api/Models/DataDeleteResponse.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+using Altinn.App.Core.Models.Validation;
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.Api.Models;
+
+/// <summary>
+/// Response object for POST to /org/app/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/data/{dataType}
+/// </summary>
+public class DataDeleteResponse
+{
+    /// <summary>
+    /// The instance with updated data
+    /// </summary>
+    [JsonPropertyName("instance")]
+    public required Instance Instance { get; init; }
+
+    /// <summary>
+    /// List of validation issues that reported to have relevant changes after a new data element was added
+    /// </summary>
+    [JsonPropertyName("validationIssues")]
+    public required List<ValidationSourcePair> ValidationIssues { get; init; }
+
+    /// <summary>
+    /// List of updated DataModels caused by dataProcessing
+    /// </summary>
+    [JsonPropertyName("newDataModels")]
+    public required List<DataModelPairResponse> NewDataModels { get; init; }
+}

--- a/src/Altinn.App.Core/Features/IInstanceDataMutator.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataMutator.cs
@@ -1,4 +1,7 @@
+using Altinn.App.Core.Features.FileAnalysis;
+using Altinn.App.Core.Features.Validation;
 using Altinn.App.Core.Models;
+using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Features;
@@ -59,4 +62,12 @@ public interface IInstanceDataMutator : IInstanceDataAccessor
     /// Actual removal from storage is not done until the instance is saved.
     /// </summary>
     void RemoveDataElement(DataElementIdentifier dataElementIdentifier);
+
+    /// <summary>
+    /// Stop processing the request with current changes and return a BadRequest with the following issues
+    /// This is intended to be an alternative to a <see cref="IFileAnalyser"/> <see cref="IFileValidator"/>
+    /// pair to ensure that new binary data is not saved if the data is not valid.
+    /// </summary>
+    /// <param name="validationIssues"></param>
+    void AbandonAllChanges(IEnumerable<ValidationIssue> validationIssues);
 }

--- a/src/Altinn.App.Core/Internal/Patch/DataPatchError.cs
+++ b/src/Altinn.App.Core/Internal/Patch/DataPatchError.cs
@@ -1,3 +1,5 @@
+using Altinn.App.Core.Features;
+
 namespace Altinn.App.Core.Internal.Patch;
 
 /// <summary>
@@ -40,4 +42,9 @@ public enum DataPatchErrorType
     /// The patch operation lead to an invalid data model.
     /// </summary>
     DeserializationFailed,
+
+    /// <summary>
+    /// The request was abandoned using <see cref="IInstanceDataMutator.AbandonAllChanges"/>
+    /// </summary>
+    AbandonedRequest,
 }

--- a/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
+++ b/src/Altinn.App.Core/Internal/Patch/DataPatchResult.cs
@@ -22,7 +22,7 @@ public class DataPatchResult
     /// <summary>
     /// Get updated data elements that have app logic in a dictionary with the data element id as key.
     /// </summary>
-    public required List<DataModelPair> UpdatedData { get; init; }
+    public required DataElementChanges FormDataChanges { get; init; }
 
     /// <summary>
     /// Store a pair with Id and Data

--- a/src/Altinn.App.Core/Internal/Patch/PatchService.cs
+++ b/src/Altinn.App.Core/Internal/Patch/PatchService.cs
@@ -179,34 +179,32 @@ internal class PatchService : IPatchService
             dataAccessor.VerifyDataElementsUnchangedSincePreviousChanges(changes);
         }
 
-        // report back updated and created data elements with appLogic
-        var updatedData = changes
-            .FormDataChanges.Where(change => change.Type is ChangeType.Updated or ChangeType.Created)
-            .Select(change => new DataPatchResult.DataModelPair(
-                change.DataElement
-                    ?? throw new InvalidOperationException(
-                        "DataElement must be set in data changes of type update or created"
-                    ),
-                change.CurrentFormData
-            ))
-            .ToList();
+        var formDataChanges = changes.FormDataChanges.ToList();
 
         // Ensure that all data elements that were patched are included in the updated data
         // (even if they were not changed or the change was reverted by dataProcessor)
         foreach (var patchedElementGuid in patches.Keys)
         {
             var patchedElementId = patchedElementGuid.ToString();
-            if (changes.FormDataChanges.All(c => c.DataElement?.Id != patchedElementId))
+            if (formDataChanges.TrueForAll(c => c.DataElement?.Id != patchedElementId))
             {
-                DataElementIdentifier? dataElement = instance.Data.Find(d => d.Id == patchedElementId);
+                // The element from the patch was not included in the changes, so add it
+                var dataElement = instance.Data.Find(d => d.Id == patchedElementId);
                 if (dataElement is not null)
                 {
-                    // Don't return deleted data elements
-                    updatedData.Add(
-                        new DataPatchResult.DataModelPair(
-                            dataElement.Value,
-                            await dataAccessor.GetFormData(dataElement.Value)
-                        )
+                    // Create a change with the current data of the unchanged element
+                    formDataChanges.Add(
+                        new FormDataChange
+                        {
+                            Type = ChangeType.Updated,
+                            DataElement = dataElement,
+                            ContentType = dataElement.ContentType,
+                            DataType = dataAccessor.GetDataType(dataElement),
+                            PreviousFormData = await dataAccessor.GetFormData(dataElement),
+                            CurrentFormData = await dataAccessor.GetFormData(dataElement),
+                            PreviousBinaryData = await dataAccessor.GetBinaryData(dataElement),
+                            CurrentBinaryData = await dataAccessor.GetBinaryData(dataElement),
+                        }
                     );
                 }
             }
@@ -215,7 +213,7 @@ internal class PatchService : IPatchService
         return new DataPatchResult
         {
             Instance = instance,
-            UpdatedData = updatedData,
+            FormDataChanges = new DataElementChanges(formDataChanges),
             ValidationIssues = validationIssues,
         };
     }

--- a/src/Altinn.App.Core/Internal/Patch/PatchService.cs
+++ b/src/Altinn.App.Core/Internal/Patch/PatchService.cs
@@ -155,6 +155,20 @@ internal class PatchService : IPatchService
             language
         );
 
+        if (dataAccessor.AbandonIssues.Count > 0)
+        {
+            return new DataPatchError()
+            {
+                Title = "Data processors abandoned the patch",
+                Detail = "Data processors abandoned the patch",
+                ErrorType = DataPatchErrorType.AbandonedRequest,
+                Extensions = new Dictionary<string, object?>()
+                {
+                    { "uploadValidationIssues", dataAccessor.AbandonIssues },
+                } // use same key as in DataPostErrorResponse
+            };
+        }
+
         // Get all changes to data elements by comparing the serialized values
         var changes = dataAccessor.GetDataElementChanges(initializeAltinnRowId: true);
         // Start saving changes in parallel with validation

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
@@ -195,6 +195,13 @@ public class ProcessEngine : IProcessEngine
             return result;
         }
 
+        if (cachedDataMutator.AbandonIssues.Count > 0)
+        {
+            throw new Exception(
+                "Abandon issues found in data elements. Abandon issues should be handled by the action handler."
+            );
+        }
+
         var changes = cachedDataMutator.GetDataElementChanges(initializeAltinnRowId: false);
         await cachedDataMutator.UpdateInstanceData(changes);
         await cachedDataMutator.SaveChanges(changes);

--- a/src/Altinn.App.Core/Models/DataElementChanges.cs
+++ b/src/Altinn.App.Core/Models/DataElementChanges.cs
@@ -25,7 +25,7 @@ public sealed class DataElementChanges
     /// <summary>
     /// Get changes to attachments elements
     /// </summary>
-    public IEnumerable<BinaryDataChange> BinaryChanges => AllChanges.OfType<BinaryDataChange>();
+    public IEnumerable<BinaryDataChange> BinaryDataChanges => AllChanges.OfType<BinaryDataChange>();
 }
 
 /// <summary>

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -254,6 +254,7 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
             .ContainSingle(p => p.Source == "Required")
             .Which.Issues.Should()
             .BeEmpty();
+        parsedResponse.Instance.Data.Should().ContainSingle(d => d.DataType == prefillDataType);
 
         parsedResponse.NewDataModels.Should().HaveCount(2);
         var newData = parsedResponse

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -1354,6 +1354,13 @@
             }
           },
           {
+            "name": "ignoredValidators",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "language",
             "in": "query",
             "schema": {
@@ -1363,7 +1370,24 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataPostResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataPostResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataPostResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -825,6 +825,10 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: ignoredValidators
+          in: query
+          schema:
+            type: string
         - name: language
           in: query
           schema:
@@ -832,6 +836,16 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/DataPostResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataPostResponse'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/DataPostResponse'
   '/{org}/{app}/api/datalists/{id}':
     get:
       tags:

--- a/test/Altinn.App.Core.Tests/Internal/Patch/PatchServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Patch/PatchServiceTests.cs
@@ -47,7 +47,6 @@ public sealed class PatchServiceTests : IDisposable
     private readonly Mock<IDataProcessor> _dataProcessorMock = new(MockBehavior.Strict);
     private readonly Mock<IAppModel> _appModelMock = new(MockBehavior.Strict);
     private readonly Mock<IAppMetadata> _appMetadataMock = new(MockBehavior.Strict);
-    private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock = new(MockBehavior.Strict);
     private readonly TelemetrySink _telemetrySink = new();
     private readonly Mock<IWebHostEnvironment> _webHostEnvironment = new(MockBehavior.Strict);
 

--- a/test/Altinn.App.Core.Tests/Internal/Patch/PatchServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Patch/PatchServiceTests.cs
@@ -173,14 +173,9 @@ public sealed class PatchServiceTests : IDisposable
         response.Success.Should().BeTrue();
         response.Ok.Should().NotBeNull();
         var res = response.Ok!;
-        var change = res
-            .UpdatedData.Should()
-            .ContainSingle()
-            .Which.Should()
-            .BeOfType<DataPatchResult.DataModelPair>()
-            .Which;
-        change.Identifier.Id.Should().Be(_dataGuid.ToString());
-        change.Data.Should().BeOfType<MyModel>().Subject.Name.Should().Be("Test Testesen");
+        var change = res.FormDataChanges.FormDataChanges.Should().ContainSingle().Which;
+        change.DataElementIdentifier.Id.Should().Be(_dataGuid.ToString());
+        change.CurrentFormData.Should().BeOfType<MyModel>().Subject.Name.Should().Be("Test Testesen");
         var validator = res.ValidationIssues.Should().ContainSingle().Which;
         validator.Source.Should().Be("formDataValidator");
         var issue = validator.Issues.Should().ContainSingle().Which;


### PR DESCRIPTION
This enables IDataWriteProcessor to signal that the current change set is bad, and should be ignored, with a list of errors that can be shown to the user.

```C#
public class DataWriteProcessor : IDataWriteProcessor
{
    public Task ProcessDataWrite(
        IInstanceDataMutator instanceDataMutator,
        string taskId,
        DataElementChanges changes,
        string? language
    )
    {
        var fileDataChanges = changes.BinaryDataChanges.Where(d => d.DataType.Id == "file").ToArray();
        if (fileDataChanges is [var fileDataChange])
        {
            if (fileDataChange.FileName == "newFileName")
            {
                instanceDataMutator.AbandonAllChanges(
                    [new() { Severity = ValidationIssueSeverity.Error, Description = "hello, this is strange" }]
                );
            }
        }

        return Task.CompletedTask;
    }
}
```

This also fixes a bug where POST data element (used to create subform instances) created duplicates.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
