### PR TITLE
Use 'instanceandevents' endpoint when updating process state, so that process and events are updated in a single transaction

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -335,10 +335,6 @@ public class InstancesController : ControllerBase
 
             // create the instance
             instance = await _instanceClient.CreateInstance(org, app, instanceTemplate);
-            foreach (var instanceEvent in result.ProcessStateChange?.Events ?? [])
-            {
-                instanceEvent.InstanceId = instance.Id;
-            }
         }
         catch (Exception exception)
         {
@@ -570,10 +566,6 @@ public class InstancesController : ControllerBase
             }
 
             instance = await _instanceClient.CreateInstance(org, app, instanceTemplate);
-            foreach (var instanceEvent in processResult.ProcessStateChange?.Events ?? [])
-            {
-                instanceEvent.InstanceId = instance.Id;
-            }
 
             if (isCopyRequest && source is not null)
             {
@@ -691,10 +683,6 @@ public class InstancesController : ControllerBase
         ProcessChangeResult startResult = await _processEngine.GenerateProcessStartEvents(processStartRequest);
 
         targetInstance = await _instanceClient.CreateInstance(org, app, targetInstance);
-        foreach (var instanceEvent in startResult.ProcessStateChange?.Events ?? [])
-        {
-            instanceEvent.InstanceId = targetInstance.Id;
-        }
 
         await CopyDataFromSourceInstance(application, targetInstance, sourceInstance);
 

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -335,6 +335,10 @@ public class InstancesController : ControllerBase
 
             // create the instance
             instance = await _instanceClient.CreateInstance(org, app, instanceTemplate);
+            foreach (var instanceEvent in result.ProcessStateChange?.Events ?? [])
+            {
+                instanceEvent.InstanceId = instance.Id;
+            }
         }
         catch (Exception exception)
         {
@@ -566,6 +570,10 @@ public class InstancesController : ControllerBase
             }
 
             instance = await _instanceClient.CreateInstance(org, app, instanceTemplate);
+            foreach (var instanceEvent in processResult.ProcessStateChange?.Events ?? [])
+            {
+                instanceEvent.InstanceId = instance.Id;
+            }
 
             if (isCopyRequest && source is not null)
             {
@@ -683,6 +691,10 @@ public class InstancesController : ControllerBase
         ProcessChangeResult startResult = await _processEngine.GenerateProcessStartEvents(processStartRequest);
 
         targetInstance = await _instanceClient.CreateInstance(org, app, targetInstance);
+        foreach (var instanceEvent in startResult.ProcessStateChange?.Events ?? [])
+        {
+            instanceEvent.InstanceId = targetInstance.Id;
+        }
 
         await CopyDataFromSourceInstance(application, targetInstance, sourceInstance);
 

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.Instances.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.Instances.cs
@@ -76,10 +76,11 @@ partial class Telemetry
         return activity;
     }
 
-    internal Activity? StartUpdateProcessActivity(Instance instance)
+    internal Activity? StartUpdateProcessActivity(Instance instance, int eventCount = 0)
     {
         var activity = ActivitySource.StartActivity($"{Prefix}.UpdateProcess");
         activity?.SetInstanceId(instance);
+        activity?.SetTag(Labels.InstanceEventsCount, eventCount);
         return activity;
     }
 

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.cs
@@ -127,6 +127,11 @@ public sealed partial class Telemetry : IDisposable
         public static readonly string InstanceGuid = "instance.guid";
 
         /// <summary>
+        /// Label for the guid that identifies the instance.
+        /// </summary>
+        public static readonly string InstanceEventsCount = "instance.events.count";
+
+        /// <summary>
         /// Label for the guid that identifies the data.
         /// </summary>
         public static readonly string DataGuid = "data.guid";

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
@@ -162,6 +162,36 @@ public class InstanceClient : IInstanceClient
         }
     }
 
+    /// <inheritdoc />
+    public async Task<Instance> UpdateProcessAndEvents(Instance instance, List<InstanceEvent> events)
+    {
+        using var activity = _telemetry?.StartUpdateProcessActivity(instance, events.Count);
+        ProcessState processState = instance.Process;
+
+        string apiUrl = $"instances/{instance.Id}/process/instanceandevents";
+        string token = _userTokenProvider.GetUserToken();
+
+        var update = new ProcessStateUpdate { State = processState, Events = events };
+        string updateString = JsonConvert.SerializeObject(update);
+        _logger.LogInformation($"update process state: {updateString}");
+
+        StringContent httpContent = new(updateString, Encoding.UTF8, "application/json");
+        HttpResponseMessage response = await _client.PutAsync(token, apiUrl, httpContent);
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            string instanceData = await response.Content.ReadAsStringAsync();
+            Instance updatedInstance =
+                JsonConvert.DeserializeObject<Instance>(instanceData)
+                ?? throw new Exception("Could not deserialize instance");
+            return updatedInstance;
+        }
+        else
+        {
+            _logger.LogError($"Unable to update instance process with instance id {instance.Id}");
+            throw await PlatformHttpException.CreateAsync(response);
+        }
+    }
+
     /// <inheritdoc/>
     public async Task<Instance> CreateInstance(string org, string app, Instance instanceTemplate)
     {

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/InstanceClient.cs
@@ -168,6 +168,9 @@ public class InstanceClient : IInstanceClient
         using var activity = _telemetry?.StartUpdateProcessActivity(instance, events.Count);
         ProcessState processState = instance.Process;
 
+        foreach (var instanceEvent in events)
+            instanceEvent.InstanceId = instance.Id;
+
         string apiUrl = $"instances/{instance.Id}/process/instanceandevents";
         string token = _userTokenProvider.GetUserToken();
 

--- a/src/Altinn.App.Core/Internal/Instances/IInstanceClient.cs
+++ b/src/Altinn.App.Core/Internal/Instances/IInstanceClient.cs
@@ -30,6 +30,11 @@ public interface IInstanceClient
     Task<Instance> UpdateProcess(Instance instance);
 
     /// <summary>
+    /// Updates the process model of the instance and the instance events and returns the updated instance.
+    /// </summary>
+    Task<Instance> UpdateProcessAndEvents(Instance instance, List<InstanceEvent> events);
+
+    /// <summary>
     /// Creates an instance of an application with no data.
     /// </summary>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>

--- a/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
@@ -116,6 +116,11 @@ public class InstanceClientMockSi : IInstanceClient
         return Task.FromResult(storedInstance);
     }
 
+    public Task<Instance> UpdateProcessAndEvents(Instance instance, List<InstanceEvent> events)
+    {
+        return UpdateProcess(instance);
+    }
+
     private static Instance GetTestInstance(string app, string org, int instanceOwnerId, Guid instanceId)
     {
         string instancePath = GetInstancePath(app, org, instanceOwnerId, instanceId);


### PR DESCRIPTION
## Description
Uses the new endpoint which commits new process state and instance events in one transaction.

The related tests were a little funny. Test names said they were testing more than they actually were, it seems like most of the variation comes from the `AltinnTaskType` thingy. 

## Related Issue(s)
- https://github.com/Altinn/altinn-storage/issues/544

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
