### PR TITLE
Revert to using Newtonsoft.Json for parsing instance

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -1,6 +1,6 @@
 using System.Globalization;
 using System.Net;
-using System.Text.Json;
+using System.Text;
 using Altinn.App.Api.Extensions;
 using Altinn.App.Api.Helpers.Patch;
 using Altinn.App.Api.Helpers.RequestHandling;
@@ -71,7 +71,7 @@ public class InstancesController : ControllerBase
     private readonly IHostEnvironment _env;
     private readonly ModelSerializationService _serializationService;
     private readonly InternalPatchService _patchService;
-    private static readonly JsonSerializerOptions _jsonSerializerOptionsWeb = new(JsonSerializerDefaults.Web);
+
     private const long RequestSizeLimit = 2000 * 1024 * 1024;
 
     /// <summary>
@@ -1244,10 +1244,7 @@ public class InstancesController : ControllerBase
                 && instancePart.ContentType.Contains("application/json", StringComparison.Ordinal)
             )
             {
-                return System.Text.Json.JsonSerializer.Deserialize<Instance>(
-                    instancePart.Bytes,
-                    _jsonSerializerOptionsWeb
-                );
+                return JsonConvert.DeserializeObject<Instance>(Encoding.UTF8.GetString(instancePart.Bytes));
             }
         }
 

--- a/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
+++ b/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
@@ -98,10 +98,17 @@ public class ApiTestBase
         }
     }
 
-    public HttpClient GetRootedClient(string org, string app, int userId, int? partyId, int authenticationLevel = 2)
+    public HttpClient GetRootedClient(
+        string org,
+        string app,
+        int userId,
+        int? partyId,
+        int authenticationLevel = 2,
+        string? serviceOwnerOrg = null
+    )
     {
         var client = GetRootedClient(org, app);
-        string token = PrincipalUtil.GetToken(userId, partyId, authenticationLevel);
+        string token = PrincipalUtil.GetToken(userId, partyId, authenticationLevel, org: serviceOwnerOrg);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return client;
     }

--- a/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
@@ -21,26 +21,14 @@ public class InstanceClientMockSi : IInstanceClient
         _httpContextAccessor = httpContextAccessor;
     }
 
-    public Task<Instance> CreateInstance(string org, string app, Instance instanceTemplate)
+    public Task<Instance> CreateInstance(string org, string app, Instance instance)
     {
-        string partyId = instanceTemplate.InstanceOwner.PartyId;
+        string partyId = instance.InstanceOwner.PartyId;
         Guid instanceGuid = Guid.NewGuid();
-
-        Instance instance =
-            new()
-            {
-                Id = $"{partyId}/{instanceGuid}",
-                AppId = $"{org}/{app}",
-                Org = org,
-                InstanceOwner = instanceTemplate.InstanceOwner,
-                Process = instanceTemplate.Process,
-                Data = new List<DataElement>(),
-            };
-
-        if (instanceTemplate.DataValues != null)
-        {
-            instance.DataValues = instanceTemplate.DataValues;
-        }
+        instance.Id = $"{partyId}/{instanceGuid}";
+        instance.AppId = $"{org}/{app}";
+        instance.Org = org;
+        instance.Data = new List<DataElement>();
 
         string instancePath = GetInstancePath(app, org, int.Parse(partyId), instanceGuid);
         string directory =


### PR DESCRIPTION
There was reported inconsistent behaviour when deserializing enums, which would likely be fixed if we add System.Text.Json annotations to Storage.Interfaces

The change was introduced in https://github.com/Altinn/app-lib-dotnet/pull/853, so it makes sense to revert.
https://github.com/Altinn/app-lib-dotnet/commit/6bac8a1264211d29cf964a7195b372ff7ce1e044#diff-509e2ea0fedd1d6a1d2d1c84b39ad128f078c03b225ce39ef5b578614beccbadL1224-R1233

## Related Issue(s)
- reported privately by @chrrust on slack

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
