### PR TITLE
Improve token generation and test parameterization for TestAuthentication

### DIFF
--- a/src/Altinn.App.Core/Configuration/GeneralSettings.cs
+++ b/src/Altinn.App.Core/Configuration/GeneralSettings.cs
@@ -41,6 +41,8 @@ public class GeneralSettings
 
     internal bool DisableAppConfigurationCache { get; set; }
 
+    internal bool IsTest { get; set; }
+
     /// <summary>
     /// The externally accesible base url for the app with trailing /
     /// </summary>

--- a/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Features.Maskinporten.Constants;

--- a/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
+++ b/src/Altinn.App.Core/Features/Auth/AuthenticationContext.cs
@@ -62,10 +62,9 @@ internal sealed class AuthenticationContext : IAuthenticationContext
                 var generalSettings = _generalSettings.CurrentValue;
                 var token = JwtTokenUtil.GetTokenFromContext(httpContext, appSettings.RuntimeCookieName);
 
-                var isLocaltest = generalSettings.HostName.StartsWith(
-                    "local.altinn.cloud",
-                    StringComparison.OrdinalIgnoreCase
-                );
+                var isLocaltest =
+                    generalSettings.HostName.StartsWith("local.altinn.cloud", StringComparison.OrdinalIgnoreCase)
+                    && !generalSettings.IsTest;
                 if (isLocaltest)
                 {
                     authInfo = Authenticated.FromLocalTest(

--- a/test/Altinn.App.Api.Tests/Helpers/DataElementAccessCheckerTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/DataElementAccessCheckerTests.cs
@@ -45,8 +45,8 @@ public class DataElementAccessCheckerTests
         {
             (null, null, _) => TestAuthentication.GetNoneAuthentication(),
             (string orgName, int orgNo, _) => TestAuthentication.GetServiceOwnerAuthentication(
-                orgNo.ToString(CultureInfo.InvariantCulture),
-                orgName
+                orgNumber: orgNo.ToString(CultureInfo.InvariantCulture),
+                org: orgName
             ),
             (null, int orgNumber, bool systemUser) when !systemUser => TestAuthentication.GetOrgAuthentication(
                 orgNumber.ToString(CultureInfo.InvariantCulture)

--- a/test/Altinn.App.Api.Tests/Mocks/JwtTokenMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/JwtTokenMock.cs
@@ -40,6 +40,22 @@ public static class JwtTokenMock
         return tokenstring;
     }
 
+    public static string GenerateToken(JwtPayload payload, TimeSpan tokenExpiry, TimeProvider? timeProvider = null)
+    {
+        var header = new JwtHeader(GetSigningCredentials());
+
+        var now = timeProvider?.GetUtcNow() ?? DateTimeOffset.UtcNow;
+        payload.TryAdd("exp", now.Add(tokenExpiry).ToUnixTimeSeconds());
+        payload.TryAdd("iat", now.ToUnixTimeSeconds());
+        payload.TryAdd("nbf", now.ToUnixTimeSeconds());
+        payload.TryAdd("jti", Guid.NewGuid().ToString());
+
+        var securityToken = new JwtSecurityToken(header, payload);
+        var handler = new JwtSecurityTokenHandler();
+
+        return handler.WriteToken(securityToken);
+    }
+
     /// <summary>
     /// Validates a token and return the ClaimsPrincipal if successful. The validation key used is from the self signed certificate
     /// and is included in the integration test project as a separate file.

--- a/test/Altinn.App.Api.Tests/Program.cs
+++ b/test/Altinn.App.Api.Tests/Program.cs
@@ -60,6 +60,7 @@ builder.Configuration.GetSection("MetricsSettings:Enabled").Value = "false";
 builder.Configuration.GetSection("AppSettings:UseOpenTelemetry").Value = "true";
 builder.Services.Configure<GeneralSettings>(settings => settings.DisableLocaltestValidation = true);
 builder.Services.Configure<GeneralSettings>(settings => settings.DisableAppConfigurationCache = true);
+builder.Services.Configure<GeneralSettings>(settings => settings.IsTest = true);
 
 // AppConfigurationCache.Disable = true;
 

--- a/test/Altinn.App.Api.Tests/Utils/TestAuthentication.cs
+++ b/test/Altinn.App.Api.Tests/Utils/TestAuthentication.cs
@@ -121,12 +121,12 @@ public static class TestAuthentication
         }
     }
 
-    public static None GetNoneAuthentication()
+    public static None GetNoneAuthentication(ApplicationMetadata? applicationMetadata = null)
     {
         var auth = Authenticated.From(
             "",
             false,
-            NewApplicationMetadata(),
+            applicationMetadata ?? NewApplicationMetadata(),
             () => null,
             _ => Task.FromResult<UserProfile?>(null),
             _ => Task.FromResult<Party?>(null),
@@ -177,7 +177,8 @@ public static class TestAuthentication
         int authenticationLevel = DefaultUserAuthenticationLevel,
         string? email = null,
         string? ssn = null,
-        ProfileSettingPreference? profileSettingPreference = null
+        ProfileSettingPreference? profileSettingPreference = null,
+        ApplicationMetadata? applicationMetadata = null
     )
     {
         var token = GetUserToken(userId: userId, partyId: userPartyId, authenticationLevel: authenticationLevel);
@@ -192,7 +193,7 @@ public static class TestAuthentication
         var auth = Authenticated.From(
             token,
             true,
-            NewApplicationMetadata(),
+            applicationMetadata ?? NewApplicationMetadata(),
             getSelectedParty: () => $"{userPartyId}",
             getUserProfile: uid =>
             {
@@ -270,7 +271,8 @@ public static class TestAuthentication
         int userId = DefaultUserId,
         int partyId = DefaultUserPartyId,
         string? email = null,
-        ProfileSettingPreference? profileSettingPreference = null
+        ProfileSettingPreference? profileSettingPreference = null,
+        ApplicationMetadata? applicationMetadata = null
     )
     {
         var token = GetSelfIdentifiedUserToken(username: username, userId: userId, partyId: partyId);
@@ -284,7 +286,7 @@ public static class TestAuthentication
         var auth = Authenticated.From(
             token,
             true,
-            NewApplicationMetadata(),
+            applicationMetadata ?? NewApplicationMetadata(),
             getSelectedParty: () => $"{partyId}",
             getUserProfile: uid =>
             {
@@ -359,7 +361,8 @@ public static class TestAuthentication
     public static Org GetOrgAuthentication(
         string orgNumber = DefaultOrgNumber,
         int partyId = DefaultOrgPartyId,
-        string scope = DefaultOrgScope
+        string scope = DefaultOrgScope,
+        ApplicationMetadata? applicationMetadata = null
     )
     {
         var token = GetOrgToken(orgNumber: orgNumber, scope: scope);
@@ -373,7 +376,7 @@ public static class TestAuthentication
         var auth = Authenticated.From(
             token,
             true,
-            NewApplicationMetadata(),
+            applicationMetadata ?? NewApplicationMetadata(),
             getSelectedParty: () => throw new NotImplementedException(),
             getUserProfile: _ => throw new NotImplementedException(),
             lookupUserParty: _ => throw new NotImplementedException(),
@@ -441,7 +444,8 @@ public static class TestAuthentication
         string orgNumber = DefaultOrgNumber,
         string scope = DefaultServiceOwnerScope,
         string org = DefaultOrg,
-        int partyId = DefaultOrgPartyId
+        int partyId = DefaultOrgPartyId,
+        ApplicationMetadata? applicationMetadata = null
     )
     {
         var token = GetServiceOwnerToken(orgNumber: orgNumber, scope: scope, org: org);
@@ -455,7 +459,7 @@ public static class TestAuthentication
         var auth = Authenticated.From(
             token,
             true,
-            NewApplicationMetadata(org: org),
+            applicationMetadata ?? NewApplicationMetadata(org: org),
             getSelectedParty: () => throw new NotImplementedException(),
             getUserProfile: _ => throw new NotImplementedException(),
             lookupUserParty: _ => throw new NotImplementedException(),
@@ -543,7 +547,8 @@ public static class TestAuthentication
         string systemUserOrgNumber = DefaultSystemUserOrgNumber,
         string supplierOrgNumber = DefaultSystemUserSupplierOrgNumber,
         string scope = DefaultOrgScope,
-        int partyId = DefaultOrgPartyId
+        int partyId = DefaultOrgPartyId,
+        ApplicationMetadata? applicationMetadata = null
     )
     {
         var token = GetSystemUserToken(
@@ -563,7 +568,7 @@ public static class TestAuthentication
         var auth = Authenticated.From(
             token,
             true,
-            NewApplicationMetadata(),
+            applicationMetadata ?? NewApplicationMetadata(),
             getSelectedParty: () => throw new NotImplementedException(),
             getUserProfile: _ => throw new NotImplementedException(),
             lookupUserParty: _ => throw new NotImplementedException(),

--- a/test/Altinn.App.Api.Tests/Utils/TestAuthentication.cs
+++ b/test/Altinn.App.Api.Tests/Utils/TestAuthentication.cs
@@ -1,3 +1,4 @@
+using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text.Json;
 using Altinn.App.Api.Tests.Mocks;
@@ -10,6 +11,7 @@ using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using AltinnCore.Authentication.Constants;
+using Xunit.Abstractions;
 using static Altinn.App.Core.Features.Auth.Authenticated;
 
 namespace Altinn.App.Api.Tests.Utils;
@@ -23,9 +25,57 @@ public enum AuthenticationTypes
     ServiceOwner,
 }
 
-public sealed record TestJwtToken(AuthenticationTypes Type, int PartyId, string Token, Authenticated Auth)
+public sealed class TestJwtToken : IXunitSerializable
 {
+    public AuthenticationTypes Type { get; set; }
+    public int PartyId { get; set; }
+    public string Token { get; set; } = "";
+
+    private Authenticated? _auth;
+    public Authenticated Auth
+    {
+        get
+        {
+            if (_auth is not null)
+                return _auth;
+            // csharpier-ignore
+            _auth = Type switch
+            {
+                AuthenticationTypes.User => TestAuthentication.GetUserAuthentication(userPartyId: PartyId),
+                AuthenticationTypes.SelfIdentifiedUser => TestAuthentication.GetSelfIdentifiedUserAuthentication(partyId: PartyId),
+                // AuthenticationTypes.Org => TestAuthentication.GetOrgAuthentication(),
+                AuthenticationTypes.ServiceOwner => TestAuthentication.GetServiceOwnerAuthentication(partyId: PartyId),
+                AuthenticationTypes.SystemUser => TestAuthentication.GetSystemUserAuthentication(partyId: PartyId),
+                _ => throw new Exception(),
+            };
+            return _auth;
+        }
+    }
+
     public override string ToString() => $"{Type}={PartyId}";
+
+    public TestJwtToken() { }
+
+    public TestJwtToken(AuthenticationTypes type, int partyId, string token)
+    {
+        Type = type;
+        PartyId = partyId;
+        Token = token;
+    }
+
+    public void Deserialize(IXunitSerializationInfo info)
+    {
+        Type = (AuthenticationTypes)info.GetValue<int>("Type");
+        PartyId = info.GetValue<int>("PartyId");
+        Token = info.GetValue<string>("Token");
+    }
+
+    public void Serialize(IXunitSerializationInfo info)
+    {
+        info.AddValue("Type", (int)Type);
+        info.AddValue("PartyId", PartyId);
+        info.AddValue("Token", Token);
+    }
 }
 
 public static class TestAuthentication
@@ -51,32 +101,11 @@ public static class TestAuthentication
     {
         public AllTokens()
         {
-            Add(new(AuthenticationTypes.User, DefaultUserPartyId, GetUserToken(), GetUserAuthentication()));
-            Add(
-                new(
-                    AuthenticationTypes.SelfIdentifiedUser,
-                    DefaultUserPartyId,
-                    GetSelfIdentifiedUserToken(),
-                    GetSelfIdentifiedUserAuthentication()
-                )
-            );
-            // Add(new(AuthenticationTypes.Org, DefaultOrgPartyId, GetOrgAuthentication()));
-            Add(
-                new(
-                    AuthenticationTypes.ServiceOwner,
-                    DefaultOrgPartyId,
-                    GetServiceOwnerToken(),
-                    GetServiceOwnerAuthentication()
-                )
-            );
-            Add(
-                new(
-                    AuthenticationTypes.SystemUser,
-                    DefaultOrgPartyId,
-                    GetSystemUserToken(),
-                    GetSystemUserAuthentication()
-                )
-            );
+            Add(new(AuthenticationTypes.User, DefaultUserPartyId, GetUserToken()));
+            Add(new(AuthenticationTypes.SelfIdentifiedUser, DefaultUserPartyId, GetSelfIdentifiedUserToken()));
+            // Add(new(AuthenticationTypes.Org, DefaultOrgPartyId));
+            Add(new(AuthenticationTypes.ServiceOwner, DefaultOrgPartyId, GetServiceOwnerToken()));
+            Add(new(AuthenticationTypes.SystemUser, DefaultOrgPartyId, GetSystemUserToken()));
         }
     }
 
@@ -425,7 +454,7 @@ public static class TestAuthentication
         );
     }
 
-    public static ClaimsPrincipal GetSystemUserPrincipal(
+    public static JwtPayload GetSystemUserPayload(
         string systemId = DefaultSystemId,
         string systemUserId = DefaultSystemUserId,
         string systemUserOrgNumber = DefaultSystemUserOrgNumber,
@@ -441,7 +470,19 @@ public static class TestAuthentication
         if (scopes.HasScopeWithPrefix("altinn:serviceowner/"))
             throw new InvalidOperationException("System user tokens cannot have serviceowner scopes");
 
-        AuthorizationDetailsClaim details = new SystemUserAuthorizationDetailsClaim(
+        var payload = new JwtPayload
+        {
+            { JwtClaimTypes.Issuer, iss },
+            { "token_type", "Bearer" },
+            { JwtClaimTypes.Scope, scope },
+            { "client_id", Guid.NewGuid().ToString() },
+            { "jti", Guid.NewGuid().ToString() },
+            { AltinnCoreClaimTypes.OrgNumber, supplierOrgNumber },
+            { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
+        };
+
+        AuthorizationDetailsClaim authorizationDetails = new SystemUserAuthorizationDetailsClaim(
             [Guid.Parse(systemUserId)],
             systemId,
             new OrgClaim(
@@ -449,27 +490,15 @@ public static class TestAuthentication
                 OrganisationNumber.Parse(systemUserOrgNumber).Get(OrganisationNumberFormat.International)
             )
         );
-        var consumer = JsonSerializer.Serialize(
-            new OrgClaim(
-                "iso6523-actorid-upis",
-                OrganisationNumber.Parse(supplierOrgNumber).Get(OrganisationNumberFormat.International)
-            )
-        );
-        List<Claim> claims =
-        [
-            new("authorization_details", JsonSerializer.Serialize(details), ClaimValueTypes.String, iss),
-            new(JwtClaimTypes.Scope, scope, ClaimValueTypes.String, iss),
-            new("token_type", "Bearer", ClaimValueTypes.String, iss),
-            new("client_id", Guid.NewGuid().ToString(), ClaimValueTypes.String, iss),
-            new("consumer", consumer, ClaimValueTypes.String, iss),
-            new(AltinnCoreClaimTypes.OrgNumber, supplierOrgNumber, ClaimValueTypes.String, iss),
-            new(AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten", ClaimValueTypes.String, iss),
-            new(AltinnCoreClaimTypes.AuthenticationLevel, "3", ClaimValueTypes.Integer32, iss),
-            new(JwtClaimTypes.Issuer, iss, ClaimValueTypes.String, iss),
-            new("jti", Guid.NewGuid().ToString(), ClaimValueTypes.String, iss),
-        ];
 
-        return new ClaimsPrincipal(new ClaimsIdentity(claims, "mock"));
+        var consumer = new OrgClaim(
+            "iso6523-actorid-upis",
+            OrganisationNumber.Parse(supplierOrgNumber).Get(OrganisationNumberFormat.International)
+        );
+        payload.Add("authorization_details", JsonSerializer.SerializeToElement(authorizationDetails));
+        payload.Add("consumer", JsonSerializer.SerializeToElement(consumer));
+
+        return payload;
     }
 
     public static string GetSystemUserToken(
@@ -482,14 +511,14 @@ public static class TestAuthentication
         TimeProvider? timeProvider = null
     )
     {
-        ClaimsPrincipal principal = GetSystemUserPrincipal(
+        JwtPayload payload = GetSystemUserPayload(
             systemId,
             systemUserId,
             systemUserOrgNumber,
             supplierOrgNumber,
             scope
         );
-        return JwtTokenMock.GenerateToken(principal, expiry ?? TimeSpan.FromMinutes(2), timeProvider);
+        return JwtTokenMock.GenerateToken(payload, expiry ?? TimeSpan.FromMinutes(2), timeProvider);
     }
 
     public static SystemUser GetSystemUserAuthentication(

--- a/test/Altinn.App.Api.Tests/Utils/TestAuthentication.cs
+++ b/test/Altinn.App.Api.Tests/Utils/TestAuthentication.cs
@@ -18,11 +18,11 @@ namespace Altinn.App.Api.Tests.Utils;
 
 public enum AuthenticationTypes
 {
-    User,
-    SelfIdentifiedUser,
-    Org,
-    SystemUser,
-    ServiceOwner,
+    User = 1,
+    SelfIdentifiedUser = 2,
+    Org = 3,
+    SystemUser = 4,
+    ServiceOwner = 5,
 }
 
 public sealed class TestJwtToken : IXunitSerializable
@@ -38,14 +38,14 @@ public sealed class TestJwtToken : IXunitSerializable
         {
             if (_auth is not null)
                 return _auth;
-            // csharpier-ignore
+
             _auth = Type switch
             {
-                AuthenticationTypes.User => TestAuthentication.GetUserAuthentication(userPartyId: PartyId),
-                AuthenticationTypes.SelfIdentifiedUser => TestAuthentication.GetSelfIdentifiedUserAuthentication(partyId: PartyId),
+                AuthenticationTypes.User => TestAuthentication.GetUserAuthentication(),
+                AuthenticationTypes.SelfIdentifiedUser => TestAuthentication.GetSelfIdentifiedUserAuthentication(),
                 // AuthenticationTypes.Org => TestAuthentication.GetOrgAuthentication(),
-                AuthenticationTypes.ServiceOwner => TestAuthentication.GetServiceOwnerAuthentication(partyId: PartyId),
-                AuthenticationTypes.SystemUser => TestAuthentication.GetSystemUserAuthentication(partyId: PartyId),
+                AuthenticationTypes.ServiceOwner => TestAuthentication.GetServiceOwnerAuthentication(),
+                AuthenticationTypes.SystemUser => TestAuthentication.GetSystemUserAuthentication(),
                 _ => throw new Exception(),
             };
             return _auth;

--- a/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
@@ -154,7 +154,7 @@ public class SigningUserActionTests
         var userActionContext = new UserActionContext(
             instance,
             1337,
-            authentication: TestAuthentication.GetUserAuthentication(1337)
+            authentication: TestAuthentication.GetUserAuthentication(userId: 1337, applicationMetadata: appMetadata)
         );
 
         // Act
@@ -232,7 +232,7 @@ public class SigningUserActionTests
         var userActionContext = new UserActionContext(
             instance,
             1337,
-            authentication: TestAuthentication.GetUserAuthentication(1337)
+            authentication: TestAuthentication.GetUserAuthentication(1337, applicationMetadata: appMetadata)
         );
 
         // Act
@@ -263,7 +263,7 @@ public class SigningUserActionTests
         var userActionContext = new UserActionContext(
             instance,
             1337,
-            authentication: TestAuthentication.GetUserAuthentication(1337)
+            authentication: TestAuthentication.GetUserAuthentication(1337, applicationMetadata: _defaultAppMetadata)
         );
 
         // Act
@@ -295,7 +295,7 @@ public class SigningUserActionTests
         var userActionContext = new UserActionContext(
             instance,
             1337,
-            authentication: TestAuthentication.GetUserAuthentication(1337)
+            authentication: TestAuthentication.GetUserAuthentication(1337, applicationMetadata: appMetadata)
         );
 
         // Act

--- a/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Core.Features.Action;
@@ -21,6 +22,7 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
     private readonly Mock<IInstanceClient> _instanceClientMock;
     private readonly Mock<IDataClient> _dataClientMock;
     private readonly Mock<IAppMetadata> _appMetadataMock;
+    private ApplicationMetadata? _applicationMetadata;
 
     public UniqueSignatureAuthorizerTests()
     {
@@ -41,7 +43,7 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication()
+                TestAuthentication.GetUserAuthentication(applicationMetadata: _applicationMetadata)
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -59,7 +61,7 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication()
+                TestAuthentication.GetUserAuthentication(applicationMetadata: _applicationMetadata)
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -91,7 +93,7 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication()
+                TestAuthentication.GetUserAuthentication(userId: 1000, applicationMetadata: _applicationMetadata)
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -120,7 +122,11 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication(userId: 1000, authenticationLevel: 2)
+                TestAuthentication.GetUserAuthentication(
+                    userId: 1000,
+                    authenticationLevel: 2,
+                    applicationMetadata: _applicationMetadata
+                )
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -158,7 +164,11 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication(userId: 1000, authenticationLevel: 2)
+                TestAuthentication.GetUserAuthentication(
+                    userId: 1000,
+                    authenticationLevel: 2,
+                    applicationMetadata: _applicationMetadata
+                )
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -209,7 +219,11 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication(userId: 1337, authenticationLevel: 2)
+                TestAuthentication.GetUserAuthentication(
+                    userId: 1337,
+                    authenticationLevel: 2,
+                    applicationMetadata: _applicationMetadata
+                )
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -260,7 +274,11 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 null,
                 "sign",
-                TestAuthentication.GetUserAuthentication(userId: 1337, authenticationLevel: 2)
+                TestAuthentication.GetUserAuthentication(
+                    userId: 1337,
+                    authenticationLevel: 2,
+                    applicationMetadata: _applicationMetadata
+                )
             )
         );
         result.Should().BeTrue();
@@ -300,7 +318,11 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication(userId: 1337, authenticationLevel: 2)
+                TestAuthentication.GetUserAuthentication(
+                    userId: 1337,
+                    authenticationLevel: 2,
+                    applicationMetadata: _applicationMetadata
+                )
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -354,7 +376,11 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication(userId: 1337, authenticationLevel: 2)
+                TestAuthentication.GetUserAuthentication(
+                    userId: 1337,
+                    authenticationLevel: 2,
+                    applicationMetadata: _applicationMetadata
+                )
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -408,7 +434,11 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication(userId: 1337, authenticationLevel: 2)
+                TestAuthentication.GetUserAuthentication(
+                    userId: 1337,
+                    authenticationLevel: 2,
+                    applicationMetadata: _applicationMetadata
+                )
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -462,7 +492,11 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 new InstanceIdentifier("500001/abba2e90-f86f-4881-b0e8-38334408bcb4"),
                 "Task_2",
                 "sign",
-                TestAuthentication.GetUserAuthentication(userId: 1337, authenticationLevel: 2)
+                TestAuthentication.GetUserAuthentication(
+                    userId: 1337,
+                    authenticationLevel: 2,
+                    applicationMetadata: _applicationMetadata
+                )
             )
         );
         _processReaderMock.Verify(p => p.GetFlowElement("Task_2"));
@@ -482,13 +516,15 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
         result.Should().BeTrue();
     }
 
+    [MemberNotNull(nameof(_applicationMetadata))]
     private UniqueSignatureAuthorizer CreateUniqueSignatureAuthorizer(
         ProcessElement? task,
         string signatureFileToRead = "signature.json"
     )
     {
         _processReaderMock.Setup(sr => sr.GetFlowElement(It.IsAny<string>())).Returns(task);
-        _appMetadataMock.Setup(a => a.GetApplicationMetadata()).ReturnsAsync(new ApplicationMetadata("ttd/xunit-app"));
+        _applicationMetadata = new ApplicationMetadata("ttd/xunit-app");
+        _appMetadataMock.Setup(a => a.GetApplicationMetadata()).ReturnsAsync(_applicationMetadata);
         _instanceClientMock
             .Setup(i => i.GetInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Guid>()))
             .ReturnsAsync(

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticationInfoTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticationInfoTests.cs
@@ -1,5 +1,4 @@
 using Altinn.App.Api.Tests.Utils;
-using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Internal.Language;
 using Altinn.Platform.Profile.Models;
 using FluentAssertions;

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -1166,7 +1166,8 @@ public sealed class ProcessEngineTest
             Mock<IAppModel> appModelMock = new(MockBehavior.Strict);
             Mock<IAppMetadata> appMetadataMock = new(MockBehavior.Strict);
             Mock<IAppResources> appResourcesMock = new(MockBehavior.Strict);
-            appMetadataMock.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(new ApplicationMetadata("org/app"));
+            var appMetadata = new ApplicationMetadata("org/app");
+            appMetadataMock.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(appMetadata);
 
             authenticationContextMock
                 .Setup(a => a.Current)
@@ -1175,7 +1176,8 @@ public sealed class ProcessEngineTest
                         ?? TestAuthentication.GetUserAuthentication(
                             userId: 1337,
                             email: "test@example.com",
-                            ssn: "22927774937"
+                            ssn: "22927774937",
+                            applicationMetadata: appMetadata
                         )
                 );
             processNavigatorMock


### PR DESCRIPTION
## Description

* Generate systemuser token using `JwtPayload` so we get correct serialization
  * Upon inspecting the systemuser tokens, the `consumer` and `authorization_details` claims where strings with JSON content, but are now plain JSON object claims instead, which is the correct representation. `Claim`'s can only hold string values 
* Make `TestJwtToken` impelement `IXunitSerializable` so that tooling/test explorer sees different test items per parameter value
* Refactor `Authenticated`, use `JwtPayload` instead of `Claim` when parsing/reading token

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
