### PR TITLE
Fix case where querying for roles for a user without any roles threw exception

### DIFF
--- a/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using Altinn.App.Core.Configuration;
@@ -198,6 +199,9 @@ public class AuthorizationClient : IAuthorizationClient
         try
         {
             HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return roles;
+
             if (response.IsSuccessStatusCode)
             {
                 string responseContent = await response.Content.ReadAsStringAsync();

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_token=User_tokenType=Altinn_issuer=False_isExchanged=True.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_token=User_tokenType=Altinn_issuer=False_isExchanged=True.verified.txt
@@ -1,0 +1,67 @@
+﻿{
+  User: {
+    UserId: 1433953,
+    UserPartyId: 50593193,
+    SelectedPartyId: 50593193,
+    AuthenticationLevel: 3,
+    AuthenticationMethod: IdportenTestId,
+    InAltinnPortal: true,
+    TokenIssuer: Altinn,
+    TokenIsExchanged: false,
+    Scopes: {},
+    Token: eyJhbGciOiJSUzI1NiIsImtpZCI6IkQ4RDg2N0M3RDUyMTM2MEY0RjM1Q0Q1MTU4MEM0OUEwNTE2NUQ0RTEiLCJ4NXQiOiIyTmhueDlVaE5nOVBOYzFSV0F4Sm9GRmwxT0UiLCJ0eXAiOiJKV1QifQ.eyJuYW1laWQiOiIxNDMzOTUzIiwidXJuOmFsdGlubjp1c2VyaWQiOiIxNDMzOTUzIiwidXJuOmFsdGlubjpwYXJ0eWlkIjo1MDU5MzE5MywidXJuOmFsdGlubjphdXRoZW50aWNhdGVtZXRob2QiOiJJZHBvcnRlblRlc3RJZCIsInVybjphbHRpbm46YXV0aGxldmVsIjozLCJqdGkiOiJkMDk2YjBkYy1lYTgyLTRiNGUtYjY0ZS04Y2NjYzA2OWVmYzYiLCJzY29wZSI6ImFsdGlubjpwb3J0YWwvZW5kdXNlciIsIm5iZiI6MTczNzgxNTM0MSwiZXhwIjoxNzM3ODE3MTQxLCJpYXQiOjE3Mzc4MTUzNDF9.dLYVBOSu99_CjcrIqsw6OmdwfKTKthnG2j1kl2pdsVUgn34vFVDF-VAE40IfSpnKUk4VKG-EkGHISi7S2U9rvLrIU_ptTcchg7XCXYSpQhm1DqfsbVwKarTEDBtlSITeqzUI5t2C6DOGSg4QEip92cOAVPw-m34bxBmnXxo6g-3babb-qSsLty_IPBhj86M0Y6zEomE-ysNVNSLJ-0ccAWi4ByzdfdsA5PnBDoeNTzPSZ3PscMOWe3z5d43WRVq30uKVE3XYWt6W0Yf2CbGXVSCTM9J45P2Ps4qiJysQM0zw2guh3s1IIdF7c0-IrppB-3sLNrDzAZ71kyKJXrc5JQ
+  },
+  Details: {
+    UserParty: {
+      PartyId: 50593193,
+      PartyTypeName: Person,
+      SSN: 12345678901,
+      Name: Test Testesen,
+      IsDeleted: false,
+      OnlyHierarchyElementWithNoAccess: false
+    },
+    SelectedParty: {
+      PartyId: 50593193,
+      PartyTypeName: Person,
+      SSN: 12345678901,
+      Name: Test Testesen,
+      IsDeleted: false,
+      OnlyHierarchyElementWithNoAccess: false
+    },
+    Profile: {
+      UserId: 1433953,
+      IsReserved: false,
+      PartyId: 50593193,
+      Party: {
+        PartyId: 50593193,
+        PartyTypeName: Person,
+        SSN: 12345678901,
+        Name: Test Testesen,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false
+      }
+    },
+    RepresentsSelf: true,
+    Parties: [
+      {
+        PartyId: 50593193,
+        PartyTypeName: Person,
+        SSN: 12345678901,
+        Name: Test Testesen,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false
+      }
+    ],
+    PartiesAllowedToInstantiate: [
+      {
+        PartyId: 50593193,
+        PartyTypeName: Person,
+        SSN: 12345678901,
+        Name: Test Testesen,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false
+      }
+    ],
+    CanRepresent: true
+  }
+}

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_token=User_tokenType=IDporten_issuer=True_isExchanged=True.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_token=User_tokenType=IDporten_issuer=True_isExchanged=True.verified.txt
@@ -1,0 +1,67 @@
+﻿{
+  User: {
+    UserId: 1433953,
+    UserPartyId: 50593193,
+    SelectedPartyId: 50593193,
+    AuthenticationLevel: 3,
+    AuthenticationMethod: NotDefined,
+    InAltinnPortal: false,
+    TokenIssuer: IDporten,
+    TokenIsExchanged: true,
+    Scopes: {},
+    Token: eyJhbGciOiJSUzI1NiIsImtpZCI6IkQ4RDg2N0M3RDUyMTM2MEY0RjM1Q0Q1MTU4MEM0OUEwNTE2NUQ0RTEiLCJ4NXQiOiIyTmhueDlVaE5nOVBOYzFSV0F4Sm9GRmwxT0UiLCJ0eXAiOiJKV1QifQ.eyJuYW1laWQiOiIxNDMzOTUzIiwidXJuOmFsdGlubjp1c2VyaWQiOiIxNDMzOTUzIiwidXJuOmFsdGlubjp1c2VybmFtZSI6IiIsInVybjphbHRpbm46cGFydHlpZCI6NTA1OTMxOTMsInVybjphbHRpbm46YXV0aGVudGljYXRlbWV0aG9kIjoiTm90RGVmaW5lZCIsInVybjphbHRpbm46YXV0aGxldmVsIjozLCJhY3IiOiJpZHBvcnRlbi1sb2Etc3Vic3RhbnRpYWwiLCJzY29wZSI6ImFsdGlubjppbnN0YW5jZXMucmVhZCBvcGVuaWQgcHJvZmlsZSIsImNsaWVudF9hbXIiOiJjbGllbnRfc2VjcmV0X2Jhc2ljIiwicGlkIjoiMTk5MTQ4OTcyODEiLCJleHAiOjE3Mzc4MTU3NDYsImlhdCI6MTczNzgxNTE1NywiY2xpZW50X2lkIjoiZGVtb2NsaWVudF9pZHBvcnRlbl90ZXN0IiwiY29uc3VtZXIiOnsiYXV0aG9yaXR5IjoiaXNvNjUyMy1hY3RvcmlkLXVwaXMiLCJJRCI6IjAxOTI6OTkxODI1ODI3In0sImlzcyI6Imh0dHBzOi8vcGxhdGZvcm0udHQwMi5hbHRpbm4ubm8vYXV0aGVudGljYXRpb24vYXBpL3YxL29wZW5pZC8iLCJqdGkiOiI3MTMzYmMwNy1iZWE0LTRkNDAtOWRjNC1jMWFmZGZjMmU2NTEiLCJuYmYiOjE3Mzc4MTUxNTd9.W71Z1FiSYUBJ8G1De-aGYOiUbpD_FCB9gTceLSItZN33y98IzAvNRKJEfXUxVge-GPInjm1DmJ6MVs6ZcVRunigiLa5gNR_W5kkV6kBkaTbZ4SJQsMdT3AaHoBziJEL2ey_ONyDT4ffScx-lRoF_qKQXbkpqLm-Qkj1VKjEBVSTsaqKxJMQrhmKZ4zK6rwhFOPZv5HnGSt56CWh2jrkk8IFzIJZbvO738qHscZ--1UhwHcZ_hpjsdLGaxENiC25kAiqV8gTAyihOAg9ii7jwxLiQYRe_ahqBv5IqT_ZNKKa3q9t7Yh57hQjPWOqtTFTgaBCCYQohYqv-FQtOenbd5g
+  },
+  Details: {
+    UserParty: {
+      PartyId: 50593193,
+      PartyTypeName: Person,
+      SSN: 12345678901,
+      Name: Test Testesen,
+      IsDeleted: false,
+      OnlyHierarchyElementWithNoAccess: false
+    },
+    SelectedParty: {
+      PartyId: 50593193,
+      PartyTypeName: Person,
+      SSN: 12345678901,
+      Name: Test Testesen,
+      IsDeleted: false,
+      OnlyHierarchyElementWithNoAccess: false
+    },
+    Profile: {
+      UserId: 1433953,
+      IsReserved: false,
+      PartyId: 50593193,
+      Party: {
+        PartyId: 50593193,
+        PartyTypeName: Person,
+        SSN: 12345678901,
+        Name: Test Testesen,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false
+      }
+    },
+    RepresentsSelf: true,
+    Parties: [
+      {
+        PartyId: 50593193,
+        PartyTypeName: Person,
+        SSN: 12345678901,
+        Name: Test Testesen,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false
+      }
+    ],
+    PartiesAllowedToInstantiate: [
+      {
+        PartyId: 50593193,
+        PartyTypeName: Person,
+        SSN: 12345678901,
+        Name: Test Testesen,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false
+      }
+    ],
+    CanRepresent: true
+  }
+}

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
@@ -16,7 +16,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
-using Moq.Protected;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -265,6 +264,8 @@ public class AuthorizationClientTests
         var xacmlJesonRespons = File.ReadAllText(
             Path.Join("Infrastructure", "Clients", "Authorization", "TestData", $"{filename}.json")
         );
-        return JsonSerializer.Deserialize<XacmlJsonResponse>(xacmlJesonRespons);
+        var response = JsonSerializer.Deserialize<XacmlJsonResponse>(xacmlJesonRespons);
+        Assert.NotNull(response);
+        return response;
     }
 }

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
@@ -1,21 +1,25 @@
-#nullable disable
 using System.Security.Claims;
 using System.Text.Json;
 using Altinn.App.Common.Tests;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Constants;
-using Altinn.App.Core.Features;
 using Altinn.App.Core.Infrastructure.Clients.Authorization;
+using Altinn.App.Core.Internal.Auth;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Interface.Models;
 using Authorization.Platform.Authorization.Models;
 using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
 
 namespace Altinn.App.Core.Tests.Infrastructure.Clients.Authorization;
 
@@ -113,134 +117,131 @@ public class AuthorizationClientTests
     }
 
     [Fact]
-    public async Task GetUserRolesAsync_returns_roles_on_success()
+    public async Task GetUserRoles_Handles_200()
     {
-        var userId = 1337;
-        var userPartyId = 2001;
-        var expectedRoles = new List<Role>()
-        {
-            new() { Type = "altinn", Value = "bobet" },
-            new() { Type = "altinn", Value = "bobes" },
-        };
+        await using var fixture = Fixture.Create();
 
-        var responseJson = JsonSerializer.Serialize(expectedRoles);
+        Role[] expectedRoles =
+        [
+            new Role { Type = "altinn", Value = "bobet" },
+            new Role { Type = "altinn", Value = "bobes" },
+        ];
 
-        var httpMessageHandler = new Mock<HttpMessageHandler>();
-
-        httpMessageHandler
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.Is<HttpRequestMessage>(m =>
-                    m.RequestUri != null
-                    && m.RequestUri.ToString()
-                        .Contains($"roles?coveredByUserId={userId}&offeredByPartyId={userPartyId}")
-                ),
-                ItExpr.IsAny<CancellationToken>()
-            )
-            .ReturnsAsync(
-                new HttpResponseMessage
-                {
-                    StatusCode = System.Net.HttpStatusCode.OK,
-                    Content = new StringContent(responseJson, System.Text.Encoding.UTF8, "application/json"),
-                }
+        var server = fixture.Server;
+        server
+            .Given(Request.Create().WithPath(Fixture.ApiPath).UsingGet())
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBodyAsJson(expectedRoles)
             );
-        var httpClient = new HttpClient(httpMessageHandler.Object);
 
-        TelemetrySink telemetrySink = new();
-        var pdpMock = new Mock<IPDP>();
+        var actualRoles = await fixture.Client.GetUserRoles(1337, 2001);
 
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.Headers["Cookie"] = "AltinnStudioRuntime=myFakeJwtToken";
-
-        var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-        httpContextAccessorMock.Setup(_ => _.HttpContext).Returns(httpContext);
-
-        var appSettingsMock = new Mock<IOptionsMonitor<AppSettings>>();
-        appSettingsMock
-            .Setup(s => s.CurrentValue)
-            .Returns(new AppSettings { RuntimeCookieName = "AltinnStudioRuntime" });
-
-        var platformSettings = Options.Create(
-            new PlatformSettings
-            {
-                ApiAuthorizationEndpoint = "http://authorization.test/",
-                SubscriptionKey = "dummyKey",
-            }
-        );
-        var logger = NullLogger<AuthorizationClient>.Instance;
-
-        var client = new AuthorizationClient(
-            platformSettings,
-            httpContextAccessorMock.Object,
-            httpClient,
-            appSettingsMock.Object,
-            pdpMock.Object,
-            logger,
-            telemetrySink.Object
-        );
-
-        var actualRoles = await client.GetUserRoles(userId, userPartyId);
-
-        actualRoles.Should().BeEquivalentTo(expectedRoles);
+        Assert.Equivalent(expectedRoles, actualRoles);
     }
 
     [Fact]
-    public async Task GetUserRolesAsync_throws_exception_on_error_status_code()
+    public async Task GetUserRoles_Handles_404()
     {
-        var userId = 1337;
-        var userPartyId = 2001;
+        await using var fixture = Fixture.Create();
 
-        var httpMessageHandler = new Mock<HttpMessageHandler>();
+        Role[] expectedRoles = [];
 
-        httpMessageHandler
-            .Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.Is<HttpRequestMessage>(m =>
-                    m.RequestUri != null
-                    && m.RequestUri.ToString()
-                        .Contains($"roles?coveredByUserId={userId}&offeredByPartyId={userPartyId}")
-                ),
-                ItExpr.IsAny<CancellationToken>()
+        var server = fixture.Server;
+        server
+            .Given(Request.Create().WithPath(Fixture.ApiPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+
+        var actualRoles = await fixture.Client.GetUserRoles(1337, 2001);
+
+        Assert.Equivalent(expectedRoles, actualRoles);
+    }
+
+    [Fact]
+    public async Task GetUserRoles_Throws_On_500()
+    {
+        await using var fixture = Fixture.Create();
+        var server = fixture.Server;
+        server
+            .Given(Request.Create().WithPath(Fixture.ApiPath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(500));
+
+        await Assert.ThrowsAnyAsync<Exception>(() => fixture.Client.GetUserRoles(1337, 2001));
+    }
+
+    private sealed record Fixture(WebApplication App) : IAsyncDisposable
+    {
+        internal const string ApiPath = "/authorization/api/v1/roles";
+
+        public Mock<IHttpClientFactory> HttpClientFactoryMock =>
+            Mock.Get(App.Services.GetRequiredService<IHttpClientFactory>());
+
+        public WireMockServer Server => App.Services.GetRequiredService<WireMockServer>();
+
+        public AuthorizationClient Client =>
+            App.Services.GetServices<IAuthorizationClient>().OfType<AuthorizationClient>().Single();
+
+        private sealed class ReqHandler(Action? onRequest = null) : DelegatingHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken
             )
-            .ReturnsAsync(
-                new HttpResponseMessage
+            {
+                onRequest?.Invoke();
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+
+        public static Fixture Create(
+            Action<IServiceCollection>? registerCustomAppServices = default,
+            Action? onRequest = null
+        )
+        {
+            var server = WireMockServer.Start();
+
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            mockHttpClientFactory
+                .Setup(f => f.CreateClient(It.IsAny<string>()))
+                .Returns(() => server.CreateClient(new ReqHandler(onRequest)));
+
+            var app = Api.Tests.TestUtils.AppBuilder.Build(
+                configData: new Dictionary<string, string?>()
                 {
-                    StatusCode = System.Net.HttpStatusCode.InternalServerError,
-                    Content = new StringContent("Internal Server Error"),
+                    // API endpoint is configured this way since we have our `PlatformSettings`
+                    // while PEP has it's own `PlatformSettings` class.
+                    // So if we went the `services.Configure` route we would have to do it twice,
+                    // once for ours and once for PEP's.
+                    { "PlatformSettings:ApiAuthorizationEndpoint", server.Url + ApiPath },
+                    { "PlatformSettings:SubscriptionKey", "dummyKey" },
+                    { "AppSettings:RuntimeCookieName", "AltinnStudioRuntime" },
+                },
+                registerCustomAppServices: services =>
+                {
+                    services.AddSingleton(_ => server);
+
+                    registerCustomAppServices?.Invoke(services);
+                },
+                overrideAltinnAppServices: services =>
+                {
+                    var httpContext = new DefaultHttpContext();
+                    httpContext.Request.Headers["Cookie"] = "AltinnStudioRuntime=myFakeJwtToken";
+
+                    var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+                    httpContextAccessorMock.Setup(_ => _.HttpContext).Returns(httpContext);
+
+                    services.AddSingleton(httpContextAccessorMock.Object);
+                    services.AddSingleton(mockHttpClientFactory.Object);
                 }
             );
 
-        var httpClient = new HttpClient(httpMessageHandler.Object);
+            return new Fixture(app);
+        }
 
-        var pdpMock = new Mock<IPDP>();
-        var appSettingsMock = new Mock<IOptionsMonitor<AppSettings>>();
-        appSettingsMock
-            .Setup(s => s.CurrentValue)
-            .Returns(new AppSettings { RuntimeCookieName = "AltinnStudioRuntime" });
-
-        var platformSettings = Options.Create(new PlatformSettings { SubscriptionKey = "subscription-key" });
-        var logger = NullLogger<AuthorizationClient>.Instance;
-        TelemetrySink telemetry = new();
-
-        var httpContext = new DefaultHttpContext();
-        httpContext.Request.Headers["Cookie"] = "AltinnStudioRuntime=myFakeJwtToken";
-
-        var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-        httpContextAccessorMock.Setup(_ => _.HttpContext).Returns(httpContext);
-
-        var client = new AuthorizationClient(
-            platformSettings,
-            httpContextAccessorMock.Object,
-            httpClient,
-            appSettingsMock.Object,
-            pdpMock.Object,
-            logger,
-            telemetry.Object
-        );
-
-        await Assert.ThrowsAsync<Exception>(() => client.GetUserRoles(userId, userPartyId));
+        public async ValueTask DisposeAsync() => await App.DisposeAsync();
     }
 
     private static ClaimsPrincipal GetClaims(string partyId)


### PR DESCRIPTION
## Description
Authorization API and localtest gives 404 when there are no roles associated with a userID, partyID pair. 
I think this means we can't tell wether a 404 is due to misconfiguration (e.g. error in URL) or if there simply are no roles.
Reported by brg

## Related Issue(s)
- #1103

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
