### PR TITLE
Add "other" as accepted label

### DIFF
--- a/.github/workflows/check-label-added.yml
+++ b/.github/workflows/check-label-added.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           script: |
             const labels = context.payload.pull_request.labels;
-            const releaseLabels = ["ignore-for-release", "breaking-change", "feature", "bugfix", "dependency"];
+            const releaseLabels = ["ignore-for-release", "breaking-change", "feature", "bugfix", "dependency", "other"];
             if(!releaseLabels.some(r=>labels.some(l=>l.name == r))){
                 core.setFailed(`The PR must have at least one of these labels: ${releaseLabels}`)
             }


### PR DESCRIPTION
Some PR belong in changelog, but does not fit in any of the existing categories