### PR TITLE
stricter handling of missing partyid

### DIFF
--- a/src/Altinn.App.Api/Controllers/StatelessDataController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessDataController.cs
@@ -35,7 +35,6 @@ public class StatelessDataController : ControllerBase
     private readonly IPrefill _prefillService;
     private readonly IAltinnPartyClient _altinnPartyClientClient;
     private readonly IPDP _pdp;
-    private readonly IAuthenticationContext _authenticationContext;
     private const long REQUEST_SIZE_LIMIT = 2000 * 1024 * 1024;
 
     private const string PartyPrefix = "partyid";
@@ -63,7 +62,6 @@ public class StatelessDataController : ControllerBase
         _prefillService = prefillService;
         _altinnPartyClientClient = altinnPartyClientClient;
         _pdp = pdp;
-        _authenticationContext = authenticationContext;
     }
 
     /// <summary>

--- a/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using Altinn.App.Api.Controllers;

--- a/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
@@ -329,7 +329,7 @@ public class StatelessDataControllerTests
         var result = await statelessDataController.Get("ttd", "demo-app", dataType, "partyId:501337");
 
         // Assert
-        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(403);q
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(403);
         appResourcesMock.Verify(x => x.GetClassRefForLogicDataType(dataType), Times.Once);
         appResourcesMock.VerifyNoOtherCalls();
         pdpMock.Verify(p => p.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()));


### PR DESCRIPTION
Removed logic in stateless controller that would return the party of the logged in user if no partyid was provided.

## Description
As noted in the comments of StatelessDataController.cs, if the client did not provide partyid, we would use the party of the logged in user.

This caused the error in the issue below.

This PR removes that fallback, we will now throw an error if the partyid is missing, or we cannot lookup instanceowner based on it.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/2065

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
