### PR TITLE
Remove use of 'dynamic' in ProcessTaskInitializer

### DIFF
--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskInitializer.cs
@@ -74,7 +74,7 @@ public class ProcessTaskInitializer : IProcessTaskInitializer
                 continue;
             }
 
-            dynamic data = _appModel.Create(dataType.AppLogic.ClassRef);
+            var data = _appModel.Create(dataType.AppLogic.ClassRef);
 
             // runs prefill from repo configuration if config exists
             await _prefillService.PrefillDataModel(instance.InstanceOwner.PartyId, dataType.Id, data, prefill);
@@ -97,10 +97,10 @@ public class ProcessTaskInitializer : IProcessTaskInitializer
         }
     }
 
-    private async Task UpdatePresentationTextsOnInstance(Instance instance, string dataType, dynamic data)
+    private async Task UpdatePresentationTextsOnInstance(Instance instance, string dataType, object data)
     {
         ApplicationMetadata applicationMetadata = await _appMetadata.GetApplicationMetadata();
-        dynamic? updatedValues = DataHelper.GetUpdatedDataValues(
+        Dictionary<string, string?> updatedValues = DataHelper.GetUpdatedDataValues(
             applicationMetadata?.PresentationFields,
             instance.PresentationTexts,
             dataType,


### PR DESCRIPTION
## Description
I don't know why we use `dynamic` here (or anywhere for that matter). Safe to remove?

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
