### PR TITLE
Publish release notes to nuget

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,12 +33,17 @@ jobs:
       - name: Install deps
         run: |
           dotnet restore
+      - name: Extract release notes
+        id: extract-notes
+        run: echo "${{ github.event.release.body }}" > RELEASE_NOTES.md
       - name: Build
         run: |
           dotnet build --configuration Release --no-restore -p:Deterministic=true -p:BuildNumber=${{ github.run_number }}
       - name: Pack
         run: |
-          dotnet pack AppLibDotnet.sln --configuration Release --no-restore --no-build -p:Deterministic=true -p:BuildNumber=${{ github.run_number }}
+          dotnet pack AppLibDotnet.sln --configuration Release --no-restore --no-build \
+            -p:Deterministic=true -p:BuildNumber=${{ github.run_number }} \
+            -p:PackageReleaseNotes="$(cat RELEASE_NOTES.md)"
       - name: Versions
         run: |
           dotnet --version


### PR DESCRIPTION
Seems like the correct thing to do when we spend time writing these notes, they should be visible on nuget.org as well

I have tested the changes to the pipeline on my fork https://github.com/ivarne/app-lib-dotnet/actions/runs/11962112985/job/33349764537, and downloaded artefacts to verify that release notes are included.

```xml

<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>Altinn.App.Api</id>
    <version>0.0.0-preview24</version>
    <authors>Altinn Platform Contributors</authors>
    <license type="file">LICENSE</license>
    <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
    <readme>README.md</readme>
    <description>This class library holds all the API controllers used by a standard Altinn 3 App.</description>
    <releaseNotes>## Finally were testing

**Full Changelog**: https://github.com/ivarne/app-lib-dotnet/compare/v0.0.0-preview23...v0.0.0-preview24</releaseNotes>
    <tags>Altinn Studio App Api Controllers</tags>
    <repository type="git" url="https://github.com/Altinn/app-lib-dotnet" commit="fda1a32213957e87c04f0e52799fd96f8c22e6ce" />
```
