### PR TITLE
Don't require auth for fetching app languages

### DIFF
--- a/src/Altinn.App.Api/Controllers/ApplicationLanguageController.cs
+++ b/src/Altinn.App.Api/Controllers/ApplicationLanguageController.cs
@@ -1,6 +1,5 @@
 #nullable disable
 using Altinn.App.Core.Internal.Language;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using ApplicationLanguage = Altinn.App.Core.Models.ApplicationLanguage;
 
@@ -10,7 +9,6 @@ namespace Altinn.App.Api.Controllers;
 /// Represents the Application language API giving access to the different languages supported by the application.
 /// </summary>
 [Route("{org}/{app}/api/v1/applicationlanguages")]
-[Authorize]
 public class ApplicationLanguageController : ControllerBase
 {
     private readonly IApplicationLanguage _applicationLanguage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove `[Authorize]` from `ApplicationLangugaeController`, see linked issue for why

## Related Issue(s)
- #1114 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
