### PR TITLE
Refactor JwtToken masking

### DIFF
--- a/src/Altinn.App.Core/Models/JwtToken.cs
+++ b/src/Altinn.App.Core/Models/JwtToken.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.IdentityModel.Tokens.Jwt;
-using System.Text.RegularExpressions;
 
 namespace Altinn.App.Core.Models;
 
@@ -9,7 +8,7 @@ namespace Altinn.App.Core.Models;
 /// Needs to be unencrypted.
 /// </summary>
 [ImmutableObject(true)] // `ImmutableObject` prevents serialization with HybridCache
-public readonly partial struct JwtToken : IEquatable<JwtToken>
+public readonly struct JwtToken : IEquatable<JwtToken>
 {
     /// <summary>
     /// The access token value (JWT format).
@@ -81,16 +80,6 @@ public readonly partial struct JwtToken : IEquatable<JwtToken>
         return true;
     }
 
-    // Matches a string with pattern eyXXX.eyXXX.XXX, allowing underscores and hyphens
-    [GeneratedRegex(@"^((?:ey[\w-]+\.){2})([\w-]+)$")]
-    private static partial Regex JwtRegex();
-
-    private static string MaskJwtSignature(string accessToken)
-    {
-        var accessTokenMatch = JwtRegex().Match(accessToken);
-        return accessTokenMatch.Success ? $"{accessTokenMatch.Groups[1]}<masked>" : "<masked>";
-    }
-
     /// <inheritdoc/>
     public bool Equals(JwtToken other) => Value == other.Value;
 
@@ -111,7 +100,7 @@ public readonly partial struct JwtToken : IEquatable<JwtToken>
     /// <summary>
     /// Returns a string representation of the access token with a masked signature component.
     /// </summary>
-    public override string ToString() => MaskJwtSignature(Value);
+    public override string ToString() => $"{_jwtSecurityToken.RawHeader}.{_jwtSecurityToken.RawPayload}.<masked>";
 
     /// <summary>
     /// Returns a string representation of the access token with an intact signature component.

--- a/test/Altinn.App.Core.Tests/Models/JwtTokenTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/JwtTokenTests.cs
@@ -168,9 +168,22 @@ public class AccessTokenTests
         var accessToken = JwtToken.Parse(encodedToken.AccessToken);
 
         // Act, Assert
-        accessToken.ToString().Should().NotBe(encodedToken.AccessToken);
-        accessToken.ToStringUnmasked().Should().Be(encodedToken.AccessToken);
+        accessToken
+            .ToString()
+            .Should()
+            .Be($"{encodedToken.Components.Header}.{encodedToken.Components.Payload}.<masked>");
         accessToken.ToString().Should().NotContain(encodedToken.Components.Signature);
         $"{accessToken}".Should().NotContain(encodedToken.Components.Signature);
+    }
+
+    [Fact]
+    public void ToStringUnmasked_ShouldNotMask_AccessToken()
+    {
+        // Arrange
+        var encodedToken = TestHelpers.GetEncodedAccessToken();
+        var accessToken = JwtToken.Parse(encodedToken.AccessToken);
+
+        // Act, Assert
+        accessToken.ToStringUnmasked().Should().Be(encodedToken.AccessToken);
     }
 }


### PR DESCRIPTION
## Description
The previous JwtToken method for masking signatures was a legacy implementation from before we parsed and stored a `JwtSecurityToken` object reference.

This reference contains all the information requried, rendering the regex check unnecessary. Additionally, the `ey....` pattern check is only valid for JWTs formatted without newlines and padding. Eg. not reliable in all contexts.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
