### PR TITLE
Mark Correspondence client and responses as `Experimental`

### DIFF
--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -5,7 +5,7 @@
     <Description>
       This class library holds all the core features used by a standard Altinn 3 App.
     </Description>
-    <NoWarn>Correspondence001</NoWarn>
+    <NoWarn>ALTINNAPP0200</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -5,6 +5,7 @@
     <Description>
       This class library holds all the core features used by a standard Altinn 3 App.
     </Description>
+    <NoWarn>Correspondence001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
@@ -18,7 +19,7 @@
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.4" />
     <PackageReference Include="JsonPatch.Net" Version="3.2.3" />
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
-    <!-- The follwoing are depencencies for JWTCookieAuthentication, but we need newer versions-->
+    <!-- The following are depencencies for JWTCookieAuthentication, but we need newer versions-->
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.3.0"
     />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />

--- a/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
@@ -43,7 +43,7 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
     }
 
     /// <inheritdoc />
-    [Experimental(diagnosticId: "Correspondence002")]
+    [Experimental(diagnosticId: "Correspondence001")]
     public async Task<SendCorrespondenceResponse> Send(
         SendCorrespondencePayload payload,
         CancellationToken cancellationToken = default
@@ -93,7 +93,7 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
     }
 
     /// <inheritdoc/>
-    [Experimental(diagnosticId: "Correspondence003")]
+    [Experimental(diagnosticId: "Correspondence001")]
     public async Task<GetCorrespondenceStatusResponse> GetStatus(
         GetCorrespondenceStatusPayload payload,
         CancellationToken cancellationToken = default

--- a/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -16,6 +17,7 @@ using CorrespondenceResult = Altinn.App.Core.Features.Telemetry.Correspondence.C
 namespace Altinn.App.Core.Features.Correspondence;
 
 /// <inheritdoc />
+[Experimental("Correspondence001")]
 internal sealed class CorrespondenceClient : ICorrespondenceClient
 {
     private readonly ILogger<CorrespondenceClient> _logger;
@@ -41,6 +43,7 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
     }
 
     /// <inheritdoc />
+    [Experimental(diagnosticId: "Correspondence002")]
     public async Task<SendCorrespondenceResponse> Send(
         SendCorrespondencePayload payload,
         CancellationToken cancellationToken = default
@@ -90,6 +93,7 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
     }
 
     /// <inheritdoc/>
+    [Experimental(diagnosticId: "Correspondence003")]
     public async Task<GetCorrespondenceStatusResponse> GetStatus(
         GetCorrespondenceStatusPayload payload,
         CancellationToken cancellationToken = default

--- a/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
@@ -17,7 +17,7 @@ using CorrespondenceResult = Altinn.App.Core.Features.Telemetry.Correspondence.C
 namespace Altinn.App.Core.Features.Correspondence;
 
 /// <inheritdoc />
-[Experimental("Correspondence001")]
+[Experimental("ALTINNAPP0200")]
 internal sealed class CorrespondenceClient : ICorrespondenceClient
 {
     private readonly ILogger<CorrespondenceClient> _logger;
@@ -43,7 +43,7 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
     }
 
     /// <inheritdoc />
-    [Experimental(diagnosticId: "Correspondence001")]
+    [Experimental(diagnosticId: "ALTINNAPP0200")]
     public async Task<SendCorrespondenceResponse> Send(
         SendCorrespondencePayload payload,
         CancellationToken cancellationToken = default
@@ -93,7 +93,7 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
     }
 
     /// <inheritdoc/>
-    [Experimental(diagnosticId: "Correspondence001")]
+    [Experimental(diagnosticId: "ALTINNAPP0200")]
     public async Task<GetCorrespondenceStatusResponse> GetStatus(
         GetCorrespondenceStatusPayload payload,
         CancellationToken cancellationToken = default

--- a/src/Altinn.App.Core/Features/Correspondence/ICorrespondenceClient.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/ICorrespondenceClient.cs
@@ -7,7 +7,7 @@ namespace Altinn.App.Core.Features.Correspondence;
 /// <p>Contains logic for interacting with the correspondence message service.</p>
 /// <p>The use of this client requires Maskinporten scopes <c>altinn:correspondence.write</c> and <c>altinn:serviceowner</c>.</p>
 /// </summary>
-[Experimental(diagnosticId: "Correspondence001")]
+[Experimental(diagnosticId: "ALTINNAPP0200")]
 public interface ICorrespondenceClient
 {
     /// <summary>

--- a/src/Altinn.App.Core/Features/Correspondence/ICorrespondenceClient.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/ICorrespondenceClient.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Altinn.App.Core.Features.Correspondence.Models;
 
 namespace Altinn.App.Core.Features.Correspondence;
@@ -6,6 +7,7 @@ namespace Altinn.App.Core.Features.Correspondence;
 /// <p>Contains logic for interacting with the correspondence message service.</p>
 /// <p>The use of this client requires Maskinporten scopes <c>altinn:correspondence.write</c> and <c>altinn:serviceowner</c>.</p>
 /// </summary>
+[Experimental(diagnosticId: "Correspondence001")]
 public interface ICorrespondenceClient
 {
     /// <summary>

--- a/src/Altinn.App.Core/Features/Correspondence/Models/GetCorrespondenceStatusResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/GetCorrespondenceStatusResponse.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Models;
 
@@ -6,6 +7,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models;
 /// <summary>
 /// Response after a successful <see cref="CorrespondenceClient.GetStatus"/> request.
 /// </summary>
+[Experimental(diagnosticId: "Correspondence005")]
 public sealed record GetCorrespondenceStatusResponse
 {
     /// <summary>

--- a/src/Altinn.App.Core/Features/Correspondence/Models/GetCorrespondenceStatusResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/GetCorrespondenceStatusResponse.cs
@@ -7,7 +7,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models;
 /// <summary>
 /// Response after a successful <see cref="CorrespondenceClient.GetStatus"/> request.
 /// </summary>
-[Experimental(diagnosticId: "Correspondence005")]
+[Experimental(diagnosticId: "Correspondence001")]
 public sealed record GetCorrespondenceStatusResponse
 {
     /// <summary>

--- a/src/Altinn.App.Core/Features/Correspondence/Models/GetCorrespondenceStatusResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/GetCorrespondenceStatusResponse.cs
@@ -7,7 +7,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models;
 /// <summary>
 /// Response after a successful <see cref="CorrespondenceClient.GetStatus"/> request.
 /// </summary>
-[Experimental(diagnosticId: "Correspondence001")]
+[Experimental(diagnosticId: "ALTINNAPP0200")]
 public sealed record GetCorrespondenceStatusResponse
 {
     /// <summary>

--- a/src/Altinn.App.Core/Features/Correspondence/Models/SendCorrespondenceResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/SendCorrespondenceResponse.cs
@@ -6,7 +6,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models;
 /// <summary>
 /// Response after a successful <see cref="CorrespondenceClient.Send"/> request.
 /// </summary>
-[Experimental(diagnosticId: "Correspondence001")]
+[Experimental(diagnosticId: "ALTINNAPP0200")]
 public sealed record SendCorrespondenceResponse
 {
     /// <summary>

--- a/src/Altinn.App.Core/Features/Correspondence/Models/SendCorrespondenceResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/SendCorrespondenceResponse.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Altinn.App.Core.Features.Correspondence.Models;
@@ -5,6 +6,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models;
 /// <summary>
 /// Response after a successful <see cref="CorrespondenceClient.Send"/> request.
 /// </summary>
+[Experimental(diagnosticId: "Correspondence004")]
 public sealed record SendCorrespondenceResponse
 {
     /// <summary>

--- a/src/Altinn.App.Core/Features/Correspondence/Models/SendCorrespondenceResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/SendCorrespondenceResponse.cs
@@ -6,7 +6,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models;
 /// <summary>
 /// Response after a successful <see cref="CorrespondenceClient.Send"/> request.
 /// </summary>
-[Experimental(diagnosticId: "Correspondence004")]
+[Experimental(diagnosticId: "Correspondence001")]
 public sealed record SendCorrespondenceResponse
 {
     /// <summary>

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -10,7 +10,7 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <NoWarn>$(NoWarn);CS1591;CS0618;Correspondence001</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS0618;ALTINNAPP0200</NoWarn>
     <!--
       CS1591: Don't warn for missing XML doc
       CS0618: This is a test project, so we usually continue testing [Obsolete] apis

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -10,7 +10,7 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <NoWarn>$(NoWarn);CS1591;CS0618</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS0618;Correspondence001</NoWarn>
     <!--
       CS1591: Don't warn for missing XML doc
       CS0618: This is a test project, so we usually continue testing [Obsolete] apis


### PR DESCRIPTION
## Description
Since the Correspondence API has not yet stabilised, this patch marks the client + methods, along with their responses as `experimental`. The request objects are not annotated, because we are not expecting any breaking changes to the _input_ for the Correspondence API.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
