### PR TITLE
Single quotes in prefill data

### DIFF
--- a/src/Altinn.App.Core/Implementation/PrefillSI.cs
+++ b/src/Altinn.App.Core/Implementation/PrefillSI.cs
@@ -268,9 +268,6 @@ public class PrefillSI : IPrefill
         }
     }
 
-    /// <summary>
-    /// Loops through the key-value dictionary and assigns each value to the datamodel target field
-    /// </summary>
     private void LoopThroughDictionaryAndAssignValuesToDataModel(
         Dictionary<string, string> dictionary,
         JObject? sourceObject,
@@ -278,18 +275,19 @@ public class PrefillSI : IPrefill
         bool continueOnError = false
     )
     {
-        foreach (KeyValuePair<string, string> keyValuePair in dictionary)
+        foreach (KeyValuePair<string, string> kvp in dictionary)
         {
-            string source = keyValuePair.Value;
-            string target = keyValuePair.Key.Replace("-", string.Empty);
-            if (source == null || source == string.Empty)
+            var source = kvp.Value;
+            var target = kvp.Key.Replace("-", string.Empty);
+
+            if (string.IsNullOrEmpty(source))
             {
                 string errorMessage = $"Could not prefill, a source value was not set for target: {target}";
                 _logger.LogError(errorMessage);
                 throw new Exception(errorMessage);
             }
 
-            if (target == null || target == string.Empty)
+            if (string.IsNullOrEmpty(target))
             {
                 string errorMessage = $"Could not prefill, a target value was not set for source: {source}";
                 _logger.LogError(errorMessage);
@@ -303,12 +301,13 @@ public class PrefillSI : IPrefill
             }
             else
             {
-                sourceValue = JToken.Parse($"'{source}'");
+                sourceValue = JValue.CreateString(source);
             }
 
-            _logger.LogInformation($"Source: {source}, target: {target}");
-            _logger.LogInformation($"Value read from source object: {sourceValue?.ToString()}");
-            string[] keys = target.Split(".");
+            _logger.LogInformation("Source: {Source}, target: {Target}", source, target);
+            _logger.LogInformation("Value read from source object: {Value}", sourceValue?.ToString());
+
+            string[] keys = target.Split('.');
             AssignValueToDataModel(keys, sourceValue, serviceModel, 0, continueOnError);
         }
     }

--- a/src/Altinn.App.Core/Implementation/PrefillSI.cs
+++ b/src/Altinn.App.Core/Implementation/PrefillSI.cs
@@ -268,6 +268,9 @@ public class PrefillSI : IPrefill
         }
     }
 
+    /// <summary>
+    /// Loops through the key-value dictionary and assigns each value to the datamodel target field
+    /// </summary>
     private void LoopThroughDictionaryAndAssignValuesToDataModel(
         Dictionary<string, string> dictionary,
         JObject? sourceObject,
@@ -275,10 +278,10 @@ public class PrefillSI : IPrefill
         bool continueOnError = false
     )
     {
-        foreach (KeyValuePair<string, string> kvp in dictionary)
+        foreach (KeyValuePair<string, string> keyValuePair in dictionary)
         {
-            var source = kvp.Value;
-            var target = kvp.Key.Replace("-", string.Empty);
+            var source = keyValuePair.Value;
+            var target = keyValuePair.Key.Replace("-", string.Empty);
 
             if (string.IsNullOrEmpty(source))
             {
@@ -304,10 +307,10 @@ public class PrefillSI : IPrefill
                 sourceValue = JValue.CreateString(source);
             }
 
-            _logger.LogInformation("Source: {Source}, target: {Target}", source, target);
-            _logger.LogInformation("Value read from source object: {Value}", sourceValue?.ToString());
+            _logger.LogInformation($"Source: {source}, target: {target}");
+            _logger.LogInformation($"Value read from source object: {sourceValue}");
+            string[] keys = target.Split(".");
 
-            string[] keys = target.Split('.');
             AssignValueToDataModel(keys, sourceValue, serviceModel, 0, continueOnError);
         }
     }

--- a/src/Altinn.App.Core/Implementation/PrefillSI.cs
+++ b/src/Altinn.App.Core/Implementation/PrefillSI.cs
@@ -280,8 +280,8 @@ public class PrefillSI : IPrefill
     {
         foreach (KeyValuePair<string, string> keyValuePair in dictionary)
         {
-            var source = keyValuePair.Value;
-            var target = keyValuePair.Key.Replace("-", string.Empty);
+            string source = keyValuePair.Value;
+            string target = keyValuePair.Key.Replace("-", string.Empty);
 
             if (string.IsNullOrEmpty(source))
             {

--- a/test/Altinn.App.Core.Tests/Implementation/PrefillSITest.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/PrefillSITest.cs
@@ -10,18 +10,18 @@ namespace Altinn.App.Core.Tests;
 
 public class PrefillTestDataModel
 {
-    public TestPrefillFields Prefill { get; set; }
+    public TestPrefillFields? Prefill { get; set; }
 }
 
 public class TestPrefillFields
 {
-    public string EraSourceEnvironment { get; set; }
-    public string KanOppretteAarligMelding { get; set; }
-    public string ArkivSaksId { get; set; }
-    public string InnsendingSvarfrist { get; set; }
-    public string YrkesskadeforsikringPolisenummer { get; set; }
-    public string YrkesskadeforsikringNavn { get; set; }
-    public string YrkesskadeforsikringGyldigTilDato { get; set; }
+    public string? EraSourceEnvironment { get; set; }
+    public string? KanOppretteAarligMelding { get; set; }
+    public string? ArkivSaksId { get; set; }
+    public string? InnsendingSvarfrist { get; set; }
+    public string? YrkesskadeforsikringPolisenummer { get; set; }
+    public string? YrkesskadeforsikringNavn { get; set; }
+    public string? YrkesskadeforsikringGyldigTilDato { get; set; }
 }
 
 public class PrefillSITests

--- a/test/Altinn.App.Core.Tests/Implementation/PrefillSITest.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/PrefillSITest.cs
@@ -1,0 +1,70 @@
+using Altinn.App.Core.Implementation;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Profile;
+using Altinn.App.Core.Internal.Registers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Altinn.App.Core.Tests;
+
+public class PrefillTestDataModel
+{
+    public TestPrefillFields Prefill { get; set; }
+}
+
+public class TestPrefillFields
+{
+    public string EraSourceEnvironment { get; set; }
+    public string KanOppretteAarligMelding { get; set; }
+    public string ArkivSaksId { get; set; }
+    public string InnsendingSvarfrist { get; set; }
+    public string YrkesskadeforsikringPolisenummer { get; set; }
+    public string YrkesskadeforsikringNavn { get; set; }
+    public string YrkesskadeforsikringGyldigTilDato { get; set; }
+}
+
+public class PrefillSITests
+{
+    [Fact]
+    public void PrefillDataModel_AssignsValuesCorrectly()
+    {
+        var externalPrefill = new Dictionary<string, string>
+        {
+            { "Prefill.EraSourceEnvironment", "prod" },
+            { "Prefill.KanOppretteAarligMelding", "True" },
+            { "Prefill.ArkivSaksId", "1203228" },
+            { "Prefill.InnsendingSvarfrist", "2025-01-01T00:00:00.0000000" },
+            { "Prefill.YrkesskadeforsikringPolisenummer", "301738.1" },
+            { "Prefill.YrkesskadeforsikringNavn", "S'oderberg og Partners" },
+            { "Prefill.YrkesskadeforsikringGyldigTilDato", "2023-12-31T12:00:00.000+01:00" },
+        };
+
+        var dataModel = new PrefillTestDataModel();
+
+        var loggerMock = new Mock<ILogger<PrefillSI>>();
+        var profileClientMock = new Mock<IProfileClient>();
+        var appResourcesMock = new Mock<IAppResources>();
+        var altinnPartyClientMock = new Mock<IAltinnPartyClient>();
+        var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+
+        var prefillToTest = new PrefillSI(
+            loggerMock.Object,
+            profileClientMock.Object,
+            appResourcesMock.Object,
+            altinnPartyClientMock.Object,
+            httpContextAccessorMock.Object
+        );
+
+        prefillToTest.PrefillDataModel(dataModel, externalPrefill, continueOnError: false);
+
+        Assert.NotNull(dataModel.Prefill);
+        Assert.Equal("prod", dataModel.Prefill.EraSourceEnvironment);
+        Assert.Equal("True", dataModel.Prefill.KanOppretteAarligMelding);
+        Assert.Equal("1203228", dataModel.Prefill.ArkivSaksId);
+        Assert.Equal("2025-01-01T00:00:00.0000000", dataModel.Prefill.InnsendingSvarfrist);
+        Assert.Equal("301738.1", dataModel.Prefill.YrkesskadeforsikringPolisenummer);
+        Assert.Equal("S'oderberg og Partners", dataModel.Prefill.YrkesskadeforsikringNavn);
+        Assert.Equal("2023-12-31T12:00:00.000+01:00", dataModel.Prefill.YrkesskadeforsikringGyldigTilDato);
+    }
+}


### PR DESCRIPTION
## Description
Fixed bug where we would try to parse a string value to json wrapped in quotes, creating the case where a string containing a single quote would not be valid json. 

Now simply parsing to string.

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/928

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
