### PR TITLE
Use extension methods instead of properties for convenience methods on IInstantanceDataAccessor

### DIFF
--- a/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
@@ -14,22 +14,6 @@ public interface IInstanceDataAccessor
     Instance Instance { get; }
 
     /// <summary>
-    /// The data elements on the instance.
-    /// </summary>
-    IEnumerable<DataElement> DataElements => Instance.Data;
-
-    /// <summary>
-    /// Data elements of the instance that has appLogic (form data elements).
-    /// </summary>
-    IEnumerable<DataElement> FormDataElements =>
-        Instance.Data.Where(d => GetDataType(d).AppLogic?.ClassRef is not null);
-
-    /// <summary>
-    /// Data elements of the instance that represents attachments/binary data (no appLogic).
-    /// </summary>
-    IEnumerable<DataElement> BinaryDataElements => Instance.Data.Where(d => GetDataType(d).AppLogic?.ClassRef is null);
-
-    /// <summary>
     /// Get the actual data represented in the data element.
     /// </summary>
     /// <returns>The deserialized data model for this data element or an exception for non-form data elements</returns>
@@ -50,8 +34,143 @@ public interface IInstanceDataAccessor
     DataElement GetDataElement(DataElementIdentifier dataElementIdentifier);
 
     /// <summary>
+    /// Get the data type from application with the given type.
+    /// </summary>
+    /// <param name="dataTypeId">DataType.Id (from applicationmetadata.json)</param>
+    /// <returns>The data type (or null if it does not exist)</returns>
+    DataType? GetDataType(string dataTypeId);
+}
+
+/// <summary>
+/// Extension methods for IInstanceDataAccessor to simplify usage.
+/// </summary>
+public static class IInstanceDataAccessorExtensions
+{
+    /// <summary>
     /// Get the dataType of a data element.
     /// </summary>
     /// <throws>Throws an InvalidOperationException if the data element is not found on the instance</throws>
-    DataType GetDataType(DataElementIdentifier dataElementIdentifier);
+    public static DataType GetDataType(
+        this IInstanceDataAccessor dataAccessor,
+        DataElementIdentifier dataElementIdentifier
+    )
+    {
+        var dataElement = dataAccessor.GetDataElement(dataElementIdentifier);
+        var dataType = dataAccessor.GetDataType(dataElement.DataType);
+        if (dataType is null)
+        {
+            throw new InvalidOperationException(
+                $"Data type {dataElement.DataType} not found in applicationmetadata.json"
+            );
+        }
+
+        return dataType;
+    }
+
+    /// <summary>
+    /// Get the actual data represented in the data element (cast into T).
+    /// </summary>
+    /// <returns>The deserialized data model for this data element or an exception for non-form data elements</returns>
+    public static async Task<T> GetFormData<T>(
+        this IInstanceDataAccessor accessor,
+        DataElementIdentifier dataElementIdentifier
+    )
+        where T : class
+    {
+        object data = await accessor.GetFormData(dataElementIdentifier);
+        if (data is T t)
+        {
+            return t;
+        }
+        throw new InvalidOperationException($"Data element {dataElementIdentifier} is not of type {typeof(T)}");
+    }
+
+    /// <summary>
+    /// Get all elements of a specific data type.
+    /// </summary>
+    public static IEnumerable<DataElement> GetDataElementsForType(
+        this IInstanceDataAccessor accessor,
+        string dataTypeId
+    ) => accessor.Instance.Data.Where(dataElement => dataTypeId.Equals(dataElement.DataType, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Get all elements of a specific data type.
+    /// </summary>
+    public static IEnumerable<DataElement> GetDataElementsForType(
+        this IInstanceDataAccessor accessor,
+        DataType dataType
+    ) => accessor.GetDataElementsForType(dataType.Id);
+
+    /// <summary>
+    /// Retrieves the data elements associated with a specific task.
+    /// </summary>
+    /// <param name="accessor">The instance data accessor.</param>
+    /// <param name="taskId">The identifier of the task.</param>
+    /// <returns>An enumerable collection of tuples containing the data type and data element associated with the specified task.</returns>
+    public static IEnumerable<(DataType dataType, DataElement dataElement)> GetDataElementsForTask(
+        this IInstanceDataAccessor accessor,
+        string taskId
+    )
+    {
+        foreach (var dataElement in accessor.Instance.Data)
+        {
+            var dataType = accessor.GetDataType(dataElement.DataType);
+            if (taskId.Equals(dataType?.TaskId, StringComparison.Ordinal))
+            {
+                yield return (dataType, dataElement);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get all form data elements along with their data types.
+    /// </summary>
+    public static IEnumerable<(DataType dataType, DataElement dataElement)> GetDataElementsWithFormData(
+        this IInstanceDataAccessor accessor
+    )
+    {
+        foreach (var dataElement in accessor.Instance.Data)
+        {
+            var dataType = accessor.GetDataType(dataElement.DataType);
+            if (dataType?.AppLogic?.ClassRef is not null)
+            {
+                yield return (dataType, dataElement);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get all form data elements along with their data types for a specific task.
+    /// </summary>
+    public static IEnumerable<(DataType dataType, DataElement dataElement)> GetDataElementsWithFormDataForTask(
+        this IInstanceDataAccessor accessor,
+        string taskId
+    )
+    {
+        foreach (var dataElement in accessor.Instance.Data)
+        {
+            var dataType = accessor.GetDataType(dataElement.DataType);
+            if (dataType?.AppLogic?.ClassRef is not null && taskId.Equals(dataType.TaskId, StringComparison.Ordinal))
+            {
+                yield return (dataType, dataElement);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get all data elements along with their data types.
+    /// </summary>
+    public static IEnumerable<(DataType dataType, DataElement dataElement)> GetDataElements(
+        this IInstanceDataAccessor accessor
+    )
+    {
+        foreach (var dataElement in accessor.Instance.Data)
+        {
+            var dataType = accessor.GetDataType(dataElement.DataType);
+            if (dataType is not null)
+            {
+                yield return (dataType, dataElement);
+            }
+        }
+    }
 }

--- a/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
@@ -54,12 +54,11 @@ public class ExpressionValidator : IValidator
     public bool ShouldRunForTask(string taskId) =>
         _appMetadata
             .GetApplicationMetadata()
-            .Result.DataTypes.Where(dt =>
+            .Result.DataTypes.Exists(dt =>
                 dt.TaskId == taskId
                 && dt.AppLogic?.ClassRef is not null
                 && _appResourceService.GetValidationConfiguration(dt.Id) is not null
-            )
-            .Any();
+            );
 
     /// <summary>
     /// This validator has the code "Expression" and this is known by the frontend, who may request this validator to not run for incremental validation.

--- a/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
@@ -51,7 +51,15 @@ public class ExpressionValidator : IValidator
     /// <summary>
     /// Only run for tasks that specifies a layout set
     /// </summary>
-    public bool ShouldRunForTask(string taskId) => GetDataTypesWithExpressionsForTask(taskId).Any();
+    public bool ShouldRunForTask(string taskId) =>
+        _appMetadata
+            .GetApplicationMetadata()
+            .Result.DataTypes.Where(dt =>
+                dt.TaskId == taskId
+                && dt.AppLogic?.ClassRef is not null
+                && _appResourceService.GetValidationConfiguration(dt.Id) is not null
+            )
+            .Any();
 
     /// <summary>
     /// This validator has the code "Expression" and this is known by the frontend, who may request this validator to not run for incremental validation.
@@ -75,10 +83,10 @@ public class ExpressionValidator : IValidator
     )
     {
         var validationIssues = new List<ValidationIssue>();
-        foreach (var (dataType, validationConfig) in GetDataTypesWithExpressionsForTask(taskId))
+        foreach (var (dataType, dataElement) in dataAccessor.GetDataElementsForTask(taskId))
         {
-            var formDataElementsForTask = dataAccessor.DataElements.Where(d => d.DataType == dataType.Id);
-            foreach (var dataElement in formDataElementsForTask)
+            var validationConfig = _appResourceService.GetValidationConfiguration(dataType.Id);
+            if (!string.IsNullOrEmpty(validationConfig))
             {
                 var issues = await ValidateFormData(dataElement, dataAccessor, validationConfig, taskId, language);
                 validationIssues.AddRange(issues);
@@ -425,20 +433,5 @@ public class ExpressionValidator : IValidator
             }
         }
         return expressionValidations;
-    }
-
-    private IEnumerable<KeyValuePair<DataType, string>> GetDataTypesWithExpressionsForTask(string taskId)
-    {
-        var appMetadata = _appMetadata.GetApplicationMetadata().Result;
-        foreach (
-            var dataType in appMetadata.DataTypes.Where(dt => dt.TaskId == taskId && dt.AppLogic?.ClassRef is not null)
-        )
-        {
-            var validationConfig = _appResourceService.GetValidationConfiguration(dataType.Id);
-            if (validationConfig != null)
-            {
-                yield return KeyValuePair.Create(dataType, validationConfig);
-            }
-        }
     }
 }

--- a/src/Altinn.App.Core/Features/Validation/Wrappers/DataElementValidatorWrapper.cs
+++ b/src/Altinn.App.Core/Features/Validation/Wrappers/DataElementValidatorWrapper.cs
@@ -11,17 +11,11 @@ internal class DataElementValidatorWrapper : IValidator
 {
     private readonly IDataElementValidator _dataElementValidator;
     private readonly string _taskId;
-    private readonly List<DataType> _dataTypes;
 
-    public DataElementValidatorWrapper(
-        IDataElementValidator dataElementValidator,
-        string taskId,
-        List<DataType> dataTypes
-    )
+    public DataElementValidatorWrapper(IDataElementValidator dataElementValidator, string taskId)
     {
         _dataElementValidator = dataElementValidator;
         _taskId = taskId;
-        _dataTypes = dataTypes;
     }
 
     /// <inheritdoc />

--- a/src/Altinn.App.Core/Features/Validation/Wrappers/DataElementValidatorWrapper.cs
+++ b/src/Altinn.App.Core/Features/Validation/Wrappers/DataElementValidatorWrapper.cs
@@ -47,17 +47,10 @@ internal class DataElementValidatorWrapper : IValidator
     {
         var issues = new List<ValidationIssue>();
         var validateAllElements = _dataElementValidator.DataType == "*";
-        foreach (var dataElement in dataAccessor.DataElements)
+        foreach (var (dataType, dataElement) in dataAccessor.GetDataElementsForTask(taskId))
         {
             if (validateAllElements || _dataElementValidator.DataType == dataElement.DataType)
             {
-                var dataType = _dataTypes.Find(d => d.Id == dataElement.DataType);
-                if (dataType is null)
-                {
-                    throw new InvalidOperationException(
-                        $"DataType {dataElement.DataType} not found in dataTypes from applicationmetadata"
-                    );
-                }
                 var dataElementValidationResult = await _dataElementValidator.ValidateDataElement(
                     dataAccessor.Instance,
                     dataElement,

--- a/src/Altinn.App.Core/Features/Validation/Wrappers/FormDataValidatorWrapper.cs
+++ b/src/Altinn.App.Core/Features/Validation/Wrappers/FormDataValidatorWrapper.cs
@@ -36,14 +36,9 @@ internal class FormDataValidatorWrapper : IValidator
     {
         var issues = new List<ValidationIssue>();
         var validateAllElements = _formDataValidator.DataType == "*";
-        foreach (var dataElement in dataAccessor.DataElements)
+        foreach (var (dataType, dataElement) in dataAccessor.GetDataElementsWithFormData())
         {
-            var dataType = dataAccessor.GetDataType(dataElement);
-            if (dataType.AppLogic?.ClassRef == null)
-            {
-                continue;
-            }
-            if (!validateAllElements && _formDataValidator.DataType != dataElement.DataType)
+            if (!validateAllElements && _formDataValidator.DataType != dataType.Id)
             {
                 continue;
             }

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModel.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModel.cs
@@ -17,20 +17,14 @@ public class DataModel
     /// <summary>
     /// Constructor that wraps a POCO data model, and gives extra tool for working with the data
     /// </summary>
-    public DataModel(IInstanceDataAccessor dataAccessor, ApplicationMetadata appMetadata)
+    public DataModel(IInstanceDataAccessor dataAccessor)
     {
         _dataAccessor = dataAccessor;
-        foreach (var dataElement in dataAccessor.DataElements)
+        foreach (var (dataType, dataElement) in dataAccessor.GetDataElementsWithFormData())
         {
-            var dataTypeId = dataElement.DataType;
-            var dataType = appMetadata.DataTypes.Find(d => d.Id == dataTypeId);
-            if (dataType is { MaxCount: 1, AppLogic.ClassRef: not null })
+            if (dataType is { MaxCount: 1 })
             {
                 _dataIdsByType.TryAdd(dataElement.DataType, dataElement);
-            }
-            else
-            {
-                _dataIdsByType.TryAdd(dataElement.Id, null);
             }
         }
     }

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -498,8 +498,8 @@ public class AppResourcesSI : IAppResources
     public string? GetValidationConfiguration(string dataTypeId)
     {
         using var activity = _telemetry?.StartGetValidationConfigurationActivity();
-        string legalPath = $"{_settings.AppBasePath}{_settings.ModelsFolder}";
-        string filename = $"{legalPath}{dataTypeId}.{_settings.ValidationConfigurationFileName}";
+        string legalPath = Path.Join(_settings.AppBasePath, _settings.ModelsFolder);
+        string filename = Path.Join(legalPath, $"{dataTypeId}.{_settings.ValidationConfigurationFileName}");
         PathHelper.EnsureLegalPath(legalPath, filename);
 
         string? filedata = null;

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -29,12 +29,11 @@ public class LayoutEvaluatorState
         IInstanceDataAccessor dataAccessor,
         LayoutModel? componentModel,
         FrontEndSettings frontEndSettings,
-        ApplicationMetadata applicationMetadata,
         string? gatewayAction = null,
         string? language = null
     )
     {
-        _dataModel = new DataModel(dataAccessor, applicationMetadata);
+        _dataModel = new DataModel(dataAccessor);
         _componentModel = componentModel;
         _frontEndSettings = frontEndSettings;
         _instanceContext = dataAccessor.Instance;

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -85,47 +85,7 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
                 );
         }
 
-        public DataType GetDataType(DataElementIdentifier dataElementIdentifier)
-        {
-            var dataElement = GetDataElement(dataElementIdentifier);
-            var dataType = _applicationMetadata.DataTypes.Find(d => d.Id == dataElement.DataType);
-            if (dataType is null)
-            {
-                throw new InvalidOperationException(
-                    $"Data type {dataElement.DataType} not found in applicationmetadata.json"
-                );
-            }
-
-            return dataType;
-        }
-
-        // Not implemented
-        public void AddFormDataElement(string dataType, object model)
-        {
-            throw new NotImplementedException(
-                "The obsolete LayoutEvaluatorStateInitializer.Init method does not support adding data elements"
-            );
-        }
-
-        public void AddAttachmentDataElement(
-            string dataType,
-            string contentType,
-            string? filename,
-            ReadOnlyMemory<byte> data
-        )
-        {
-            throw new NotImplementedException(
-                "The obsolete LayoutEvaluatorStateInitializer.Init method does not support adding data elements"
-            );
-        }
-
-        // Not implemented
-        public void RemoveDataElement(DataElementIdentifier dataElementIdentifier)
-        {
-            throw new NotImplementedException(
-                "The obsolete LayoutEvaluatorStateInitializer.Init method does not support removing data elements"
-            );
-        }
+        public DataType? GetDataType(string dataTypeId) => _applicationMetadata.DataTypes.Find(d => d.Id == dataTypeId);
     }
 
     /// <summary>
@@ -144,11 +104,11 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
         Debug.Assert(dataElement is not null);
         var appMetadata = await _appMetadata.GetApplicationMetadata();
         var dataAccessor = new SingleDataElementAccessor(instance, dataElement, appMetadata, data);
-        return new LayoutEvaluatorState(dataAccessor, layouts, _frontEndSettings, appMetadata, gatewayAction);
+        return new LayoutEvaluatorState(dataAccessor, layouts, _frontEndSettings, gatewayAction);
     }
 
     /// <inheritdoc />
-    public async Task<LayoutEvaluatorState> Init(
+    public Task<LayoutEvaluatorState> Init(
         IInstanceDataAccessor dataAccessor,
         string? taskId,
         string? gatewayAction = null,
@@ -156,8 +116,9 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
     )
     {
         LayoutModel? layouts = taskId is not null ? _appResources.GetLayoutModelForTask(taskId) : null;
-        var appMetadata = await _appMetadata.GetApplicationMetadata();
 
-        return new LayoutEvaluatorState(dataAccessor, layouts, _frontEndSettings, appMetadata, gatewayAction, language);
+        return Task.FromResult(
+            new LayoutEvaluatorState(dataAccessor, layouts, _frontEndSettings, gatewayAction, language)
+        );
     }
 }

--- a/src/Altinn.App.Core/Internal/Validation/IValidatorFactory.cs
+++ b/src/Altinn.App.Core/Internal/Validation/IValidatorFactory.cs
@@ -143,9 +143,7 @@ public class ValidatorFactory : IValidatorFactory
         foreach (var instanceValidator in _instanceValidators)
         {
             validators.Add(new LegacyIInstanceValidatorTaskValidator(_generalSettings, instanceValidator));
-            validators.Add(
-                new LegacyIInstanceValidatorFormDataValidator(_generalSettings, instanceValidator, _appMetadata)
-            );
+            validators.Add(new LegacyIInstanceValidatorFormDataValidator(_generalSettings, instanceValidator));
         }
 
         return validators;

--- a/src/Altinn.App.Core/Internal/Validation/IValidatorFactory.cs
+++ b/src/Altinn.App.Core/Internal/Validation/IValidatorFactory.cs
@@ -132,8 +132,7 @@ public class ValidatorFactory : IValidatorFactory
         var dataTypes = _appMetadata.GetApplicationMetadata().Result.DataTypes;
 
         validators.AddRange(
-            GetDataElementValidators(taskId, dataTypes)
-                .Select(dev => new DataElementValidatorWrapper(dev, taskId, dataTypes))
+            GetDataElementValidators(taskId, dataTypes).Select(dev => new DataElementValidatorWrapper(dev, taskId))
         );
         validators.AddRange(
             GetFormDataValidators(taskId, dataTypes).Select(fdv => new FormDataValidatorWrapper(fdv, taskId))

--- a/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
@@ -580,9 +580,8 @@ public class FillAction : IUserAction
                 );
                 break;
             case "update":
-                var originalDataElement = context.DataMutator.FormDataElements.First(de => de.DataType == "Scheme");
-                var originalData = await context.DataMutator.GetFormData(originalDataElement);
-                var data = (Scheme)originalData;
+                var originalDataElement = context.DataMutator.GetDataElementsForType("Scheme").First();
+                var data = await context.DataMutator.GetFormData<Scheme>(originalDataElement);
 
                 data.TestCustomButtonReadOnlyInput = "Her kommer det data fra backend";
                 break;
@@ -606,7 +605,7 @@ public class FillAction : IUserAction
                 result.AddUpdatedDataModel(dataGuid.ToString(), obsoleteData);
                 return result;
             case "delete":
-                var elementToDelete = context.DataMutator.FormDataElements.First(de => de.DataType == "Scheme");
+                var elementToDelete = context.DataMutator.GetDataElementsForType("Scheme").First();
                 context.DataMutator.RemoveDataElement(elementToDelete);
                 break;
             case "getClientActions":

--- a/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
@@ -580,7 +580,9 @@ public class FillAction : IUserAction
                 );
                 break;
             case "update":
-                var originalDataElement = context.DataMutator.GetDataElementsForType("Scheme").First();
+                var dataType =
+                    context.DataMutator.GetDataType("Scheme") ?? throw new Exception("DataType \"Scheme\" not found");
+                var originalDataElement = context.DataMutator.GetDataElementsForType(dataType).First();
                 var data = await context.DataMutator.GetFormData<Scheme>(originalDataElement);
 
                 data.TestCustomButtonReadOnlyInput = "Her kommer det data fra backend";

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PostTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PostTests.cs
@@ -69,9 +69,10 @@ public class DataController_PostTests : ApiTestBase, IClassFixture<WebApplicatio
             "Task_1",
             async (instanceDataMutator, changes, language) =>
             {
-                var originalDataElement = instanceDataMutator
-                    .DataElements.Should()
-                    .ContainSingle(d => d.Id == _formElementId)
+                var (_, originalDataElement) = instanceDataMutator
+                    .GetDataElements()
+                    .Should()
+                    .ContainSingle(d => d.dataElement.Id == _formElementId)
                     .Which;
                 var postedSkjema = changes
                     .FormDataChanges.Should()
@@ -208,7 +209,7 @@ public class DataController_PostTests : ApiTestBase, IClassFixture<WebApplicatio
                 var data = changes.BinaryDataChanges.Should().ContainSingle().Which;
                 data.CurrentBinaryData.ToArray().Should().BeEquivalentTo(binaryData);
                 instanceDataMutator.AddBinaryDataElement("specificFileType", "application/pdf", "test.pdf", binaryData);
-                var toDelete = instanceDataMutator.DataElements.Should().ContainSingle().Which;
+                var toDelete = instanceDataMutator.Instance.Data.Should().ContainSingle().Which;
                 toDelete.DataType.Should().Be("default");
                 instanceDataMutator.RemoveDataElement(toDelete);
                 await Task.CompletedTask;

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
@@ -5,6 +5,14 @@
       IdFormat: W3C
     },
     {
+      ActivityName: ApplicationMetadata.Service.GetLayoutModel,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C
+    },
+    {
       ActivityName: ApplicationMetadata.Service.GetLayoutSet,
       IdFormat: W3C
     },
@@ -14,6 +22,18 @@
     },
     {
       ActivityName: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
       IdFormat: W3C
     },
     {
@@ -33,15 +53,15 @@
       IdFormat: W3C
     },
     {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSetsForTask,
+      IdFormat: W3C
+    },
+    {
       ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
       IdFormat: W3C
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
-      IdFormat: W3C
-    },
-    {
-      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
+      ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
       IdFormat: W3C
     },
     {
@@ -149,6 +169,21 @@
         },
         {
           validator.type: RequiredLayoutValidator
+        }
+      ],
+      IdFormat: W3C
+    },
+    {
+      ActivityName: Validation.RunValidator,
+      Tags: [
+        {
+          validation.issue_count: 0
+        },
+        {
+          validator.source: Expression
+        },
+        {
+          validator.type: ExpressionValidator
         }
       ],
       IdFormat: W3C

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -5,6 +5,14 @@
       IdFormat: W3C
     },
     {
+      ActivityName: ApplicationMetadata.Service.GetLayoutModel,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C
+    },
+    {
       ActivityName: ApplicationMetadata.Service.GetLayoutSet,
       IdFormat: W3C
     },
@@ -14,6 +22,18 @@
     },
     {
       ActivityName: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
       IdFormat: W3C
     },
     {
@@ -33,6 +53,14 @@
       IdFormat: W3C
     },
     {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSetsForTask,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
+      IdFormat: W3C
+    },
+    {
       ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
       IdFormat: W3C
     },
@@ -42,14 +70,6 @@
     },
     {
       ActivityName: ApplicationMetadata.Service.GetTexts,
-      IdFormat: W3C
-    },
-    {
-      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
-      IdFormat: W3C
-    },
-    {
-      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
       IdFormat: W3C
     },
     {
@@ -279,6 +299,21 @@
         },
         {
           validator.type: RequiredLayoutValidator
+        }
+      ],
+      IdFormat: W3C
+    },
+    {
+      ActivityName: Validation.RunValidator,
+      Tags: [
+        {
+          validation.issue_count: 0
+        },
+        {
+          validator.source: Expression
+        },
+        {
+          validator.type: ExpressionValidator
         }
       ],
       IdFormat: W3C

--- a/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/models/default.validation.json
+++ b/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/models/default.validation.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/validation/validation.schema.v1.json",
+    "validations": {
+        "melding.name": [
+            {
+                "condition": [
+                    "equals",
+                    [
+                        "dataModel",
+                        "melding.name"
+                    ],
+                    "Model"
+                ],
+                "message": "The file must be of type Model"
+            }
+        ]
+    }
+}

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -79,14 +79,14 @@ public class ExpressionValidatorTests
 
         var layout = new LayoutSetComponent(testCase.Layouts.Values.ToList(), "layout", dataType);
         var componentModel = new LayoutModel([layout], null);
-        var evaluatorState = new LayoutEvaluatorState(dataModel, componentModel, _frontendSettings.Value, appMedatada);
+        var evaluatorState = new LayoutEvaluatorState(dataModel, componentModel, _frontendSettings.Value);
         _layoutInitializer
             .Setup(init =>
                 init.Init(It.IsAny<IInstanceDataAccessor>(), "Task_1", It.IsAny<string?>(), It.IsAny<string?>())
             )
             .ReturnsAsync(evaluatorState);
 
-        var dataAccessor = new InstanceDataAccessorFake(instance) { { dataElement, dataModel } };
+        var dataAccessor = new InstanceDataAccessorFake(instance, appMedatada) { { dataElement, dataModel } };
 
         var validationIssues = await _validator.ValidateFormData(
             dataElement,

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/LegacyIValidationFormDataTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/LegacyIValidationFormDataTests.cs
@@ -19,7 +19,6 @@ public class LegacyIValidationFormDataTests
 {
     private readonly LegacyIInstanceValidatorFormDataValidator _validator;
     private readonly Mock<IInstanceValidator> _instanceValidator = new(MockBehavior.Strict);
-    private readonly Mock<IAppMetadata> _appMetadata = new(MockBehavior.Strict);
     private readonly InstanceDataAccessorFake _instanceDataAccessor;
 
     private readonly ApplicationMetadata _applicationMetadata = new ApplicationMetadata("ttd/test")
@@ -45,10 +44,8 @@ public class LegacyIValidationFormDataTests
         var generalSettings = new GeneralSettings();
         _validator = new LegacyIInstanceValidatorFormDataValidator(
             Microsoft.Extensions.Options.Options.Create(generalSettings),
-            _instanceValidator.Object,
-            _appMetadata.Object
+            _instanceValidator.Object
         );
-        _appMetadata.Setup(am => am.GetApplicationMetadata()).ReturnsAsync(_applicationMetadata);
 
         _dataElement = new DataElement() { DataType = "test", Id = _dataId.ToString() };
         _instance = new Instance()

--- a/test/Altinn.App.Core.Tests/Features/Validators/LegacyValidationServiceTests/ValidationServiceOldTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/LegacyValidationServiceTests/ValidationServiceOldTests.cs
@@ -23,7 +23,6 @@ namespace Altinn.App.Core.Tests.Features.Validators.LegacyValidationServiceTests
 public class ValidationServiceOldTests
 {
     private readonly Mock<ILogger<ValidationService>> _loggerMock = new();
-    private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock = new();
     private readonly Mock<IDataClient> _dataClientMock = new(MockBehavior.Strict);
     private readonly Mock<IAppModel> _appModelMock = new(MockBehavior.Strict);
     private readonly Mock<IAppMetadata> _appMetadataMock = new(MockBehavior.Strict);
@@ -74,7 +73,7 @@ public class ValidationServiceOldTests
         var instance = new Instance() { Data = [dataElement] };
         var dataAccessor = new Mock<IInstanceDataAccessor>(MockBehavior.Strict);
         dataAccessor.SetupGet(da => da.Instance).Returns(instance);
-        dataAccessor.SetupGet(da => da.DataElements).Returns(instance.Data);
+        dataAccessor.Setup(da => da.GetDataType(dataType.Id)).Returns(dataType);
 
         List<ValidationIssueWithSource> validationIssues = await validationService.ValidateInstanceAtTask(
             dataAccessor.Object,
@@ -105,7 +104,7 @@ public class ValidationServiceOldTests
 
         var dataAccessorMock = new Mock<IInstanceDataAccessor>(MockBehavior.Strict);
         dataAccessorMock.SetupGet(da => da.Instance).Returns(instance);
-        dataAccessorMock.SetupGet(da => da.DataElements).Returns(instance.Data);
+        dataAccessorMock.Setup(da => da.GetDataType(dataType.Id)).Returns(dataType);
 
         List<ValidationIssueWithSource> validationIssues = await validationService.ValidateInstanceAtTask(
             dataAccessorMock.Object,
@@ -136,7 +135,7 @@ public class ValidationServiceOldTests
         var instance = new Instance() { Data = [dataElement] };
         var dataAccessorMock = new Mock<IInstanceDataAccessor>(MockBehavior.Strict);
         dataAccessorMock.SetupGet(da => da.Instance).Returns(instance);
-        dataAccessorMock.SetupGet(da => da.DataElements).Returns(instance.Data);
+        dataAccessorMock.Setup(da => da.GetDataType(dataType.Id)).Returns(dataType);
 
         List<ValidationIssueWithSource> validationIssues = await validationService.ValidateInstanceAtTask(
             dataAccessorMock.Object,
@@ -187,18 +186,13 @@ public class ValidationServiceOldTests
         const string taskId = "Task_1";
 
         // Mock setup
-        var appMetadata = new ApplicationMetadata("ttd/test-app")
+        var dataType = new DataType
         {
-            DataTypes = new List<DataType>
-            {
-                new DataType
-                {
-                    Id = "data",
-                    TaskId = taskId,
-                    MaxCount = 0,
-                },
-            },
+            Id = "data",
+            TaskId = taskId,
+            MaxCount = 0,
         };
+        var appMetadata = new ApplicationMetadata("ttd/test-app") { DataTypes = [dataType] };
         _appMetadataMock.Setup(a => a.GetApplicationMetadata()).ReturnsAsync(appMetadata);
 
         await using var serviceProvider = _serviceCollection.BuildServiceProvider();
@@ -215,7 +209,7 @@ public class ValidationServiceOldTests
         };
         var dataAccessorMock = new Mock<IInstanceDataAccessor>(MockBehavior.Strict);
         dataAccessorMock.SetupGet(da => da.Instance).Returns(instance);
-        dataAccessorMock.SetupGet(da => da.DataElements).Returns(instance.Data);
+        dataAccessorMock.Setup(da => da.GetDataType(dataType.Id)).Returns(dataType);
 
         var issues = await validationService.ValidateInstanceAtTask(dataAccessorMock.Object, taskId, null, null, null);
         issues.Should().BeEmpty();
@@ -230,18 +224,13 @@ public class ValidationServiceOldTests
         const string taskId = "Task_1";
 
         // Mock setup
-        var appMetadata = new ApplicationMetadata("ttd/test-app")
+        var dataType = new DataType
         {
-            DataTypes = new List<DataType>
-            {
-                new DataType
-                {
-                    Id = "data",
-                    TaskId = taskId,
-                    MaxCount = 1,
-                },
-            },
+            Id = "data",
+            TaskId = taskId,
+            MaxCount = 1,
         };
+        var appMetadata = new ApplicationMetadata("ttd/test-app") { DataTypes = [dataType] };
         _appMetadataMock.Setup(a => a.GetApplicationMetadata()).ReturnsAsync(appMetadata);
 
         await using var serviceProvider = _serviceCollection.BuildServiceProvider();
@@ -269,7 +258,7 @@ public class ValidationServiceOldTests
         };
         var dataAccessorMock = new Mock<IInstanceDataAccessor>(MockBehavior.Strict);
         dataAccessorMock.SetupGet(da => da.Instance).Returns(instance);
-        dataAccessorMock.SetupGet(da => da.DataElements).Returns(instance.Data);
+        dataAccessorMock.Setup(da => da.GetDataType(dataType.Id)).Returns(dataType);
 
         var issues = await validationService.ValidateInstanceAtTask(dataAccessorMock.Object, taskId, null, null, null);
         issues.Should().HaveCount(1);

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestBackendExclusiveFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestBackendExclusiveFunctions.cs
@@ -65,7 +65,6 @@ public class TestBackendExclusiveFunctions
         _output.WriteLine(test.RawJson);
         _output.WriteLine(test.FullPath);
         var dataType = new DataType() { Id = "default" };
-        var appMetadata = new ApplicationMetadata("org/app") { DataTypes = [dataType] };
         var layout = new LayoutSetComponent(test.Layouts!.Values.ToList(), "layout", dataType);
         var componentModel = new LayoutModel([layout], null);
         var state = new LayoutEvaluatorState(
@@ -75,7 +74,6 @@ public class TestBackendExclusiveFunctions
             ),
             componentModel,
             test.FrontEndSettings ?? new(),
-            appMetadata,
             test.GatewayAction,
             test.ProfileSettings?.Language
         );

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestContextList.cs
@@ -71,7 +71,6 @@ public class TestContextList
 
         var instance = new Instance() { Data = [] };
         var dataType = new DataType() { Id = "default" };
-        var appMetadata = new ApplicationMetadata("org/app") { DataTypes = [dataType] };
         var layout = new LayoutSetComponent(test.Layouts.Values.ToList(), "layout", dataType);
         var componentModel = new LayoutModel([layout], null);
         var state = new LayoutEvaluatorState(
@@ -80,8 +79,7 @@ public class TestContextList
                 test.DataModel ?? JsonDocument.Parse("{}").RootElement
             ),
             componentModel,
-            new(),
-            appMetadata
+            new()
         );
 
         test.ParsingException.Should().BeNull("Loading of test failed");

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
@@ -194,8 +194,6 @@ public class TestFunctions
             dataAccessor = DynamicClassBuilder.DataAccessorFromJsonDocument(test.Instance, test.DataModels);
         }
 
-        var appMedatada = new ApplicationMetadata("org/app") { DataTypes = dataTypes };
-
         LayoutModel? componentModel = null;
         if (test.Layouts is not null)
         {
@@ -206,7 +204,6 @@ public class TestFunctions
             dataAccessor,
             componentModel,
             test.FrontEndSettings ?? new FrontEndSettings(),
-            appMedatada,
             test.GatewayAction,
             test.ProfileSettings?.Language
         );

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
@@ -50,8 +50,7 @@ public class TestInvalid
                     test.DataModel ?? JsonDocument.Parse("{}").RootElement
                 ),
                 componentModel,
-                test.FrontEndSettings ?? new(),
-                new ApplicationMetadata("org/app") { DataTypes = [dataType] }
+                test.FrontEndSettings ?? new()
             );
             await ExpressionEvaluator.EvaluateExpression(
                 state,

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/DynamicClassBuilder.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/DynamicClassBuilder.cs
@@ -141,7 +141,7 @@ public class DynamicClassBuilder
     )
     {
         object data = DataObjectFromJsonDocument(doc);
-        var dataAccessor = new InstanceDataAccessorFake(instance) { { dataElement, data } };
+        var dataAccessor = new InstanceDataAccessorFake(instance, applicationMetadata: null) { { dataElement, data } };
         return dataAccessor;
     }
 
@@ -150,7 +150,7 @@ public class DynamicClassBuilder
         List<DataModelAndElement> dataModels
     )
     {
-        var dataAccessor = new InstanceDataAccessorFake(instance);
+        var dataAccessor = new InstanceDataAccessorFake(instance, applicationMetadata: null);
         foreach (var pair in dataModels)
         {
             dataAccessor.Add(pair.DataElement, DataObjectFromJsonDocument(pair.Data));


### PR DESCRIPTION
This is a cleanup effort, because after trying to use `IInstanceDataAccessor`, I wanted some changes.

The main change is to the interface that gets extension methods instead of a few properties with default implementations.

Interface properties with default implementations has a few drawbacks.

* They need to be mocked individually, because Moq does not use the default implementation
* They typically only serve as a starting point for futher filtering using linq. An extension methdod takes an argument (task/dataType) which is easier to understand than a linq .Where filter.

Another benefit is that we encapsulate appMetadata so that user code has even less reason to deal with dataType

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
