### PR TITLE
Add back AssemblyVersionTarget

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -47,6 +47,14 @@
     <PackageId>$(MSBuildProjectName).Experimental</PackageId>
   </PropertyGroup>
 
+  <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(MinVerVersion)'!='' AND '$(BuildNumber)' != ''">
+    <PropertyGroup>
+      <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BuildNumber)</FileVersion>
+      <Version>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BuildNumber)</Version>
+      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(BuildNumber)</AssemblyVersion>
+    </PropertyGroup>
+  </Target>
+
   <ItemGroup Condition="'$(Deterministic)'=='true'">
     <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Hunting down a bug, not sure if this is related..

Comparing the nupkgs of 8.5.1 vs 8.5.0:
![image](https://github.com/user-attachments/assets/c8f665d0-9b33-4e24-b734-6ca4418bde8e)


The Assembly name version is not the same, which is bad regardless. I think the msbuild target I removed is the only thing that can affect that, and I'm not sure why this was not reproduced when I tested this locally


## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
