### PR TITLE
Fix double save in multipart requests

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -1187,28 +1187,28 @@ public class InstancesController : ControllerBase
                 _logger.LogInformation("Storing part {partName}", part.Name);
                 dataMutator.AddBinaryDataElement(dataType.Id, part.ContentType, part.FileName, part.Bytes);
             }
-
-            var taskId = instance.Process?.CurrentTask?.ElementId;
-
-            if (taskId is null)
-                throw new InvalidOperationException("There should be a task while initializing data");
-
-            var changes = dataMutator.GetDataElementChanges(initializeAltinnRowId: true);
-            await _patchService.RunDataProcessors(dataMutator, changes, taskId, language);
-
-            if (dataMutator.GetAbandonResponse() is { } abandonResponse)
-            {
-                _logger.LogWarning(
-                    "Data processing failed for one or more data elements, the instance was created, but we try to delete the instance"
-                );
-                return abandonResponse;
-            }
-
-            // Update the changes list if it changed in data processors
-            changes = dataMutator.GetDataElementChanges(initializeAltinnRowId: true);
-            await dataMutator.UpdateInstanceData(changes);
-            await dataMutator.SaveChanges(changes);
         }
+
+        var taskId = instance.Process?.CurrentTask?.ElementId;
+
+        if (taskId is null)
+            throw new InvalidOperationException("There should be a task while initializing data");
+
+        var changes = dataMutator.GetDataElementChanges(initializeAltinnRowId: true);
+        await _patchService.RunDataProcessors(dataMutator, changes, taskId, language);
+
+        if (dataMutator.GetAbandonResponse() is { } abandonResponse)
+        {
+            _logger.LogWarning(
+                "Data processing failed for one or more data elements, the instance was created, but we try to delete the instance"
+            );
+            return abandonResponse;
+        }
+
+        // Update the changes list if it changed in data processors
+        changes = dataMutator.GetDataElementChanges(initializeAltinnRowId: true);
+        await dataMutator.UpdateInstanceData(changes);
+        await dataMutator.SaveChanges(changes);
 
         return null;
     }

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
@@ -69,7 +69,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
                 )
             )
             .Returns(Task.CompletedTask)
-            .Verifiable(Times.Exactly(1));
+            .Verifiable(Times.Exactly(2));
 
         // Create instance
         var createResponse = await client.PostAsync(
@@ -171,7 +171,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
                 )
             )
             .Returns(Task.CompletedTask)
-            .Verifiable(Times.Exactly(1));
+            .Verifiable(Times.Exactly(2));
 
         // Run previous test with different setup
         // Setup test data


### PR DESCRIPTION
8.5 preview versions included this bug where saving was done multiple times which caused there to be created multiple data elements with the same content.

This fixes the issue by moving the saving logic out of the loop of elements to save (which is correct behaviour for DataWriteProcessor), but somewhat changes behaviour in that `IDataWriteProcessor` gets called for all initialisations, also those that have empty change sets.

Review with hidden whitespace 😉

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
