### PR TITLE
Add label check for backport label

### DIFF
--- a/.github/workflows/check-label-added.yml
+++ b/.github/workflows/check-label-added.yml
@@ -16,3 +16,7 @@ jobs:
             if(!releaseLabels.some(r=>labels.some(l=>l.name == r))){
                 core.setFailed(`The PR must have at least one of these labels: ${releaseLabels}`)
             }
+            const backportLabels = ["backport", "backport-ignore"];
+            if(!backportLabels.some(r=>labels.some(l=>l.name == r))){
+                core.setFailed(`The PR must have at least one of these labels: ${backportLabels}`)
+            }


### PR DESCRIPTION
Now that we maintain multiple branches `main` and `release/8.5` we need to ensure that pull requests gets marked wether they make sense for backporting


