### PR TITLE
Adds party id to signing state response

### DIFF
--- a/src/Altinn.App.Api/Controllers/SigningController.cs
+++ b/src/Altinn.App.Api/Controllers/SigningController.cs
@@ -93,6 +93,7 @@ public class SigningController : ControllerBase
                         NotificationSuccessful =
                             signeeContext.SigneeState
                                 is { SignatureRequestEmailSent: false, SignatureRequestSmsSent: false },
+                        PartyId = signeeContext.Party.PartyId,
                     };
                 })
                 .ToList(),

--- a/src/Altinn.App.Api/Models/SingingStateResponse.cs
+++ b/src/Altinn.App.Api/Models/SingingStateResponse.cs
@@ -41,5 +41,9 @@ public class SigneeState
     /// </summary>
     public bool NotificationSuccessful { get; set; }
 
+    /// <summary>
+    /// The party id of the signee.
+    /// </summary>
+    public required int PartyId { get; set; }
     //TODO: Add necessary properties
 }

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -7726,7 +7726,8 @@
       },
       "SigneeState": {
         "required": [
-          "hasSigned"
+          "hasSigned",
+          "partyId"
         ],
         "type": "object",
         "properties": {
@@ -7746,6 +7747,10 @@
           },
           "notificationSuccessful": {
             "type": "boolean"
+          },
+          "partyId": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.yaml
@@ -4943,6 +4943,7 @@ components:
     SigneeState:
       required:
         - hasSigned
+        - partyId
       type: object
       properties:
         name:
@@ -4957,6 +4958,9 @@ components:
           type: boolean
         notificationSuccessful:
           type: boolean
+        partyId:
+          type: integer
+          format: int32
       additionalProperties: false
     SigningDataElementsResponse:
       required:


### PR DESCRIPTION
## Description
Adds party id to signing state response in order to determine if current user should sign.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
