### PR TITLE
Endpoint for fetching current party roles

### DIFF
--- a/src/Altinn.App.Api/Controllers/AuthorizationController.cs
+++ b/src/Altinn.App.Api/Controllers/AuthorizationController.cs
@@ -99,7 +99,7 @@ public class AuthorizationController : Controller
         }
 
         int userId = userContext.UserId;
-        List<Role> roles = await _authorization.GetUserRolesAsync(userId, currentParty.PartyId);
+        IEnumerable<Role> roles = await _authorization.GetUserRolesAsync(userId, currentParty.PartyId);
 
         return Ok(roles);
     }

--- a/src/Altinn.App.Api/Controllers/AuthorizationController.cs
+++ b/src/Altinn.App.Api/Controllers/AuthorizationController.cs
@@ -105,7 +105,7 @@ public class AuthorizationController : Controller
         }
 
         int userId = userContext.UserId;
-        IEnumerable<Role> roles = await _authorization.GetUserRolesAsync(userId, currentParty.PartyId);
+        IEnumerable<Role> roles = await _authorization.GetUserRoles(userId, currentParty.PartyId);
 
         return Ok(roles);
     }

--- a/src/Altinn.App.Api/Controllers/AuthorizationController.cs
+++ b/src/Altinn.App.Api/Controllers/AuthorizationController.cs
@@ -5,6 +5,8 @@ using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Internal.Profile;
 using Altinn.App.Core.Internal.Registers;
 using Altinn.App.Core.Models;
+using Altinn.Platform.Register.Models;
+using Authorization.Platform.Authorization.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -44,57 +46,14 @@ public class AuthorizationController : Controller
     [HttpGet("{org}/{app}/api/authorization/parties/current")]
     public async Task<ActionResult> GetCurrentParty(bool returnPartyObject = false)
     {
-        UserContext userContext = await _userHelper.GetUserContext(HttpContext);
-        int userId = userContext.UserId;
-
-        // If selected party is different than party for user self need to verify
-        if (userContext.UserParty == null || userContext.PartyId != userContext.UserParty.PartyId)
-        {
-            bool? isValid = await _authorization.ValidateSelectedParty(userId, userContext.PartyId);
-
-            if (isValid == true)
-            {
-                if (returnPartyObject)
-                {
-                    return Ok(userContext.Party);
-                }
-
-                return Ok(userContext.PartyId);
-            }
-            else if (userContext.UserParty != null)
-            {
-                userContext.Party = userContext.UserParty;
-                userContext.PartyId = userContext.UserParty.PartyId;
-            }
-            else
-            {
-                userContext.Party = null;
-                userContext.PartyId = 0;
-            }
-        }
-
-        string? cookieValue = Request.Cookies[_settings.GetAltinnPartyCookieName];
-        if (!int.TryParse(cookieValue, out int partyIdFromCookie))
-        {
-            partyIdFromCookie = 0;
-        }
-
-        // Setting cookie to partyID of logged in user if it varies from previus value.
-        if (partyIdFromCookie != userContext.PartyId)
-        {
-            Response.Cookies.Append(
-                _settings.GetAltinnPartyCookieName,
-                userContext.PartyId.ToString(CultureInfo.InvariantCulture),
-                new CookieOptions { Domain = _settings.HostName }
-            );
-        }
+        Party? currentParty = await GetCurrentPartyAsync(HttpContext);
 
         if (returnPartyObject)
         {
-            return Ok(userContext.Party);
+            return Ok(currentParty);
         }
 
-        return Ok(userContext.PartyId);
+        return Ok(currentParty?.PartyId ?? 0);
     }
 
     /// <summary>
@@ -122,5 +81,78 @@ public class AuthorizationController : Controller
         {
             return StatusCode(500, $"Something went wrong when trying to validate party {partyId} for user {userId}");
         }
+    }
+
+    /// <summary>
+    /// Fetches roles for current party.
+    /// </summary>
+    /// <returns>Boolean indicating if the selected party is valid.</returns>
+    [Authorize]
+    [HttpGet("{org}/{app}/api/authorization/roles")]
+    public async Task<IActionResult> FetchRolesForCurrentParty()
+    {
+        Party? currentParty = await GetCurrentPartyAsync(HttpContext);
+        UserContext userContext = await _userHelper.GetUserContext(HttpContext);
+        int userId = userContext.UserId;
+
+        if (currentParty == null)
+        {
+            return BadRequest("Both userId and partyId must be provided.");
+        }
+
+        List<Role> roles = await _authorization.GetUserRolesAsync(userId, currentParty.PartyId);
+
+        // TODO: implement actual logic here using currentParty
+        // For now, return false as before
+        return Ok(roles);
+    }
+
+    /// <summary>
+    /// Helper method to retrieve the current party from the HTTP context.
+    /// </summary>
+    /// <param name="context">The current HttpContext.</param>
+    /// <returns>The current party or null if none could be determined.</returns>
+    private async Task<Party?> GetCurrentPartyAsync(HttpContext context)
+    {
+        UserContext userContext = await _userHelper.GetUserContext(context);
+        int userId = userContext.UserId;
+
+        // If selected party is different than party for user self need to verify
+        if (userContext.UserParty == null || userContext.PartyId != userContext.UserParty.PartyId)
+        {
+            bool? isValid = await _authorization.ValidateSelectedParty(userId, userContext.PartyId);
+            if (isValid != true)
+            {
+                // Not valid, fall back to userParty if available
+                if (userContext.UserParty != null)
+                {
+                    userContext.Party = userContext.UserParty;
+                    userContext.PartyId = userContext.UserParty.PartyId;
+                }
+                else
+                {
+                    userContext.Party = null;
+                    userContext.PartyId = 0;
+                }
+            }
+        }
+
+        // Sync cookie if needed
+        string? cookieValue = Request.Cookies[_settings.GetAltinnPartyCookieName];
+        if (!int.TryParse(cookieValue, out int partyIdFromCookie))
+        {
+            partyIdFromCookie = 0;
+        }
+
+        if (partyIdFromCookie != userContext.PartyId)
+        {
+            Response.Cookies.Append(
+                _settings.GetAltinnPartyCookieName,
+                userContext.PartyId.ToString(CultureInfo.InvariantCulture),
+                new CookieOptions { Domain = _settings.HostName }
+            );
+        }
+
+        return userContext.Party;
     }
 }

--- a/src/Altinn.App.Api/Controllers/AuthorizationController.cs
+++ b/src/Altinn.App.Api/Controllers/AuthorizationController.cs
@@ -87,11 +87,15 @@ public class AuthorizationController : Controller
     /// Fetches roles for current party.
     /// </summary>
     /// <returns>List of roles for the current user and party.</returns>
+    // [Authorize]
+    // [HttpGet("{org}/{app}/api/authorization/roles")]
+    // [ProducesResponseType(typeof(IEnumerable<Role), StatusCodes.Status200OK)]
+    // [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize]
     [HttpGet("{org}/{app}/api/authorization/roles")]
-    [ProducesResponseType(typeof(IEnumerable<Roles), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(IEnumerable<Role>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult<IEnumerable<Roles>> GetRolesForCurrentParty()
+    public async Task<IActionResult> GetRolesForCurrentParty()
     {
         (Party? currentParty, UserContext userContext) = await GetCurrentPartyAsync(HttpContext);
 

--- a/src/Altinn.App.Api/Controllers/AuthorizationController.cs
+++ b/src/Altinn.App.Api/Controllers/AuthorizationController.cs
@@ -89,7 +89,9 @@ public class AuthorizationController : Controller
     /// <returns>List of roles for the current user and party.</returns>
     [Authorize]
     [HttpGet("{org}/{app}/api/authorization/roles")]
-    public async Task<IActionResult> GetRolesForCurrentParty()
+    [ProducesResponseType(typeof(IEnumerable<Roles), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult<IEnumerable<Roles>> GetRolesForCurrentParty()
     {
         (Party? currentParty, UserContext userContext) = await GetCurrentPartyAsync(HttpContext);
 

--- a/src/Altinn.App.Api/Controllers/AuthorizationController.cs
+++ b/src/Altinn.App.Api/Controllers/AuthorizationController.cs
@@ -89,7 +89,7 @@ public class AuthorizationController : Controller
     /// <returns>Boolean indicating if the selected party is valid.</returns>
     [Authorize]
     [HttpGet("{org}/{app}/api/authorization/roles")]
-    public async Task<IActionResult> FetchRolesForCurrentParty()
+    public async Task<IActionResult> GetRolesForCurrentParty()
     {
         Party? currentParty = await GetCurrentPartyAsync(HttpContext);
         UserContext userContext = await _userHelper.GetUserContext(HttpContext);
@@ -101,9 +101,6 @@ public class AuthorizationController : Controller
         }
 
         List<Role> roles = await _authorization.GetUserRolesAsync(userId, currentParty.PartyId);
-
-        // TODO: implement actual logic here using currentParty
-        // For now, return false as before
         return Ok(roles);
     }
 

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.Authorization.Client.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.Authorization.Client.cs
@@ -15,6 +15,15 @@ partial class Telemetry
         return activity;
     }
 
+    internal Activity? StartClientGetPartyRoleListActivity(int userId, int partyId)
+    {
+        var activity = ActivitySource.StartActivity($"{Prefix}.GetUserRolesAsync");
+        activity?.SetUserPartyId(partyId);
+        activity?.SetUserId(userId);
+
+        return activity;
+    }
+
     internal Activity? StartClientValidateSelectedPartyActivity(int userId, int partyId)
     {
         var activity = ActivitySource.StartActivity($"{Prefix}.ValidateSelectedParty");

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.Authorization.Client.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.Authorization.Client.cs
@@ -17,7 +17,7 @@ partial class Telemetry
 
     internal Activity? StartClientGetPartyRoleListActivity(int userId, int partyId)
     {
-        var activity = ActivitySource.StartActivity($"{Prefix}.GetUserRolesAsync");
+        var activity = ActivitySource.StartActivity($"{Prefix}.GetUserRoles");
         activity?.SetUserPartyId(partyId);
         activity?.SetUserId(userId);
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
@@ -187,7 +187,7 @@ public class AuthorizationClient : IAuthorizationClient
     /// <param name="userId">The user id.</param>
     /// <param name="userPartyId">The user party id.</param>
     /// <returns>A list of roles for the user on the specified party.</returns>
-    public async Task<IEnumerable<Role>> GetUserRolesAsync(int userId, int userPartyId)
+    public async Task<IEnumerable<Role>> GetUserRoles(int userId, int userPartyId)
     {
         using var activity = _telemetry?.StartClientGetPartyRoleListActivity(userId, userPartyId);
 

--- a/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
+++ b/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
+using Authorization.Platform.Authorization.Models;
 
 namespace Altinn.App.Core.Internal.Auth;
 
@@ -50,4 +51,12 @@ public interface IAuthorizationClient
     /// <param name="actions"></param>
     /// <returns></returns>
     Task<Dictionary<string, bool>> AuthorizeActions(Instance instance, ClaimsPrincipal user, List<string> actions);
+
+    /// <summary>
+    /// Retrieves roles for a user on a specified party.
+    /// </summary>
+    /// <param name="userId">The user id.</param>
+    /// <param name="userPartyId">The user party id.</param>
+    /// <returns>A list of roles for the user on the specified party.</returns>
+    Task<List<Role>?> GetUserRolesAsync(int userId, int userPartyId);
 }

--- a/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
+++ b/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
@@ -58,5 +58,5 @@ public interface IAuthorizationClient
     /// <param name="userId">The user id.</param>
     /// <param name="userPartyId">The user party id.</param>
     /// <returns>A list of roles for the user on the specified party.</returns>
-    Task<List<Role>> GetUserRolesAsync(int userId, int userPartyId);
+    Task<IEnumerable<Role>> GetUserRolesAsync(int userId, int userPartyId);
 }

--- a/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
+++ b/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
@@ -58,5 +58,5 @@ public interface IAuthorizationClient
     /// <param name="userId">The user id.</param>
     /// <param name="userPartyId">The user party id.</param>
     /// <returns>A list of roles for the user on the specified party.</returns>
-    Task<List<Role>?> GetUserRolesAsync(int userId, int userPartyId);
+    Task<List<Role>> GetUserRolesAsync(int userId, int userPartyId);
 }

--- a/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
+++ b/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
@@ -58,5 +58,5 @@ public interface IAuthorizationClient
     /// <param name="userId">The user id.</param>
     /// <param name="userPartyId">The user party id.</param>
     /// <returns>A list of roles for the user on the specified party.</returns>
-    Task<IEnumerable<Role>> GetUserRolesAsync(int userId, int userPartyId);
+    Task<IEnumerable<Role>> GetUserRoles(int userId, int userPartyId);
 }

--- a/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
@@ -3,6 +3,8 @@ using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
+using Authorization.Platform.Authorization.Models;
+using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Altinn.App.Api.Tests.Mocks;
 
@@ -68,5 +70,17 @@ public class AuthorizationMock : IAuthorizationClient
         }
 
         return authorizedActions;
+    }
+
+    public async Task<List<Role>> GetUserRolesAsync(int userId, int userPartyId)
+    {
+        await Task.CompletedTask;
+        List<Role> roles = new List<Role>
+        {
+            new Role { Type = "altinn", Value = "bobet" },
+            new Role { Type = "altinn", Value = "bobes" }
+        };
+
+        return roles;
     }
 }

--- a/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
@@ -72,7 +72,7 @@ public class AuthorizationMock : IAuthorizationClient
         return authorizedActions;
     }
 
-    public async Task<List<Role>> GetUserRolesAsync(int userId, int userPartyId)
+    public async Task<IEnumerable<Role>> GetUserRolesAsync(int userId, int userPartyId)
     {
         await Task.CompletedTask;
         List<Role> roles = new List<Role>

--- a/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
@@ -78,7 +78,7 @@ public class AuthorizationMock : IAuthorizationClient
         List<Role> roles = new List<Role>
         {
             new Role { Type = "altinn", Value = "bobet" },
-            new Role { Type = "altinn", Value = "bobes" }
+            new Role { Type = "altinn", Value = "bobes" },
         };
 
         return roles;

--- a/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
@@ -72,7 +72,7 @@ public class AuthorizationMock : IAuthorizationClient
         return authorizedActions;
     }
 
-    public async Task<IEnumerable<Role>> GetUserRolesAsync(int userId, int userPartyId)
+    public async Task<IEnumerable<Role>> GetUserRoles(int userId, int userPartyId)
     {
         await Task.CompletedTask;
         List<Role> roles = new List<Role>

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -507,6 +507,36 @@
         }
       }
     },
+    "/{org}/{app}/api/authorization/roles": {
+      "get": {
+        "tags": [
+          "Authorization"
+        ],
+        "parameters": [
+          {
+            "name": "org",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "app",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data": {
       "post": {
         "tags": [
@@ -1804,7 +1834,7 @@
             "description": "OK"
           },
           "425": {
-            "description": "Client Error"
+            "description": "Too Early"
           },
           "500": {
             "description": "Internal Server Error"
@@ -5259,8 +5289,7 @@
           "actions": {
             "type": "object",
             "additionalProperties": {
-              "type": "boolean",
-              "nullable": true
+              "type": "boolean"
             },
             "nullable": true
           },
@@ -5366,7 +5395,8 @@
             "type": "boolean"
           },
           "allowInSubform": {
-            "type": "boolean"
+            "type": "boolean",
+            "deprecated": true
           },
           "shadowFields": {
             "$ref": "#/components/schemas/ShadowFields"
@@ -5464,7 +5494,7 @@
           "copyInstanceSettings": {
             "$ref": "#/components/schemas/CopyInstanceSettings"
           },
-          "storageContainerNumber": {
+          "storageAccountNumber": {
             "type": "integer",
             "format": "int32",
             "nullable": true
@@ -5479,8 +5509,7 @@
           "features": {
             "type": "object",
             "additionalProperties": {
-              "type": "boolean",
-              "nullable": true
+              "type": "boolean"
             },
             "nullable": true
           },
@@ -6503,12 +6532,8 @@
       "JsonNodeOptions": {
         "type": "object",
         "properties": {
-          "hasValue": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "value": {
-            "$ref": "#/components/schemas/JsonNodeOptions"
+          "propertyNameCaseInsensitive": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -7349,8 +7374,7 @@
                 "items": {
                   "$ref": "#/components/schemas/ValidationIssueWithSource"
                 }
-              },
-              "nullable": true
+              }
             },
             "nullable": true
           },

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -532,7 +532,79 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Role"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Role"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Role"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Role"
+                  }
+                }
+              },
+              "text/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Role"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -7162,6 +7234,20 @@
             "nullable": true
           },
           "platform": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Role": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
             "type": "string",
             "nullable": true
           }

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -1804,7 +1804,7 @@
             "description": "OK"
           },
           "425": {
-            "description": "Too Early"
+            "description": "Client Error"
           },
           "500": {
             "description": "Internal Server Error"
@@ -5259,7 +5259,8 @@
           "actions": {
             "type": "object",
             "additionalProperties": {
-              "type": "boolean"
+              "type": "boolean",
+              "nullable": true
             },
             "nullable": true
           },
@@ -5365,8 +5366,7 @@
             "type": "boolean"
           },
           "allowInSubform": {
-            "type": "boolean",
-            "deprecated": true
+            "type": "boolean"
           },
           "shadowFields": {
             "$ref": "#/components/schemas/ShadowFields"
@@ -5464,7 +5464,7 @@
           "copyInstanceSettings": {
             "$ref": "#/components/schemas/CopyInstanceSettings"
           },
-          "storageAccountNumber": {
+          "storageContainerNumber": {
             "type": "integer",
             "format": "int32",
             "nullable": true
@@ -5479,7 +5479,8 @@
           "features": {
             "type": "object",
             "additionalProperties": {
-              "type": "boolean"
+              "type": "boolean",
+              "nullable": true
             },
             "nullable": true
           },
@@ -6502,8 +6503,12 @@
       "JsonNodeOptions": {
         "type": "object",
         "properties": {
-          "propertyNameCaseInsensitive": {
-            "type": "boolean"
+          "hasValue": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "value": {
+            "$ref": "#/components/schemas/JsonNodeOptions"
           }
         },
         "additionalProperties": false
@@ -7344,7 +7349,8 @@
                 "items": {
                   "$ref": "#/components/schemas/ValidationIssueWithSource"
                 }
-              }
+              },
+              "nullable": true
             },
             "nullable": true
           },

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -1101,7 +1101,7 @@ paths:
         '200':
           description: OK
         '425':
-          description: Too Early
+          description: Client Error
         '500':
           description: Internal Server Error
         '401':
@@ -3215,6 +3215,7 @@ components:
           type: object
           additionalProperties:
             type: boolean
+            nullable: true
           nullable: true
         userActions:
           type: array
@@ -3290,7 +3291,6 @@ components:
           type: boolean
         allowInSubform:
           type: boolean
-          deprecated: true
         shadowFields:
           $ref: '#/components/schemas/ShadowFields'
       additionalProperties: false
@@ -3361,7 +3361,7 @@ components:
           $ref: '#/components/schemas/MessageBoxConfig'
         copyInstanceSettings:
           $ref: '#/components/schemas/CopyInstanceSettings'
-        storageAccountNumber:
+        storageContainerNumber:
           type: integer
           format: int32
           nullable: true
@@ -3374,6 +3374,7 @@ components:
           type: object
           additionalProperties:
             type: boolean
+            nullable: true
           nullable: true
         logo:
           $ref: '#/components/schemas/Logo'
@@ -4114,8 +4115,11 @@ components:
     JsonNodeOptions:
       type: object
       properties:
-        propertyNameCaseInsensitive:
+        hasValue:
           type: boolean
+          readOnly: true
+        value:
+          $ref: '#/components/schemas/JsonNodeOptions'
       additionalProperties: false
     JsonPatch:
       type: object
@@ -4723,6 +4727,7 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/ValidationIssueWithSource'
+            nullable: true
           nullable: true
         clientActions:
           type: array

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -324,6 +324,50 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            text/plain:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Role'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Role'
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Role'
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Role'
+            text/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Role'
+        '400':
+          description: Bad Request
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+            text/xml:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
   '/{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data':
     post:
       tags:
@@ -4588,6 +4632,16 @@ components:
           type: string
           nullable: true
         platform:
+          type: string
+          nullable: true
+      additionalProperties: false
+    Role:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        value:
           type: string
           nullable: true
       additionalProperties: false

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -306,6 +306,24 @@ paths:
       responses:
         '200':
           description: OK
+  '/{org}/{app}/api/authorization/roles':
+    get:
+      tags:
+        - Authorization
+      parameters:
+        - name: org
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: app
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
   '/{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data':
     post:
       tags:
@@ -1101,7 +1119,7 @@ paths:
         '200':
           description: OK
         '425':
-          description: Client Error
+          description: Too Early
         '500':
           description: Internal Server Error
         '401':
@@ -3215,7 +3233,6 @@ components:
           type: object
           additionalProperties:
             type: boolean
-            nullable: true
           nullable: true
         userActions:
           type: array
@@ -3291,6 +3308,7 @@ components:
           type: boolean
         allowInSubform:
           type: boolean
+          deprecated: true
         shadowFields:
           $ref: '#/components/schemas/ShadowFields'
       additionalProperties: false
@@ -3361,7 +3379,7 @@ components:
           $ref: '#/components/schemas/MessageBoxConfig'
         copyInstanceSettings:
           $ref: '#/components/schemas/CopyInstanceSettings'
-        storageContainerNumber:
+        storageAccountNumber:
           type: integer
           format: int32
           nullable: true
@@ -3374,7 +3392,6 @@ components:
           type: object
           additionalProperties:
             type: boolean
-            nullable: true
           nullable: true
         logo:
           $ref: '#/components/schemas/Logo'
@@ -4115,11 +4132,8 @@ components:
     JsonNodeOptions:
       type: object
       properties:
-        hasValue:
+        propertyNameCaseInsensitive:
           type: boolean
-          readOnly: true
-        value:
-          $ref: '#/components/schemas/JsonNodeOptions'
       additionalProperties: false
     JsonPatch:
       type: object
@@ -4727,7 +4741,6 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/ValidationIssueWithSource'
-            nullable: true
           nullable: true
         clientActions:
           type: array

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
@@ -179,7 +179,7 @@ public class AuthorizationClientTests
             telemetrySink.Object
         );
 
-        var actualRoles = await client.GetUserRolesAsync(userId, userPartyId);
+        var actualRoles = await client.GetUserRoles(userId, userPartyId);
 
         actualRoles.Should().BeEquivalentTo(expectedRoles);
     }
@@ -239,7 +239,7 @@ public class AuthorizationClientTests
             telemetry.Object
         );
 
-        await Assert.ThrowsAsync<Exception>(() => client.GetUserRolesAsync(userId, userPartyId));
+        await Assert.ThrowsAsync<Exception>(() => client.GetUserRoles(userId, userPartyId));
     }
 
     private static ClaimsPrincipal GetClaims(string partyId)

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
@@ -125,6 +125,13 @@ public class AuthorizationClientTests
         var responseJson = JsonSerializer.Serialize(expectedRoles);
 
         var httpMessageHandler = new Mock<HttpMessageHandler>();
+
+        var reponseMessage = new HttpResponseMessage
+        {
+            StatusCode = System.Net.HttpStatusCode.OK,
+            Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json"),
+        };
+
         httpMessageHandler
             .Protected()
             .Setup<Task<HttpResponseMessage>>(
@@ -136,13 +143,7 @@ public class AuthorizationClientTests
                 ),
                 ItExpr.IsAny<CancellationToken>()
             )
-            .ReturnsAsync(
-                new HttpResponseMessage
-                {
-                    StatusCode = System.Net.HttpStatusCode.OK,
-                    Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json"),
-                }
-            );
+            .ReturnsAsync(reponseMessage);
 
         var httpClient = new HttpClient(httpMessageHandler.Object);
 
@@ -191,6 +192,13 @@ public class AuthorizationClientTests
         var userPartyId = 2001;
 
         var httpMessageHandler = new Mock<HttpMessageHandler>();
+
+        var reponseMessage = new HttpResponseMessage
+        {
+            StatusCode = System.Net.HttpStatusCode.InternalServerError,
+            Content = new StringContent("Internal Server Error"),
+        };
+
         httpMessageHandler
             .Protected()
             .Setup<Task<HttpResponseMessage>>(
@@ -202,13 +210,7 @@ public class AuthorizationClientTests
                 ),
                 ItExpr.IsAny<CancellationToken>()
             )
-            .ReturnsAsync(
-                new HttpResponseMessage
-                {
-                    StatusCode = System.Net.HttpStatusCode.InternalServerError,
-                    Content = new StringContent("Internal Server Error"),
-                }
-            );
+            .ReturnsAsync(reponseMessage);
 
         var httpClient = new HttpClient(httpMessageHandler.Object);
 

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
@@ -3,15 +3,18 @@ using System.Security.Claims;
 using System.Text.Json;
 using Altinn.App.Common.Tests;
 using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Infrastructure.Clients.Authorization;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Interface.Models;
+using Authorization.Platform.Authorization.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Moq.Protected;
 
 namespace Altinn.App.Core.Tests.Infrastructure.Clients.Authorization;
 
@@ -106,6 +109,136 @@ public class AuthorizationClientTests
         var actions = new List<string>() { "read", "write", "complete", "lookup" };
         var actual = await client.AuthorizeActions(instance, claimsPrincipal, actions);
         actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public async Task GetUserRolesAsync_returns_roles_on_success()
+    {
+        var userId = 1337;
+        var userPartyId = 2001;
+        var expectedRoles = new List<Role>()
+        {
+            new() { Type = "altinn", Value = "bobet" },
+            new() { Type = "altinn", Value = "bobes" },
+        };
+
+        var responseJson = JsonSerializer.Serialize(expectedRoles);
+
+        var httpMessageHandler = new Mock<HttpMessageHandler>();
+        httpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(m =>
+                    m.RequestUri != null
+                    && m.RequestUri.ToString()
+                        .Contains($"roles?coveredByUserId={userId}&offeredByPartyId={userPartyId}")
+                ),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(
+                new HttpResponseMessage
+                {
+                    StatusCode = System.Net.HttpStatusCode.OK,
+                    Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json"),
+                }
+            );
+
+        var httpClient = new HttpClient(httpMessageHandler.Object);
+
+        TelemetrySink telemetrySink = new();
+        var pdpMock = new Mock<IPDP>();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Cookie"] = "AltinnStudioRuntime=myFakeJwtToken";
+
+        var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        httpContextAccessorMock.Setup(_ => _.HttpContext).Returns(httpContext);
+
+        var appSettingsMock = new Mock<IOptionsMonitor<AppSettings>>();
+        appSettingsMock
+            .Setup(s => s.CurrentValue)
+            .Returns(new AppSettings { RuntimeCookieName = "AltinnStudioRuntime" });
+
+        var platformSettings = Options.Create(
+            new PlatformSettings
+            {
+                ApiAuthorizationEndpoint = "http://authorization.test/",
+                SubscriptionKey = "dummyKey",
+            }
+        );
+        var logger = NullLogger<AuthorizationClient>.Instance;
+
+        var client = new AuthorizationClient(
+            platformSettings,
+            httpContextAccessorMock.Object,
+            httpClient,
+            appSettingsMock.Object,
+            pdpMock.Object,
+            logger,
+            telemetrySink.Object
+        );
+
+        var actualRoles = await client.GetUserRolesAsync(userId, userPartyId);
+
+        actualRoles.Should().BeEquivalentTo(expectedRoles);
+    }
+
+    [Fact]
+    public async Task GetUserRolesAsync_throws_exception_on_error_status_code()
+    {
+        var userId = 1337;
+        var userPartyId = 2001;
+
+        var httpMessageHandler = new Mock<HttpMessageHandler>();
+        httpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(m =>
+                    m.RequestUri != null
+                    && m.RequestUri.ToString()
+                        .Contains($"roles?coveredByUserId={userId}&offeredByPartyId={userPartyId}")
+                ),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(
+                new HttpResponseMessage
+                {
+                    StatusCode = System.Net.HttpStatusCode.InternalServerError,
+                    Content = new StringContent("Internal Server Error"),
+                }
+            );
+
+        var httpClient = new HttpClient(httpMessageHandler.Object);
+
+        var pdpMock = new Mock<IPDP>();
+        var appSettingsMock = new Mock<IOptionsMonitor<AppSettings>>();
+        appSettingsMock
+            .Setup(s => s.CurrentValue)
+            .Returns(new AppSettings { RuntimeCookieName = "AltinnStudioRuntime" });
+
+        var platformSettings = Options.Create(new PlatformSettings { SubscriptionKey = "subscription-key" });
+        var logger = NullLogger<AuthorizationClient>.Instance;
+        TelemetrySink telemetry = new();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Cookie"] = "AltinnStudioRuntime=myFakeJwtToken";
+
+        var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        httpContextAccessorMock.Setup(_ => _.HttpContext).Returns(httpContext);
+
+        var client = new AuthorizationClient(
+            platformSettings,
+            httpContextAccessorMock.Object,
+            httpClient,
+            appSettingsMock.Object,
+            pdpMock.Object,
+            logger,
+            telemetry.Object
+        );
+
+        await Assert.ThrowsAsync<Exception>(() => client.GetUserRolesAsync(userId, userPartyId));
     }
 
     private static ClaimsPrincipal GetClaims(string partyId)

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
@@ -144,7 +144,7 @@ public class AuthorizationClientTests
                 ItExpr.IsAny<CancellationToken>()
             )
             .ReturnsAsync(reponseMessage);
-
+        reponseMessage.Dispose();
         var httpClient = new HttpClient(httpMessageHandler.Object);
 
         TelemetrySink telemetrySink = new();
@@ -211,6 +211,7 @@ public class AuthorizationClientTests
                 ItExpr.IsAny<CancellationToken>()
             )
             .ReturnsAsync(reponseMessage);
+        reponseMessage.Dispose();
 
         var httpClient = new HttpClient(httpMessageHandler.Object);
 

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
@@ -126,12 +126,6 @@ public class AuthorizationClientTests
 
         var httpMessageHandler = new Mock<HttpMessageHandler>();
 
-        var reponseMessage = new HttpResponseMessage
-        {
-            StatusCode = System.Net.HttpStatusCode.OK,
-            Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json"),
-        };
-
         httpMessageHandler
             .Protected()
             .Setup<Task<HttpResponseMessage>>(
@@ -143,8 +137,13 @@ public class AuthorizationClientTests
                 ),
                 ItExpr.IsAny<CancellationToken>()
             )
-            .ReturnsAsync(reponseMessage);
-        reponseMessage.Dispose();
+            .ReturnsAsync(
+                new HttpResponseMessage
+                {
+                    StatusCode = System.Net.HttpStatusCode.OK,
+                    Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json"),
+                }
+            );
         var httpClient = new HttpClient(httpMessageHandler.Object);
 
         TelemetrySink telemetrySink = new();
@@ -193,12 +192,6 @@ public class AuthorizationClientTests
 
         var httpMessageHandler = new Mock<HttpMessageHandler>();
 
-        var reponseMessage = new HttpResponseMessage
-        {
-            StatusCode = System.Net.HttpStatusCode.InternalServerError,
-            Content = new StringContent("Internal Server Error"),
-        };
-
         httpMessageHandler
             .Protected()
             .Setup<Task<HttpResponseMessage>>(
@@ -210,8 +203,13 @@ public class AuthorizationClientTests
                 ),
                 ItExpr.IsAny<CancellationToken>()
             )
-            .ReturnsAsync(reponseMessage);
-        reponseMessage.Dispose();
+            .ReturnsAsync(
+                new HttpResponseMessage
+                {
+                    StatusCode = System.Net.HttpStatusCode.InternalServerError,
+                    Content = new StringContent("Internal Server Error"),
+                }
+            );
 
         var httpClient = new HttpClient(httpMessageHandler.Object);
 


### PR DESCRIPTION
Adds endpoint for fetching the users current party roles.

You need this PR in localtest to test:

https://github.com/Altinn/app-localtest/pull/131

## Description
- Adds endpoint `/api/authorization/roles` to AuthorizationController
- Refactored functionality to fetch current party to reusable function
- Implemented fetching of the current parties.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/2089

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
