### PR TITLE
Send language to IUserAction's when running process/next

### DIFF
--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -370,7 +370,8 @@ public class ProcessController : ControllerBase
             {
                 Instance = instance,
                 User = User,
-                Action = checkedAction
+                Action = checkedAction,
+                Language = language
             };
             var validationProblem = await GetValidationProblemDetails(instance, currentTaskId, language);
             if (validationProblem is not null)
@@ -546,7 +547,8 @@ public class ProcessController : ControllerBase
                 {
                     Instance = instance,
                     User = User,
-                    Action = altinnTaskType
+                    Action = altinnTaskType,
+                    Language = language,
                 };
                 var result = await _processEngine.Next(request);
 

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
@@ -181,7 +181,9 @@ public class ProcessEngine : IProcessEngine
 
         UserActionResult actionResult = actionHandler is null
             ? UserActionResult.SuccessResult()
-            : await actionHandler.HandleAction(new UserActionContext(cachedDataMutator, userId));
+            : await actionHandler.HandleAction(
+                new UserActionContext(cachedDataMutator, userId, language: request.Language)
+            );
 
         if (actionResult.ResultType != ResultType.Success)
         {

--- a/src/Altinn.App.Core/Models/Process/ProcessNextRequest.cs
+++ b/src/Altinn.App.Core/Models/Process/ProcessNextRequest.cs
@@ -8,21 +8,23 @@ namespace Altinn.App.Core.Models.Process;
 /// </summary>
 public class ProcessNextRequest
 {
-#nullable disable
     /// <summary>
     /// The instance to be moved to the next task
     /// </summary>
-    public Instance Instance { get; set; }
+    public required Instance Instance { get; init; }
 
     /// <summary>
     /// The user that is performing the action
     /// </summary>
-    public ClaimsPrincipal User { get; set; }
-
-#nullable restore
+    public required ClaimsPrincipal User { get; init; }
 
     /// <summary>
     /// The action that is performed
     /// </summary>
-    public string? Action { get; set; }
+    public required string? Action { get; init; }
+
+    /// <summary>
+    /// The language the user sent with process/next (not required)
+    /// </summary>
+    public required string? Language { get; init; }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -369,7 +369,13 @@ public sealed class ProcessEngineTest : IDisposable
             AppId = "org/app",
             Process = null
         };
-        ProcessNextRequest processNextRequest = new ProcessNextRequest() { Instance = instance };
+        ProcessNextRequest processNextRequest = new ProcessNextRequest()
+        {
+            Instance = instance,
+            Action = null,
+            User = null!,
+            Language = null
+        };
         ProcessChangeResult result = await processEngine.Next(processNextRequest);
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().Be("Instance does not have current task information!");
@@ -386,7 +392,13 @@ public sealed class ProcessEngineTest : IDisposable
             AppId = "org/app",
             Process = new ProcessState() { CurrentTask = null }
         };
-        ProcessNextRequest processNextRequest = new ProcessNextRequest() { Instance = instance };
+        ProcessNextRequest processNextRequest = new ProcessNextRequest()
+        {
+            Instance = instance,
+            User = null!,
+            Action = null,
+            Language = null
+        };
         ProcessChangeResult result = await processEngine.Next(processNextRequest);
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().Be("Instance does not have current task information!");
@@ -448,7 +460,8 @@ public sealed class ProcessEngineTest : IDisposable
         {
             Instance = instance,
             User = user,
-            Action = "sign"
+            Action = "sign",
+            Language = null
         };
         ProcessChangeResult result = await processEngine.Next(processNextRequest);
         result.Success.Should().BeFalse();
@@ -510,7 +523,13 @@ public sealed class ProcessEngineTest : IDisposable
                     }
                 )
             );
-        ProcessNextRequest processNextRequest = new ProcessNextRequest() { Instance = instance, User = user };
+        ProcessNextRequest processNextRequest = new ProcessNextRequest()
+        {
+            Instance = instance,
+            User = user,
+            Action = null,
+            Language = null
+        };
         ProcessChangeResult result = await processEngine.Next(processNextRequest);
         _processReaderMock.Verify(r => r.IsProcessTask("Task_1"), Times.Once);
         _processReaderMock.Verify(r => r.IsEndEvent("Task_2"), Times.Once);
@@ -662,7 +681,8 @@ public sealed class ProcessEngineTest : IDisposable
         {
             Instance = instance,
             User = user,
-            Action = "reject"
+            Action = "reject",
+            Language = null
         };
         ProcessChangeResult result = await processEngine.Next(processNextRequest);
         _processReaderMock.Verify(r => r.IsProcessTask("Task_1"), Times.Once);
@@ -800,7 +820,13 @@ public sealed class ProcessEngineTest : IDisposable
                     }
                 )
             );
-        ProcessNextRequest processNextRequest = new ProcessNextRequest() { Instance = instance, User = user };
+        ProcessNextRequest processNextRequest = new ProcessNextRequest()
+        {
+            Instance = instance,
+            User = user,
+            Action = null,
+            Language = null
+        };
         ProcessChangeResult result = await processEngine.Next(processNextRequest);
         _processReaderMock.Verify(r => r.IsProcessTask("Task_2"), Times.Once);
         _processReaderMock.Verify(r => r.IsEndEvent("EndEvent_1"), Times.Once);


### PR DESCRIPTION
Reported as a bug on slack https://altinn.slack.com/archives/C02EJ9HKQA3/p1730288654465039 @violaguttorm 

Previously we only sendt language to `IUserAction` implementations when triggering an action from a specific url, not as part of process/next. Seems like an obvious oversight.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
