### PR TITLE
Make vulnerable transitive deps not an error when running in CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup Condition="'$(DOTNET_TREATWARNINGSASERRORS)' == 'true' OR '$(CI)' == 'true'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "8.0.100",
+        "rollForward": "latestFeature",
+        "allowPrerelease": false
+    }
+}


### PR DESCRIPTION
Dotnet 9 (which seems to be installed on some of githubs workers) has enabled checks for transitive vulnerabilities. Blocking PR builds for unrelated vulnerabilities seems wrong to me.

This is also kind of a recommendation from microsoft
> If these warnings are causing restore to fail because you are using TreatWarningsAsErrors, you can add &lt;WarningsNotAsErrors&gt;NU1901;NU1902;NU1903;NU1904&lt;/WarningsNotAsErrors&gt; to allow these codes to remain as warnings.
https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1901-nu1904#solution

I'm somewhat surprised our renovate does not catch and fix these kind of issues.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
