### PR TITLE
A few minor issues discovered when writing tests

### DIFF
--- a/src/Altinn.App.Core/Internal/App/AppMetadata.cs
+++ b/src/Altinn.App.Core/Internal/App/AppMetadata.cs
@@ -23,7 +23,7 @@ public class AppMetadata : IAppMetadata
 
     private readonly AppSettings _settings;
     private readonly IFrontendFeatures _frontendFeatures;
-    private readonly IExternalApiFactory _externalApiFactory;
+    private readonly IExternalApiFactory? _externalApiFactory;
     private readonly Telemetry? _telemetry;
     private ApplicationMetadata? _application;
 
@@ -32,19 +32,19 @@ public class AppMetadata : IAppMetadata
     /// </summary>
     /// <param name="settings">The app repository settings.</param>
     /// <param name="frontendFeatures">Application features service</param>
-    /// <param name="serviceProvider"></param>
+    /// <param name="serviceProvider">A way to resolve internal services</param>
     /// <param name="telemetry">Telemetry for traces and metrics.</param>
     public AppMetadata(
         IOptions<AppSettings> settings,
         IFrontendFeatures frontendFeatures,
-        IServiceProvider serviceProvider,
+        IServiceProvider? serviceProvider = null,
         Telemetry? telemetry = null
     )
     {
         _settings = settings.Value;
         _frontendFeatures = frontendFeatures;
         _telemetry = telemetry;
-        _externalApiFactory = serviceProvider.GetRequiredService<IExternalApiFactory>();
+        _externalApiFactory = serviceProvider?.GetRequiredService<IExternalApiFactory>();
     }
 
     /// <inheritdoc />
@@ -81,7 +81,7 @@ public class AppMetadata : IAppMetadata
                 }
 
                 application.Features = await _frontendFeatures.GetFrontendFeatures();
-                application.ExternalApiIds = _externalApiFactory.GetAllExternalApiIds();
+                application.ExternalApiIds = _externalApiFactory?.GetAllExternalApiIds();
 
                 _application = application;
 

--- a/test/Altinn.App.Api.Tests/Mocks/AppModelMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AppModelMock.cs
@@ -3,7 +3,7 @@ using Altinn.App.Core.Internal.AppModel;
 
 namespace Altinn.App.Api.Tests.Mocks;
 
-public class AppModelMock : IAppModel
+public class AppModelMock<TAssemblyMarker> : IAppModel
 {
     public object Create(string classRef)
     {
@@ -13,6 +13,6 @@ public class AppModelMock : IAppModel
     public Type GetModelType(string classRef)
     {
         // The default implementations uses the executing assembly, but this does not work in the test project.
-        return Assembly.GetAssembly(typeof(AppModelMock))!.GetType(classRef, true)!;
+        return Assembly.GetAssembly(typeof(TAssemblyMarker))!.GetType(classRef, true)!;
     }
 }

--- a/test/Altinn.App.Api.Tests/Program.cs
+++ b/test/Altinn.App.Api.Tests/Program.cs
@@ -104,7 +104,7 @@ void ConfigureMockServices(IServiceCollection services, ConfigurationManager con
     services.AddTransient<IAltinnPartyClient, AltinnPartyClientMock>();
     services.AddTransient<IProfileClient, ProfileClientMock>();
     services.AddTransient<IInstanceEventClient, InstanceEventClientMock>();
-    services.AddTransient<IAppModel, AppModelMock>();
+    services.AddTransient<IAppModel, AppModelMock<Program>>();
 }
 
 void Configure()


### PR DESCRIPTION
Frontend-tests used the AppMetadata constructor directly, and as it can be compatible it should be compatible.

AppModelMock used an internal assembly marker, but with an external assembly marker it can be reused (I rather commit it now, than to have it as a note for the next time I might need it).