### PR TITLE
Authorize process next as 'sign' when the process task type is signing

### DIFF
--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -349,7 +349,10 @@ public class ProcessController : ControllerBase
             }
 
             _logger.LogDebug(
-                $"User successfully authorized to perform process next with action '{processNext?.Action}' on task {currentTaskId} with task type {altinnTaskType}."
+                "User successfully authorized to perform process next with action '{Action}' on task {CurrentTaskId} with task type {AltinnTaskType}.",
+                LogSanitizer.Sanitize(processNext?.Action),
+                currentTaskId,
+                altinnTaskType
             );
 
             string checkedAction = processNext?.Action ?? ConvertTaskTypeToAction(altinnTaskType);

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -733,10 +733,11 @@ public class ProcessController : ControllerBase
         {
             case "data":
             case "feedback":
-            case "signing":
                 return "write";
             case "confirmation":
                 return "confirm";
+            case "signing":
+                return "sign";
             default:
                 // Not any known task type, so assume it is an action type
                 return actionOrTaskType;

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -338,6 +338,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddTransient<IProcessExclusiveGateway, ExpressionsExclusiveGateway>();
         services.TryAddTransient<IProcessEngine, ProcessEngine>();
+        services.TryAddTransient<IProcessEngineAuthorizer, ProcessEngineAuthorizer>();
         services.TryAddTransient<IProcessNavigator, ProcessNavigator>();
         services.TryAddSingleton<IProcessReader, ProcessReader>();
         services.TryAddTransient<IProcessEventHandlerDelegator, ProcessEventHandlingDelegator>();

--- a/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
@@ -99,8 +99,12 @@ internal sealed class SigningTaskValidator : IValidator
             return [];
         }
 
-        var allHaveSigned = signeeContextsResult.Ok.All(signeeContext => signeeContext.SignDocument is not null);
-        if (allHaveSigned)
+        bool atLeastOneSignature = signeeContextsResult.Ok.Any(signeeContext => signeeContext.SignDocument is not null);
+        bool allSigneesHaveSigned = signeeContextsResult.Ok.All(signeeContext =>
+            signeeContext.SignDocument is not null
+        );
+
+        if (atLeastOneSignature && allSigneesHaveSigned)
         {
             return [];
         }

--- a/src/Altinn.App.Core/Helpers/LogSanitizer.cs
+++ b/src/Altinn.App.Core/Helpers/LogSanitizer.cs
@@ -1,0 +1,45 @@
+﻿namespace Altinn.App.Core.Helpers;
+
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Provides methods to sanitize user-controlled input before logging.
+/// Removes potentially dangerous characters to prevent log injection attacks.
+/// </summary>
+internal static partial class LogSanitizer
+{
+    // Regex pattern to match only Unicode control characters (category Cc) like newlines, tabs, etc.
+    private static readonly Regex _controlCharPattern = ControlCharPattern();
+
+    // Maximum length for sanitized log entries to prevent DoS from extremely long inputs
+    private const int MaxSanitizedLength = 1000;
+
+    /// <summary>
+    /// Remove control characters (newlines, carriage returns, tabs, etc.) that could affect log structure
+    /// </summary>
+    /// <param name="input">The nullable string input to sanitize.</param>
+    /// <returns>A sanitized string safe for logging.</returns>
+    public static string Sanitize(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return string.Empty;
+
+        // Remove all control characters (including newlines, carriage returns, tabs, etc.)
+        string sanitized = _controlCharPattern.Replace(input, "");
+
+        // Trim whitespace
+        sanitized = sanitized.Trim();
+
+        // Limit length to prevent DoS attacks via extremely long log entries
+        if (sanitized.Length > MaxSanitizedLength)
+            sanitized = string.Concat(sanitized.AsSpan(0, MaxSanitizedLength), "... (truncated)");
+
+        return sanitized;
+    }
+
+    // Matches only Unicode control characters (category Cc) such as newlines, carriage returns,
+    // tabs, and other non-printable control characters that could enable log injection attacks, while
+    // preserving other Unicode characters including surrogate pairs, formatting characters, and emojis.
+    [GeneratedRegex(@"[\p{Cc}]", RegexOptions.Compiled)]
+    private static partial Regex ControlCharPattern();
+}

--- a/src/Altinn.App.Core/Internal/Process/Interfaces/IProcessEngineAuthorizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/Interfaces/IProcessEngineAuthorizer.cs
@@ -1,0 +1,14 @@
+﻿using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.Core.Internal.Process;
+
+/// <summary>
+/// Authorizer for the process engine.
+/// </summary>
+public interface IProcessEngineAuthorizer
+{
+    /// <summary>
+    /// Use this to determine if the user is allowed to perform process next for the current task.
+    /// </summary>
+    Task<bool> AuthorizeProcessNext(Instance instance, string? action = null);
+}

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
@@ -1,0 +1,99 @@
+﻿using System.Text.Json;
+using Altinn.App.Core.Features.Auth;
+using Altinn.App.Core.Internal.Auth;
+using Altinn.App.Core.Internal.Process.Elements;
+using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
+using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.App.Core.Internal.Process;
+
+/// <summary>
+/// Authorizer for the process engine.
+/// </summary>
+internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<ProcessEngineAuthorizer> _logger;
+
+    public ProcessEngineAuthorizer(
+        IAuthorizationService authorizationService,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<ProcessEngineAuthorizer> logger
+    )
+    {
+        _authorizationService = authorizationService;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Use this to determine if the user is allowed to perform process next for the current task.
+    /// </summary>
+    public async Task<bool> AuthorizeProcessNext(Instance instance, string? action = null)
+    {
+        if (instance.Process.CurrentTask is null)
+        {
+            _logger.LogError(
+                $"Instance {instance.Id} has no current task. The process must be started before process next can be authorized."
+            );
+            return false;
+        }
+
+        string currentTaskId = instance.Process.CurrentTask.ElementId;
+        string altinnTaskType = instance.Process.CurrentTask.AltinnTaskType;
+
+        // When an action is provided we only allow process next if that action is allowed.
+        if (action is not null)
+        {
+            return await _authorizationService.AuthorizeAction(
+                new AppIdentifier(instance.Org, instance.AppId),
+                new InstanceIdentifier(instance),
+                _httpContext.User,
+                action,
+                currentTaskId
+            );
+        }
+
+        // When no action is provided we check if the user is authorized for at least one of the actions that allow process next for the current task type.
+        string[] actionsThatAllowProcessNextForTaskType = GetActionsThatAllowProcessNextForTaskType(altinnTaskType);
+
+        List<AltinnAction> altinnActions = actionsThatAllowProcessNextForTaskType
+            .Select(actionName => new AltinnAction { ActionType = ActionType.ProcessAction, Value = actionName })
+            .ToList();
+
+        List<UserAction> authorizeActionsResult = await _authorizationService.AuthorizeActions(
+            instance,
+            _httpContext.User,
+            altinnActions
+        );
+
+        bool isProcessNextAllowed = authorizeActionsResult.Any(x => x.Authorized);
+
+        _logger.LogInformation(
+            $"Process next authorization check: {isProcessNextAllowed}. Per action result: {JsonSerializer.Serialize(authorizeActionsResult)}"
+        );
+
+        return isProcessNextAllowed;
+    }
+
+    private HttpContext _httpContext =>
+        _httpContextAccessor.HttpContext ?? throw new AuthenticationContextException("No HTTP context available");
+
+    /// <summary>
+    /// Get all actions that allow process next for the given task type. Meant to be used to authorize the process next when no action is provided.
+    /// </summary>
+    private static string[] GetActionsThatAllowProcessNextForTaskType(string taskType)
+    {
+        return taskType switch
+        {
+            "payment" => ["pay", "write"],
+            "confirmation" => ["confirm"],
+            "signing" => ["sign", "write"],
+            _ => ["write"],
+        };
+    }
+}

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
@@ -73,22 +73,30 @@
       IdFormat: W3C
     },
     {
-      ActivityName: Authorization.Service.AuthorizeAction,
+      ActivityName: Authorization.Service.AuthorizeActions,
       Tags: [
         {
-          authorization.action: write
-        },
-        {
           instance.guid: Guid_1
-        },
-        {
-          instance.owner.party.id: 500600
-        },
-        {
-          task.id: Task_1
         }
       ],
-      IdFormat: W3C
+      IdFormat: W3C,
+      Events: [
+        {
+          Name: actions,
+          Timestamp: DateTimeOffset_1,
+          Tags: [
+            {
+              actions.count: 1
+            },
+            {
+              actions.0.value: write
+            },
+            {
+              actions.0.type: ProcessAction
+            }
+          ]
+        }
+      ]
     },
     {
       ActivityName: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -81,22 +81,30 @@
       IdFormat: W3C
     },
     {
-      ActivityName: Authorization.Service.AuthorizeAction,
+      ActivityName: Authorization.Service.AuthorizeActions,
       Tags: [
         {
-          authorization.action: write
-        },
-        {
           instance.guid: Guid_1
-        },
-        {
-          instance.owner.party.id: 500600
-        },
-        {
-          task.id: Task_1
         }
       ],
-      IdFormat: W3C
+      IdFormat: W3C,
+      Events: [
+        {
+          Name: actions,
+          Timestamp: DateTimeOffset_1,
+          Tags: [
+            {
+              actions.count: 1
+            },
+            {
+              actions.0.value: write
+            },
+            {
+              actions.0.type: ProcessAction
+            }
+          ]
+        }
+      ]
     },
     {
       ActivityName: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,

--- a/test/Altinn.App.Core.Tests/Helpers/LogSanitizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/LogSanitizerTests.cs
@@ -1,0 +1,95 @@
+﻿using Altinn.App.Core.Helpers;
+
+namespace Altinn.App.Core.Tests.Helpers;
+
+public class LogSanitizerTests
+{
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    [InlineData("NormalText", "NormalText")]
+    [InlineData("  NormalText  ", "NormalText")]
+    [InlineData("Text\nWith\nNewlines", "TextWithNewlines")]
+    [InlineData("Text\rWith\rReturns", "TextWithReturns")]
+    [InlineData("Text\tWith\tTabs", "TextWithTabs")]
+    [InlineData("\n\nInjected\nLog\nLines\n", "InjectedLogLines")]
+    public void Sanitize_RemovesControlCharactersAndTrimsWhitespace(string? input, string expected)
+    {
+        // Act
+        string result = LogSanitizer.Sanitize(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Sanitize_TruncatesLongInput()
+    {
+        // Arrange
+        var input = new string('A', 1500);
+        string expected = new string('A', 1000) + "... (truncated)";
+
+        // Act
+        string result = LogSanitizer.Sanitize(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Sanitize_HandlesComplexInjectionAttempt()
+    {
+        // Arrange
+        const string input = "Malicious\nEntry\r\n[ERROR] Fake Log Entry\tInjected 🚨";
+        const string expected = "MaliciousEntry[ERROR] Fake Log EntryInjected 🚨";
+
+        // Act
+        string result = LogSanitizer.Sanitize(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Sanitize_WhitespaceWithControlCharacters_TrimsCorrectly()
+    {
+        // Arrange
+        const string input = " \n Text \n ";
+        const string expected = "Text";
+
+        // Act
+        string result = LogSanitizer.Sanitize(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Sanitize_ExactlyMaxLength_NoTruncation()
+    {
+        // Arrange
+        var input = new string('A', 1000);
+        var expected = new string('A', 1000);
+
+        // Act
+        string result = LogSanitizer.Sanitize(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Sanitize_OneCharacterOverMax_Truncates()
+    {
+        // Arrange
+        var input = new string('A', 1001);
+        string expected = new string('A', 1000) + "... (truncated)";
+
+        // Act
+        string result = LogSanitizer.Sanitize(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+}

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
@@ -88,9 +88,9 @@ public class ProcessEngineAuthorizerTests
         _authServiceMock.Verify(
             x =>
                 x.AuthorizeAction(
-                    It.Is<AppIdentifier>(a => a.Org == "org" && a.App == "app"),
+                    It.IsAny<AppIdentifier>(),
                     It.IsAny<InstanceIdentifier>(),
-                    _user,
+                    It.IsAny<ClaimsPrincipal>(),
                     action,
                     "task1"
                 ),
@@ -127,7 +127,7 @@ public class ProcessEngineAuthorizerTests
             x =>
                 x.AuthorizeActions(
                     instance,
-                    _user,
+                    It.IsAny<ClaimsPrincipal>(),
                     It.Is<List<AltinnAction>>(a => a.Count == 1 && a[0].Value == "write")
                 ),
             Times.Once
@@ -166,7 +166,7 @@ public class ProcessEngineAuthorizerTests
             x =>
                 x.AuthorizeActions(
                     instance,
-                    _user,
+                    It.IsAny<ClaimsPrincipal>(),
                     It.Is<List<AltinnAction>>(a =>
                         a.Count == 2 && a.Any(act => act.Value == "pay") && a.Any(act => act.Value == "write")
                     )
@@ -204,7 +204,7 @@ public class ProcessEngineAuthorizerTests
             x =>
                 x.AuthorizeActions(
                     instance,
-                    _user,
+                    It.IsAny<ClaimsPrincipal>(),
                     It.Is<List<AltinnAction>>(a => a.Count == 1 && a[0].Value == "confirm")
                 ),
             Times.Once
@@ -242,8 +242,8 @@ public class ProcessEngineAuthorizerTests
         _authServiceMock.Verify(
             x =>
                 x.AuthorizeActions(
-                    instance,
-                    _user,
+                    It.IsAny<Instance>(),
+                    It.IsAny<ClaimsPrincipal>(),
                     It.Is<List<AltinnAction>>(a =>
                         a.Count == 2 && a.Any(act => act.Value == "sign") && a.Any(act => act.Value == "write")
                     )

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
@@ -1,0 +1,313 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Altinn.App.Core.Features.Auth;
+using Altinn.App.Core.Internal.Auth;
+using Altinn.App.Core.Internal.Process;
+using Altinn.App.Core.Internal.Process.Elements;
+using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
+using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Altinn.App.Core.Tests.Internal.Process;
+
+public class ProcessEngineAuthorizerTests
+{
+    private readonly Mock<IAuthorizationService> _authServiceMock;
+    private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock;
+    private readonly ProcessEngineAuthorizer _authorizer;
+    private readonly ClaimsPrincipal _user;
+
+    public ProcessEngineAuthorizerTests()
+    {
+        _authServiceMock = new Mock<IAuthorizationService>();
+        _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        var loggerMock = new Mock<ILogger<ProcessEngineAuthorizer>>();
+
+        _user = new ClaimsPrincipal(
+            new ClaimsIdentity(
+                new List<Claim> { new Claim("sub", "12345"), new Claim("name", "Test User") },
+                "TestAuthentication"
+            )
+        );
+
+        HttpContext httpContext = new DefaultHttpContext { };
+
+        _httpContextAccessorMock.Setup(x => x.HttpContext).Returns(httpContext);
+
+        _authorizer = new ProcessEngineAuthorizer(
+            _authServiceMock.Object,
+            _httpContextAccessorMock.Object,
+            loggerMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeProcessNext_WithNullCurrentTask_ReturnsFalse()
+    {
+        // Arrange
+        Instance instance = CreateInstance(null);
+
+        // Act
+        bool result = await _authorizer.AuthorizeProcessNext(instance);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task AuthorizeProcessNext_WithSpecificAction_CallsAuthorizationService()
+    {
+        // Arrange
+        Instance instance = CreateInstance("task1", "data");
+        const string action = "write";
+
+        _authServiceMock
+            .Setup(x =>
+                x.AuthorizeAction(
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<InstanceIdentifier>(),
+                    It.IsAny<ClaimsPrincipal>(),
+                    action,
+                    "task1"
+                )
+            )
+            .ReturnsAsync(true);
+
+        // Act
+        bool result = await _authorizer.AuthorizeProcessNext(instance, action);
+
+        // Assert
+        Assert.True(result);
+        _authServiceMock.Verify(
+            x =>
+                x.AuthorizeAction(
+                    It.Is<AppIdentifier>(a => a.Org == "org" && a.App == "app"),
+                    It.IsAny<InstanceIdentifier>(),
+                    _user,
+                    action,
+                    "task1"
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeProcessNext_WithNoAction_DataTask_ChecksWriteAction()
+    {
+        // Arrange
+        Instance instance = CreateInstance("task1", "data");
+        var authorizeActionsResult = new List<UserAction>
+        {
+            new() { Id = "write", Authorized = true },
+        };
+
+        _authServiceMock
+            .Setup(x =>
+                x.AuthorizeActions(
+                    It.IsAny<Instance>(),
+                    It.IsAny<ClaimsPrincipal>(),
+                    It.Is<List<AltinnAction>>(a => a.Any(action => action.Value == "write"))
+                )
+            )
+            .ReturnsAsync(authorizeActionsResult);
+
+        // Act
+        bool result = await _authorizer.AuthorizeProcessNext(instance);
+
+        // Assert
+        Assert.True(result);
+        _authServiceMock.Verify(
+            x =>
+                x.AuthorizeActions(
+                    instance,
+                    _user,
+                    It.Is<List<AltinnAction>>(a => a.Count == 1 && a[0].Value == "write")
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeProcessNext_WithNoAction_PaymentTask_ChecksBothPayAndWriteActions()
+    {
+        // Arrange
+        Instance instance = CreateInstance("task1", "payment");
+        var authorizeActionsResult = new List<UserAction>
+        {
+            new() { Id = "pay", Authorized = false },
+            new() { Id = "write", Authorized = true },
+        };
+
+        _authServiceMock
+            .Setup(x =>
+                x.AuthorizeActions(
+                    It.IsAny<Instance>(),
+                    It.IsAny<ClaimsPrincipal>(),
+                    It.Is<List<AltinnAction>>(a =>
+                        a.Any(action => action.Value == "pay") && a.Any(action => action.Value == "write")
+                    )
+                )
+            )
+            .ReturnsAsync(authorizeActionsResult);
+
+        // Act
+        bool result = await _authorizer.AuthorizeProcessNext(instance);
+
+        // Assert
+        Assert.True(result);
+        _authServiceMock.Verify(
+            x =>
+                x.AuthorizeActions(
+                    instance,
+                    _user,
+                    It.Is<List<AltinnAction>>(a =>
+                        a.Count == 2 && a.Any(act => act.Value == "pay") && a.Any(act => act.Value == "write")
+                    )
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeProcessNext_WithNoAction_ConfirmationTask_ChecksConfirmAction()
+    {
+        // Arrange
+        Instance instance = CreateInstance("task1", "confirmation");
+        var authorizeActionsResult = new List<UserAction>
+        {
+            new() { Id = "confirm", Authorized = true },
+        };
+
+        _authServiceMock
+            .Setup(x =>
+                x.AuthorizeActions(
+                    It.IsAny<Instance>(),
+                    It.IsAny<ClaimsPrincipal>(),
+                    It.Is<List<AltinnAction>>(a => a.Any(action => action.Value == "confirm"))
+                )
+            )
+            .ReturnsAsync(authorizeActionsResult);
+
+        // Act
+        bool result = await _authorizer.AuthorizeProcessNext(instance);
+
+        // Assert
+        Assert.True(result);
+        _authServiceMock.Verify(
+            x =>
+                x.AuthorizeActions(
+                    instance,
+                    _user,
+                    It.Is<List<AltinnAction>>(a => a.Count == 1 && a[0].Value == "confirm")
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeProcessNext_WithNoAction_SigningTask_ChecksSignAndWriteActions()
+    {
+        // Arrange
+        Instance instance = CreateInstance("task1", "signing");
+        var authorizeActionsResult = new List<UserAction>
+        {
+            new() { Id = "sign", Authorized = false },
+            new() { Id = "write", Authorized = true },
+        };
+
+        _authServiceMock
+            .Setup(x =>
+                x.AuthorizeActions(
+                    It.IsAny<Instance>(),
+                    It.IsAny<ClaimsPrincipal>(),
+                    It.Is<List<AltinnAction>>(a =>
+                        a.Any(action => action.Value == "sign") && a.Any(action => action.Value == "write")
+                    )
+                )
+            )
+            .ReturnsAsync(authorizeActionsResult);
+
+        // Act
+        bool result = await _authorizer.AuthorizeProcessNext(instance);
+
+        // Assert
+        Assert.True(result);
+        _authServiceMock.Verify(
+            x =>
+                x.AuthorizeActions(
+                    instance,
+                    _user,
+                    It.Is<List<AltinnAction>>(a =>
+                        a.Count == 2 && a.Any(act => act.Value == "sign") && a.Any(act => act.Value == "write")
+                    )
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task AuthorizeProcessNext_WithNoAuthorizedActions_ReturnsFalse()
+    {
+        // Arrange
+        Instance instance = CreateInstance("task1", "data");
+        var authorizeActionsResult = new List<UserAction>
+        {
+            new() { Id = "write", Authorized = false },
+        };
+
+        _authServiceMock
+            .Setup(x =>
+                x.AuthorizeActions(It.IsAny<Instance>(), It.IsAny<ClaimsPrincipal>(), It.IsAny<List<AltinnAction>>())
+            )
+            .ReturnsAsync(authorizeActionsResult);
+
+        // Act
+        bool result = await _authorizer.AuthorizeProcessNext(instance);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task AuthorizeProcessNext_NoHttpContext_ThrowsAuthenticationContextException()
+    {
+        // Arrange
+        Instance instance = CreateInstance("task1", "data");
+        _httpContextAccessorMock.Setup(x => x.HttpContext).Returns((HttpContext?)null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<AuthenticationContextException>(
+            async () => await _authorizer.AuthorizeProcessNext(instance)
+        );
+    }
+
+    private static Instance CreateInstance(string? taskId, string? taskType = null)
+    {
+        var instance = new Instance
+        {
+            Id = "1337/12df57b6-cecf-4e7d-9415-857d93a817b3",
+            InstanceOwner = new InstanceOwner { PartyId = "1337" },
+            AppId = "app",
+            Org = "org",
+            Process = new ProcessState(),
+        };
+
+        if (taskId != null)
+        {
+            instance.Process.CurrentTask = new ProcessElementInfo
+            {
+                ElementId = taskId,
+                AltinnTaskType = taskType ?? "unknown",
+            };
+        }
+
+        return instance;
+    }
+}


### PR DESCRIPTION
Authorize process next as 'sign' when the process task type is signing and and no action was submitted. This is how storage authorizes it, and it means that the party that should run process next when everyone has signed, needs the 'sign' access right.

Today, before we release the new signing stuff, the process next in a signature step will always have action=sign, so this will only have effect for our new functionality.

This might enable automatic process next after the last signee has signed (successful validation of signing step).

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
