### PR TITLE
Improve backwards compatibility for apps that use LayoutEvaluator.RemoveHiddenData

### DIFF
--- a/src/Altinn.App.Core/Helpers/DataModel/RowRemovalOption.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/RowRemovalOption.cs
@@ -1,4 +1,5 @@
-namespace Altinn.App.Core.Helpers.DataModel;
+// ReSharper disable once CheckNamespace // Namespace is kept after refactoring
+namespace Altinn.App.Core.Helpers;
 
 /// <summary>
 /// Option for how to handle row removal

--- a/src/Altinn.App.Core/Internal/App/IAppResources.cs
+++ b/src/Altinn.App.Core/Internal/App/IAppResources.cs
@@ -133,7 +133,7 @@ public interface IAppResources
     /// <summary>
     /// Gets the full layout model for the optional set
     /// </summary>
-    [Obsolete("Use GetLayoutModelForTask instead", true)]
+    [Obsolete("Use GetLayoutModelForTask instead", false)]
     LayoutModel GetLayoutModel(string? layoutSetId = null);
 
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluator.cs
@@ -125,7 +125,7 @@ public static class LayoutEvaluator
     [Obsolete("Use the async version of this method RemoveHiddenDataAsync")]
     public static void RemoveHiddenData(LayoutEvaluatorState state, RowRemovalOption rowRemovalOption)
     {
-        RemoveHiddenDataAsync(state, rowRemovalOption).Wait();
+        RemoveHiddenDataAsync(state, rowRemovalOption).GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluator.cs
@@ -1,4 +1,4 @@
-using Altinn.App.Core.Helpers.DataModel;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Models.Expressions;
 using Altinn.App.Core.Models.Layout;
 using Altinn.App.Core.Models.Layout.Components;
@@ -122,7 +122,16 @@ public static class LayoutEvaluator
     /// <summary>
     /// Remove fields that are only referenced from hidden fields from the data object in the state.
     /// </summary>
-    public static async Task RemoveHiddenData(LayoutEvaluatorState state, RowRemovalOption rowRemovalOption)
+    [Obsolete("Use the async version of this method RemoveHiddenDataAsync")]
+    public static void RemoveHiddenData(LayoutEvaluatorState state, RowRemovalOption rowRemovalOption)
+    {
+        RemoveHiddenDataAsync(state, rowRemovalOption).Wait();
+    }
+
+    /// <summary>
+    /// Remove fields that are only referenced from hidden fields from the data object in the state.
+    /// </summary>
+    public static async Task RemoveHiddenDataAsync(LayoutEvaluatorState state, RowRemovalOption rowRemovalOption)
     {
         var fields = await GetHiddenFieldsForRemoval(state);
         foreach (var dataReference in fields)

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.DataModel;
 using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Expressions;

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -91,7 +91,8 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
     /// <summary>
     /// Initialize LayoutEvaluatorState with given Instance, data object and layoutSetId
     /// </summary>
-    [Obsolete("Use the overload with ILayoutEvaluatorStateInitializer instead")]
+    //[Obsolete("Use the overload with ILayoutEvaluatorStateInitializer instead")]
+    // We don't yet have a good alternative for this method
     public async Task<LayoutEvaluatorState> Init(
         Instance instance,
         object data,
@@ -99,7 +100,9 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
         string? gatewayAction = null
     )
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         var layouts = _appResources.GetLayoutModel(layoutSetId);
+#pragma warning restore CS0618 // Type or member is obsolete
         var dataElement = instance.Data.Find(d => d.DataType == layouts.DefaultDataType.Id);
         Debug.Assert(dataElement is not null);
         var appMetadata = await _appMetadata.GetApplicationMetadata();

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizer.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Helpers;
-using Altinn.App.Core.Helpers.DataModel;
 using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
@@ -105,7 +104,7 @@ public class ProcessTaskFinalizer : IProcessTaskFinalizer
                 gatewayAction: null,
                 language
             );
-            await LayoutEvaluator.RemoveHiddenData(evaluationState, RowRemovalOption.DeleteRow);
+            await LayoutEvaluator.RemoveHiddenDataAsync(evaluationState, RowRemovalOption.DeleteRow);
         }
 
         // Remove shadow fields

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/RunTest2.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test2/RunTest2.cs
@@ -1,5 +1,5 @@
 using System.Text.Json.Serialization;
-using Altinn.App.Core.Helpers.DataModel;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Models.Layout;
 using FluentAssertions;
@@ -88,7 +88,7 @@ public class RunTest2
         data.Some.Data[0].Binding2.Should().Be(0); // binding is not nullable, but will be reset to zero
         data.Some.Data[1].Binding.Should().Be("binding");
         data.Some.Data[1].Binding2.Should().Be(2);
-        await LayoutEvaluator.RemoveHiddenData(state, RowRemovalOption.DeleteRow);
+        await LayoutEvaluator.RemoveHiddenDataAsync(state, RowRemovalOption.DeleteRow);
 
         // Verify data was removed
         data.Some.Data[0].Binding.Should().BeNull();

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test3/RunTest3.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/Test3/RunTest3.cs
@@ -1,5 +1,5 @@
 using System.Text.Json.Serialization;
-using Altinn.App.Core.Helpers.DataModel;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Models.Layout;
 using FluentAssertions;
@@ -73,7 +73,7 @@ public class RunTest3
         data.Some.Data[2].Binding.Should().Be("hideRow");
         data.Some.Data[2].Binding2.Should().Be(3);
         data.Some.Data[2].Binding3.Should().Be("text");
-        await LayoutEvaluator.RemoveHiddenData(state, RowRemovalOption.SetToNull);
+        await LayoutEvaluator.RemoveHiddenDataAsync(state, RowRemovalOption.SetToNull);
 
         // Verify row not deleted but fields null
         data.Some.Data.Should().HaveCount(3);
@@ -142,7 +142,7 @@ public class RunTest3
         data.Some.Data[2].Binding3.Should().Be("text");
 
         // Verify rows deleted
-        await LayoutEvaluator.RemoveHiddenData(state, RowRemovalOption.DeleteRow);
+        await LayoutEvaluator.RemoveHiddenDataAsync(state, RowRemovalOption.DeleteRow);
         data.Some.Data.Should().HaveCount(2);
         data.Some.Data[0].Binding.Should().BeNull();
         data.Some.Data[0].Binding2.Should().Be(0); // binding is not nullable, but will be reset to zero

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/TestDataModel.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/TestDataModel.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.DataModel;
 using Altinn.App.Core.Tests.LayoutExpressions.TestUtilities;
 using Altinn.Platform.Storage.Interface.Models;


### PR DESCRIPTION
SSB complains that updating to 8.5.0 is not friction less, so I made a few changes to fix it


* Un[Obsolete] `LayoutEvaluatorStateInitializer.Init()`, as it still works and we don't have a good alternative finished yet.
* Move RowRemovalOption back to original namespace
* Create RemoveHiddenDataAsync and ensure that the old version is `Wait()`ed. (Code without mulitple datamodels is syncronous anyway)