### PR TITLE
Add link to github view of release notes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Extract release notes
         id: extract-notes
         run: |
-          echo "Relese notes looks best on github: ${{ github.event.release.html_url }}" > RELEASE_NOTES.md
+          echo "Release notes look best on GitHub: ${{ github.event.release.html_url }}" > RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
           echo "${{ github.event.release.body }}" >> RELEASE_NOTES.md
           cat RELEASE_NOTES.md

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,7 +35,11 @@ jobs:
           dotnet restore
       - name: Extract release notes
         id: extract-notes
-        run: echo "${{ github.event.release.body }}" > RELEASE_NOTES.md
+        run: |
+          echo "Relese notes looks best on github: ${{ github.event.release.html_url }}" > RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+          echo "${{ github.event.release.body }}" >> RELEASE_NOTES.md
+          cat RELEASE_NOTES.md
       - name: Build
         run: |
           dotnet build --configuration Release --no-restore -p:Deterministic=true -p:BuildNumber=${{ github.run_number }}


### PR DESCRIPTION
The nuget release notes does not support markdown, so add a link for the best viewing experience.