### PR TITLE
Enable scope validation in api tests

### DIFF
--- a/test/Altinn.App.Api.Tests/Controllers/Conventions/EnumSerializationTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/Conventions/EnumSerializationTests.cs
@@ -50,8 +50,8 @@ public class EnumSerializationTests : ApiTestBase, IClassFixture<WebApplicationF
                     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
                 });
 
-            services.AddScoped(_ => _authorizationClientMock.Object);
-            services.AddScoped(_ => _appMetadataMock.Object);
+            services.AddSingleton(_authorizationClientMock.Object);
+            services.AddSingleton(_appMetadataMock.Object);
         };
     }
 

--- a/test/Altinn.App.Api.Tests/Program.cs
+++ b/test/Altinn.App.Api.Tests/Program.cs
@@ -36,7 +36,14 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(
     {
         ApplicationName = "Altinn.App.Api.Tests",
         WebRootPath = Path.Join(TestData.GetTestDataRootDirectory(), "apps", "tdd", "contributer-restriction"),
-        EnvironmentName = "Production",
+        EnvironmentName = "Production"
+    }
+);
+builder.WebHost.UseDefaultServiceProvider(
+    (context, options) =>
+    {
+        options.ValidateScopes = true; // Allways validate scopes in test
+        options.ValidateOnBuild = true;
     }
 );
 


### PR DESCRIPTION
When we started running tests with hostEnvironment == Production we disabled scope validation, wich is probably a nice thing to have.


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
