### PR TITLE
Fixes signing notification status mapping

### DIFF
--- a/src/Altinn.App.Api/Controllers/SigningController.cs
+++ b/src/Altinn.App.Api/Controllers/SigningController.cs
@@ -107,9 +107,10 @@ public class SigningController : ControllerBase
                     Organisation = signeeContext.OnBehalfOfOrganisation?.Name,
                     HasSigned = signeeContext.SignDocument is not null,
                     DelegationSuccessful = signeeContext.SigneeState.IsAccessDelegated,
-                    NotificationSuccessful =
-                        signeeContext.SigneeState
-                            is { SignatureRequestEmailSent: false, SignatureRequestSmsSent: false },
+                    NotificationSuccessful = (
+                        signeeContext.SigneeState is
+                        { SignatureRequestEmailNotSentReason: null, SignatureRequestSmsNotSentReason: null }
+                    ),
                     PartyId = signeeContext.OriginalParty.PartyId,
                 }),
             ],

--- a/src/Altinn.App.Core/Features/Signing/SigningNotificationService.cs
+++ b/src/Altinn.App.Core/Features/Signing/SigningNotificationService.cs
@@ -41,6 +41,7 @@ internal sealed class SigningNotificationService : ISigningNotificationService
         CancellationToken? ct = null
     )
     {
+        _logger.LogInformation("Notifying signees of signature task.");
         using var activity = _telemetry?.StartNotifySigneesActivity();
         foreach (SigneeContext signeeContext in signeeContexts)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes setting notification success only if there are no error messages for sending email or sms. This will also support the case where notification should not be sent, that is it doesn't set notification failed if it hasn't even tried to send any notifications.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
