### PR TITLE
Remove roles from IAuthenticationContext, API and IAuthorizationClient

### DIFF
--- a/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -12,7 +12,6 @@ using Altinn.App.Core.Models;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
 using AltinnCore.Authentication.Constants;
-using Authorization.Platform.Authorization.Models;
 
 namespace Altinn.App.Core.Features.Auth;
 
@@ -125,7 +124,6 @@ public abstract class Authenticated
         private readonly Func<int, Task<Party?>> _lookupParty;
         private readonly Func<int, Task<List<Party>?>> _getPartyList;
         private readonly Func<int, int, Task<bool?>> _validateSelectedParty;
-        private readonly Func<int, int, Task<IEnumerable<Role>>> _getUserRoles;
         private readonly ApplicationMetadata _appMetadata;
 
         internal User(
@@ -143,7 +141,6 @@ public abstract class Authenticated
             Func<int, Task<Party?>> lookupParty,
             Func<int, Task<List<Party>?>> getPartyList,
             Func<int, int, Task<bool?>> validateSelectedParty,
-            Func<int, int, Task<IEnumerable<Role>>> getUserRoles,
             ApplicationMetadata appMetadata
         )
             : base(tokenIssuer, tokenIsExchanged, scopes, token)
@@ -158,7 +155,6 @@ public abstract class Authenticated
             _lookupParty = lookupParty;
             _getPartyList = getPartyList;
             _validateSelectedParty = validateSelectedParty;
-            _getUserRoles = getUserRoles;
             _appMetadata = appMetadata;
         }
 
@@ -174,7 +170,6 @@ public abstract class Authenticated
         /// <param name="RepresentsSelf">True if the user represents itself (user party will equal selected party)</param>
         /// <param name="Parties">List of parties the user can represent</param>
         /// <param name="PartiesAllowedToInstantiate">List of parties the user can instantiate as</param>
-        /// <param name="Roles">List of roles the user has</param>
         /// <param name="CanRepresent">True if the user can represent the selected party. Only set if details were loaded with validateSelectedParty set to true</param>
         public sealed record Details(
             Party UserParty,
@@ -183,7 +178,6 @@ public abstract class Authenticated
             bool RepresentsSelf,
             IReadOnlyList<Party> Parties,
             IReadOnlyList<Party> PartiesAllowedToInstantiate,
-            IReadOnlyList<Role> Roles,
             bool? CanRepresent = null
         )
         {
@@ -305,8 +299,6 @@ public abstract class Authenticated
                 canRepresent = await _validateSelectedParty(UserId, SelectedPartyId);
             }
 
-            var roles = await _getUserRoles(UserId, SelectedPartyId);
-
             var partiesAllowedToInstantiate = InstantiationHelper.FilterPartiesByAllowedPartyTypes(
                 parties,
                 _appMetadata.PartyTypesAllowed
@@ -319,7 +311,6 @@ public abstract class Authenticated
                 representsSelf,
                 parties,
                 partiesAllowedToInstantiate,
-                roles.ToArray(),
                 canRepresent
             );
             return _extra;
@@ -706,8 +697,7 @@ public abstract class Authenticated
         Func<int, Task<Party?>> lookupUserParty,
         Func<string, Task<Party>> lookupOrgParty,
         Func<int, Task<List<Party>?>> getPartyList,
-        Func<int, int, Task<bool?>> validateSelectedParty,
-        Func<int, int, Task<IEnumerable<Role>>> getUserRoles
+        Func<int, int, Task<bool?>> validateSelectedParty
     )
     {
         if (string.IsNullOrWhiteSpace(tokenStr))
@@ -828,7 +818,6 @@ public abstract class Authenticated
             lookupUserParty,
             getPartyList,
             validateSelectedParty,
-            getUserRoles,
             appMetadata
         );
     }
@@ -842,8 +831,7 @@ public abstract class Authenticated
         Func<int, Task<Party?>> lookupUserParty,
         Func<string, Task<Party>> lookupOrgParty,
         Func<int, Task<List<Party>?>> getPartyList,
-        Func<int, int, Task<bool?>> validateSelectedParty,
-        Func<int, int, Task<IEnumerable<Role>>> getUserRoles
+        Func<int, int, Task<bool?>> validateSelectedParty
     )
     {
         if (string.IsNullOrWhiteSpace(tokenStr))
@@ -1056,7 +1044,6 @@ public abstract class Authenticated
             lookupUserParty,
             getPartyList,
             validateSelectedParty,
-            getUserRoles,
             appMetadata
         );
     }

--- a/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
+++ b/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
@@ -75,8 +75,7 @@ internal sealed class AuthenticationContext : IAuthenticationContext
                         _altinnPartyClient.GetParty,
                         (string orgNr) => _altinnPartyClient.LookupParty(new PartyLookup { OrgNo = orgNr }),
                         _authorizationClient.GetPartyList,
-                        _authorizationClient.ValidateSelectedParty,
-                        _authorizationClient.GetUserRoles
+                        _authorizationClient.ValidateSelectedParty
                     );
                 }
                 else
@@ -91,8 +90,7 @@ internal sealed class AuthenticationContext : IAuthenticationContext
                         _altinnPartyClient.GetParty,
                         (string orgNr) => _altinnPartyClient.LookupParty(new PartyLookup { OrgNo = orgNr }),
                         _authorizationClient.GetPartyList,
-                        _authorizationClient.ValidateSelectedParty,
-                        _authorizationClient.GetUserRoles
+                        _authorizationClient.ValidateSelectedParty
                     );
                 }
 

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.Authorization.Client.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.Authorization.Client.cs
@@ -15,15 +15,6 @@ partial class Telemetry
         return activity;
     }
 
-    internal Activity? StartClientGetPartyRoleListActivity(int userId, int partyId)
-    {
-        var activity = ActivitySource.StartActivity($"{Prefix}.GetUserRoles");
-        activity?.SetUserPartyId(partyId);
-        activity?.SetUserId(userId);
-
-        return activity;
-    }
-
     internal Activity? StartClientValidateSelectedPartyActivity(int userId, int partyId)
     {
         var activity = ActivitySource.StartActivity($"{Prefix}.ValidateSelectedParty");

--- a/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Authorization/AuthorizationClient.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using Altinn.App.Core.Configuration;
@@ -14,7 +13,6 @@ using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using AltinnCore.Authentication.Utils;
-using Authorization.Platform.Authorization.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -180,53 +178,5 @@ public class AuthorizationClient : IAuthorizationClient
             actionsResult.Add(action, false);
         }
         return MultiDecisionHelper.ValidatePdpMultiDecision(actionsResult, response.Response, user);
-    }
-
-    /// <summary>
-    /// Retrieves roles for a user on a specified party.
-    /// </summary>
-    /// <param name="userId">The user id.</param>
-    /// <param name="userPartyId">The user party id.</param>
-    /// <returns>A list of roles for the user on the specified party.</returns>
-    public async Task<IEnumerable<Role>> GetUserRoles(int userId, int userPartyId)
-    {
-        using var activity = _telemetry?.StartClientGetPartyRoleListActivity(userId, userPartyId);
-
-        List<Role> roles = new();
-        string apiUrl = $"roles?coveredByUserId={userId}&offeredByPartyId={userPartyId}";
-        string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _settings.RuntimeCookieName);
-
-        try
-        {
-            HttpResponseMessage response = await _client.GetAsync(token, apiUrl);
-            if (response.StatusCode == HttpStatusCode.NotFound)
-                return roles;
-
-            if (response.IsSuccessStatusCode)
-            {
-                string responseContent = await response.Content.ReadAsStringAsync();
-                var deserialized = JsonConvert.DeserializeObject<List<Role>>(responseContent);
-                if (deserialized is not null)
-                {
-                    roles = deserialized;
-                }
-            }
-            else
-            {
-                throw new Exception("Unexpected response from auth API:" + response.StatusCode);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(
-                ex,
-                "An error occurred while retrieving roles for userId {UserId} and partyId {PartyId}",
-                userId,
-                userPartyId
-            );
-            throw;
-        }
-
-        return roles;
     }
 }

--- a/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
+++ b/src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs
@@ -2,7 +2,6 @@ using System.Security.Claims;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
-using Authorization.Platform.Authorization.Models;
 
 namespace Altinn.App.Core.Internal.Auth;
 
@@ -51,12 +50,4 @@ public interface IAuthorizationClient
     /// <param name="actions"></param>
     /// <returns></returns>
     Task<Dictionary<string, bool>> AuthorizeActions(Instance instance, ClaimsPrincipal user, List<string> actions);
-
-    /// <summary>
-    /// Retrieves roles for a user on a specified party.
-    /// </summary>
-    /// <param name="userId">The user id.</param>
-    /// <param name="userPartyId">The user party id.</param>
-    /// <returns>A list of roles for the user on the specified party.</returns>
-    Task<IEnumerable<Role>> GetUserRoles(int userId, int userPartyId);
 }

--- a/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AuthorizationMock.cs
@@ -3,7 +3,6 @@ using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
-using Authorization.Platform.Authorization.Models;
 
 namespace Altinn.App.Api.Tests.Mocks;
 
@@ -69,17 +68,5 @@ public class AuthorizationMock : IAuthorizationClient
         }
 
         return authorizedActions;
-    }
-
-    public async Task<IEnumerable<Role>> GetUserRoles(int userId, int userPartyId)
-    {
-        await Task.CompletedTask;
-        List<Role> roles = new List<Role>
-        {
-            new Role { Type = "altinn", Value = "bobet" },
-            new Role { Type = "altinn", Value = "bobes" },
-        };
-
-        return roles;
     }
 }

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.txt
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.txt
@@ -538,109 +538,6 @@ If org and app does not match, this returns a 409 Conflict response,
         }
       }
     },
-    /{org}/{app}/api/authorization/roles: {
-      get: {
-        tags: [
-          Authorization
-        ],
-        summary: Fetches roles for current party.,
-        parameters: [
-          {
-            name: org,
-            in: path,
-            required: true,
-            schema: {
-              type: string
-            }
-          },
-          {
-            name: app,
-            in: path,
-            required: true,
-            schema: {
-              type: string
-            }
-          }
-        ],
-        responses: {
-          200: {
-            description: OK,
-            content: {
-              text/plain: {
-                schema: {
-                  type: array,
-                  items: {
-                    $ref: #/components/schemas/Role
-                  }
-                }
-              },
-              application/json: {
-                schema: {
-                  type: array,
-                  items: {
-                    $ref: #/components/schemas/Role
-                  }
-                }
-              },
-              text/json: {
-                schema: {
-                  type: array,
-                  items: {
-                    $ref: #/components/schemas/Role
-                  }
-                }
-              },
-              application/xml: {
-                schema: {
-                  type: array,
-                  items: {
-                    $ref: #/components/schemas/Role
-                  }
-                }
-              },
-              text/xml: {
-                schema: {
-                  type: array,
-                  items: {
-                    $ref: #/components/schemas/Role
-                  }
-                }
-              }
-            }
-          },
-          400: {
-            description: Bad Request,
-            content: {
-              text/plain: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
-                }
-              },
-              application/json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
-                }
-              },
-              text/json: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
-                }
-              },
-              application/xml: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
-                }
-              },
-              text/xml: {
-                schema: {
-                  $ref: #/components/schemas/ProblemDetails
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     /{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data: {
       post: {
         tags: [
@@ -7826,20 +7723,6 @@ version that supports multiple data models in the same request.
             nullable: true
           },
           platform: {
-            type: string,
-            nullable: true
-          }
-        },
-        additionalProperties: false
-      },
-      Role: {
-        type: object,
-        properties: {
-          type: {
-            type: string,
-            nullable: true
-          },
-          value: {
             type: string,
             nullable: true
           }

--- a/test/Altinn.App.Api.Tests/OpenApi/swagger.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/swagger.json
@@ -529,109 +529,6 @@
         }
       }
     },
-    "/{org}/{app}/api/authorization/roles": {
-      "get": {
-        "tags": [
-          "Authorization"
-        ],
-        "summary": "Fetches roles for current party.",
-        "parameters": [
-          {
-            "name": "org",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "app",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Role"
-                  }
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Role"
-                  }
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Role"
-                  }
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Role"
-                  }
-                }
-              },
-              "text/xml": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Role"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data": {
       "post": {
         "tags": [
@@ -7823,20 +7720,6 @@
             "nullable": true
           },
           "platform": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "Role": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "nullable": true
-          },
-          "value": {
             "type": "string",
             "nullable": true
           }

--- a/test/Altinn.App.Api.Tests/Utils/TestAuthentication.cs
+++ b/test/Altinn.App.Api.Tests/Utils/TestAuthentication.cs
@@ -10,7 +10,6 @@ using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using AltinnCore.Authentication.Constants;
-using Authorization.Platform.Authorization.Models;
 using static Altinn.App.Core.Features.Auth.Authenticated;
 
 namespace Altinn.App.Api.Tests.Utils;
@@ -189,12 +188,6 @@ public static class TestAuthentication
                 Assert.Equal(userId, uid);
                 Assert.Equal(userPartyId, pid);
                 return Task.FromResult<bool?>(true);
-            },
-            getUserRoles: (uid, pid) =>
-            {
-                Assert.Equal(userId, uid);
-                Assert.Equal(userPartyId, pid);
-                return Task.FromResult<IEnumerable<Role>>([]);
             },
             appMetadata: NewApplicationMetadata()
         );

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
@@ -8,7 +8,6 @@ using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 using AltinnCore.Authentication.Constants;
-using global::Authorization.Platform.Authorization.Models;
 
 public class AuthenticatedTests
 {
@@ -145,8 +144,7 @@ public class AuthenticatedTests
                     lookupUserParty: _ => Task.FromResult<Party?>(party),
                     lookupOrgParty: _ => null!,
                     getPartyList: _ => Task.FromResult<List<Party>?>([party]),
-                    validateSelectedParty: (_, _) => Task.FromResult<bool?>(true),
-                    getUserRoles: (_, _) => Task.FromResult<IEnumerable<Role>>([])
+                    validateSelectedParty: (_, _) => Task.FromResult<bool?>(true)
                 );
                 break;
             default:
@@ -159,8 +157,7 @@ public class AuthenticatedTests
                     lookupUserParty: _ => null!,
                     lookupOrgParty: _ => null!,
                     getPartyList: _ => null!,
-                    validateSelectedParty: (_, _) => null!,
-                    getUserRoles: (_, _) => null!
+                    validateSelectedParty: (_, _) => null!
                 );
                 break;
         }

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.cs
@@ -4,21 +4,14 @@ using Altinn.App.Common.Tests;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Infrastructure.Clients.Authorization;
-using Altinn.App.Core.Internal.Auth;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Storage.Interface.Models;
-using Authorization.Platform.Authorization.Models;
 using FluentAssertions;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
-using WireMock.RequestBuilders;
-using WireMock.ResponseBuilders;
-using WireMock.Server;
 
 namespace Altinn.App.Core.Tests.Infrastructure.Clients.Authorization;
 
@@ -113,134 +106,6 @@ public class AuthorizationClientTests
         var actions = new List<string>() { "read", "write", "complete", "lookup" };
         var actual = await client.AuthorizeActions(instance, claimsPrincipal, actions);
         actual.Should().BeEquivalentTo(expected);
-    }
-
-    [Fact]
-    public async Task GetUserRoles_Handles_200()
-    {
-        await using var fixture = Fixture.Create();
-
-        Role[] expectedRoles =
-        [
-            new Role { Type = "altinn", Value = "bobet" },
-            new Role { Type = "altinn", Value = "bobes" },
-        ];
-
-        var server = fixture.Server;
-        server
-            .Given(Request.Create().WithPath(Fixture.ApiPath).UsingGet())
-            .RespondWith(
-                Response
-                    .Create()
-                    .WithStatusCode(200)
-                    .WithHeader("Content-Type", "application/json")
-                    .WithBodyAsJson(expectedRoles)
-            );
-
-        var actualRoles = await fixture.Client.GetUserRoles(1337, 2001);
-
-        Assert.Equivalent(expectedRoles, actualRoles);
-    }
-
-    [Fact]
-    public async Task GetUserRoles_Handles_404()
-    {
-        await using var fixture = Fixture.Create();
-
-        Role[] expectedRoles = [];
-
-        var server = fixture.Server;
-        server
-            .Given(Request.Create().WithPath(Fixture.ApiPath).UsingGet())
-            .RespondWith(Response.Create().WithStatusCode(404));
-
-        var actualRoles = await fixture.Client.GetUserRoles(1337, 2001);
-
-        Assert.Equivalent(expectedRoles, actualRoles);
-    }
-
-    [Fact]
-    public async Task GetUserRoles_Throws_On_500()
-    {
-        await using var fixture = Fixture.Create();
-        var server = fixture.Server;
-        server
-            .Given(Request.Create().WithPath(Fixture.ApiPath).UsingGet())
-            .RespondWith(Response.Create().WithStatusCode(500));
-
-        await Assert.ThrowsAnyAsync<Exception>(() => fixture.Client.GetUserRoles(1337, 2001));
-    }
-
-    private sealed record Fixture(WebApplication App) : IAsyncDisposable
-    {
-        internal const string ApiPath = "/authorization/api/v1/roles";
-
-        public Mock<IHttpClientFactory> HttpClientFactoryMock =>
-            Mock.Get(App.Services.GetRequiredService<IHttpClientFactory>());
-
-        public WireMockServer Server => App.Services.GetRequiredService<WireMockServer>();
-
-        public AuthorizationClient Client =>
-            App.Services.GetServices<IAuthorizationClient>().OfType<AuthorizationClient>().Single();
-
-        private sealed class ReqHandler(Action? onRequest = null) : DelegatingHandler
-        {
-            protected override Task<HttpResponseMessage> SendAsync(
-                HttpRequestMessage request,
-                CancellationToken cancellationToken
-            )
-            {
-                onRequest?.Invoke();
-                return base.SendAsync(request, cancellationToken);
-            }
-        }
-
-        public static Fixture Create(
-            Action<IServiceCollection>? registerCustomAppServices = default,
-            Action? onRequest = null
-        )
-        {
-            var server = WireMockServer.Start();
-
-            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
-            mockHttpClientFactory
-                .Setup(f => f.CreateClient(It.IsAny<string>()))
-                .Returns(() => server.CreateClient(new ReqHandler(onRequest)));
-
-            var app = Api.Tests.TestUtils.AppBuilder.Build(
-                configData: new Dictionary<string, string?>()
-                {
-                    // API endpoint is configured this way since we have our `PlatformSettings`
-                    // while PEP has it's own `PlatformSettings` class.
-                    // So if we went the `services.Configure` route we would have to do it twice,
-                    // once for ours and once for PEP's.
-                    { "PlatformSettings:ApiAuthorizationEndpoint", server.Url + ApiPath },
-                    { "PlatformSettings:SubscriptionKey", "dummyKey" },
-                    { "AppSettings:RuntimeCookieName", "AltinnStudioRuntime" },
-                },
-                registerCustomAppServices: services =>
-                {
-                    services.AddSingleton(_ => server);
-
-                    registerCustomAppServices?.Invoke(services);
-                },
-                overrideAltinnAppServices: services =>
-                {
-                    var httpContext = new DefaultHttpContext();
-                    httpContext.Request.Headers["Cookie"] = "AltinnStudioRuntime=myFakeJwtToken";
-
-                    var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-                    httpContextAccessorMock.Setup(_ => _.HttpContext).Returns(httpContext);
-
-                    services.AddSingleton(httpContextAccessorMock.Object);
-                    services.AddSingleton(mockHttpClientFactory.Object);
-                }
-            );
-
-            return new Fixture(app);
-        }
-
-        public async ValueTask DisposeAsync() => await App.DisposeAsync();
     }
 
     private static ClaimsPrincipal GetClaims(string partyId)


### PR DESCRIPTION
## Description
I think we made a mistake adding roles APIs, as it seems it will be entirely removed at some point (when tilgangspakker are ready and A2 goes down)

Considerations
* No apps seem to be using `GetUserRoles` on the client directly
* Not sure if we can check callers of the roles API (will check if we have metrics on this)

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
