### PR TITLE
Second try on publishing github release notes to nuget

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -42,8 +42,7 @@ jobs:
       - name: Pack
         run: |
           dotnet pack AppLibDotnet.sln --configuration Release --no-restore --no-build \
-            -p:Deterministic=true -p:BuildNumber=${{ github.run_number }} \
-            -p:PackageReleaseNotes="$(cat RELEASE_NOTES.md)"
+            -p:Deterministic=true -p:BuildNumber=${{ github.run_number }}
       - name: Versions
         run: |
           dotnet --version

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,6 +12,15 @@
     <None Include="../../LICENSE" Pack="true" PackagePath="/" />
   </ItemGroup>
 
+  <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">
+    <ReadLinesFromFile File="../../RELEASE_NOTES.md">
+      <Output TaskParameter="Lines" ItemName="ReleaseNoteLines" />
+    </ReadLinesFromFile>
+    <PropertyGroup>
+      <PackageReleaseNotes>@(ReleaseNoteLines, '%0a')</PackageReleaseNotes>
+    </PropertyGroup>
+  </Target>
+
   <PropertyGroup>
     <AnalysisMode>Recommended</AnalysisMode>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -23,13 +32,11 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>https://github.com/Altinn/app-lib-dotnet/releases</PackageReleaseNotes>
     <Authors>Altinn Platform Contributors</Authors>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Altinn/app-lib-dotnet</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
This time use a custom MSBuildStep to read the file.

## Related Issue(s)
- first attempt: #921 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
