### PR TITLE
moves sign action back to SigningUserAction and reimplement tests

### DIFF
--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -1,10 +1,24 @@
+using System.Globalization;
+using Altinn.App.Core.Exceptions;
+using Altinn.App.Core.Features.Auth;
+using Altinn.App.Core.Features.Correspondence.Models;
+using Altinn.App.Core.Features.Signing.Exceptions;
 using Altinn.App.Core.Features.Signing.Interfaces;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Process;
 using Altinn.App.Core.Internal.Process.Elements;
+using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
+using Altinn.App.Core.Internal.Sign;
+using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Process;
+using Altinn.App.Core.Models.Result;
 using Altinn.App.Core.Models.UserAction;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Register.Models;
+using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.Extensions.Logging;
+using Signee = Altinn.App.Core.Internal.Sign.Signee;
 
 namespace Altinn.App.Core.Features.Action;
 
@@ -14,23 +28,31 @@ namespace Altinn.App.Core.Features.Action;
 public class SigningUserAction : IUserAction
 {
     private readonly IProcessReader _processReader;
+    private readonly IAppMetadata _appMetadata;
+    private readonly ISigningReceiptService _signingReceiptService;
     private readonly ILogger<SigningUserAction> _logger;
-    private readonly ISigningService _signingService;
+    private readonly ISignClient _signClient;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SigningUserAction"/> class
     /// </summary>
     /// <param name="processReader">The process reader</param>
+    /// <param name="signClient">The sign client</param>
+    /// <param name="appMetadata">The application metadata</param>
+    /// <param name="signingReceiptService">The signing receipt service</param>
     /// <param name="logger">The logger</param>
-    /// <param name="signingService">The signing service</param>
     public SigningUserAction(
         IProcessReader processReader,
-        ISigningService signingService,
+        ISignClient signClient,
+        IAppMetadata appMetadata,
+        ISigningReceiptService signingReceiptService,
         ILogger<SigningUserAction> logger
     )
     {
         _processReader = processReader;
-        _signingService = signingService;
+        _signClient = signClient;
+        _appMetadata = appMetadata;
+        _signingReceiptService = signingReceiptService;
         _logger = logger;
     }
 
@@ -42,7 +64,12 @@ public class SigningUserAction : IUserAction
     /// <exception cref="ApplicationConfigException"></exception>
     public async Task<UserActionResult> HandleAction(UserActionContext context)
     {
-        if (context.UserId is null)
+        if (
+            context.Authentication
+            is not Authenticated.User
+                and not Authenticated.SelfIdentifiedUser
+                and not Authenticated.SystemUser
+        )
         {
             return UserActionResult.FailureResult(
                 error: new ActionError { Code = "NoUserId", Message = "User id is missing in token" },
@@ -50,13 +77,12 @@ public class SigningUserAction : IUserAction
             );
         }
 
-        ProcessTask? currentTask =
-            _processReader.GetFlowElement(context.Instance.Process.CurrentTask.ElementId) as ProcessTask;
-
-        if (currentTask is null)
+        if (
+            _processReader.GetFlowElement(context.Instance.Process.CurrentTask.ElementId) is not ProcessTask currentTask
+        )
         {
             return UserActionResult.FailureResult(
-                new ActionError { Code = "NoProcessTask", Message = "Current task is not a process task." }
+                new ActionError() { Code = "NoProcessTask", Message = "Current task is not a process task." }
             );
         }
 
@@ -66,10 +92,162 @@ public class SigningUserAction : IUserAction
             currentTask.Id
         );
 
-        await _signingService.Sign(context, currentTask);
+        ApplicationMetadata appMetadata = await _appMetadata.GetApplicationMetadata();
+        AltinnSignatureConfiguration? signatureConfiguration = currentTask
+            .ExtensionElements
+            ?.TaskExtension
+            ?.SignatureConfiguration;
+        List<string> dataTypeIds = signatureConfiguration?.DataTypesToSign ?? [];
+        List<DataType>? dataTypesToSign = appMetadata
+            .DataTypes?.Where(d => dataTypeIds.Contains(d.Id, StringComparer.OrdinalIgnoreCase))
+            .ToList();
 
-        // TODO: Metrics
+        string signatureDataType =
+            GetDataTypeForSignature(currentTask, context.Instance.Data, dataTypesToSign)
+            ?? throw new ApplicationConfigException(
+                "Missing configuration for signing. Check that the task has a signature configuration and that the data types to sign are defined."
+            );
+
+        List<DataElementSignature>? dataElementSignatures = GetDataElementSignatures(
+            context.Instance.Data,
+            dataTypesToSign
+        );
+        SignatureContext signatureContext = new(
+            new InstanceIdentifier(context.Instance),
+            currentTask.Id,
+            signatureDataType,
+            await GetSignee(context),
+            dataElementSignatures
+        );
+
+        try
+        {
+            await _signClient.SignDataElements(signatureContext);
+        }
+        catch (PlatformHttpException)
+        {
+            return UserActionResult.FailureResult(
+                error: new ActionError() { Code = "SignDataElementsFailed", Message = "Failed to sign data elements." },
+                errorType: ProcessErrorType.Internal
+            );
+        }
+
+        ServiceResult<SendCorrespondenceResponse?, Exception> res = await CatchError(
+            _signingReceiptService.SendSignatureReceipt(
+                signatureContext.InstanceIdentifier,
+                signatureContext.Signee,
+                dataElementSignatures,
+                context,
+                signatureConfiguration?.CorrespondenceResources
+            )
+        );
+
+        if (res.Success)
+        {
+            _logger.LogInformation(
+                "Correspondence successfully sent to {Recipients}",
+                string.Join(", ", res.Ok.Correspondences.Select(x => x.Recipient))
+            );
+        }
+        else if (res.Error is ConfigurationException configurationException)
+        {
+            // TODO: What do we do here? Probably nothing.
+            _logger.LogError(
+                configurationException,
+                "Correspondence send failed: {Exception}",
+                configurationException.Message
+            );
+        }
+        else
+        {
+            // TODO: What do we do here? This failure is pretty silent... but throwing would cause havoc
+            _logger.LogWarning("Correspondence configuration error: {Exception}", res.Error.Message);
+        }
 
         return UserActionResult.SuccessResult();
+    }
+
+    private static string? GetDataTypeForSignature(
+        ProcessTask currentTask,
+        List<DataElement> dataElements,
+        List<DataType>? dataTypesToSign
+    )
+    {
+        var signatureDataType = currentTask.ExtensionElements?.TaskExtension?.SignatureConfiguration?.SignatureDataType;
+        if (dataTypesToSign is null or [] || signatureDataType is null)
+        {
+            return null;
+        }
+
+        var dataElementMatchExists = dataElements.Any(de =>
+            dataTypesToSign.Any(dt => string.Equals(dt.Id, de.DataType, StringComparison.OrdinalIgnoreCase))
+        );
+        var allDataTypesAreOptional = dataTypesToSign.All(d => d.MinCount == 0);
+        return dataElementMatchExists || allDataTypesAreOptional ? signatureDataType : null;
+    }
+
+    private static List<DataElementSignature> GetDataElementSignatures(
+        List<DataElement> dataElements,
+        List<DataType>? dataTypesToSign
+    )
+    {
+        var connectedDataElements = new List<DataElementSignature>();
+        if (dataTypesToSign is null or [])
+            return connectedDataElements;
+        foreach (var dataType in dataTypesToSign)
+        {
+            connectedDataElements.AddRange(
+                dataElements
+                    .Where(d => d.DataType.Equals(dataType.Id, StringComparison.OrdinalIgnoreCase))
+                    .Select(d => new DataElementSignature(d.Id))
+            );
+        }
+
+        return connectedDataElements;
+    }
+
+    private static async Task<Signee> GetSignee(UserActionContext context)
+    {
+        switch (context.Authentication)
+        {
+            case Authenticated.User user:
+            {
+                UserProfile userProfile = await user.LookupProfile();
+                Party orgProfile = await user.LookupSelectedParty();
+
+                return new Signee
+                {
+                    UserId = userProfile.UserId.ToString(CultureInfo.InvariantCulture),
+                    PersonNumber = userProfile.Party.SSN,
+                    OrganisationNumber = orgProfile.OrgNumber,
+                };
+            }
+            case Authenticated.SelfIdentifiedUser selfIdentifiedUser:
+                return new Signee { UserId = selfIdentifiedUser.UserId.ToString(CultureInfo.InvariantCulture) };
+            case Authenticated.SystemUser systemUser:
+                return new Signee
+                {
+                    SystemUserId = systemUser.SystemUserId[0],
+                    OrganisationNumber = systemUser.SystemUserOrgNr.Get(OrganisationNumberFormat.Local),
+                };
+            default:
+                throw new SigningException("Could not get signee");
+        }
+    }
+
+    /// <summary>
+    /// Catch exceptions from a task and return them as a ServiceResult record with the result.
+    /// </summary>
+    private static async Task<ServiceResult<T, Exception>> CatchError<T>(Task<T> task)
+    {
+        try
+        {
+            var result = await task;
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
     }
 }

--- a/src/Altinn.App.Core/Features/Signing/Interfaces/ISigningReceiptService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Interfaces/ISigningReceiptService.cs
@@ -16,7 +16,7 @@ public interface ISigningReceiptService
     /// </summary>
     public Task<SendCorrespondenceResponse?> SendSignatureReceipt(
         InstanceIdentifier instanceIdentifier,
-        Internal.Sign.Signee signee,
+        Signee signee,
         IEnumerable<DataElementSignature> dataElementSignatures,
         UserActionContext context,
         List<AltinnEnvironmentConfig>? correspondenceResources

--- a/src/Altinn.App.Core/Features/Signing/Interfaces/ISigningService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Interfaces/ISigningService.cs
@@ -1,7 +1,5 @@
 ﻿using Altinn.App.Core.Features.Signing.Models;
-using Altinn.App.Core.Internal.Process.Elements;
 using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
-using Altinn.App.Core.Models.UserAction;
 
 namespace Altinn.App.Core.Features.Signing.Interfaces;
 
@@ -38,11 +36,6 @@ public interface ISigningService
         IInstanceDataAccessor instanceDataAccessor,
         AltinnSignatureConfiguration signatureConfiguration
     );
-
-    /// <summary>
-    /// Signs the current task.
-    /// </summary>
-    Task Sign(UserActionContext userActionContext, ProcessTask currentTask);
 
     /// <summary>
     /// Aborts runtime delegated signing. Deletes all signing data and revokes delegated access.

--- a/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
@@ -1,31 +1,57 @@
+using System.Globalization;
 using System.Text.Json;
+using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Action;
+using Altinn.App.Core.Features.Auth;
+using Altinn.App.Core.Features.Correspondence.Models;
 using Altinn.App.Core.Features.Signing.Interfaces;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Process;
 using Altinn.App.Core.Internal.Process.Elements;
+using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
+using Altinn.App.Core.Internal.Sign;
+using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Process;
 using Altinn.App.Core.Models.UserAction;
 using Altinn.App.Core.Tests.Internal.Process.TestUtils;
 using Altinn.Platform.Storage.Interface.Models;
+using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Signee = Altinn.App.Core.Internal.Sign.Signee;
 
 namespace Altinn.App.Core.Tests.Features.Action;
 
 public class SigningUserActionTests
 {
+    private static readonly ApplicationMetadata _defaultAppMetadata = new("org/id")
+    {
+        DataTypes = [new DataType { Id = "model" }],
+    };
+
+    private static readonly Instance _defaultInstance = new()
+    {
+        Id = "500000/b194e9f5-02d0-41bc-8461-a0cbac8a6efc",
+        InstanceOwner = new InstanceOwner { PartyId = "5000" },
+        Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "Task2" } },
+        Data = [new DataElement { Id = "a499c3ef-e88a-436b-8650-1c43e5037ada", DataType = "Model" }],
+    };
+
     private sealed record Fixture(
         IProcessReader ProcessReader,
         Instance Instance,
-        Mock<ISigningService> SigningServiceMock,
+        Mock<ISigningReceiptService> SigningReceiptService,
+        Mock<IAppMetadata> AppMetadata,
+        Mock<ISignClient> SignClient,
         Mock<IInstanceDataMutator> InstanceDataMutatorMock,
         SigningUserAction SigningUserAction
     )
     {
         public static Fixture Create(
             IProcessReader? processReader = null,
+            Instance? instance = null,
             string testBpmnFilename = "signing-task-process.bpmn"
         )
         {
@@ -35,23 +61,45 @@ public class SigningUserActionTests
                     testBpmnFilename,
                     Path.Combine("Features", "Action", "TestData")
                 );
+            Instance _instance = instance ?? _defaultInstance;
 
-            var signingServiceMock = new Mock<ISigningService>();
+            var signingReceiptService = new Mock<ISigningReceiptService>();
+            var appMetadata = new Mock<IAppMetadata>();
+            var signClient = new Mock<ISignClient>();
             var instanceDataMutatorMock = new Mock<IInstanceDataMutator>();
-            var instance = new Instance
-            {
-                Id = "500000/b194e9f5-02d0-41bc-8461-a0cbac8a6efc",
-                InstanceOwner = new InstanceOwner { PartyId = "5000" },
-                Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "Task2" } },
-                Data = [new DataElement { Id = "a499c3ef-e88a-436b-8650-1c43e5037ada", DataType = "Model" }],
-            };
+
+            appMetadata.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(_defaultAppMetadata);
+            instanceDataMutatorMock.Setup(x => x.Instance).Returns(_instance);
+            signingReceiptService
+                .Setup(x =>
+                    x.SendSignatureReceipt(
+                        It.IsAny<InstanceIdentifier>(),
+                        It.IsAny<Signee>(),
+                        It.IsAny<IEnumerable<DataElementSignature>>(),
+                        It.IsAny<UserActionContext>(),
+                        It.IsAny<List<AltinnEnvironmentConfig>>()
+                    )
+                )
+                .Returns(
+                    Task.FromResult<SendCorrespondenceResponse?>(
+                        new SendCorrespondenceResponse { Correspondences = [] }
+                    )
+                );
 
             return new Fixture(
                 _processReader,
-                instance,
-                signingServiceMock,
+                _instance,
+                signingReceiptService,
+                appMetadata,
+                signClient,
                 instanceDataMutatorMock,
-                new SigningUserAction(_processReader, signingServiceMock.Object, new NullLogger<SigningUserAction>())
+                new SigningUserAction(
+                    _processReader,
+                    signClient.Object,
+                    appMetadata.Object,
+                    signingReceiptService.Object,
+                    new NullLogger<SigningUserAction>()
+                )
             );
         }
     }
@@ -82,12 +130,17 @@ public class SigningUserActionTests
         // Arrange
         var processReaderMock = new Mock<IProcessReader>();
         processReaderMock.Setup(x => x.GetFlowElement(It.IsAny<string>())).Returns(null as ProcessTask);
+
         var fixture = Fixture.Create(processReaderMock.Object);
         fixture.InstanceDataMutatorMock.Setup(x => x.Instance).Returns(fixture.Instance);
 
         // Act
         var result = await fixture.SigningUserAction.HandleAction(
-            new UserActionContext(fixture.InstanceDataMutatorMock.Object, 1337)
+            new UserActionContext(
+                fixture.InstanceDataMutatorMock.Object,
+                1337,
+                authentication: TestAuthentication.GetUserAuthentication(1337)
+            )
         );
 
         // Assert
@@ -104,8 +157,11 @@ public class SigningUserActionTests
         // Arrange
         var fixture = Fixture.Create();
 
-        fixture.InstanceDataMutatorMock.Setup(x => x.Instance).Returns(fixture.Instance);
-        var userActionContext = new UserActionContext(fixture.InstanceDataMutatorMock.Object, 1337);
+        var userActionContext = new UserActionContext(
+            fixture.InstanceDataMutatorMock.Object,
+            1337,
+            authentication: TestAuthentication.GetUserAuthentication(1337)
+        );
 
         // Act
         var result = await fixture.SigningUserAction.HandleAction(userActionContext);
@@ -115,24 +171,241 @@ public class SigningUserActionTests
     }
 
     [Fact]
-    public async Task HandleAction_throws_when_SigningService_Sign_throws()
+    public async Task HandleAction_throws_when_SignClient_SignDataElements_throws()
     {
         // Arrange
         var fixture = Fixture.Create();
-        fixture.InstanceDataMutatorMock.Setup(x => x.Instance).Returns(fixture.Instance);
-        var userActionContext = new UserActionContext(fixture.InstanceDataMutatorMock.Object, 1337);
-
         fixture
-            .SigningServiceMock.Setup(x => x.Sign(It.IsAny<UserActionContext>(), It.IsAny<ProcessTask>()))
-            .ThrowsAsync(new ApplicationConfigException());
+            .SignClient.Setup(x => x.SignDataElements(It.IsAny<SignatureContext>()))
+            .ThrowsAsync(new PlatformHttpException(new HttpResponseMessage(), "Failed to sign dataelements"));
+
+        var userActionContext = new UserActionContext(
+            fixture.InstanceDataMutatorMock.Object,
+            1337,
+            authentication: TestAuthentication.GetUserAuthentication(1337)
+        );
+
+        // Act
+        var result = await fixture.SigningUserAction.HandleAction(userActionContext);
+        var expected = UserActionResult.FailureResult(
+            error: new ActionError() { Code = "SignDataElementsFailed", Message = "Failed to sign data elements." },
+            errorType: ProcessErrorType.Internal
+        );
+        Assert.Equal(JsonSerializer.Serialize(expected), JsonSerializer.Serialize(result));
+        fixture.SignClient.Verify(x => x.SignDataElements(It.IsAny<SignatureContext>()), Times.Once);
+    }
+
+    [Theory]
+    [ClassData(typeof(TestAuthentication.AllTokens))]
+    public async Task HandleAction_returns_ok_if_user_is_valid(TestJwtToken token)
+    {
+        // Arrange
+        var fixture = Fixture.Create();
+
+        var instance = fixture.Instance;
+        var signClient = fixture.SignClient;
+
+        // Act
+        var result = await fixture.SigningUserAction.HandleAction(
+            new UserActionContext(fixture.InstanceDataMutatorMock.Object, 1337, authentication: token.Auth)
+        );
+
+        // Assert
+        switch (token.Auth)
+        {
+            case Authenticated.User user:
+                {
+                    var details = await user.LoadDetails();
+                    SignatureContext expected = new(
+                        new InstanceIdentifier(instance),
+                        instance.Process.CurrentTask.ElementId,
+                        "signature",
+                        new Signee()
+                        {
+                            UserId = user.UserId.ToString(CultureInfo.InvariantCulture),
+                            PersonNumber = details.SelectedParty.SSN,
+                        },
+                        new DataElementSignature("a499c3ef-e88a-436b-8650-1c43e5037ada")
+                    );
+                    signClient.Verify(
+                        s =>
+                            s.SignDataElements(
+                                It.Is<SignatureContext>(sc => AssertSigningContextAsExpected(sc, expected))
+                            ),
+                        Times.Once
+                    );
+                    result.Should().BeEquivalentTo(UserActionResult.SuccessResult());
+                    signClient.VerifyNoOtherCalls();
+                }
+                break;
+            case Authenticated.SelfIdentifiedUser selfIdentifiedUser:
+                {
+                    SignatureContext expected = new(
+                        new InstanceIdentifier(instance),
+                        instance.Process.CurrentTask.ElementId,
+                        "signature",
+                        new Signee()
+                        {
+                            UserId = selfIdentifiedUser.UserId.ToString(CultureInfo.InvariantCulture),
+                            PersonNumber = null,
+                        },
+                        new DataElementSignature("a499c3ef-e88a-436b-8650-1c43e5037ada")
+                    );
+                    signClient.Verify(
+                        s =>
+                            s.SignDataElements(
+                                It.Is<SignatureContext>(sc => AssertSigningContextAsExpected(sc, expected))
+                            ),
+                        Times.Once
+                    );
+                    result.Should().BeEquivalentTo(UserActionResult.SuccessResult());
+                    signClient.VerifyNoOtherCalls();
+                }
+                break;
+            case Authenticated.SystemUser systemUser:
+                {
+                    SignatureContext expected = new SignatureContext(
+                        new InstanceIdentifier(instance),
+                        instance.Process.CurrentTask.ElementId,
+                        "signature",
+                        new Signee()
+                        {
+                            SystemUserId = systemUser.SystemUserId[0],
+                            OrganisationNumber = systemUser.SystemUserOrgNr.Get(OrganisationNumberFormat.Local),
+                        },
+                        new DataElementSignature("a499c3ef-e88a-436b-8650-1c43e5037ada")
+                    );
+                    signClient.Verify(
+                        s =>
+                            s.SignDataElements(
+                                It.Is<SignatureContext>(sc => AssertSigningContextAsExpected(sc, expected))
+                            ),
+                        Times.Once
+                    );
+                    result.Should().BeEquivalentTo(UserActionResult.SuccessResult());
+                    signClient.VerifyNoOtherCalls();
+                }
+                break;
+            default:
+                Assert.Equal(ProcessErrorType.Unauthorized, result.ErrorType);
+                break;
+        }
+    }
+
+    [Fact]
+    public async Task HandleAction_returns_ok_if_no_dataElementSignature_and_optional_datatypes()
+    {
+        // Arrange
+        var appMetadata = new ApplicationMetadata("org/id")
+        {
+            // Optional because MinCount == 0
+            DataTypes = [new DataType { Id = "model", MinCount = 0 }],
+        };
+
+        var fixture = Fixture.Create();
+
+        fixture.AppMetadata.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(appMetadata);
+
+        var instance = fixture.Instance;
+        var signClientMock = fixture.SignClient;
+
+        // Act
+        var result = await fixture.SigningUserAction.HandleAction(
+            new UserActionContext(instance, 1337, authentication: TestAuthentication.GetUserAuthentication(1337))
+        );
+
+        // Assert
+        SignatureContext expected = new(
+            new InstanceIdentifier(instance),
+            instance.Process.CurrentTask.ElementId,
+            "signature",
+            new Signee() { UserId = "1337", PersonNumber = "12345678901" },
+            new DataElementSignature("a499c3ef-e88a-436b-8650-1c43e5037ada")
+        );
+        signClientMock.Verify(
+            s => s.SignDataElements(It.Is<SignatureContext>(sc => AssertSigningContextAsExpected(sc, expected))),
+            Times.Once
+        );
+        result.Should().BeEquivalentTo(UserActionResult.SuccessResult());
+        signClientMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task HandleAction_throws_ApplicationConfigException_when_no_dataElementSignature_and_mandatory_datatypes()
+    {
+        // Arrange
+        var appMetadata = new ApplicationMetadata("org/id")
+        {
+            // Mandatory because MinCount != 0
+            DataTypes =
+            [
+                new DataType { Id = "not_match", MinCount = 0 },
+                new DataType { Id = "not_match_2", MinCount = 1 },
+            ],
+        };
+        var fixture = Fixture.Create();
+        fixture.AppMetadata.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(appMetadata);
+
+        var instance = fixture.Instance;
+
+        var userActionContext = new UserActionContext(
+            instance,
+            1337,
+            authentication: TestAuthentication.GetUserAuthentication(1337)
+        );
 
         // Act
         await Assert.ThrowsAsync<ApplicationConfigException>(
             async () => await fixture.SigningUserAction.HandleAction(userActionContext)
         );
-        fixture.SigningServiceMock.Verify(
-            x => x.Sign(It.IsAny<UserActionContext>(), It.IsAny<ProcessTask>()),
-            Times.Once
+        fixture.SignClient.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task HandleAction_throws_ApplicationConfigException_if_SignatureDataType_is_missing_from_bpmn_config()
+    {
+        // Arrange
+        var fixture = Fixture.Create(testBpmnFilename: "signing-task-process-missing-config.bpmn");
+        var instance = fixture.Instance;
+        var signClientMock = fixture.SignClient;
+
+        var userActionContext = new UserActionContext(
+            instance,
+            1337,
+            authentication: TestAuthentication.GetUserAuthentication(1337)
         );
+
+        // Act
+        await Assert.ThrowsAsync<ApplicationConfigException>(
+            async () => await fixture.SigningUserAction.HandleAction(userActionContext)
+        );
+        signClientMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task HandleAction_throws_ApplicationConfigException_if_empty_DataTypesToSign_in_bpmn_config()
+    {
+        // Arrange
+        var fixture = Fixture.Create(testBpmnFilename: "signing-task-process-empty-datatypes-to-sign.bpmn");
+        var instance = fixture.Instance;
+        var signClientMock = fixture.SignClient;
+
+        var userActionContext = new UserActionContext(
+            instance,
+            1337,
+            authentication: TestAuthentication.GetUserAuthentication(1337)
+        );
+
+        // Act
+        await Assert.ThrowsAsync<ApplicationConfigException>(
+            async () => await fixture.SigningUserAction.HandleAction(userActionContext)
+        );
+        signClientMock.VerifyNoOtherCalls();
+    }
+
+    private bool AssertSigningContextAsExpected(SignatureContext s1, SignatureContext s2)
+    {
+        s1.Should().BeEquivalentTo(s2);
+        return true;
     }
 }

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
@@ -7,7 +7,6 @@ using Altinn.App.Core.Features.Signing.Models;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
 using Altinn.App.Core.Internal.Registers;
-using Altinn.App.Core.Internal.Sign;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -31,9 +30,7 @@ public sealed class SigningServiceTests : IDisposable
     private readonly Mock<ISigneeProvider> _signeeProvider = new(MockBehavior.Strict);
     private readonly Mock<ILogger<SigningService>> _logger = new();
     private readonly Mock<IAppMetadata> _appMetadata = new(MockBehavior.Strict);
-    private readonly Mock<ISignClient> _signClient = new(MockBehavior.Strict);
     private readonly Mock<ISigningCallToActionService> _signingCallToActionService = new(MockBehavior.Strict);
-    private readonly Mock<ISigningReceiptService> _signingReceiptService = new(MockBehavior.Strict);
 
     public void Dispose() => _serviceProvider.Dispose();
 
@@ -49,8 +46,6 @@ public sealed class SigningServiceTests : IDisposable
             _signingDelegationService.Object,
             _serviceProvider.GetRequiredService<AppImplementationFactory>(),
             _appMetadata.Object,
-            _signClient.Object,
-            _signingReceiptService.Object,
             _signingCallToActionService.Object,
             _logger.Object
         );

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -25,7 +25,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using Xunit.Abstractions;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moves the signing action back to `SigningUserAction` and reimplements tests. 

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
