### PR TITLE
Don't require scope claim when reading token (breaks localtest tokens)

### DIFF
--- a/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -636,9 +636,9 @@ public abstract class Authenticated
             TryAssign(claim, JwtClaimTypes.Scope, ref context.ScopeClaim);
         }
 
-        if (!context.ScopeClaim.IsValidString(out var scopeClaimValue))
-            throw new AuthenticationContextException("Invalid scope claim value for token");
-        context.Scopes = new Scopes(scopeClaimValue);
+        context.Scopes = context.ScopeClaim.IsValidString(out var scopeClaimValue)
+            ? new Scopes(scopeClaimValue)
+            : new Scopes(null);
 
         int? partyId = null;
         if (context.PartyIdClaim.Exists)
@@ -854,9 +854,9 @@ public abstract class Authenticated
                 context.ConsumerClaimValue = JsonSerializer.Deserialize<OrgClaim>(consumerJsonClaim);
         }
 
-        if (!context.ScopeClaim.IsValidString(out var scopeClaimValue))
-            throw new AuthenticationContextException("Invalid scope claim value for token");
-        context.Scopes = new Scopes(scopeClaimValue);
+        context.Scopes = context.ScopeClaim.IsValidString(out var scopeClaimValue)
+            ? new Scopes(scopeClaimValue)
+            : new Scopes(null);
         context.IsInAltinnPortal = context.Scopes.HasScope("altinn:portal/enduser");
 
         context.ResolveIssuer();


### PR DESCRIPTION
## Description
Too high expectations of token when building `Authenticated` (started in https://github.com/Altinn/app-lib-dotnet/pull/1168)

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
