### PR TITLE
Add IExceptionHandler and use it to warn about old localtest

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -23,6 +23,7 @@ using Altinn.App.Core.Internal.Process;
 using Altinn.App.Core.Internal.Profile;
 using Altinn.App.Core.Internal.Registers;
 using Altinn.App.Core.Models;
+using Altinn.App.Core.Models.Exceptions;
 using Altinn.App.Core.Models.Process;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
@@ -368,6 +369,12 @@ public class InstancesController : ControllerBase
             // notify app and store events
             _logger.LogInformation("Events sent to process engine: {Events}", change?.Events);
             await _processEngine.HandleEventsAndUpdateStorage(instance, null, change?.Events);
+        }
+        // Let the AltinnAppException through as it is handled in IExceptionHandler
+        catch (AltinnAppException)
+        {
+            // TODO: handle all exceptions (not just this) in IExceptionHandler
+            throw;
         }
         catch (Exception exception)
         {

--- a/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Altinn.App.Api.Controllers.Attributes;
 using Altinn.App.Api.Controllers.Conventions;
 using Altinn.App.Api.Helpers;
 using Altinn.App.Api.Helpers.Patch;
+using Altinn.App.Api.Infrastructure;
 using Altinn.App.Api.Infrastructure.Filters;
 using Altinn.App.Api.Infrastructure.Health;
 using Altinn.App.Api.Infrastructure.Middleware;
@@ -64,6 +65,8 @@ public static class ServiceCollectionExtensions
             {
                 options.JsonSerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase;
             });
+        services.AddProblemDetails();
+        services.AddExceptionHandler<RequestExceptionHandler>();
     }
 
     /// <summary>

--- a/src/Altinn.App.Api/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/WebApplicationBuilderExtensions.cs
@@ -16,10 +16,7 @@ public static class WebApplicationBuilderExtensions
     public static IApplicationBuilder UseAltinnAppCommonConfiguration(this IApplicationBuilder app)
     {
         var appId = StartupHelper.GetApplicationId();
-        if (app is WebApplication webApp && webApp.Environment.IsDevelopment())
-        {
-            app.UseDeveloperExceptionPage();
-        }
+        app.UseExceptionHandler();
 
         app.UseDefaultSecurityHeaders();
         app.UseRouting();

--- a/src/Altinn.App.Api/Infrastructure/RequestExceptionHandler.cs
+++ b/src/Altinn.App.Api/Infrastructure/RequestExceptionHandler.cs
@@ -1,0 +1,56 @@
+using Altinn.App.Core.Models.Exceptions;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.App.Api.Infrastructure;
+
+internal class RequestExceptionHandler : IExceptionHandler
+{
+    private readonly IProblemDetailsService _problemDetailsService;
+    private ILogger<RequestExceptionHandler> _logger;
+
+    public RequestExceptionHandler(
+        IProblemDetailsService problemDetailsService,
+        ILogger<RequestExceptionHandler> logger
+    )
+    {
+        _problemDetailsService = problemDetailsService;
+        _logger = logger;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken
+    )
+    {
+        _logger.LogError(exception, "Handling exception in IExceptionHandler");
+        if (exception is AltinnAppException altinn3AppException)
+        {
+            await HandleAltinn3AppExceptionAsync(httpContext, altinn3AppException);
+            return true;
+        }
+        return false;
+    }
+
+    private async ValueTask HandleAltinn3AppExceptionAsync(
+        HttpContext httpContext,
+        AltinnAppException altinnAppException
+    )
+    {
+        _logger.LogError(altinnAppException, "An Altinn3AppException occurred");
+        await _problemDetailsService.WriteAsync(
+            new ProblemDetailsContext()
+            {
+                HttpContext = httpContext,
+                ProblemDetails = new ProblemDetails()
+                {
+                    Type = altinnAppException.Type,
+                    Title = altinnAppException.Title,
+                    Detail = altinnAppException.Description,
+                    Status = altinnAppException.StatusCode,
+                },
+            }
+        );
+    }
+}

--- a/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -7,6 +7,7 @@ using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Models;
+using Altinn.App.Core.Models.Exceptions;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -588,14 +589,22 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
         var changes = GetDataElementChanges(initializeAltinnRowId: false);
         if (changes.AllChanges.Count != previousChanges.AllChanges.Count)
         {
-            throw new Exception("Number of data elements have changed by validators");
+            throw new AltinnAppException()
+            {
+                Title = "Validators have changed data elements",
+                Description = "Number of data elements have changed by validators",
+            };
         }
 
         foreach (var previousChange in previousChanges.AllChanges)
         {
             var currentChange =
                 changes.AllChanges.FirstOrDefault(c => c.DataElement?.Id == previousChange.DataElement?.Id)
-                ?? throw new Exception("Number of data elements have changed by validators");
+                ?? throw new AltinnAppException()
+                {
+                    Title = "Validators have changed data elements",
+                    Description = "Number of data elements have changed by validators",
+                };
 
             var equal = (currentChange, previousChange) switch
             {
@@ -606,13 +615,20 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
                 (BinaryDataChange current, BinaryDataChange previous) => current.CurrentBinaryData.Span.SequenceEqual(
                     previous.CurrentBinaryData.Span
                 ),
-                _ => throw new Exception("Data element type has changed by validators"),
+                _ => throw new AltinnAppException()
+                {
+                    Title = "Validators have changed data elements",
+                    Description = "Number of data elements have changed by validators",
+                },
             };
             if (!equal)
             {
-                throw new Exception(
-                    $"Data element {previousChange.DataType.Id} with id {previousChange.DataElement?.Id} has been changed by validators"
-                );
+                throw new AltinnAppException()
+                {
+                    Title = "Validators have changed data elements",
+                    Description =
+                        $"Data element {previousChange.DataType.Id} with id {previousChange.DataElement?.Id} has been changed by validators",
+                };
             }
         }
     }

--- a/src/Altinn.App.Core/Models/Exceptions/AltinnAppException.cs
+++ b/src/Altinn.App.Core/Models/Exceptions/AltinnAppException.cs
@@ -1,0 +1,75 @@
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.App.Core.Models.Exceptions;
+
+/// <summary>
+/// Custom exception for fatal errors in Altinn that should result in a
+/// with a <see cref="ProblemDetails"/> response with status 500 or 400
+/// </summary>
+/// <remarks>
+/// <see cref="ProblemDetails.Status" /> is set to 500 Internal Server Error by default
+/// and can be changed to 403 Forbidden or 400 Bad Request by setting <see cref="IsForbidden"/> or <see cref="IsBadRequest"/>
+/// on initialization
+/// </remarks>
+/// <example>
+/// <code>
+/// throw new AltinnAppException
+/// {
+///     Title = "Bad Request",
+///     Description = "Set the ProblemDetails.Status to 400 Bad Request",
+///     IsBadRequest = true,
+/// };
+/// </code>
+/// </example>
+internal class AltinnAppException : Exception
+{
+    public AltinnAppException([CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = 0)
+        : base($"An error occurred in {filePath} at line {lineNumber}") { }
+
+    /// <summary>
+    /// The type to use in <see cref="ProblemDetails.Type"/> of the response
+    ///
+    /// Defaults to the class name of the exception
+    /// </summary>
+    public string? Type { get; init; }
+
+    /// <summary>
+    /// The title to use in <see cref="ProblemDetails.Title"/> of the response
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Human-readable description of the error to be shown to the user
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// The status code to be used in the response
+    /// </summary>
+    /// <remarks>
+    /// Use custom setters for specific allowed status codes like 403 Forbidden or 400 Bad Request
+    ///
+    /// This exception should only be used for errors that is visible
+    /// </remarks>
+    public int StatusCode { get; private init; } = StatusCodes.Status500InternalServerError;
+
+    /// <summary>
+    /// Set the status code to 403 Forbidden
+    /// </summary>
+    public bool IsForbidden
+    {
+        // ReSharper disable once ValueParameterNotUsed
+        init { StatusCode = StatusCodes.Status403Forbidden; }
+    }
+
+    /// <summary>
+    /// Set the status code to 400 Bad Request
+    /// </summary>
+    public bool IsBadRequest
+    {
+        // ReSharper disable once ValueParameterNotUsed
+        init { StatusCode = StatusCodes.Status400BadRequest; }
+    }
+}

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -1098,15 +1098,13 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
 
         var url = $"/{Org}/{App}/instances/{_instanceId}/data?language=nb";
 
-        var action = async () =>
-        {
-            using var updateDataElementContent = JsonContent.Create(patch);
-            await GetClient().PatchAsync(url, updateDataElementContent);
-        };
-        // Not sure why the exception propagates out of the api call in WebApplicationFactory.
-        (await action.Should().ThrowAsync<Exception>())
-            .Which.Message.Should()
-            .Contain("changed by validators");
+        using var updateDataElementContent = JsonContent.Create(patch);
+        var response = await GetClient().PatchAsync(url, updateDataElementContent);
+
+        response.Should().HaveStatusCode(HttpStatusCode.InternalServerError);
+        var responseString = await response.Content.ReadAsStringAsync();
+        OutputHelper.WriteLine(responseString);
+        responseString.Should().Contain("changed by validators");
     }
 
     ~DataControllerPatchTests()


### PR DESCRIPTION
This PR introduces a new concept `IExceptionHandler` that currently only handles the new `AltinnAppException` and customises the `ProblemDetails` response to include the data from the exception

The use case is to warn about old localtest, but in the future I think this Is a richer way to both ensure that exceptions gets logged, and that api users gets more helpful error messages.

## New stuff
* New RequestExceptionHandler: IExceptionHandler to create ProblemDetails
* New AltinnAppException with the fields of ProblemDetails
* Throw exception for old localtest with text for ProblemDetails about upgrading
* Modify catch blocks to let the exception bubble through.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
