### PR TITLE
Use StatusCode constants instead of casting HttpStatusCode enum to int

### DIFF
--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -157,7 +157,7 @@ public class DataController : ControllerBase
         {
             return BadRequest(await GetErrorDetails(fileValidationError.UploadValidationIssues));
         }
-        if (response.Error.Status == (int)HttpStatusCode.BadRequest)
+        if (response.Error.Status == StatusCodes.Status400BadRequest)
         {
             // Old clients will expect BadRequest to have a list of issues or a string
             // not problem details.
@@ -194,10 +194,10 @@ public class DataController : ControllerBase
     [HttpPost("{dataType}")]
     [DisableFormValueModelBinding]
     [RequestSizeLimit(REQUEST_SIZE_LIMIT)]
-    [ProducesResponseType(typeof(DataPostResponse), (int)HttpStatusCode.Created)]
-    [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.Conflict)]
-    [ProducesResponseType(typeof(DataPostErrorResponse), (int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType(typeof(ProblemDetails), (int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(typeof(DataPostResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(DataPostErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<DataPostResponse>> Post(
         [FromRoute] string org,
         [FromRoute] string app,
@@ -322,7 +322,7 @@ public class DataController : ControllerBase
                     {
                         Title = "Missing content type",
                         Detail = "The request is missing a content type header.",
-                        Status = (int)HttpStatusCode.BadRequest,
+                        Status = StatusCodes.Status400BadRequest,
                     };
                 }
 
@@ -334,7 +334,7 @@ public class DataController : ControllerBase
                         Title = "Request too large",
                         Detail =
                             $"The request body is too large. The content length is {actualLength} bytes, which exceeds the limit of {dataType.MaxSize} MB",
-                        Status = (int)HttpStatusCode.RequestEntityTooLarge,
+                        Status = StatusCodes.Status413RequestEntityTooLarge,
                     };
                 }
 
@@ -344,7 +344,7 @@ public class DataController : ControllerBase
                     {
                         Title = "Invalid data",
                         Detail = "Invalid data provided. Error: The file is zero bytes.",
-                        Status = (int)HttpStatusCode.BadRequest,
+                        Status = StatusCodes.Status400BadRequest,
                     };
                 }
 
@@ -635,9 +635,9 @@ public class DataController : ControllerBase
     /// <returns>A response object with the new full model and validation issues from all the groups that run</returns>
     [Authorize(Policy = AuthzConstants.POLICY_INSTANCE_WRITE)]
     [HttpPatch("{dataGuid:guid}")]
-    [ProducesResponseType(typeof(DataPatchResponse), 200)]
-    [ProducesResponseType(typeof(ProblemDetails), 409)]
-    [ProducesResponseType(typeof(ProblemDetails), 422)]
+    [ProducesResponseType(typeof(DataPatchResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     [Obsolete("Use PatchFormDataMultiple instead")]
     public async Task<ActionResult<DataPatchResponse>> PatchFormData(
         [FromRoute] string org,
@@ -874,7 +874,7 @@ public class DataController : ControllerBase
             return StatusCode((int)se.StatusCode, se.Message);
         }
 
-        return StatusCode((int)HttpStatusCode.InternalServerError, $"{message}");
+        return StatusCode(StatusCodes.Status500InternalServerError, $"{message}");
     }
 
     /// <summary>
@@ -1161,7 +1161,7 @@ public class DataController : ControllerBase
 
     private ObjectResult Problem(ProblemDetails error)
     {
-        return StatusCode(error.Status ?? (int)HttpStatusCode.InternalServerError, error);
+        return StatusCode(error.Status ?? StatusCodes.Status500InternalServerError, error);
     }
 
     private async Task<
@@ -1177,7 +1177,7 @@ public class DataController : ControllerBase
                 {
                     Title = "Instance Not Found",
                     Detail = $"Did not find instance {instanceOwnerPartyId}/{instanceGuid}",
-                    Status = (int)HttpStatusCode.NotFound,
+                    Status = StatusCodes.Status404NotFound,
                 };
             }
 
@@ -1192,7 +1192,7 @@ public class DataController : ControllerBase
                     Title = "Data Element Not Found",
                     Detail =
                         $"Did not find data element {dataElementGuid} on instance {instanceOwnerPartyId}/{instanceGuid}",
-                    Status = (int)HttpStatusCode.BadRequest,
+                    Status = StatusCodes.Status404NotFound,
                 };
             }
 
@@ -1204,7 +1204,7 @@ public class DataController : ControllerBase
                     Title = "Data Type Not Found",
                     Detail =
                         $"""Could not find the specified data type: "{dataElement.DataType}" in applicationmetadata.json""",
-                    Status = (int)HttpStatusCode.BadRequest,
+                    Status = StatusCodes.Status400BadRequest,
                 };
             }
 
@@ -1239,7 +1239,7 @@ public class DataController : ControllerBase
                 {
                     Title = "Instance Not Found",
                     Detail = $"Did not find instance {instanceOwnerPartyId}/{instanceGuid}",
-                    Status = (int)HttpStatusCode.NotFound,
+                    Status = StatusCodes.Status404NotFound,
                 };
             }
 
@@ -1258,7 +1258,7 @@ public class DataController : ControllerBase
                         Title = "Data Element Not Found",
                         Detail =
                             $"Did not find data element {dataElementGuid} on instance {instanceOwnerPartyId}/{instanceGuid}",
-                        Status = (int)HttpStatusCode.NotFound,
+                        Status = StatusCodes.Status404NotFound,
                     };
                 }
 
@@ -1270,7 +1270,7 @@ public class DataController : ControllerBase
                         Title = "Data Type Not Found",
                         Detail =
                             $"""Data element {dataElement.Id} requires data type "{dataElement.DataType}", but it was not found in applicationmetadata.json""",
-                        Status = (int)HttpStatusCode.InternalServerError,
+                        Status = StatusCodes.Status500InternalServerError,
                     };
                 }
 
@@ -1303,7 +1303,7 @@ public class DataController : ControllerBase
                 {
                     Title = "Instance Not Found",
                     Detail = $"Did not find instance {instanceOwnerPartyId}/{instanceGuid}",
-                    Status = (int)HttpStatusCode.NotFound,
+                    Status = StatusCodes.Status404NotFound,
                 };
             }
 
@@ -1316,7 +1316,7 @@ public class DataController : ControllerBase
                 {
                     Title = "Data Type Not Found",
                     Detail = $"""Could not find the specified data type: "{dataTypeId}" in applicationmetadata.json""",
-                    Status = (int)HttpStatusCode.BadRequest,
+                    Status = StatusCodes.Status400BadRequest,
                 };
             }
 

--- a/src/Altinn.App.Api/Controllers/ExternalApiController.cs
+++ b/src/Altinn.App.Api/Controllers/ExternalApiController.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features.ExternalApi;
 using Altinn.App.Core.Models;
@@ -74,7 +73,7 @@ public class ExternalApiController : ControllerBase
                 return StatusCode((int)httpEx.StatusCode.Value, errorMessage);
             }
 
-            return StatusCode((int)HttpStatusCode.InternalServerError, $"{genericErrorDescription}: {ex.Message}");
+            return StatusCode(StatusCodes.Status500InternalServerError, $"{genericErrorDescription}: {ex.Message}");
         }
     }
 }

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -285,7 +285,7 @@ public class InstancesController : ControllerBase
             {
                 if (sexp.StatusCode.Equals(HttpStatusCode.Unauthorized))
                 {
-                    return StatusCode((int)HttpStatusCode.Forbidden);
+                    return StatusCode(StatusCodes.Status403Forbidden);
                 }
             }
 
@@ -301,7 +301,7 @@ public class InstancesController : ControllerBase
         if (!InstantiationHelper.IsPartyAllowedToInstantiate(party, application.PartyTypesAllowed))
         {
             return StatusCode(
-                (int)HttpStatusCode.Forbidden,
+                StatusCodes.Status403Forbidden,
                 $"Party {party.PartyId} is not allowed to instantiate this application {org}/{app}"
             );
         }
@@ -310,7 +310,7 @@ public class InstancesController : ControllerBase
         InstantiationValidationResult? validationResult = await _instantiationValidator.Validate(instanceTemplate);
         if (validationResult != null && !validationResult.Valid)
         {
-            return StatusCode((int)HttpStatusCode.Forbidden, validationResult);
+            return StatusCode(StatusCodes.Status403Forbidden, validationResult);
         }
 
         instanceTemplate.Org = application.Org;
@@ -400,7 +400,7 @@ public class InstancesController : ControllerBase
                 return null;
 
             return StatusCode(
-                (int)HttpStatusCode.Forbidden,
+                StatusCodes.Status403Forbidden,
                 $"User instantiation is disabled for this application {org}/{app}"
             );
         }
@@ -476,7 +476,7 @@ public class InstancesController : ControllerBase
             {
                 if (sexp.StatusCode.Equals(HttpStatusCode.Unauthorized))
                 {
-                    return StatusCode((int)HttpStatusCode.Forbidden);
+                    return StatusCode(StatusCodes.Status403Forbidden);
                 }
             }
 
@@ -502,7 +502,7 @@ public class InstancesController : ControllerBase
         if (!InstantiationHelper.IsPartyAllowedToInstantiate(party, application.PartyTypesAllowed))
         {
             return StatusCode(
-                (int)HttpStatusCode.Forbidden,
+                StatusCodes.Status403Forbidden,
                 $"Party {party.PartyId} is not allowed to instantiate this application {org}/{app}"
             );
         }
@@ -521,7 +521,7 @@ public class InstancesController : ControllerBase
         InstantiationValidationResult? validationResult = await _instantiationValidator.Validate(instanceTemplate);
         if (validationResult != null && !validationResult.Valid)
         {
-            return StatusCode((int)HttpStatusCode.Forbidden, validationResult);
+            return StatusCode(StatusCodes.Status403Forbidden, validationResult);
         }
 
         Instance instance;
@@ -675,7 +675,7 @@ public class InstancesController : ControllerBase
         InstantiationValidationResult? validationResult = await _instantiationValidator.Validate(targetInstance);
         if (validationResult != null && !validationResult.Valid)
         {
-            return StatusCode((int)HttpStatusCode.Forbidden, validationResult);
+            return StatusCode(StatusCodes.Status403Forbidden, validationResult);
         }
 
         ProcessStartRequest processStartRequest = new() { Instance = targetInstance, User = User };
@@ -1267,10 +1267,10 @@ public class InstancesController : ControllerBase
     {
         if (enforcementResult.FailedObligations != null && enforcementResult.FailedObligations.Count > 0)
         {
-            return StatusCode((int)HttpStatusCode.Forbidden, enforcementResult.FailedObligations);
+            return StatusCode(StatusCodes.Status403Forbidden, enforcementResult.FailedObligations);
         }
 
-        return StatusCode((int)HttpStatusCode.Forbidden);
+        return StatusCode(StatusCodes.Status403Forbidden);
     }
 
     private async Task UpdatePresentationTextsOnInstance(

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -271,7 +271,7 @@ public class ProcessController : ControllerBase
             return new ProblemDetails()
             {
                 Detail = $"{errorCount} validation errors found for task {currentTaskId}",
-                Status = (int)HttpStatusCode.Conflict,
+                Status = StatusCodes.Status409Conflict,
                 Title = "Validation failed for task",
                 Extensions = new Dictionary<string, object?>() { { "validationIssues", validationIssues } },
             };
@@ -316,7 +316,7 @@ public class ProcessController : ControllerBase
                 return Conflict(
                     new ProblemDetails()
                     {
-                        Status = (int)HttpStatusCode.Conflict,
+                        Status = StatusCodes.Status409Conflict,
                         Title = "Process is not started. Use start!",
                     }
                 );
@@ -325,7 +325,7 @@ public class ProcessController : ControllerBase
             if (instance.Process.Ended.HasValue)
             {
                 return Conflict(
-                    new ProblemDetails() { Status = (int)HttpStatusCode.Conflict, Title = "Process is ended." }
+                    new ProblemDetails() { Status = StatusCodes.Status409Conflict, Title = "Process is ended." }
                 );
             }
 
@@ -336,7 +336,7 @@ public class ProcessController : ControllerBase
                 return Conflict(
                     new ProblemDetails()
                     {
-                        Status = (int)HttpStatusCode.Conflict,
+                        Status = StatusCodes.Status409Conflict,
                         Title = "Instance does not have current altinn task type information!",
                     }
                 );
@@ -358,7 +358,7 @@ public class ProcessController : ControllerBase
                     403,
                     new ProblemDetails()
                     {
-                        Status = (int)HttpStatusCode.Forbidden,
+                        Status = StatusCodes.Status403Forbidden,
                         Detail = $"User is not authorized to perform action {checkedAction} on task {currentTaskId}",
                         Title = "Unauthorized",
                     }
@@ -412,7 +412,7 @@ public class ProcessController : ControllerBase
                     new ProblemDetails()
                     {
                         Detail = result.ErrorMessage,
-                        Status = (int)HttpStatusCode.Conflict,
+                        Status = StatusCodes.Status409Conflict,
                         Title = "Conflict",
                     }
                 );
@@ -422,7 +422,7 @@ public class ProcessController : ControllerBase
                     new ProblemDetails()
                     {
                         Detail = result.ErrorMessage,
-                        Status = (int)HttpStatusCode.InternalServerError,
+                        Status = StatusCodes.Status500InternalServerError,
                         Title = "Internal server error",
                     }
                 );
@@ -432,7 +432,7 @@ public class ProcessController : ControllerBase
                     new ProblemDetails()
                     {
                         Detail = result.ErrorMessage,
-                        Status = (int)HttpStatusCode.Forbidden,
+                        Status = StatusCodes.Status403Forbidden,
                         Title = "Unauthorized",
                     }
                 );
@@ -442,7 +442,7 @@ public class ProcessController : ControllerBase
                     new ProblemDetails()
                     {
                         Detail = $"Unknown ProcessErrorType {result.ErrorType}",
-                        Status = (int)HttpStatusCode.InternalServerError,
+                        Status = StatusCodes.Status500InternalServerError,
                         Title = "Internal server error",
                     }
                 );
@@ -487,7 +487,7 @@ public class ProcessController : ControllerBase
             return Conflict(
                 new ProblemDetails()
                 {
-                    Status = (int)HttpStatusCode.Conflict,
+                    Status = StatusCodes.Status409Conflict,
                     Title = "Process is not started. Use start!",
                 }
             );

--- a/src/Altinn.App.Api/Controllers/StatelessDataController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessDataController.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Net;
 using Altinn.App.Api.Infrastructure.Filters;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Auth;
@@ -390,9 +389,9 @@ public class StatelessDataController : ControllerBase
     {
         if (enforcementResult.FailedObligations != null && enforcementResult.FailedObligations.Count > 0)
         {
-            return StatusCode((int)HttpStatusCode.Forbidden, enforcementResult.FailedObligations);
+            return StatusCode(StatusCodes.Status403Forbidden, enforcementResult.FailedObligations);
         }
 
-        return StatusCode((int)HttpStatusCode.Forbidden);
+        return StatusCode(StatusCodes.Status403Forbidden);
     }
 }

--- a/src/Altinn.App.Api/Helpers/DataElementAccessChecker.cs
+++ b/src/Altinn.App.Api/Helpers/DataElementAccessChecker.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -84,7 +83,7 @@ internal static class DataElementAccessChecker
             {
                 Title = "Instance Not Active",
                 Detail = $"Cannot update data element of archived or deleted instance {instance.Id}",
-                Status = (int)HttpStatusCode.Conflict,
+                Status = StatusCodes.Status409Conflict,
             };
         }
         if (!IsValidContributor(dataType, auth))
@@ -123,7 +122,7 @@ internal static class DataElementAccessChecker
             {
                 Title = "Max Count Exceeded",
                 Detail = $"Cannot create more than {dataType.MaxCount} data elements of type {dataType.Id}",
-                Status = (int)HttpStatusCode.Conflict,
+                Status = StatusCodes.Status409Conflict,
             };
         }
 
@@ -135,7 +134,7 @@ internal static class DataElementAccessChecker
                 Title = "Max Size Exceeded",
                 Detail =
                     $"Cannot create data element of size {contentLength} which exceeds the max size of {dataType.MaxSize}",
-                Status = (int)HttpStatusCode.BadRequest,
+                Status = StatusCodes.Status400BadRequest,
             };
         }
 
@@ -146,7 +145,7 @@ internal static class DataElementAccessChecker
             {
                 Title = "User Create Disallowed",
                 Detail = $"Cannot create data element of type {dataType.Id} as it is disallowed by app logic",
-                Status = (int)HttpStatusCode.BadRequest,
+                Status = StatusCodes.Status400BadRequest,
             };
         }
 
@@ -191,7 +190,7 @@ internal static class DataElementAccessChecker
             {
                 Title = "Cannot Delete main data element",
                 Detail = "Cannot delete the only data element of a class with app logic",
-                Status = (int)HttpStatusCode.BadRequest,
+                Status = StatusCodes.Status400BadRequest,
             };
         }
 
@@ -201,7 +200,7 @@ internal static class DataElementAccessChecker
             {
                 Title = "User Delete Disallowed",
                 Detail = $"Cannot delete data element of type {dataType.Id} as it is disallowed by app logic",
-                Status = (int)HttpStatusCode.BadRequest,
+                Status = StatusCodes.Status400BadRequest,
             };
         }
 

--- a/src/Altinn.App.Api/Helpers/Patch/InternalPatchService.cs
+++ b/src/Altinn.App.Api/Helpers/Patch/InternalPatchService.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -97,7 +96,7 @@ public class InternalPatchService
                 {
                     Title = "Unknown data element to patch",
                     Detail = $"Data element with id {dataElementGuid} not found in instance",
-                    Status = (int)HttpStatusCode.NotFound,
+                    Status = StatusCodes.Status404NotFound,
                 };
             }
 
@@ -134,7 +133,7 @@ public class InternalPatchService
                     Title = "Patch operation did not deserialize",
                     Type = "https://datatracker.ietf.org/doc/html/rfc6902/",
                     Detail = newModelResult.Error,
-                    Status = (int)HttpStatusCode.UnprocessableContent,
+                    Status = StatusCodes.Status422UnprocessableEntity,
                 };
             }
 

--- a/src/Altinn.App.Api/Helpers/Patch/InternalPatchService.cs
+++ b/src/Altinn.App.Api/Helpers/Patch/InternalPatchService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;

--- a/src/Altinn.App.Api/Models/DataPostResponse.cs
+++ b/src/Altinn.App.Api/Models/DataPostResponse.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using System.Net;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
@@ -49,7 +48,7 @@ public class DataPostErrorResponse : ProblemDetails
     {
         Title = "File validation failed";
         Detail = detail;
-        Status = (int)HttpStatusCode.BadRequest;
+        Status = StatusCodes.Status400BadRequest;
         UploadValidationIssues = validationIssues;
     }
 

--- a/test/Altinn.App.Api.Tests/Controllers/ExternalApiControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ExternalApiControllerTests.cs
@@ -3,6 +3,7 @@ using Altinn.App.Api.Controllers;
 using Altinn.App.Core.Features.ExternalApi;
 using Altinn.App.Core.Models;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -40,7 +41,7 @@ public class ExternalApiControllerTests
         // Assert
         var okResult = result as OkObjectResult;
         Assert.NotNull(okResult);
-        okResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        okResult.StatusCode.Should().Be(StatusCodes.Status200OK);
         okResult.Value.Should().Be(externalApiData);
     }
 
@@ -63,7 +64,7 @@ public class ExternalApiControllerTests
         // Assert
         var objectResult = result as BadRequestObjectResult;
         Assert.NotNull(objectResult);
-        objectResult.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);
+        objectResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
         objectResult.Value.Should().Be($"External api with id '{externalApiId}' not found.");
     }
 
@@ -86,7 +87,7 @@ public class ExternalApiControllerTests
         // Assert
         var objectResult = result as ObjectResult;
         Assert.NotNull(objectResult);
-        objectResult.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+        objectResult.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
         objectResult.Value.Should().Match(x => ((string)x).EndsWith("Error message"));
     }
 
@@ -113,7 +114,7 @@ public class ExternalApiControllerTests
         // Assert
         var objectResult = result as ObjectResult;
         Assert.NotNull(objectResult);
-        objectResult.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);
+        objectResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
 
         objectResult
             .Value.Should()


### PR DESCRIPTION
Microsoft.AspNetCore.Mvc StatusCodes are int constants which is prettier than casting the System.Net.HttpStatusCode enums to int when an int is required
