### PR TITLE
Associate releases with GitHub environments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -152,3 +152,7 @@ dotnet_diagnostic.CA1816.severity = warning
 [Program.cs]
 dotnet_diagnostic.CA1050.severity = none
 dotnet_diagnostic.S1118.severity = none
+
+[*.{yml,yaml}]
+indent_size = 2
+end_of_line = lf

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,12 @@ jobs:
   release-nugets:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    environment: |-
+      ${{
+         contains(github.event.release.tag_name, 'preview') && 'test'
+      || contains(github.event.release.tag_name, 'rc')      && 'staging'
+      ||                                                       'prod'
+      }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

For the DORA metrics initiative, we will use the following environments
* `test` (aka AT)
* `staging` (aka TT02)
* `prod`

In our case we should map previews to `test`, RC releases to `staging` and stable releases to `prod`

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
