### PR TITLE
Disable renovate for v7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,5 @@
     "local>Altinn/renovate-config"
   ],
   "labels": ["dependency"],
-  "baseBranches": ["main", "v7"]
+  "baseBranches": ["main"]
 }


### PR DESCRIPTION
## Description
Since .NET 6 is out of support, we don't have to patch v7 anymore

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
