### PR TITLE
Make a InstanceDataUnitOfWorkInitalizer instead of injection all dependencies everywhere we need one

### DIFF
--- a/src/Altinn.App.Api/Controllers/ActionsController.cs
+++ b/src/Altinn.App.Api/Controllers/ActionsController.cs
@@ -30,7 +30,7 @@ public class ActionsController : ControllerBase
     private readonly IInstanceClient _instanceClient;
     private readonly UserActionService _userActionService;
     private readonly IValidationService _validationService;
-    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
+    private readonly InstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
     private readonly IAuthenticationContext _authenticationContext;
 
     /// <summary>
@@ -41,7 +41,7 @@ public class ActionsController : ControllerBase
         IInstanceClient instanceClient,
         UserActionService userActionService,
         IValidationService validationService,
-        InternalInstanceDataUnitOfWorkInitializer internalInstanceDataUnitOfWorkInitializer,
+        IServiceProvider serviceProvider,
         IAuthenticationContext authenticationContext
     )
     {
@@ -49,7 +49,7 @@ public class ActionsController : ControllerBase
         _instanceClient = instanceClient;
         _userActionService = userActionService;
         _validationService = validationService;
-        _internalInstanceDataUnitOfWorkInitializer = internalInstanceDataUnitOfWorkInitializer;
+        _instanceDataUnitOfWorkInitializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
         _authenticationContext = authenticationContext;
     }
 
@@ -120,7 +120,7 @@ public class ActionsController : ControllerBase
             return Forbid();
         }
         var taskId = instance.Process?.CurrentTask?.ElementId;
-        var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
+        var dataMutator = await _instanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
         UserActionContext userActionContext = new(
             dataMutator,

--- a/src/Altinn.App.Api/Controllers/ActionsController.cs
+++ b/src/Altinn.App.Api/Controllers/ActionsController.cs
@@ -4,8 +4,6 @@ using Altinn.App.Api.Models;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Action;
 using Altinn.App.Core.Features.Auth;
-using Altinn.App.Core.Helpers.Serialization;
-using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Validation;
@@ -32,9 +30,7 @@ public class ActionsController : ControllerBase
     private readonly IInstanceClient _instanceClient;
     private readonly UserActionService _userActionService;
     private readonly IValidationService _validationService;
-    private readonly IDataClient _dataClient;
-    private readonly IAppMetadata _appMetadata;
-    private readonly ModelSerializationService _modelSerialization;
+    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
     private readonly IAuthenticationContext _authenticationContext;
 
     /// <summary>
@@ -45,9 +41,7 @@ public class ActionsController : ControllerBase
         IInstanceClient instanceClient,
         UserActionService userActionService,
         IValidationService validationService,
-        IDataClient dataClient,
-        IAppMetadata appMetadata,
-        ModelSerializationService modelSerialization,
+        InternalInstanceDataUnitOfWorkInitializer internalInstanceDataUnitOfWorkInitializer,
         IAuthenticationContext authenticationContext
     )
     {
@@ -55,9 +49,7 @@ public class ActionsController : ControllerBase
         _instanceClient = instanceClient;
         _userActionService = userActionService;
         _validationService = validationService;
-        _dataClient = dataClient;
-        _appMetadata = appMetadata;
-        _modelSerialization = modelSerialization;
+        _internalInstanceDataUnitOfWorkInitializer = internalInstanceDataUnitOfWorkInitializer;
         _authenticationContext = authenticationContext;
     }
 
@@ -127,14 +119,9 @@ public class ActionsController : ControllerBase
         {
             return Forbid();
         }
+        var taskId = instance.Process?.CurrentTask?.ElementId;
+        var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
-        var dataMutator = new InstanceDataUnitOfWork(
-            instance,
-            _dataClient,
-            _instanceClient,
-            await _appMetadata.GetApplicationMetadata(),
-            _modelSerialization
-        );
         UserActionContext userActionContext = new(
             dataMutator,
             user.UserId,

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -235,7 +235,7 @@ public class DataController : ControllerBase
                 return instanceResult.Error;
             }
 
-            var (instance, dataType, applicationMetadata) = instanceResult.Ok;
+            var (instance, dataType, _) = instanceResult.Ok;
 
             if (
                 DataElementAccessChecker.GetCreateProblem(instance, dataType, _authenticationContext.Current) is

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -54,6 +54,7 @@ public class DataController : ControllerBase
     private readonly IFeatureManager _featureManager;
     private readonly InternalPatchService _patchService;
     private readonly ModelSerializationService _modelDeserializer;
+    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
     private readonly IAuthenticationContext _authenticationContext;
     private readonly AppImplementationFactory _appImplementationFactory;
 
@@ -66,13 +67,14 @@ public class DataController : ControllerBase
     /// <param name="instanceClient">instance service to store instances</param>
     /// <param name="dataClient">A service with access to data storage.</param>
     /// <param name="appModel">Service for generating app model</param>
-    /// <param name="appMetadata">The app metadata service</param>
-    /// <param name="featureManager">The feature manager controlling enabled features.</param>
     /// <param name="prefillService">A service with prefill related logic.</param>
     /// <param name="fileAnalyserService">Service used to analyse files uploaded.</param>
     /// <param name="fileValidationService">Service used to validate files uploaded.</param>
+    /// <param name="appMetadata">The app metadata service</param>
+    /// <param name="featureManager">The feature manager controlling enabled features.</param>
     /// <param name="patchService">Service for applying a json patch to a json serializable object</param>
     /// <param name="modelDeserializer">Service for serializing and deserializing models</param>
+    /// <param name="internalInstanceDataUnitOfWorkInitializer"></param>
     /// <param name="authenticationContext">The authentication context service</param>
     /// <param name="serviceProvider">Service provider</param>
     public DataController(
@@ -103,6 +105,8 @@ public class DataController : ControllerBase
         _featureManager = featureManager;
         _patchService = patchService;
         _modelDeserializer = modelDeserializer;
+        _internalInstanceDataUnitOfWorkInitializer =
+            serviceProvider.GetRequiredService<InternalInstanceDataUnitOfWorkInitializer>();
         _authenticationContext = authenticationContext;
         _appImplementationFactory = serviceProvider.GetRequiredService<AppImplementationFactory>();
     }
@@ -256,13 +260,17 @@ public class DataController : ControllerBase
                 return accessProblem;
             }
 
-            var dataMutator = new InstanceDataUnitOfWork(
-                instance,
-                _dataClient,
-                _instanceClient,
-                applicationMetadata,
-                _modelDeserializer
-            );
+            var taskId = instance.Process?.CurrentTask?.ElementId;
+            if (taskId is null)
+            {
+                return new ProblemDetails()
+                {
+                    Title = "No current task",
+                    Detail = "Cannot create data element without a current task",
+                    Status = StatusCodes.Status409Conflict,
+                };
+            }
+            var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
             // Save data elements with form data
             if (dataType.AppLogic?.ClassRef is { } classRef)
@@ -365,12 +373,7 @@ public class DataController : ControllerBase
                 throw new InvalidOperationException("Expected exactly one change in initialChanges");
             }
 
-            await _patchService.RunDataProcessors(
-                dataMutator,
-                initialChanges,
-                instance.Process.CurrentTask.ElementId,
-                language
-            );
+            await _patchService.RunDataProcessors(dataMutator, initialChanges, taskId, language);
 
             if (dataMutator.GetAbandonResponse() is { } abandonResponse)
             {
@@ -389,7 +392,7 @@ public class DataController : ControllerBase
                     .ToList();
                 validationIssues = await _patchService.RunIncrementalValidation(
                     dataMutator,
-                    instance.Process.CurrentTask.ElementId,
+                    taskId,
                     finalChanges,
                     ignoredValidators,
                     language
@@ -804,13 +807,7 @@ public class DataController : ControllerBase
                 instance.Process?.CurrentTask?.ElementId
                 ?? throw new InvalidOperationException("Instance have no process");
 
-            var dataMutator = new InstanceDataUnitOfWork(
-                instance,
-                _dataClient,
-                _instanceClient,
-                await _appMetadata.GetApplicationMetadata(),
-                _modelDeserializer
-            );
+            var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
             dataMutator.RemoveDataElement(dataElement);
 
@@ -1083,13 +1080,21 @@ public class DataController : ControllerBase
 
         var serviceModel = deserializationResult.Ok;
 
-        var dataMutator = new InstanceDataUnitOfWork(
-            instance,
-            _dataClient,
-            _instanceClient,
-            await _appMetadata.GetApplicationMetadata(),
-            _modelDeserializer
-        );
+        var taskId = instance.Process?.CurrentTask?.ElementId;
+        if (taskId is null)
+        {
+            return Problem(
+                new ProblemDetails()
+                {
+                    Title = "No current task",
+                    Detail = "Cannot update data element without a current task",
+                    Status = StatusCodes.Status409Conflict,
+                }
+            );
+        }
+
+        var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
+
         // Get the previous service model for dataProcessing to work
         var oldServiceModel = await dataMutator.GetFormData(dataElement);
         // Set the new service model so that dataAccessors see the new state
@@ -1109,12 +1114,7 @@ public class DataController : ControllerBase
 
         // Run data processors keeping track of changes for diff return
         var jsonBeforeDataProcessors = JsonSerializer.Serialize(serviceModel);
-        await _patchService.RunDataProcessors(
-            dataMutator,
-            new DataElementChanges([requestedChange]),
-            instance.Process.CurrentTask.ElementId,
-            language
-        );
+        await _patchService.RunDataProcessors(dataMutator, new DataElementChanges([requestedChange]), taskId, language);
         var jsonAfterDataProcessors = JsonSerializer.Serialize(serviceModel);
 
         if (dataMutator.GetAbandonResponse() is { } abandonResponse)

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -54,7 +54,7 @@ public class DataController : ControllerBase
     private readonly IFeatureManager _featureManager;
     private readonly InternalPatchService _patchService;
     private readonly ModelSerializationService _modelDeserializer;
-    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
+    private readonly InstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
     private readonly IAuthenticationContext _authenticationContext;
     private readonly AppImplementationFactory _appImplementationFactory;
 
@@ -63,20 +63,6 @@ public class DataController : ControllerBase
     /// <summary>
     /// The data controller is responsible for adding business logic to the data elements.
     /// </summary>
-    /// <param name="logger">logger</param>
-    /// <param name="instanceClient">instance service to store instances</param>
-    /// <param name="dataClient">A service with access to data storage.</param>
-    /// <param name="appModel">Service for generating app model</param>
-    /// <param name="prefillService">A service with prefill related logic.</param>
-    /// <param name="fileAnalyserService">Service used to analyse files uploaded.</param>
-    /// <param name="fileValidationService">Service used to validate files uploaded.</param>
-    /// <param name="appMetadata">The app metadata service</param>
-    /// <param name="featureManager">The feature manager controlling enabled features.</param>
-    /// <param name="patchService">Service for applying a json patch to a json serializable object</param>
-    /// <param name="modelDeserializer">Service for serializing and deserializing models</param>
-    /// <param name="internalInstanceDataUnitOfWorkInitializer"></param>
-    /// <param name="authenticationContext">The authentication context service</param>
-    /// <param name="serviceProvider">Service provider</param>
     public DataController(
         ILogger<DataController> logger,
         IInstanceClient instanceClient,
@@ -105,8 +91,7 @@ public class DataController : ControllerBase
         _featureManager = featureManager;
         _patchService = patchService;
         _modelDeserializer = modelDeserializer;
-        _internalInstanceDataUnitOfWorkInitializer =
-            serviceProvider.GetRequiredService<InternalInstanceDataUnitOfWorkInitializer>();
+        _instanceDataUnitOfWorkInitializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
         _authenticationContext = authenticationContext;
         _appImplementationFactory = serviceProvider.GetRequiredService<AppImplementationFactory>();
     }
@@ -270,7 +255,7 @@ public class DataController : ControllerBase
                     Status = StatusCodes.Status409Conflict,
                 };
             }
-            var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
+            var dataMutator = await _instanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
             // Save data elements with form data
             if (dataType.AppLogic?.ClassRef is { } classRef)
@@ -807,7 +792,7 @@ public class DataController : ControllerBase
                 instance.Process?.CurrentTask?.ElementId
                 ?? throw new InvalidOperationException("Instance have no process");
 
-            var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
+            var dataMutator = await _instanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
             dataMutator.RemoveDataElement(dataElement);
 
@@ -1093,7 +1078,7 @@ public class DataController : ControllerBase
             );
         }
 
-        var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
+        var dataMutator = await _instanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
         // Get the previous service model for dataProcessing to work
         var oldServiceModel = await dataMutator.GetFormData(dataElement);

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -70,7 +70,7 @@ public class InstancesController : ControllerBase
     private readonly IHostEnvironment _env;
     private readonly ModelSerializationService _serializationService;
     private readonly InternalPatchService _patchService;
-    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
+    private readonly InstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
 
     private const long RequestSizeLimit = 2000 * 1024 * 1024;
 
@@ -114,8 +114,7 @@ public class InstancesController : ControllerBase
         _env = env;
         _serializationService = serializationService;
         _patchService = patchService;
-        _internalInstanceDataUnitOfWorkInitializer =
-            serviceProvider.GetRequiredService<InternalInstanceDataUnitOfWorkInitializer>();
+        _instanceDataUnitOfWorkInitializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
     }
 
     /// <summary>
@@ -1134,7 +1133,7 @@ public class InstancesController : ControllerBase
         string? language
     )
     {
-        var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId: null, language);
+        var dataMutator = await _instanceDataUnitOfWorkInitializer.Init(instance, taskId: null, language);
 
         for (int partIndex = 0; partIndex < parts.Count; partIndex++)
         {

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -70,6 +70,7 @@ public class InstancesController : ControllerBase
     private readonly IHostEnvironment _env;
     private readonly ModelSerializationService _serializationService;
     private readonly InternalPatchService _patchService;
+    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
 
     private const long RequestSizeLimit = 2000 * 1024 * 1024;
 
@@ -113,6 +114,8 @@ public class InstancesController : ControllerBase
         _env = env;
         _serializationService = serializationService;
         _patchService = patchService;
+        _internalInstanceDataUnitOfWorkInitializer =
+            serviceProvider.GetRequiredService<InternalInstanceDataUnitOfWorkInitializer>();
     }
 
     /// <summary>
@@ -1131,13 +1134,7 @@ public class InstancesController : ControllerBase
         string? language
     )
     {
-        var dataMutator = new InstanceDataUnitOfWork(
-            instance,
-            _dataClient,
-            _instanceClient,
-            appInfo,
-            _serializationService
-        );
+        var dataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId: null, language);
 
         for (int partIndex = 0; partIndex < parts.Count; partIndex++)
         {

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -39,7 +39,7 @@ public class ProcessController : ControllerBase
     private readonly IAuthorizationService _authorization;
     private readonly IProcessEngine _processEngine;
     private readonly IProcessReader _processReader;
-    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
+    private readonly InstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProcessController"/>
@@ -52,7 +52,7 @@ public class ProcessController : ControllerBase
         IAuthorizationService authorization,
         IProcessReader processReader,
         IProcessEngine processEngine,
-        InternalInstanceDataUnitOfWorkInitializer internalInstanceDataUnitOfWorkInitializer
+        IServiceProvider serviceProvider
     )
     {
         _logger = logger;
@@ -62,7 +62,7 @@ public class ProcessController : ControllerBase
         _authorization = authorization;
         _processReader = processReader;
         _processEngine = processEngine;
-        _internalInstanceDataUnitOfWorkInitializer = internalInstanceDataUnitOfWorkInitializer;
+        _instanceDataUnitOfWorkInitializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
     }
 
     /// <summary>
@@ -241,7 +241,7 @@ public class ProcessController : ControllerBase
         string? language
     )
     {
-        var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, currentTaskId, language);
+        var dataAccessor = await _instanceDataUnitOfWorkInitializer.Init(instance, currentTaskId, language);
 
         var validationIssues = await _validationService.ValidateInstanceAtTask(
             dataAccessor,

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -4,8 +4,6 @@ using Altinn.App.Api.Infrastructure.Filters;
 using Altinn.App.Api.Models;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Helpers;
-using Altinn.App.Core.Helpers.Serialization;
-using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Process;
@@ -41,9 +39,7 @@ public class ProcessController : ControllerBase
     private readonly IAuthorizationService _authorization;
     private readonly IProcessEngine _processEngine;
     private readonly IProcessReader _processReader;
-    private readonly IDataClient _dataClient;
-    private readonly IAppMetadata _appMetadata;
-    private readonly ModelSerializationService _modelSerialization;
+    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProcessController"/>
@@ -56,9 +52,7 @@ public class ProcessController : ControllerBase
         IAuthorizationService authorization,
         IProcessReader processReader,
         IProcessEngine processEngine,
-        IDataClient dataClient,
-        IAppMetadata appMetadata,
-        ModelSerializationService modelSerialization
+        InternalInstanceDataUnitOfWorkInitializer internalInstanceDataUnitOfWorkInitializer
     )
     {
         _logger = logger;
@@ -68,9 +62,7 @@ public class ProcessController : ControllerBase
         _authorization = authorization;
         _processReader = processReader;
         _processEngine = processEngine;
-        _dataClient = dataClient;
-        _appMetadata = appMetadata;
-        _modelSerialization = modelSerialization;
+        _internalInstanceDataUnitOfWorkInitializer = internalInstanceDataUnitOfWorkInitializer;
     }
 
     /// <summary>
@@ -249,13 +241,8 @@ public class ProcessController : ControllerBase
         string? language
     )
     {
-        var dataAccessor = new InstanceDataUnitOfWork(
-            instance,
-            _dataClient,
-            _instanceClient,
-            await _appMetadata.GetApplicationMetadata(),
-            _modelSerialization
-        );
+        var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, currentTaskId, language);
+
         var validationIssues = await _validationService.ValidateInstanceAtTask(
             dataAccessor,
             currentTaskId, // run full validation

--- a/src/Altinn.App.Api/Controllers/ValidateController.cs
+++ b/src/Altinn.App.Api/Controllers/ValidateController.cs
@@ -19,7 +19,7 @@ namespace Altinn.App.Api.Controllers;
 public class ValidateController : ControllerBase
 {
     private readonly IInstanceClient _instanceClient;
-    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
+    private readonly InstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
     private readonly IAppMetadata _appMetadata;
     private readonly IValidationService _validationService;
 
@@ -30,13 +30,13 @@ public class ValidateController : ControllerBase
         IInstanceClient instanceClient,
         IValidationService validationService,
         IAppMetadata appMetadata,
-        InternalInstanceDataUnitOfWorkInitializer internalInstanceDataUnitOfWorkInitializer
+        IServiceProvider serviceProvider
     )
     {
         _instanceClient = instanceClient;
         _validationService = validationService;
         _appMetadata = appMetadata;
-        _internalInstanceDataUnitOfWorkInitializer = internalInstanceDataUnitOfWorkInitializer;
+        _instanceDataUnitOfWorkInitializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ public class ValidateController : ControllerBase
 
         try
         {
-            var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
+            var dataAccessor = await _instanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
             var ignoredSources = ignoredValidators?.Split(',').ToList();
             List<ValidationIssueWithSource> messages = await _validationService.ValidateInstanceAtTask(
@@ -171,7 +171,7 @@ public class ValidateController : ControllerBase
             messages.Add(message);
         }
 
-        var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, dataType.TaskId, language);
+        var dataAccessor = await _instanceDataUnitOfWorkInitializer.Init(instance, dataType.TaskId, language);
 
         // Run validations for all data elements, but only return the issues for the specific data element
         var issues = await _validationService.ValidateInstanceAtTask(

--- a/src/Altinn.App.Api/Controllers/ValidateController.cs
+++ b/src/Altinn.App.Api/Controllers/ValidateController.cs
@@ -1,5 +1,4 @@
 using Altinn.App.Core.Helpers;
-using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Instances;
@@ -20,8 +19,7 @@ namespace Altinn.App.Api.Controllers;
 public class ValidateController : ControllerBase
 {
     private readonly IInstanceClient _instanceClient;
-    private readonly IDataClient _dataClient;
-    private readonly ModelSerializationService _modelSerialization;
+    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
     private readonly IAppMetadata _appMetadata;
     private readonly IValidationService _validationService;
 
@@ -32,15 +30,13 @@ public class ValidateController : ControllerBase
         IInstanceClient instanceClient,
         IValidationService validationService,
         IAppMetadata appMetadata,
-        IDataClient dataClient,
-        ModelSerializationService modelSerialization
+        InternalInstanceDataUnitOfWorkInitializer internalInstanceDataUnitOfWorkInitializer
     )
     {
         _instanceClient = instanceClient;
         _validationService = validationService;
         _appMetadata = appMetadata;
-        _dataClient = dataClient;
-        _modelSerialization = modelSerialization;
+        _internalInstanceDataUnitOfWorkInitializer = internalInstanceDataUnitOfWorkInitializer;
     }
 
     /// <summary>
@@ -81,13 +77,8 @@ public class ValidateController : ControllerBase
 
         try
         {
-            var dataAccessor = new InstanceDataUnitOfWork(
-                instance,
-                _dataClient,
-                _instanceClient,
-                await _appMetadata.GetApplicationMetadata(),
-                _modelSerialization
-            );
+            var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
+
             var ignoredSources = ignoredValidators?.Split(',').ToList();
             List<ValidationIssueWithSource> messages = await _validationService.ValidateInstanceAtTask(
                 dataAccessor,
@@ -161,24 +152,6 @@ public class ValidateController : ControllerBase
             throw new ValidationException("Unknown element type.");
         }
 
-        var dataAccessor = new InstanceDataUnitOfWork(
-            instance,
-            _dataClient,
-            _instanceClient,
-            application,
-            _modelSerialization
-        );
-
-        // Run validations for all data elements, but only return the issues for the specific data element
-        var issues = await _validationService.ValidateInstanceAtTask(
-            dataAccessor,
-            dataType.TaskId,
-            ignoredValidators: null,
-            onlyIncrementalValidators: true,
-            language: language
-        );
-        messages.AddRange(issues.Where(i => i.DataElementId == element.Id));
-
         string taskId = instance.Process.CurrentTask.ElementId;
 
         // Should this be a BadRequest instead?
@@ -197,6 +170,18 @@ public class ValidateController : ControllerBase
             };
             messages.Add(message);
         }
+
+        var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, dataType.TaskId, language);
+
+        // Run validations for all data elements, but only return the issues for the specific data element
+        var issues = await _validationService.ValidateInstanceAtTask(
+            dataAccessor,
+            dataType.TaskId,
+            ignoredValidators: null,
+            onlyIncrementalValidators: true,
+            language: language
+        );
+        messages.AddRange(issues.Where(i => i.DataElementId == element.Id));
 
         return Ok(messages);
     }

--- a/src/Altinn.App.Api/Helpers/Patch/InternalPatchService.cs
+++ b/src/Altinn.App.Api/Helpers/Patch/InternalPatchService.cs
@@ -4,10 +4,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Altinn.App.Api.Extensions;
 using Altinn.App.Core.Features;
-using Altinn.App.Core.Helpers.Serialization;
-using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
-using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Validation;
 using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Result;
@@ -23,11 +20,8 @@ namespace Altinn.App.Api.Helpers.Patch;
 /// </summary>
 public class InternalPatchService
 {
-    private readonly IAppMetadata _appMetadata;
-    private readonly IDataClient _dataClient;
-    private readonly IInstanceClient _instanceClient;
-    private readonly ModelSerializationService _modelSerializationService;
     private readonly IHostEnvironment _hostingEnvironment;
+    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
     private readonly AppImplementationFactory _appImplementationFactory;
     private readonly Telemetry? _telemetry;
     private readonly IValidationService _validationService;
@@ -42,22 +36,16 @@ public class InternalPatchService
     /// Creates a new instance of the <see cref="InternalPatchService"/> class
     /// </summary>
     public InternalPatchService(
-        IAppMetadata appMetadata,
-        IDataClient dataClient,
-        IInstanceClient instanceClient,
         IValidationService validationService,
-        ModelSerializationService modelSerializationService,
         IHostEnvironment hostingEnvironment,
         IServiceProvider serviceProvider,
         Telemetry? telemetry = null
     )
     {
-        _appMetadata = appMetadata;
-        _dataClient = dataClient;
-        _instanceClient = instanceClient;
         _validationService = validationService;
-        _modelSerializationService = modelSerializationService;
         _hostingEnvironment = hostingEnvironment;
+        _internalInstanceDataUnitOfWorkInitializer =
+            serviceProvider.GetRequiredService<InternalInstanceDataUnitOfWorkInitializer>();
         _appImplementationFactory = serviceProvider.GetRequiredService<AppImplementationFactory>();
         _telemetry = telemetry;
     }
@@ -73,14 +61,9 @@ public class InternalPatchService
     )
     {
         using var activity = _telemetry?.StartDataPatchActivity(instance);
+        var taskId = instance.Process.CurrentTask.ElementId;
 
-        var dataAccessor = new InstanceDataUnitOfWork(
-            instance,
-            _dataClient,
-            _instanceClient,
-            await _appMetadata.GetApplicationMetadata(),
-            _modelSerializationService
-        );
+        var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
         List<FormDataChange> changesAfterPatch = [];
 

--- a/src/Altinn.App.Api/Helpers/Patch/InternalPatchService.cs
+++ b/src/Altinn.App.Api/Helpers/Patch/InternalPatchService.cs
@@ -21,7 +21,7 @@ namespace Altinn.App.Api.Helpers.Patch;
 public class InternalPatchService
 {
     private readonly IHostEnvironment _hostingEnvironment;
-    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
+    private readonly InstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
     private readonly AppImplementationFactory _appImplementationFactory;
     private readonly Telemetry? _telemetry;
     private readonly IValidationService _validationService;
@@ -44,8 +44,7 @@ public class InternalPatchService
     {
         _validationService = validationService;
         _hostingEnvironment = hostingEnvironment;
-        _internalInstanceDataUnitOfWorkInitializer =
-            serviceProvider.GetRequiredService<InternalInstanceDataUnitOfWorkInitializer>();
+        _instanceDataUnitOfWorkInitializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
         _appImplementationFactory = serviceProvider.GetRequiredService<AppImplementationFactory>();
         _telemetry = telemetry;
     }
@@ -63,7 +62,7 @@ public class InternalPatchService
         using var activity = _telemetry?.StartDataPatchActivity(instance);
         var taskId = instance.Process.CurrentTask.ElementId;
 
-        var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
+        var dataAccessor = await _instanceDataUnitOfWorkInitializer.Init(instance, taskId, language);
 
         List<FormDataChange> changesAfterPatch = [];
 

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -116,6 +116,7 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient<IAccessTokenGenerator, AccessTokenGenerator>();
         services.TryAddTransient<IApplicationLanguage, Internal.Language.ApplicationLanguage>();
         services.TryAddTransient<IAuthorizationService, AuthorizationService>();
+        services.AddTransient<InternalInstanceDataUnitOfWorkInitializer>();
 
         services.AddAuthenticationContext();
     }

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -116,7 +116,7 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient<IAccessTokenGenerator, AccessTokenGenerator>();
         services.TryAddTransient<IApplicationLanguage, Internal.Language.ApplicationLanguage>();
         services.TryAddTransient<IAuthorizationService, AuthorizationService>();
-        services.AddTransient<InternalInstanceDataUnitOfWorkInitializer>();
+        services.AddTransient<InstanceDataUnitOfWorkInitializer>();
 
         services.AddAuthenticationContext();
     }

--- a/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
@@ -16,21 +16,21 @@ public interface IInstanceDataAccessor
     /// <summary>
     /// Get the actual data represented in the data element.
     /// </summary>
-    /// <returns>The deserialized data model for this data element or an exception for non-form data elements</returns>
+    /// <returns>The deserialized data model for this data element</returns>
+    /// <exception cref="InvalidOperationException">when identifier does not exist in instance.Data with an applogic data type</exception>
     Task<object> GetFormData(DataElementIdentifier dataElementIdentifier);
 
     /// <summary>
     /// Gets the raw binary data from a DataElement.
-    /// </summary>´
+    /// </summary>
     /// <remarks>Form data elements (with appLogic) will get json serialized UTF-8</remarks>
-    /// <throws>Throws an InvalidOperationException if the data element is not found on the instance</throws>
-    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">when identifier does not exist in instance.Data</exception>
     Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier);
 
     /// <summary>
     /// Get a data element from an instance by id,
     /// </summary>
-    /// <throws>Throws an InvalidOperationException if the data element is not found on the instance</throws>
+    /// <exception cref="InvalidOperationException">If the data element is not found on the instance</exception>
     DataElement GetDataElement(DataElementIdentifier dataElementIdentifier);
 
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Data/DataElementCache.cs
+++ b/src/Altinn.App.Core/Internal/Data/DataElementCache.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.CodeAnalysis;
+using Altinn.App.Core.Models;
+
+namespace Altinn.App.Core.Internal.Data;
+
+/// <summary>
+/// Simple wrapper around a Dictionary using Lazy to ensure that the valueFactory is only called once
+/// </summary>
+internal sealed class DataElementCache<T>
+{
+    private readonly Dictionary<Guid, Lazy<Task<T>>> _cache = [];
+
+    public async Task<T> GetOrCreate(DataElementIdentifier key, Func<Task<T>> valueFactory)
+    {
+        Lazy<Task<T>>? lazyTask;
+        lock (_cache)
+        {
+            if (!_cache.TryGetValue(key.Guid, out lazyTask))
+            {
+                lazyTask = new Lazy<Task<T>>(valueFactory);
+                _cache.Add(key.Guid, lazyTask);
+            }
+        }
+        return await lazyTask.Value;
+    }
+
+    public void Set(DataElementIdentifier key, T data)
+    {
+        lock (_cache)
+        {
+            _cache[key.Guid] = new Lazy<Task<T>>(Task.FromResult(data));
+        }
+    }
+
+    public bool TryGetCachedValue(DataElementIdentifier identifier, [NotNullWhen(true)] out T? value)
+    {
+        lock (_cache)
+        {
+            if (
+                _cache.TryGetValue(identifier.Guid, out var lazyTask)
+                && lazyTask is { IsValueCreated: true, Value.IsCompletedSuccessfully: true }
+            )
+            {
+                value = lazyTask.Value.Result ?? throw new InvalidOperationException("Value in cache is null");
+                return true;
+            }
+        }
+        value = default;
+        return false;
+    }
+}

--- a/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWorkInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWorkInitializer.cs
@@ -10,7 +10,7 @@ namespace Altinn.App.Core.Internal.Data;
 /// <summary>
 /// Service for initializing an <see cref="InstanceDataUnitOfWork"/> with all the services it needs.
 /// </summary>
-public class InternalInstanceDataUnitOfWorkInitializer
+internal class InstanceDataUnitOfWorkInitializer
 {
     private readonly IDataClient _dataClient;
     private readonly IInstanceClient _instanceClient;
@@ -22,7 +22,7 @@ public class InternalInstanceDataUnitOfWorkInitializer
     /// <summary>
     /// Constructor with services from dependency injection
     /// </summary>
-    public InternalInstanceDataUnitOfWorkInitializer(
+    public InstanceDataUnitOfWorkInitializer(
         IDataClient dataClient,
         IInstanceClient instanceClient,
         IAppMetadata applicationMetadata,

--- a/src/Altinn.App.Core/Internal/Data/InternalInstanceDataUnitOfWorkInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Data/InternalInstanceDataUnitOfWorkInitializer.cs
@@ -1,0 +1,61 @@
+using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Instances;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.App.Core.Internal.Data;
+
+/// <summary>
+/// Service for initializing an <see cref="InstanceDataUnitOfWork"/> with all the services it needs.
+/// </summary>
+public class InternalInstanceDataUnitOfWorkInitializer
+{
+    private readonly IDataClient _dataClient;
+    private readonly IInstanceClient _instanceClient;
+    private readonly ModelSerializationService _modelSerializationService;
+    private readonly IAppResources _appResources;
+    private readonly IOptions<FrontEndSettings> _frontEndSettings;
+    private readonly IAppMetadata _applicationMetadata;
+
+    /// <summary>
+    /// Constructor with services from dependency injection
+    /// </summary>
+    public InternalInstanceDataUnitOfWorkInitializer(
+        IDataClient dataClient,
+        IInstanceClient instanceClient,
+        IAppMetadata applicationMetadata,
+        ModelSerializationService modelSerializationService,
+        IAppResources appResources,
+        IOptions<FrontEndSettings> frontEndSettings
+    )
+    {
+        _dataClient = dataClient;
+        _instanceClient = instanceClient;
+        _modelSerializationService = modelSerializationService;
+        _appResources = appResources;
+        _frontEndSettings = frontEndSettings;
+        _applicationMetadata = applicationMetadata;
+    }
+
+    /// <summary>
+    /// Initializes an <see cref="InstanceDataUnitOfWork"/> with all the services it needs.
+    /// This is marked as internal so that this class can only be used internally. Even if it is public for usage (as a DI service) in public classes.
+    /// </summary>
+    internal async Task<InstanceDataUnitOfWork> Init(Instance instance, string? taskId, string? language)
+    {
+        var applicationMetadata = await _applicationMetadata.GetApplicationMetadata();
+        return new InstanceDataUnitOfWork(
+            instance,
+            _dataClient,
+            _instanceClient,
+            applicationMetadata,
+            _modelSerializationService,
+            _appResources,
+            _frontEndSettings,
+            taskId,
+            language
+        );
+    }
+}

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -164,7 +164,7 @@ public class LayoutEvaluatorState
     }
 
     /// <summary>
-    /// Get all of the resolved keys (including all possible indexes) from a data model key
+    /// Get all the resolved keys (including all possible indexes) from a data model key
     /// </summary>
     public async Task<DataReference[]> GetResolvedKeys(DataReference reference)
     {

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
@@ -4,10 +4,7 @@ using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Action;
 using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Helpers;
-using Altinn.App.Core.Helpers.Serialization;
-using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
-using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.App.Core.Internal.Process.Elements.Base;
 using Altinn.App.Core.Internal.Process.ProcessTasks;
@@ -30,11 +27,8 @@ public class ProcessEngine : IProcessEngine
     private readonly UserActionService _userActionService;
     private readonly Telemetry? _telemetry;
     private readonly IAuthenticationContext _authenticationContext;
+    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
     private readonly IProcessTaskCleaner _processTaskCleaner;
-    private readonly IDataClient _dataClient;
-    private readonly IInstanceClient _instanceClient;
-    private readonly ModelSerializationService _modelSerialization;
-    private readonly IAppMetadata _appMetadata;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProcessEngine"/> class
@@ -46,11 +40,8 @@ public class ProcessEngine : IProcessEngine
         IProcessEventDispatcher processEventDispatcher,
         IProcessTaskCleaner processTaskCleaner,
         UserActionService userActionService,
-        IDataClient dataClient,
-        IInstanceClient instanceClient,
-        ModelSerializationService modelSerialization,
-        IAppMetadata appMetadata,
         IAuthenticationContext authenticationContext,
+        InternalInstanceDataUnitOfWorkInitializer internalInstanceDataUnitOfWorkInitializer,
         Telemetry? telemetry = null
     )
     {
@@ -60,12 +51,9 @@ public class ProcessEngine : IProcessEngine
         _processEventDispatcher = processEventDispatcher;
         _processTaskCleaner = processTaskCleaner;
         _userActionService = userActionService;
-        _dataClient = dataClient;
-        _instanceClient = instanceClient;
-        _modelSerialization = modelSerialization;
-        _appMetadata = appMetadata;
         _telemetry = telemetry;
         _authenticationContext = authenticationContext;
+        _internalInstanceDataUnitOfWorkInitializer = internalInstanceDataUnitOfWorkInitializer;
     }
 
     /// <inheritdoc/>
@@ -164,12 +152,10 @@ public class ProcessEngine : IProcessEngine
 
         var currentAuth = _authenticationContext.Current;
         IUserAction? actionHandler = _userActionService.GetActionHandler(request.Action);
-        var cachedDataMutator = new InstanceDataUnitOfWork(
+        var cachedDataMutator = await _internalInstanceDataUnitOfWorkInitializer.Init(
             instance,
-            _dataClient,
-            _instanceClient,
-            await _appMetadata.GetApplicationMetadata(),
-            _modelSerialization
+            taskId: null,
+            request.Language
         );
 
         int? userId = currentAuth switch

--- a/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
@@ -1,8 +1,5 @@
 using Altinn.App.Core.Features;
-using Altinn.App.Core.Helpers.Serialization;
-using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
-using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.App.Core.Internal.Process.Elements.Base;
 using Altinn.App.Core.Models.Process;
@@ -19,10 +16,7 @@ public class ProcessNavigator : IProcessNavigator
     private readonly IProcessReader _processReader;
     private readonly ExclusiveGatewayFactory _gatewayFactory;
     private readonly ILogger<ProcessNavigator> _logger;
-    private readonly IDataClient _dataClient;
-    private readonly IInstanceClient _instanceClient;
-    private readonly IAppMetadata _appMetadata;
-    private readonly ModelSerializationService _modelSerialization;
+    private readonly InternalInstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
 
     /// <summary>
     /// Initialize a new instance of <see cref="ProcessNavigator"/>
@@ -31,19 +25,13 @@ public class ProcessNavigator : IProcessNavigator
         IProcessReader processReader,
         ExclusiveGatewayFactory gatewayFactory,
         ILogger<ProcessNavigator> logger,
-        IDataClient dataClient,
-        IInstanceClient instanceClient,
-        IAppMetadata appMetadata,
-        ModelSerializationService modelSerialization
+        InternalInstanceDataUnitOfWorkInitializer instanceDataUnitOfWorkInitializer
     )
     {
         _processReader = processReader;
         _gatewayFactory = gatewayFactory;
         _logger = logger;
-        _dataClient = dataClient;
-        _appMetadata = appMetadata;
-        _modelSerialization = modelSerialization;
-        _instanceClient = instanceClient;
+        _instanceDataUnitOfWorkInitializer = instanceDataUnitOfWorkInitializer;
     }
 
     /// <inheritdoc/>
@@ -113,13 +101,13 @@ public class ProcessNavigator : IProcessNavigator
                     Action = action,
                     DataTypeId = gateway.ExtensionElements?.GatewayExtension?.ConnectedDataTypeId,
                 };
-                IInstanceDataAccessor dataAccessor = new InstanceDataUnitOfWork(
+
+                IInstanceDataAccessor dataAccessor = await _instanceDataUnitOfWorkInitializer.Init(
                     instance,
-                    _dataClient,
-                    _instanceClient,
-                    await _appMetadata.GetApplicationMetadata(),
-                    _modelSerialization
+                    taskId: null,
+                    language: null
                 );
+
                 filteredList = await gatewayFilter.FilterAsync(
                     outgoingFlows,
                     instance,

--- a/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessNavigator.cs
@@ -4,6 +4,7 @@ using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.App.Core.Internal.Process.Elements.Base;
 using Altinn.App.Core.Models.Process;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Altinn.App.Core.Internal.Process;
@@ -16,7 +17,7 @@ public class ProcessNavigator : IProcessNavigator
     private readonly IProcessReader _processReader;
     private readonly ExclusiveGatewayFactory _gatewayFactory;
     private readonly ILogger<ProcessNavigator> _logger;
-    private readonly InternalInstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
+    private readonly InstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
 
     /// <summary>
     /// Initialize a new instance of <see cref="ProcessNavigator"/>
@@ -25,13 +26,13 @@ public class ProcessNavigator : IProcessNavigator
         IProcessReader processReader,
         ExclusiveGatewayFactory gatewayFactory,
         ILogger<ProcessNavigator> logger,
-        InternalInstanceDataUnitOfWorkInitializer instanceDataUnitOfWorkInitializer
+        IServiceProvider serviceProvider
     )
     {
         _processReader = processReader;
         _gatewayFactory = gatewayFactory;
         _logger = logger;
-        _instanceDataUnitOfWorkInitializer = instanceDataUnitOfWorkInitializer;
+        _instanceDataUnitOfWorkInitializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
     }
 
     /// <inheritdoc/>

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizer.cs
@@ -1,12 +1,10 @@
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Helpers;
-using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Expressions;
-using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.Extensions.Options;
@@ -17,33 +15,27 @@ namespace Altinn.App.Core.Internal.Process.ProcessTasks;
 public class ProcessTaskFinalizer : IProcessTaskFinalizer
 {
     private readonly IAppMetadata _appMetadata;
-    private readonly IDataClient _dataClient;
-    private readonly IInstanceClient _intanceClient;
     private readonly IAppModel _appModel;
     private readonly ILayoutEvaluatorStateInitializer _layoutEvaluatorStateInitializer;
+    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
     private readonly IOptions<AppSettings> _appSettings;
-    private readonly ModelSerializationService _modelSerializer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ProcessTaskFinalizer"/> class.
     /// </summary>
     public ProcessTaskFinalizer(
         IAppMetadata appMetadata,
-        IDataClient dataClient,
-        IInstanceClient intanceClient,
         IAppModel appModel,
-        ModelSerializationService modelSerializer,
         ILayoutEvaluatorStateInitializer layoutEvaluatorStateInitializer,
+        InternalInstanceDataUnitOfWorkInitializer internalInstanceDataUnitOfWorkInitializer,
         IOptions<AppSettings> appSettings
     )
     {
         _appMetadata = appMetadata;
-        _dataClient = dataClient;
         _layoutEvaluatorStateInitializer = layoutEvaluatorStateInitializer;
+        _internalInstanceDataUnitOfWorkInitializer = internalInstanceDataUnitOfWorkInitializer;
         _appSettings = appSettings;
-        _intanceClient = intanceClient;
         _appModel = appModel;
-        _modelSerializer = modelSerializer;
     }
 
     /// <inheritdoc/>
@@ -51,13 +43,7 @@ public class ProcessTaskFinalizer : IProcessTaskFinalizer
     {
         ApplicationMetadata applicationMetadata = await _appMetadata.GetApplicationMetadata();
 
-        var dataAccessor = new InstanceDataUnitOfWork(
-            instance,
-            _dataClient,
-            _intanceClient,
-            applicationMetadata,
-            _modelSerializer
-        );
+        var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, "nb");
 
         List<Task> tasks = [];
         foreach (

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizer.cs
@@ -7,6 +7,7 @@ using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Altinn.App.Core.Internal.Process.ProcessTasks;
@@ -17,7 +18,7 @@ public class ProcessTaskFinalizer : IProcessTaskFinalizer
     private readonly IAppMetadata _appMetadata;
     private readonly IAppModel _appModel;
     private readonly ILayoutEvaluatorStateInitializer _layoutEvaluatorStateInitializer;
-    private readonly InternalInstanceDataUnitOfWorkInitializer _internalInstanceDataUnitOfWorkInitializer;
+    private readonly InstanceDataUnitOfWorkInitializer _instanceDataUnitOfWorkInitializer;
     private readonly IOptions<AppSettings> _appSettings;
 
     /// <summary>
@@ -27,13 +28,13 @@ public class ProcessTaskFinalizer : IProcessTaskFinalizer
         IAppMetadata appMetadata,
         IAppModel appModel,
         ILayoutEvaluatorStateInitializer layoutEvaluatorStateInitializer,
-        InternalInstanceDataUnitOfWorkInitializer internalInstanceDataUnitOfWorkInitializer,
+        IServiceProvider serviceProvider,
         IOptions<AppSettings> appSettings
     )
     {
         _appMetadata = appMetadata;
         _layoutEvaluatorStateInitializer = layoutEvaluatorStateInitializer;
-        _internalInstanceDataUnitOfWorkInitializer = internalInstanceDataUnitOfWorkInitializer;
+        _instanceDataUnitOfWorkInitializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
         _appSettings = appSettings;
         _appModel = appModel;
     }
@@ -43,7 +44,7 @@ public class ProcessTaskFinalizer : IProcessTaskFinalizer
     {
         ApplicationMetadata applicationMetadata = await _appMetadata.GetApplicationMetadata();
 
-        var dataAccessor = await _internalInstanceDataUnitOfWorkInitializer.Init(instance, taskId, "nb");
+        var dataAccessor = await _instanceDataUnitOfWorkInitializer.Init(instance, taskId, "nb");
 
         List<Task> tasks = [];
         foreach (

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
@@ -77,12 +77,14 @@ internal sealed record InstancesControllerFixture(IServiceProvider ServiceProvid
         services.AddSingleton(new Mock<IOrganizationClient>().Object);
         services.AddSingleton(new Mock<IHostEnvironment>().Object);
         services.AddSingleton(new Mock<IValidationService>().Object);
+        services.AddSingleton(new Mock<IAppResources>(MockBehavior.Strict).Object);
 
         var httpContextMock = new Mock<HttpContext>();
         services.AddTransient(_ => httpContextMock.Object);
 
         services.AddTransient<InternalPatchService>();
         services.AddTransient<ModelSerializationService>();
+        services.AddTransient<InternalInstanceDataUnitOfWorkInitializer>();
 
         services.AddTransient(sp =>
         {

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
@@ -84,7 +84,7 @@ internal sealed record InstancesControllerFixture(IServiceProvider ServiceProvid
 
         services.AddTransient<InternalPatchService>();
         services.AddTransient<ModelSerializationService>();
-        services.AddTransient<InternalInstanceDataUnitOfWorkInitializer>();
+        services.AddTransient<InstanceDataUnitOfWorkInitializer>();
 
         services.AddTransient(sp =>
         {

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateControllerTests.cs
@@ -14,6 +14,7 @@ using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
 
@@ -32,12 +33,24 @@ public class ValidateControllerTests
     private readonly Mock<IDataClient> _dataClientMock = new(MockBehavior.Strict);
     private readonly Mock<IAppModel> _appModelMock = new(MockBehavior.Strict);
     private readonly Mock<IAppResources> _appResourcesMock = new(MockBehavior.Strict);
+    private readonly ServiceCollection _services = new();
 
     public ValidateControllerTests()
     {
         _appMetadataMock
             .Setup(a => a.GetApplicationMetadata())
             .ReturnsAsync(new ApplicationMetadata($"{Org}/{App}") { DataTypes = [] });
+
+        _services.AddSingleton(_instanceMock.Object);
+        _services.AddSingleton(_appMetadataMock.Object);
+        _services.AddSingleton(_validationMock.Object);
+        _services.AddSingleton(_dataClientMock.Object);
+        _services.AddSingleton(_appModelMock.Object);
+        _services.AddSingleton(_appResourcesMock.Object);
+        _services.AddSingleton(Options.Create(new FrontEndSettings()));
+        _services.AddTransient<InstanceDataUnitOfWorkInitializer>();
+        _services.AddTransient<ModelSerializationService>();
+        _services.AddTransient<ValidateController>();
     }
 
     [Fact]
@@ -49,7 +62,8 @@ public class ValidateControllerTests
             .Returns(Task.FromResult<Instance>(null!));
 
         // Act
-        var validateController = GetValidateController();
+        await using var sp = _services.BuildStrictServiceProvider();
+        var validateController = sp.GetRequiredService<ValidateController>();
         var result = await validateController.ValidateInstance(Org, App, InstanceOwnerPartyId, _instanceId);
 
         // Assert
@@ -69,7 +83,8 @@ public class ValidateControllerTests
             .Returns(Task.FromResult<Instance>(instance));
 
         // Act
-        var validateController = GetValidateController();
+        await using var sp = _services.BuildStrictServiceProvider();
+        var validateController = sp.GetRequiredService<ValidateController>();
 
         // Assert
         var exception = await Assert.ThrowsAsync<ValidationException>(
@@ -93,7 +108,8 @@ public class ValidateControllerTests
             .Returns(Task.FromResult<Instance>(instance));
 
         // Act
-        var validateController = GetValidateController();
+        await using var sp = _services.BuildStrictServiceProvider();
+        var validateController = sp.GetRequiredService<ValidateController>();
 
         // Assert
         var exception = await Assert.ThrowsAsync<ValidationException>(
@@ -139,7 +155,8 @@ public class ValidateControllerTests
             .ReturnsAsync(validationResult);
 
         // Act
-        var validateController = GetValidateController();
+        await using var sp = _services.BuildStrictServiceProvider();
+        var validateController = sp.GetRequiredService<ValidateController>();
         var result = await validateController.ValidateInstance(Org, App, InstanceOwnerPartyId, _instanceId);
 
         // Assert
@@ -171,7 +188,8 @@ public class ValidateControllerTests
             .Throws(exception);
 
         // Act
-        var validateController = GetValidateController();
+        await using var sp = _services.BuildStrictServiceProvider();
+        var validateController = sp.GetRequiredService<ValidateController>();
         var result = await validateController.ValidateInstance(Org, App, InstanceOwnerPartyId, _instanceId);
 
         // Assert
@@ -203,29 +221,13 @@ public class ValidateControllerTests
             .Throws(exception);
 
         // Act
-        var validateController = GetValidateController();
+        await using var sp = _services.BuildStrictServiceProvider();
+        var validateController = sp.GetRequiredService<ValidateController>();
 
         // Assert
         var thrownException = await Assert.ThrowsAsync<PlatformHttpException>(
             () => validateController.ValidateInstance(Org, App, InstanceOwnerPartyId, _instanceId)
         );
         Assert.Equal(exception, thrownException);
-    }
-
-    private ValidateController GetValidateController()
-    {
-        return new ValidateController(
-            _instanceMock.Object,
-            _validationMock.Object,
-            _appMetadataMock.Object,
-            new InternalInstanceDataUnitOfWorkInitializer(
-                _dataClientMock.Object,
-                _instanceMock.Object,
-                _appMetadataMock.Object,
-                new ModelSerializationService(_appModelMock.Object),
-                _appResourcesMock.Object,
-                Options.Create<FrontEndSettings>(new())
-            )
-        );
     }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Altinn.App.Api.Controllers;
+using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.Serialization;
@@ -13,6 +14,7 @@ using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Altinn.App.Api.Tests.Controllers;
@@ -24,11 +26,12 @@ public class ValidateControllerTests
     private const int InstanceOwnerPartyId = 1337;
     private static readonly Guid _instanceId = Guid.NewGuid();
 
-    private readonly Mock<IInstanceClient> _instanceMock = new();
-    private readonly Mock<IAppMetadata> _appMetadataMock = new();
-    private readonly Mock<IValidationService> _validationMock = new();
-    private readonly Mock<IDataClient> _dataClientMock = new();
-    private readonly Mock<IAppModel> _appModelMock = new();
+    private readonly Mock<IInstanceClient> _instanceMock = new(MockBehavior.Strict);
+    private readonly Mock<IAppMetadata> _appMetadataMock = new(MockBehavior.Strict);
+    private readonly Mock<IValidationService> _validationMock = new(MockBehavior.Strict);
+    private readonly Mock<IDataClient> _dataClientMock = new(MockBehavior.Strict);
+    private readonly Mock<IAppModel> _appModelMock = new(MockBehavior.Strict);
+    private readonly Mock<IAppResources> _appResourcesMock = new(MockBehavior.Strict);
 
     public ValidateControllerTests()
     {
@@ -215,8 +218,14 @@ public class ValidateControllerTests
             _instanceMock.Object,
             _validationMock.Object,
             _appMetadataMock.Object,
-            _dataClientMock.Object,
-            new ModelSerializationService(_appModelMock.Object)
+            new InternalInstanceDataUnitOfWorkInitializer(
+                _dataClientMock.Object,
+                _instanceMock.Object,
+                _appMetadataMock.Object,
+                new ModelSerializationService(_appModelMock.Object),
+                _appResourcesMock.Object,
+                Options.Create<FrontEndSettings>(new())
+            )
         );
     }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
@@ -15,6 +15,7 @@ using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
 
@@ -194,6 +195,7 @@ public class ValidationControllerValidateDataTests
     private readonly Mock<IDataClient> _dataClientMock = new(MockBehavior.Strict);
     private readonly Mock<IAppModel> _appModelMock = new(MockBehavior.Strict);
     private readonly Mock<IAppResources> _appResourcesMock = new(MockBehavior.Strict);
+    private readonly ServiceCollection _services = new();
 
     [Theory]
     [ClassData(typeof(TestScenariosData))]
@@ -202,19 +204,9 @@ public class ValidationControllerValidateDataTests
         // Arrange
 
         SetupMocks(App, Org, InstanceOwnerId, testScenario);
-        var validateController = new ValidateController(
-            _instanceMock.Object,
-            _validationMock.Object,
-            _appMetadataMock.Object,
-            new InternalInstanceDataUnitOfWorkInitializer(
-                _dataClientMock.Object,
-                _instanceMock.Object,
-                _appMetadataMock.Object,
-                new ModelSerializationService(_appModelMock.Object),
-                _appResourcesMock.Object,
-                Options.Create<FrontEndSettings>(new())
-            )
-        );
+        await using var sp = _services.BuildStrictServiceProvider();
+
+        var validateController = sp.GetRequiredService<ValidateController>();
 
         // Act and Assert
         if (testScenario.ExpectedExceptionMessage == null)
@@ -266,6 +258,16 @@ public class ValidationControllerValidateDataTests
                 )
                 .ReturnsAsync(testScenario.ReceivedValidationIssues);
         }
+        _services.AddSingleton(_instanceMock.Object);
+        _services.AddSingleton(_appMetadataMock.Object);
+        _services.AddSingleton(_validationMock.Object);
+        _services.AddSingleton(_dataClientMock.Object);
+        _services.AddSingleton(_appModelMock.Object);
+        _services.AddSingleton(_appResourcesMock.Object);
+        _services.AddSingleton(Options.Create(new FrontEndSettings()));
+        _services.AddTransient<InstanceDataUnitOfWorkInitializer>();
+        _services.AddTransient<ModelSerializationService>();
+        _services.AddTransient<ValidateController>();
     }
 }
 

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using Altinn.App.Api.Controllers;
+using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.Serialization;
@@ -14,6 +15,7 @@ using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Altinn.App.Api.Tests.Controllers;
@@ -191,6 +193,7 @@ public class ValidationControllerValidateDataTests
     private readonly Mock<IValidationService> _validationMock = new(MockBehavior.Strict);
     private readonly Mock<IDataClient> _dataClientMock = new(MockBehavior.Strict);
     private readonly Mock<IAppModel> _appModelMock = new(MockBehavior.Strict);
+    private readonly Mock<IAppResources> _appResourcesMock = new(MockBehavior.Strict);
 
     [Theory]
     [ClassData(typeof(TestScenariosData))]
@@ -203,8 +206,14 @@ public class ValidationControllerValidateDataTests
             _instanceMock.Object,
             _validationMock.Object,
             _appMetadataMock.Object,
-            _dataClientMock.Object,
-            new ModelSerializationService(_appModelMock.Object)
+            new InternalInstanceDataUnitOfWorkInitializer(
+                _dataClientMock.Object,
+                _instanceMock.Object,
+                _appMetadataMock.Object,
+                new ModelSerializationService(_appModelMock.Object),
+                _appResourcesMock.Object,
+                Options.Create<FrontEndSettings>(new())
+            )
         );
 
         // Act and Assert

--- a/test/Altinn.App.Api.Tests/Helpers/Patch/PatchServiceTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/Patch/PatchServiceTests.cs
@@ -95,7 +95,7 @@ public sealed class PatchServiceTests : IDisposable
         services.AddSingleton<IDataElementValidator>(_dataElementValidator.Object);
         services.AddSingleton<IFormDataValidator>(_formDataValidator.Object);
         services.AddSingleton<IValidatorFactory, ValidatorFactory>();
-        services.AddTransient<InternalInstanceDataUnitOfWorkInitializer>();
+        services.AddTransient<InstanceDataUnitOfWorkInitializer>();
         services.AddSingleton(_appMetadataMock.Object);
         services.AddSingleton(_dataProcessorMock.Object);
         services.AddSingleton(_appResourcesMock.Object);

--- a/test/Altinn.App.Api.Tests/Helpers/Patch/PatchServiceTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/Patch/PatchServiceTests.cs
@@ -48,6 +48,7 @@ public sealed class PatchServiceTests : IDisposable
     private readonly Mock<IAppMetadata> _appMetadataMock = new(MockBehavior.Strict);
     private readonly TelemetrySink _telemetrySink = new();
     private readonly Mock<IWebHostEnvironment> _webHostEnvironment = new(MockBehavior.Strict);
+    private readonly Mock<IAppResources> _appResourcesMock = new(MockBehavior.Strict);
 
     // ValidatorMocks
     private readonly Mock<IFormDataValidator> _formDataValidator = new(MockBehavior.Strict);
@@ -94,21 +95,22 @@ public sealed class PatchServiceTests : IDisposable
         services.AddSingleton<IDataElementValidator>(_dataElementValidator.Object);
         services.AddSingleton<IFormDataValidator>(_formDataValidator.Object);
         services.AddSingleton<IValidatorFactory, ValidatorFactory>();
+        services.AddTransient<InternalInstanceDataUnitOfWorkInitializer>();
         services.AddSingleton(_appMetadataMock.Object);
         services.AddSingleton(_dataProcessorMock.Object);
+        services.AddSingleton(_appResourcesMock.Object);
+        services.AddSingleton(_dataClientMock.Object);
+        services.AddSingleton(_instanceClientMock.Object);
+        _modelSerializationService = new ModelSerializationService(_appModelMock.Object);
+        services.AddSingleton(_modelSerializationService);
         services.Configure<GeneralSettings>(_ => { });
+
         _serviceProvider = services.BuildStrictServiceProvider();
         var validatorFactory = _serviceProvider.GetRequiredService<IValidatorFactory>();
         var validationService = new ValidationService(validatorFactory, _vLoggerMock.Object);
 
-        _modelSerializationService = new ModelSerializationService(_appModelMock.Object);
-
         _patchService = new InternalPatchService(
-            _appMetadataMock.Object,
-            _dataClientMock.Object,
-            _instanceClientMock.Object,
             validationService,
-            _modelSerializationService,
             _webHostEnvironment.Object,
             _serviceProvider,
             _telemetrySink.Object

--- a/test/Altinn.App.Core.Tests/Features/Validators/LegacyValidationServiceTests/ValidationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/LegacyValidationServiceTests/ValidationServiceTests.cs
@@ -135,7 +135,11 @@ public sealed class ValidationServiceTests : IDisposable
             _dataClientMock.Object,
             _instanceClientMock.Object,
             _defaultAppMetadata,
-            _modelSerialization
+            _modelSerialization,
+            null!,
+            null!,
+            DefaultTaskId,
+            DefaultLanguage
         );
         _serviceCollection.AddAppImplementationFactory();
         _serviceCollection.AddSingleton(_loggerMock.Object);
@@ -407,7 +411,11 @@ public sealed class ValidationServiceTests : IDisposable
             _dataClientMock.Object,
             _instanceClientMock.Object,
             _defaultAppMetadata,
-            _modelSerialization
+            _modelSerialization,
+            null!,
+            null!,
+            DefaultTaskId,
+            DefaultLanguage
         );
         var resultData = await validatorService.ValidateIncrementalFormData(
             dataAccessor,
@@ -485,7 +493,11 @@ public sealed class ValidationServiceTests : IDisposable
             _dataClientMock.Object,
             _instanceClientMock.Object,
             _defaultAppMetadata,
-            _modelSerialization
+            _modelSerialization,
+            null!,
+            null!,
+            DefaultTaskId,
+            DefaultLanguage
         );
 
         var taskResult = await validationService.ValidateInstanceAtTask(

--- a/test/Altinn.App.Core.Tests/Internal/Process/ExpressionsExclusiveGatewayTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ExpressionsExclusiveGatewayTests.cs
@@ -277,7 +277,11 @@ public class ExpressionsExclusiveGatewayTests
             _dataClient.Object,
             _instanceClient.Object,
             appMetadata,
-            modelSerializationService
+            modelSerializationService,
+            null!,
+            null!,
+            TaskId,
+            null
         );
 
         var layoutStateInit = new LayoutEvaluatorStateInitializer(

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -1202,7 +1202,7 @@ public sealed class ProcessEngineTest
             services.TryAddTransient<IAppModel>(_ => appModelMock.Object);
             services.TryAddTransient<IAppMetadata>(_ => appMetadataMock.Object);
             services.TryAddTransient<IAppResources>(_ => appResourcesMock.Object);
-            services.TryAddTransient<InternalInstanceDataUnitOfWorkInitializer>();
+            services.TryAddTransient<InstanceDataUnitOfWorkInitializer>();
             services.TryAddTransient<ModelSerializationService>();
 
             foreach (var userAction in userActions ?? [])

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Security.Claims;
 using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Common.Tests;
+using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Action;
@@ -25,6 +26,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using Xunit.Abstractions;
@@ -1134,6 +1136,7 @@ public sealed class ProcessEngineTest
             Mock<IInstanceClient> instanceClientMock = new(MockBehavior.Strict);
             Mock<IAppModel> appModelMock = new(MockBehavior.Strict);
             Mock<IAppMetadata> appMetadataMock = new(MockBehavior.Strict);
+            Mock<IAppResources> appResourcesMock = new(MockBehavior.Strict);
             appMetadataMock.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(new ApplicationMetadata("org/app"));
 
             authenticationContextMock
@@ -1198,6 +1201,8 @@ public sealed class ProcessEngineTest
             services.TryAddTransient<IInstanceClient>(_ => instanceClientMock.Object);
             services.TryAddTransient<IAppModel>(_ => appModelMock.Object);
             services.TryAddTransient<IAppMetadata>(_ => appMetadataMock.Object);
+            services.TryAddTransient<IAppResources>(_ => appResourcesMock.Object);
+            services.TryAddTransient<InternalInstanceDataUnitOfWorkInitializer>();
             services.TryAddTransient<ModelSerializationService>();
 
             foreach (var userAction in userActions ?? [])

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
@@ -295,7 +295,7 @@ public class ProcessNavigatorTests
         services.AddSingleton(new Mock<IAppModel>(MockBehavior.Strict).Object);
         services.AddSingleton(new Mock<IAppResources>(MockBehavior.Strict).Object);
         services.AddSingleton<ModelSerializationService>();
-        services.AddTransient<InternalInstanceDataUnitOfWorkInitializer>();
+        services.AddTransient<InstanceDataUnitOfWorkInitializer>();
 
         var sp = services.BuildStrictServiceProvider();
         return new(sp);

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessNavigatorTests.cs
@@ -1,3 +1,4 @@
+using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
@@ -15,6 +16,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Altinn.App.Core.Tests.Internal.Process;
@@ -291,7 +293,9 @@ public class ProcessNavigatorTests
         services.AddSingleton(appMetadata.Object);
         services.AddSingleton(new Mock<IDataClient>(MockBehavior.Strict).Object);
         services.AddSingleton(new Mock<IAppModel>(MockBehavior.Strict).Object);
+        services.AddSingleton(new Mock<IAppResources>(MockBehavior.Strict).Object);
         services.AddSingleton<ModelSerializationService>();
+        services.AddTransient<InternalInstanceDataUnitOfWorkInitializer>();
 
         var sp = services.BuildStrictServiceProvider();
         return new(sp);

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/Common/ProcessTaskFinalizerTests.cs
@@ -9,6 +9,7 @@ using Altinn.App.Core.Internal.Process.ProcessTasks;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Enums;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
 
@@ -20,30 +21,24 @@ public class ProcessTaskFinalizerTests
     private readonly Mock<IDataClient> _dataClientMock = new(MockBehavior.Strict);
     private readonly Mock<IInstanceClient> _instanceClientMock = new(MockBehavior.Strict);
     private readonly Mock<IAppModel> _appModelMock = new(MockBehavior.Strict);
-    private readonly Mock<ILayoutEvaluatorStateInitializer> _layoutEvaluatorStateInitializerMock = new(
-        MockBehavior.Strict
-    );
     private readonly Mock<IAppResources> _appResourcesMock = new(MockBehavior.Strict);
 
     private readonly IOptions<AppSettings> _appSettings = Options.Create(new AppSettings());
-    private readonly ProcessTaskFinalizer _processTaskFinalizer;
+    private readonly ServiceCollection _services = new();
 
     public ProcessTaskFinalizerTests()
     {
-        _processTaskFinalizer = new ProcessTaskFinalizer(
-            _appMetadataMock.Object,
-            _appModelMock.Object,
-            _layoutEvaluatorStateInitializerMock.Object,
-            new InternalInstanceDataUnitOfWorkInitializer(
-                _dataClientMock.Object,
-                _instanceClientMock.Object,
-                _appMetadataMock.Object,
-                new ModelSerializationService(_appModelMock.Object),
-                _appResourcesMock.Object,
-                Options.Create<FrontEndSettings>(new())
-            ),
-            _appSettings
-        );
+        _services.AddSingleton(_appSettings);
+        _services.AddSingleton(_appMetadataMock.Object);
+        _services.AddSingleton(_dataClientMock.Object);
+        _services.AddSingleton(_instanceClientMock.Object);
+        _services.AddSingleton(_appModelMock.Object);
+        _services.AddSingleton(_appResourcesMock.Object);
+        _services.AddSingleton(Options.Create(new FrontEndSettings()));
+        _services.AddTransient<IProcessTaskFinalizer, ProcessTaskFinalizer>();
+        _services.AddTransient<ILayoutEvaluatorStateInitializer, LayoutEvaluatorStateInitializer>();
+        _services.AddTransient<InstanceDataUnitOfWorkInitializer>();
+        _services.AddTransient<ModelSerializationService>();
     }
 
     [Fact]
@@ -76,7 +71,9 @@ public class ProcessTaskFinalizerTests
         _appMetadataMock.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(applicationMetadata);
 
         // Act
-        await _processTaskFinalizer.Finalize(instance.Process.CurrentTask.ElementId, instance);
+        await using var sp = _services.BuildStrictServiceProvider();
+        var processTaskFinalizer = sp.GetRequiredService<IProcessTaskFinalizer>();
+        await processTaskFinalizer.Finalize(instance.Process.CurrentTask.ElementId, instance);
 
         // Assert
         // Called once in Finalize and once when initializing the dataAccessor


### PR DESCRIPTION
This is a precursor to adding the method we need to create a data accessor that cleans hidden data (as defined by layout components)

Part of
* https://github.com/Altinn/app-lib-dotnet/issues/1157

The constructor for `IInstanceDataUnitOfWork` now needs the following properties so that it is able to execute expressions. In the future we might add more (eg. appOptions), so a separate initialiser makes a lot of sense.
* `IAppResources`
* `IOptions<FrontEndSettings>`
* `string? taskId`
* `string? language`