### PR TITLE
Correspondence client updates

### DIFF
--- a/src/Altinn.App.Core/Features/Correspondence/CorrespondenceAuthorisationFactory.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/CorrespondenceAuthorisationFactory.cs
@@ -1,3 +1,5 @@
+using Altinn.App.Core.Features.Correspondence.Exceptions;
+using Altinn.App.Core.Features.Correspondence.Models;
 using Altinn.App.Core.Features.Maskinporten;
 using Altinn.App.Core.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,18 +11,38 @@ internal sealed class CorrespondenceAuthorisationFactory
     private IMaskinportenClient? _maskinportenClient;
     private readonly IServiceProvider _serviceProvider;
 
-    public Func<Task<JwtToken>> Maskinporten =>
-        async () =>
+    public Func<string, Task<JwtToken>> Maskinporten =>
+        async (scope) =>
         {
             _maskinportenClient ??= _serviceProvider.GetRequiredService<IMaskinportenClient>();
-
-            return await _maskinportenClient.GetAltinnExchangedToken(
-                ["altinn:correspondence.write", "altinn:serviceowner"]
-            );
+            return await _maskinportenClient.GetAltinnExchangedToken([CorrespondenceApiScopes.ServiceOwner, scope]);
         };
 
     public CorrespondenceAuthorisationFactory(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
+    }
+
+    public async Task<JwtToken> Resolve(CorrespondencePayloadBase payload)
+    {
+        if (payload.AccessTokenFactory is null && payload.AuthorisationMethod is null)
+        {
+            throw new CorrespondenceArgumentException(
+                "Neither AccessTokenFactory nor AuthorisationMethod was provided in the CorrespondencePayload object"
+            );
+        }
+
+        if (payload.AccessTokenFactory is not null)
+        {
+            return await payload.AccessTokenFactory();
+        }
+
+        return payload.AuthorisationMethod switch
+        {
+            CorrespondenceAuthorisation.Maskinporten => await Maskinporten(payload.RequiredScope),
+            _ => throw new CorrespondenceArgumentException(
+                $"Unknown CorrespondenceAuthorisation `{payload.AuthorisationMethod}`"
+            ),
+        };
     }
 }

--- a/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
@@ -40,29 +40,6 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
         _authorisationFactory = new CorrespondenceAuthorisationFactory(serviceProvider);
     }
 
-    private async Task<JwtToken> AuthorisationResolver(CorrespondencePayloadBase payload)
-    {
-        if (payload.AccessTokenFactory is null && payload.AuthorisationMethod is null)
-        {
-            throw new CorrespondenceArgumentException(
-                "Neither AccessTokenFactory nor AuthorisationMethod was provided in the CorrespondencePayload object"
-            );
-        }
-
-        if (payload.AccessTokenFactory is not null)
-        {
-            return await payload.AccessTokenFactory();
-        }
-
-        return payload.AuthorisationMethod switch
-        {
-            CorrespondenceAuthorisation.Maskinporten => await _authorisationFactory.Maskinporten(),
-            _ => throw new CorrespondenceArgumentException(
-                $"Unknown CorrespondenceAuthorisation `{payload.AuthorisationMethod}`"
-            ),
-        };
-    }
-
     /// <inheritdoc />
     public async Task<SendCorrespondenceResponse> Send(
         SendCorrespondencePayload payload,
@@ -162,7 +139,7 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
     )
     {
         _logger.LogDebug("Fetching access token via factory");
-        JwtToken accessToken = await AuthorisationResolver(payload);
+        JwtToken accessToken = await _authorisationFactory.Resolve(payload);
 
         _logger.LogDebug("Constructing authorized http request for target uri {TargetEndpoint}", uri);
         HttpRequestMessage request = new(method, uri) { Content = content };

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceApiScopes.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceApiScopes.cs
@@ -1,0 +1,11 @@
+namespace Altinn.App.Core.Features.Correspondence.Models;
+
+/// <summary>
+/// Known scopes for the correspondence API.
+/// </summary>
+internal static class CorrespondenceApiScopes
+{
+    public const string ServiceOwner = "altinn:serviceowner";
+    public const string Read = "altinn:correspondence.read";
+    public const string Write = "altinn:correspondence.write";
+}

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceAuthorisation.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceAuthorisation.cs
@@ -1,0 +1,14 @@
+using Altinn.App.Core.Features.Maskinporten;
+
+namespace Altinn.App.Core.Features.Correspondence.Models;
+
+/// <summary>
+/// Defines an authorisation method to use with the correspondence server.
+/// </summary>
+public enum CorrespondenceAuthorisation
+{
+    /// <summary>
+    /// Uses the built-in <see cref="MaskinportenClient"/> for authorization.
+    /// </summary>
+    Maskinporten,
+}

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondencePayload.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondencePayload.cs
@@ -4,17 +4,6 @@ using Altinn.App.Core.Models;
 namespace Altinn.App.Core.Features.Correspondence.Models;
 
 /// <summary>
-/// Defines an authorisation method to use with the correspondence server.
-/// </summary>
-public enum CorrespondenceAuthorisation
-{
-    /// <summary>
-    /// Uses the built-in <see cref="MaskinportenClient"/> for authorization.
-    /// </summary>
-    Maskinporten,
-}
-
-/// <summary>
 /// Authorisation properties which are common for all correspondence interaction.
 /// </summary>
 public abstract record CorrespondencePayloadBase
@@ -22,6 +11,8 @@ public abstract record CorrespondencePayloadBase
     internal Func<Task<JwtToken>>? AccessTokenFactory { get; init; }
 
     internal CorrespondenceAuthorisation? AuthorisationMethod { get; init; }
+
+    internal abstract string RequiredScope { get; }
 }
 
 /// <summary>
@@ -30,6 +21,7 @@ public abstract record CorrespondencePayloadBase
 public sealed record SendCorrespondencePayload : CorrespondencePayloadBase
 {
     internal CorrespondenceRequest CorrespondenceRequest { get; init; }
+    internal override string RequiredScope => CorrespondenceApiScopes.Write;
 
     /// <summary>
     /// Instantiates a new payload for <see cref="SendCorrespondencePayload"/>.
@@ -59,10 +51,8 @@ public sealed record SendCorrespondencePayload : CorrespondencePayloadBase
 /// </summary>
 public sealed record GetCorrespondenceStatusPayload : CorrespondencePayloadBase
 {
-    /// <summary>
-    /// The correspondence identifier.
-    /// </summary>
-    public Guid CorrespondenceId { get; init; }
+    internal Guid CorrespondenceId { get; init; }
+    internal override string RequiredScope => CorrespondenceApiScopes.Read;
 
     /// <summary>
     /// Instantiates a new payload for <see cref="CorrespondenceClient.GetStatus"/>.


### PR DESCRIPTION
## Description
As discussed on [Slack](https://digdir.slack.com/archives/C079AJR5TEX/p1734429151436709?thread_ts=1734352363.739069&cid=C079AJR5TEX), the Correspondence API endpoints for `send` and `details` will soon require different authorisation scopes.

The Correspondence client in general was poorly designed in this regard, with the authorisation factory attempting to provide the same scopes for every request regardless of target endpoint.

## Summary
The changes offered in this pull request aren't very large, but some things have moved around a bit. Here's the tl;dr:
- The scope requirements for each request have been moved from a static value in `CorrespondenceAuthorisationFactory`, to a configuration property in `CorrespondencePayloadBase` 
- The `CorrespondenceClient.GetStatus` method now requires a new scope: `altinn:correspondence.read`
- `CorrespondenceClient.AuthorisationResolver` has moved to `CorrespondenceAuthorisationFactory.Resolve`

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
