### PR TITLE
Legacy implementation of `IMaskinportenTokenProvider`

### DIFF
--- a/src/Altinn.App.Core/Features/Maskinporten/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features.Maskinporten.Models;
+using Altinn.App.Core.Internal.Maskinporten;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -30,6 +31,10 @@ internal static class ServiceCollectionExtensions
             MaskinportenClient.VariantInternal,
             (sp, key) => ActivatorUtilities.CreateInstance<MaskinportenClient>(sp, MaskinportenClient.VariantInternal)
         );
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        services.TryAddTransient<IMaskinportenTokenProvider, LegacyMaskinportenTokenProvider>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         return services;
     }

--- a/src/Altinn.App.Core/Features/Maskinporten/LegacyMaskinportenTokenProvider.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/LegacyMaskinportenTokenProvider.cs
@@ -1,0 +1,29 @@
+using Altinn.App.Core.Internal.Maskinporten;
+
+namespace Altinn.App.Core.Features.Maskinporten;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+
+/// <summary>
+/// Legacy token provider for <see cref="Altinn.App.Core.EFormidling.Implementation.EformidlingStatusCheckEventHandler2"/>
+/// and others that rely on a <see cref="IMaskinportenTokenProvider"/> implementation.
+/// </summary>
+internal sealed class LegacyMaskinportenTokenProvider : IMaskinportenTokenProvider
+{
+    private readonly IMaskinportenClient _maskinportenClient;
+
+    public LegacyMaskinportenTokenProvider(IMaskinportenClient maskinportenClient)
+    {
+        _maskinportenClient = maskinportenClient;
+    }
+
+    public async Task<string> GetToken(string scopes)
+    {
+        return await _maskinportenClient.GetAccessToken([scopes]);
+    }
+
+    public async Task<string> GetAltinnExchangedToken(string scopes)
+    {
+        return await _maskinportenClient.GetAltinnExchangedToken([scopes]);
+    }
+}

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/LegacyMaskinportenTokenProviderTest.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/LegacyMaskinportenTokenProviderTest.cs
@@ -1,0 +1,77 @@
+using Altinn.App.Core.Features.Maskinporten;
+using Altinn.App.Core.Models;
+using Moq;
+
+namespace Altinn.App.Core.Tests.Features.Maskinporten;
+
+public class LegacyMaskinportenTokenProviderTest
+{
+    private sealed record Fixture
+    {
+        public required LegacyMaskinportenTokenProvider TokenProvider { get; init; }
+        public required Mock<IMaskinportenClient> MaskinportenClientMock { get; init; }
+
+        public static JwtToken MaskinportenToken =>
+            JwtToken.Parse(
+                "eyJraWQiOiJiZFhMRVduRGpMSGpwRThPZnl5TUp4UlJLbVo3MUxCOHUxeUREbVBpdVQwIiwiYWxnIjoiUlMyNTYifQ.eyJzY29wZSI6ImFsdGlubjpyZXNvdXJjZXJlZ2lzdHJ5L3Jlc291cmNlLnJlYWQgYWx0aW5uOnNlcnZpY2Vvd25lciBhbHRpbm46Y29ycmVzcG9uZGVuY2Uud3JpdGUiLCJpc3MiOiJodHRwczovL3Rlc3QubWFza2lucG9ydGVuLm5vLyIsImNsaWVudF9hbXIiOiJwcml2YXRlX2tleV9qd3QiLCJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiZXhwIjoxNzQwNTg0NDQxLCJpYXQiOjE3NDA1ODA4NDEsImNsaWVudF9pZCI6ImQyMjEzMGNmLTMzZjEtNGI2Yy1hMjM4LTVmMjZmZTk1NTRiMyIsImp0aSI6IjktVGs3VjloLVRPdTV3U09Dd1BPTEFFY3Jxd0MtYTFoZElfV1h2cXJhMEUiLCJjb25zdW1lciI6eyJhdXRob3JpdHkiOiJpc282NTIzLWFjdG9yaWQtdXBpcyIsIklEIjoiMDE5Mjo5OTE4MjU4MjcifX0.kucCO2tj2GdRhZQ09Drt39gcBRbFlCCD0_xiQQEhxOXUrJW93aGtVvFuSbtPHke6ndH-QVBEOMlKaovLp-8T2ZfoW3mjQ5NeZnkF4j-yN9sTv5baxFe6e2sVhSsQieC30KhPdJvYBYwU8reLY_JLmqLntL-VfOIUZz3Reh7FhDq-qXa8qvqWX1orN1GkQSSG8WoVzr7Gt7weNmqRRP9Wavfq0J-pbxT4CgQmHOFj0OkkqlrC-OCwD-Y9iqJgxJqlXgJapZljIfaxJeDyQiEDLCP_H-dTmDp1eOBwdLZDRx4TLJ45F0VXmwsIWGwdsvDpDCaL0t_GDfu61bfaDw7NFS4ZQnzTrbb53C55jSYEixQbEqX_vn4mCWzV0iPrBP_6B5x9QwVC3mhnSLuG77AgmA2h7ZmEHmVNtCu8WyvcUc-SbE9rg6wtRL9fycBBgqs61k_B2elDHImzKVSWyZVKQAIlj-eb0Hmspr380E4zTqBLJIvAiDZA0jBCGsNHlXPd"
+            );
+        public static JwtToken AltinnToken =>
+            JwtToken.Parse(
+                "eyJhbGciOiJSUzI1NiIsImtpZCI6IkQ4RDg2N0M3RDUyMTM2MEY0RjM1Q0Q1MTU4MEM0OUEwNTE2NUQ0RTEiLCJ4NXQiOiIyTmhueDlVaE5nOVBOYzFSV0F4Sm9GRmwxT0UiLCJ0eXAiOiJKV1QifQ.eyJzY29wZSI6ImFsdGlubjpyZXNvdXJjZXJlZ2lzdHJ5L3Jlc291cmNlLnJlYWQgYWx0aW5uOnNlcnZpY2Vvd25lciBhbHRpbm46Y29ycmVzcG9uZGVuY2Uud3JpdGUiLCJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiZXhwIjoxNzQwNTgyNjU2LCJpYXQiOjE3NDA1ODA4NTYsImNsaWVudF9pZCI6ImQyMjEzMGNmLTMzZjEtNGI2Yy1hMjM4LTVmMjZmZTk1NTRiMyIsImNvbnN1bWVyIjp7ImF1dGhvcml0eSI6ImlzbzY1MjMtYWN0b3JpZC11cGlzIiwiSUQiOiIwMTkyOjk5MTgyNTgyNyJ9LCJ1cm46YWx0aW5uOm9yZyI6ImRpZ2RpciIsInVybjphbHRpbm46b3JnTnVtYmVyIjoiOTkxODI1ODI3IiwidXJuOmFsdGlubjphdXRoZW50aWNhdGVtZXRob2QiOiJtYXNraW5wb3J0ZW4iLCJ1cm46YWx0aW5uOmF1dGhsZXZlbCI6MywiaXNzIjoiaHR0cHM6Ly9wbGF0Zm9ybS50dDAyLmFsdGlubi5uby9hdXRoZW50aWNhdGlvbi9hcGkvdjEvb3BlbmlkLyIsImp0aSI6IjQyMGRkYmU4LWM0YjktNGY1MS05NDUxLTVhNjNmZjcyZGQ5NyIsIm5iZiI6MTc0MDU4MDg1Nn0.DQydmTFzbC21YmQ29LDg7qGmlmptX9Zwj_mvlZkol32LbpbOexeM5PC-hSaEYanuFxg5xZvfSYdoptk8GzznlINGe79bdD01g5RHxbsSrJ2SAuoK93oSDTVi0ncunz5UyG00PRimCvsTxj1CZ7r8JhL-C40nxGDQQM8fm-pAEyJtW6rehtg6EDfJCiQuCIqdxYFkM4vt0AKXS_ka-xQZcbEliZ5S7HD-RVeC4zWPdbqhA8BX0oQZwsTDma25vestv1D8YgoPe1Llu5ozSxfjh_Svp9rg7GroKGik0a6sCbP5zLcRcgAOd9lzcDDvDfksrNNJ5KPeL2XNCkyVPbiDTw"
+            );
+
+        public static Fixture Create()
+        {
+            var maskinportenClientMock = new Mock<IMaskinportenClient>();
+            var tokenProvider = new LegacyMaskinportenTokenProvider(maskinportenClientMock.Object);
+
+            maskinportenClientMock
+                .Setup(x => x.GetAccessToken(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(MaskinportenToken);
+
+            maskinportenClientMock
+                .Setup(x => x.GetAltinnExchangedToken(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(AltinnToken);
+
+            return new Fixture { TokenProvider = tokenProvider, MaskinportenClientMock = maskinportenClientMock };
+        }
+    }
+
+    [Fact]
+    public async Task GetToken_CallsMaskinportenClientCorrectly()
+    {
+        // Arrange
+        var fixture = Fixture.Create();
+        var scopes = "test1 test2";
+
+        // Act
+        var token = await fixture.TokenProvider.GetToken(scopes);
+
+        // Assert
+        Assert.Equal(Fixture.MaskinportenToken.Value, token);
+        fixture.MaskinportenClientMock.Verify(
+            x => x.GetAccessToken(new[] { scopes }, It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+        fixture.MaskinportenClientMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task GetAltinnExchangedToken_CallsMaskinportenClientCorrectly()
+    {
+        // Arrange
+        var fixture = Fixture.Create();
+        var scopes = "test";
+
+        // Act
+        var token = await fixture.TokenProvider.GetAltinnExchangedToken(scopes);
+
+        // Assert
+        Assert.Equal(Fixture.AltinnToken.Value, token);
+        fixture.MaskinportenClientMock.Verify(
+            x => x.GetAltinnExchangedToken(new[] { scopes }, It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+        fixture.MaskinportenClientMock.VerifyNoOtherCalls();
+    }
+}

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
@@ -5,6 +5,7 @@ using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Core.Features.Maskinporten;
 using Altinn.App.Core.Features.Maskinporten.Exceptions;
 using Altinn.App.Core.Features.Maskinporten.Models;
+using Altinn.App.Core.Internal.Maskinporten;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Caching.Memory;
@@ -108,6 +109,10 @@ public class MaskinportenClientTests
         internalClient.Settings.Should().BeEquivalentTo(Fixture.InternalSettings);
         internalClient.Variant.Should().Be(MaskinportenClient.VariantInternal);
         defaultClient.Variant.Should().Be(MaskinportenClient.VariantDefault);
+        fixture
+            .App.Services.GetRequiredService<IMaskinportenTokenProvider>()
+            .Should()
+            .BeOfType<LegacyMaskinportenTokenProvider>();
     }
 
     [Fact]


### PR DESCRIPTION
## Description
[EformidlingStatusCheckEventHandler2](https://github.com/Altinn/app-lib-dotnet/blob/26182f1e0d8428791008a6d2ddca830b420ca5c9/src/Altinn.App.Core/EFormidling/Implementation/EformidlingStatusCheckEventHandler2.cs#L44) currently requires an `IMaskinportenTokenProvider` implementation to operate. This makes eFormidling dependent on the external MaskinportenClient package and unable to switch over to the updated, internal, client.

This PR aims to rectify that.

## Notes
Practical testing for this is proving to be difficult. We currently don't have access to an eFormidling receiver in a test environment, which means we are unable to properly test for a "message received" status. We _can_, however, check that the authentication has succeeded. I'm exploring that option now.

## Related Issue(s)
- #1020 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
