### PR TITLE
Use presence of org in user claims for conditionally setting read status on instance create

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -905,9 +905,9 @@ public class InstancesController : ControllerBase
 
     private void ConditionallySetReadStatus(Instance instance)
     {
-        string? orgClaimValue = User.GetOrg();
+        var isInstantiatedByOrg = User.GetOrg() is not null;
 
-        if (orgClaimValue == instance.Org)
+        if (isInstantiatedByOrg)
         {
             // Default value for ReadStatus is "not read"
             return;


### PR DESCRIPTION
## Description
Uses the presence of org in user claim to conditionally set created instance to read or unread. The problem this tries to solve is when the instance is created by a different org than owns the instance. This is the case for Digital Gravferdsmelding. This project uses Digdir as Maskinporten-tenant, but the apps are owned by Statsforvalteren i Vestfold og Telemark (sfvt).

## Related Issue(s)
N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
