### PR TITLE
Update workflows to run on all Pull Requests

### DIFF
--- a/.github/workflows/check-label-added.yml
+++ b/.github/workflows/check-label-added.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           script: |
             const labels = context.payload.pull_request.labels;
-            const releaseLabels = ["ignore-for-release", "breaking-change", "feature", "bugfix"];
+            const releaseLabels = ["ignore-for-release", "breaking-change", "feature", "bugfix", "dependency"];
             if(!releaseLabels.some(r=>labels.some(l=>l.name == r))){
                 core.setFailed(`The PR must have at least one of these labels: ${releaseLabels}`)
             }

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -2,8 +2,6 @@ name: Verify dotnet format
 
 on:
   pull_request:
-    branches:
-      - "main"
 
 jobs:
   verify-no-changes:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1,12 +1,6 @@
 name: Build and Test on windows, macos and ubuntu
 on:
-  push:
-    branches:
-      - "main"
   pull_request:
-    branches:
-      - "main"
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
 jobs:
   analyze:

--- a/.github/workflows/test-and-analyze-fork.yml
+++ b/.github/workflows/test-and-analyze-fork.yml
@@ -1,9 +1,6 @@
 name: Code test and analysis (fork)
 on:
   pull_request:
-    branches:
-      - "main"
-    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   test:
     if: github.repository_owner == 'Altinn' && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)

--- a/.github/workflows/test-and-analyze.yml
+++ b/.github/workflows/test-and-analyze.yml
@@ -1,12 +1,6 @@
 name: Code test and analysis
 on:
-  push:
-    branches:
-      - "main"
   pull_request:
-    branches:
-      - "main"
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
 jobs:
   analyze:


### PR DESCRIPTION
It seems to me like the simple definition (without `types:`)
```
on:
    pull_request:
````
typically matches our expectation of when a job should run, and these should run on all branches.

Also add "dependency" as an acceptable label for release notes

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
