### PR TITLE
Use v8 deps for main .NET/MS packages, update renovate config to stick to v8

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.404",
+        "version": "8.0.405",
         "rollForward": "latestFeature",
         "allowPrerelease": false
     }

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,11 @@
     "local>Altinn/renovate-config"
   ],
   "labels": ["dependency"],
-  "baseBranches": ["main"]
+  "baseBranches": ["main"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["/dotnet(-|\\/)sdk/", "/^Microsoft\\.AspNetCore/", "/^Microsoft\\.Extensions/", "!Microsoft.Extensions.Caching.Hybrid"],
+      "allowedVersions": "<=8"
+    }
+  ]
 }

--- a/test/Altinn.App.Common.Tests/Altinn.App.Common.Tests.csproj
+++ b/test/Altinn.App.Common.Tests/Altinn.App.Common.Tests.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" />
     <PackageReference Include="Verify.Xunit" Version="28.4.0" />
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
     <PackageReference Include="Verify.Xunit" Version="28.4.0" />
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />


### PR DESCRIPTION
## Description
Use v8 deps for main .NET/MS packages, update renovate config to stick to v8

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
