### PR TITLE
implements default signing task validator

### DIFF
--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -216,6 +216,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IFormDataValidator, DataAnnotationValidator>();
         services.AddTransient<IDataElementValidator, DefaultDataElementValidator>();
         services.AddTransient<ITaskValidator, DefaultTaskValidator>();
+        services.AddTransient<IValidator, SigningTaskValidator>();
 
         var appSettings = configuration.GetSection("AppSettings").Get<AppSettings>();
         if (appSettings?.RequiredValidation is true)

--- a/src/Altinn.App.Core/Features/Signing/Interfaces/ISigningService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Interfaces/ISigningService.cs
@@ -25,7 +25,7 @@ internal interface ISigningService
     );
 
     Task<List<SigneeContext>> GetSigneeContexts(
-        IInstanceDataMutator instanceMutator,
+        IInstanceDataAccessor instanceDataAccessor,
         AltinnSignatureConfiguration signatureConfiguration
     );
 }

--- a/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
@@ -124,7 +124,7 @@ internal class SigningTaskValidator : IValidator
         ];
     }
 
-    public static async Task<Tuple<Exception?, T?>> CatchError<T>(Task<T> task)
+    private static async Task<Tuple<Exception?, T?>> CatchError<T>(Task<T> task)
     {
         try
         {

--- a/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
@@ -1,0 +1,139 @@
+using Altinn.App.Core.Features.Signing.Interfaces;
+using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Instances;
+using Altinn.App.Core.Internal.Process;
+using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
+using Altinn.App.Core.Models;
+using Altinn.App.Core.Models.Validation;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.App.Core.Features.Validation.Default;
+
+/// <summary>
+/// Validates that all required parties have signed the current task
+/// </summary>
+internal class SigningTaskValidator : IValidator
+{
+    private readonly IProcessReader _processReader;
+    private readonly ISigningService _signingService;
+    private readonly IDataClient _dataClient;
+    private readonly IInstanceClient _instanceClient;
+    private readonly IAppMetadata _appMetadata;
+    private readonly ModelSerializationService _modelSerialization;
+    private readonly ILogger<SigningTaskValidator> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SigningTaskValidator"/> class.
+    /// </summary>
+    public SigningTaskValidator(
+        ILogger<SigningTaskValidator> logger,
+        IProcessReader processReader,
+        ISigningService signingService,
+        IDataClient dataClient,
+        IInstanceClient instanceClient,
+        IAppMetadata appMetadata,
+        ModelSerializationService modelSerialization
+    )
+    {
+        _logger = logger;
+        _processReader = processReader;
+        _signingService = signingService;
+        _dataClient = dataClient;
+        _instanceClient = instanceClient;
+        _appMetadata = appMetadata;
+        _modelSerialization = modelSerialization;
+    }
+
+    /// <summary>
+    /// We implement <see cref="ShouldRunForTask"/> instead
+    /// </summary>
+    public string TaskId => "*";
+
+    /// <summary>
+    /// Only run for tasks that are of type "signing"
+    /// </summary>
+    public bool ShouldRunForTask(string taskId)
+    {
+        return _processReader.GetAltinnTaskExtension(taskId)?.TaskType == "signing";
+    }
+
+    public bool NoIncrementalValidation => true;
+
+    // Should never be called because NoIncrementalValidation is true
+    public Task<bool> HasRelevantChanges(IInstanceDataAccessor dataAccessor, string taskId, DataElementChanges changes)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<List<ValidationIssue>> Validate(
+        IInstanceDataAccessor dataAccessor,
+        string taskId,
+        string? language
+    )
+    {
+        AltinnSignatureConfiguration? signingConfiguration = (
+            _processReader.GetAltinnTaskExtension(taskId)?.SignatureConfiguration
+        );
+
+        if (signingConfiguration == null)
+        {
+            _logger.LogError($"No signing configuration found for task {taskId}");
+            return [];
+        }
+
+        var (getAppMetadataError, appMetadata) = await CatchError(_appMetadata.GetApplicationMetadata());
+        if (getAppMetadataError != null || appMetadata == null)
+        {
+            _logger.LogError(getAppMetadataError, "Error while fetching application metadata");
+            return [];
+        }
+
+        var cachedDataMutator = new InstanceDataUnitOfWork(
+            instance: dataAccessor.Instance,
+            _dataClient,
+            _instanceClient,
+            appMetadata,
+            _modelSerialization
+        );
+
+        var (getSigneeContextsError, signeeContexts) = await CatchError(
+            _signingService.GetSigneeContexts(cachedDataMutator, signingConfiguration)
+        );
+        if (getSigneeContextsError != null || signeeContexts == null)
+        {
+            _logger.LogError(getSigneeContextsError, "Error while fetching signee contexts");
+            return [];
+        }
+
+        var allHaveSigned = signeeContexts.All(signeeContext => signeeContext.SignDocument != null);
+        if (allHaveSigned)
+        {
+            return [];
+        }
+
+        return
+        [
+            new ValidationIssue
+            {
+                Code = ValidationIssueCodes.DataElementCodes.MissingSignatures,
+                Severity = ValidationIssueSeverity.Error,
+                Description = ValidationIssueCodes.DataElementCodes.MissingSignatures,
+            },
+        ];
+    }
+
+    public static async Task<Tuple<Exception?, T?>> CatchError<T>(Task<T> task)
+    {
+        try
+        {
+            var result = await task;
+            return Tuple.Create<Exception?, T?>(null, result);
+        }
+        catch (Exception ex)
+        {
+            return Tuple.Create<Exception?, T?>(ex, default);
+        }
+    }
+}

--- a/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
@@ -14,7 +14,7 @@ namespace Altinn.App.Core.Features.Validation.Default;
 /// <summary>
 /// Default validator for signing tasks. Validates that all parties have signed the current task.
 /// </summary>
-internal class SigningTaskValidator : IValidator
+internal sealed class SigningTaskValidator : IValidator
 {
     private readonly IProcessReader _processReader;
     private readonly ISigningService _signingService;
@@ -69,7 +69,7 @@ internal class SigningTaskValidator : IValidator
 
         AltinnSignatureConfiguration? signingConfiguration = taskConfig?.SignatureConfiguration;
 
-        return signingConfiguration?.RunDefaultValidator == true && taskConfig?.TaskType == "signing";
+        return signingConfiguration?.RunDefaultValidator == true && taskConfig?.TaskType is "signing";
     }
 
     public bool NoIncrementalValidation => true;

--- a/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnSignatureConfiguration.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnSignatureConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Xml.Serialization;
+using Altinn.App.Core.Features.Validation.Default;
 
 namespace Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
 
@@ -54,4 +55,10 @@ public class AltinnSignatureConfiguration
     /// </summary>
     [XmlElement(ElementName = "correspondenceResource", Namespace = "http://altinn.no/process")]
     public List<AltinnEnvironmentConfig> CorrespondenceResources { get; set; } = [];
+
+    /// <summary>
+    /// Sets if the default signing validator, <see cref="SigningTaskValidator"/>, should run. The default validation checks if all parties have signed the task.
+    /// </summary>
+    [XmlElement("runDefaultValidator", Namespace = "http://altinn.no/process")]
+    public bool RunDefaultValidator { get; set; } = true;
 }

--- a/src/Altinn.App.Core/Models/Validation/ValidationIssueCodes.cs
+++ b/src/Altinn.App.Core/Models/Validation/ValidationIssueCodes.cs
@@ -65,5 +65,10 @@ public static class ValidationIssueCodes
         /// Gets a value that represents a validation issue where the data element is missing a file name.
         /// </summary>
         public static string MissingFileName => nameof(MissingFileName);
+
+        /// <summary>
+        /// Gets a value that represents a validation issue where the data element does not contain all required signatures.
+        /// </summary>
+        public static string MissingSignatures => nameof(MissingSignatures);
     }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/DataControllerPatchTests.InvalidTestValue_ReturnsConflict.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/DataControllerPatchTests.InvalidTestValue_ReturnsConflict.verified.txt
@@ -65,6 +65,10 @@
       Kind: Server
     },
     {
+      ActivityName: ProcessClient.GetProcessDefinition,
+      IdFormat: W3C
+    },
+    {
       ActivityName: SerializationService.DeserializeXml,
       Tags: [
         {

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
@@ -150,6 +150,14 @@
       IdFormat: W3C
     },
     {
+      ActivityName: ProcessReader.GetAltinnTaskExtension,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ProcessReader.GetFlowElement,
+      IdFormat: W3C
+    },
+    {
       ActivityName: SerializationService.DeserializeXml,
       Tags: [
         {

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -209,6 +209,10 @@
       IdFormat: W3C
     },
     {
+      ActivityName: ProcessReader.GetAltinnTaskExtension,
+      IdFormat: W3C
+    },
+    {
       ActivityName: ProcessReader.GetEndEventIds,
       IdFormat: W3C
     },
@@ -222,6 +226,10 @@
     },
     {
       ActivityName: ProcessReader.GetExclusiveGateways,
+      IdFormat: W3C
+    },
+    {
+      ActivityName: ProcessReader.GetFlowElement,
       IdFormat: W3C
     },
     {

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/SigningTaskValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/SigningTaskValidatorTests.cs
@@ -2,11 +2,7 @@ using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Signing.Interfaces;
 using Altinn.App.Core.Features.Signing.Models;
 using Altinn.App.Core.Features.Validation.Default;
-using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
-using Altinn.App.Core.Internal.AppModel;
-using Altinn.App.Core.Internal.Data;
-using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Process;
 using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
 using Altinn.App.Core.Models;
@@ -22,10 +18,7 @@ public class SigningTaskValidatorTest
 {
     private readonly Mock<IProcessReader> _processReaderMock = new();
     private readonly Mock<ISigningService> _signingServiceMock = new();
-    private readonly Mock<IDataClient> _dataClientMock = new();
-    private readonly Mock<IInstanceClient> _instanceClientMock = new();
     private readonly Mock<IAppMetadata> _appMetadataMock = new();
-    private readonly Mock<ModelSerializationService> _modelSerializationMock = new(new Mock<IAppModel>().Object, null!);
     private readonly Mock<ILogger<SigningTaskValidator>> _loggerMock = new();
     private readonly SigningTaskValidator _validator;
 
@@ -35,10 +28,7 @@ public class SigningTaskValidatorTest
             _loggerMock.Object,
             _processReaderMock.Object,
             _signingServiceMock.Object,
-            _dataClientMock.Object,
-            _instanceClientMock.Object,
-            _appMetadataMock.Object,
-            _modelSerializationMock.Object
+            _appMetadataMock.Object
         );
     }
 
@@ -67,11 +57,11 @@ public class SigningTaskValidatorTest
             .Returns(new AltinnTaskExtension { SignatureConfiguration = signingConfiguration });
         _appMetadataMock.Setup(am => am.GetApplicationMetadata()).ReturnsAsync(appMetadata);
         _signingServiceMock
-            .Setup(ss => ss.GetSigneeContexts(It.IsAny<InstanceDataUnitOfWork>(), signingConfiguration))
+            .Setup(ss => ss.GetSigneeContexts(It.IsAny<IInstanceDataAccessor>(), signingConfiguration))
             .ReturnsAsync(signeeContexts);
 
         // Act
-        var result = await _validator.Validate(dataAccessorMock.Object, taskId, null);
+        var result = await _validator.Validate(dataAccessorMock.Object, taskId, null!);
 
         // Assert
         Assert.Empty(result);
@@ -102,11 +92,11 @@ public class SigningTaskValidatorTest
             .Returns(new AltinnTaskExtension { SignatureConfiguration = signingConfiguration });
         _appMetadataMock.Setup(am => am.GetApplicationMetadata()).ReturnsAsync(appMetadata);
         _signingServiceMock
-            .Setup(ss => ss.GetSigneeContexts(It.IsAny<InstanceDataUnitOfWork>(), signingConfiguration))
+            .Setup(ss => ss.GetSigneeContexts(It.IsAny<IInstanceDataAccessor>(), signingConfiguration))
             .ReturnsAsync(signeeContexts);
 
         // Act
-        var result = await _validator.Validate(dataAccessorMock.Object, taskId, null);
+        var result = await _validator.Validate(dataAccessorMock.Object, taskId, null!);
 
         // Assert
         Assert.Single(result);
@@ -129,7 +119,7 @@ public class SigningTaskValidatorTest
         _appMetadataMock.Setup(am => am.GetApplicationMetadata()).ThrowsAsync(exception);
 
         // Act
-        var result = await _validator.Validate(dataAccessorMock.Object, taskId, null);
+        var result = await _validator.Validate(dataAccessorMock.Object, taskId, null!);
 
         // Assert
         Assert.Empty(result);
@@ -164,11 +154,11 @@ public class SigningTaskValidatorTest
             .Returns(new AltinnTaskExtension { SignatureConfiguration = signingConfiguration });
         _appMetadataMock.Setup(am => am.GetApplicationMetadata()).ReturnsAsync(appMetadata);
         _signingServiceMock
-            .Setup(ss => ss.GetSigneeContexts(It.IsAny<InstanceDataUnitOfWork>(), signingConfiguration))
+            .Setup(ss => ss.GetSigneeContexts(It.IsAny<IInstanceDataAccessor>(), signingConfiguration))
             .ThrowsAsync(exception);
 
         // Act
-        var result = await _validator.Validate(dataAccessorMock.Object, taskId, null);
+        var result = await _validator.Validate(dataAccessorMock.Object, taskId, null!);
 
         // Assert
         Assert.Empty(result);

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/SigningTaskValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/SigningTaskValidatorTests.cs
@@ -25,11 +25,9 @@ public class SigningTaskValidatorTest
     private readonly Mock<IDataClient> _dataClientMock = new();
     private readonly Mock<IInstanceClient> _instanceClientMock = new();
     private readonly Mock<IAppMetadata> _appMetadataMock = new();
-    private readonly Mock<ModelSerializationService> _modelSerializationMock = new(new Mock<IAppModel>().Object, null);
+    private readonly Mock<ModelSerializationService> _modelSerializationMock = new(new Mock<IAppModel>().Object, null!);
     private readonly Mock<ILogger<SigningTaskValidator>> _loggerMock = new();
     private readonly SigningTaskValidator _validator;
-
-    private readonly ILogger _logger;
 
     public SigningTaskValidatorTest()
     {
@@ -42,8 +40,6 @@ public class SigningTaskValidatorTest
             _appMetadataMock.Object,
             _modelSerializationMock.Object
         );
-        using ILoggerFactory factory = LoggerFactory.Create(builder => builder.AddConsole());
-        _logger = factory.CreateLogger("SigningTaskValidatorTest");
     }
 
     [Fact]
@@ -76,7 +72,6 @@ public class SigningTaskValidatorTest
 
         // Act
         var result = await _validator.Validate(dataAccessorMock.Object, taskId, null);
-        _logger.LogInformation("Validation result: {result}", result);
 
         // Assert
         Assert.Empty(result);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Default validator for all signing tasks. Runs by default if not `runDefaultValidator="false"` in `process.bpmn`.

Should it be called `runDefaultValidations` instead? 🤷‍♀️ 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
