### PR TITLE
Verify the actual response from api, instead of the parsed and potentially modified response

### DIFF
--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
+++ b/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
@@ -53,9 +53,6 @@ public class CustomOpenApiController : Controller
         _schemaRepository = new SchemaRepository();
     }
 
-    internal static readonly OpenApiSpecVersion SpecVersion = OpenApiSpecVersion.OpenApi3_0;
-    internal static readonly OpenApiFormat SpecFormat = OpenApiFormat.Json;
-
     /// <summary>
     /// Generate the custom OpenAPI documentation for the app
     /// </summary>
@@ -122,7 +119,7 @@ public class CustomOpenApiController : Controller
         var walker = new OpenApiWalker(new SchemaPostVisitor());
         walker.Walk(document);
 
-        return Ok(document.Serialize(SpecVersion, SpecFormat));
+        return Ok(document.Serialize(OpenApiSpecVersion.OpenApi3_0, OpenApiFormat.Json));
     }
 
     private string GetIntroDoc(ApplicationMetadata appMetadata)

--- a/src/Altinn.App.Api/Extensions/SwaggerFilterExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/SwaggerFilterExtensions.cs
@@ -1,3 +1,4 @@
+using Altinn.App.Core.Helpers;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -28,5 +29,12 @@ internal class DocumentFilter : IDocumentFilter
         swaggerDoc.Paths.Remove(
             "/{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data/{dataGuid}/type/{dataType}"
         );
+
+        // Remove the dataType parameter from the route where it does not apply.
+        // The previous lines removed the paths that used the dataType parameter.
+        swaggerDoc
+            .Paths["/{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data/{dataGuid}"]
+            .Operations.Values.ToList()
+            .ForEach(o => o.Parameters.RemoveAll(p => p.Name == "dataType" && p.In == ParameterLocation.Path));
     }
 }

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
@@ -7,7 +7,7 @@
       "name": "Digitaliseringsdirektoratet (altinn)",
       "url": "https://altinn.slack.com"
     },
-    "version": ""
+    "version": "{Scrubbed}"
   },
   "servers": [
     {

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.4",
   "info": {
     "title": "Altinn App Api",
-    "version": ""
+    "version": "{Scrubbed}"
   },
   "paths": {
     "/{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/actions": {
@@ -1065,15 +1065,6 @@
             }
           },
           {
-            "name": "dataType",
-            "in": "path",
-            "description": "Optional parameter, verified if pressent. Used to have different schemas for different data types in openApi spec",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "includeRowId",
             "in": "query",
             "description": "Whether to initialize or remove AltinnRowId fields in the model",
@@ -1149,15 +1140,6 @@
             "schema": {
               "type": "string",
               "format": "uuid"
-            }
-          },
-          {
-            "name": "dataType",
-            "in": "path",
-            "description": "Optional parameter, verified if pressent. Used to have different schemas for different data types in openApi spec,",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           },
           {
@@ -1441,15 +1423,6 @@
             "schema": {
               "type": "string",
               "format": "uuid"
-            }
-          },
-          {
-            "name": "dataType",
-            "in": "path",
-            "description": "Optional parameter, verified if pressent. Used to have different schemas for different data types in openApi spec,",
-            "required": true,
-            "schema": {
-              "type": "string"
             }
           },
           {


### PR DESCRIPTION
Follow up from https://github.com/Altinn/app-lib-dotnet/pull/1183#issuecomment-2717969882


Use .ScrubMember("version") to remove the nuget version from the info section

Use Microsoft.OpenApi.Readers only to verify that the package don't have validations that break.

Filter out the path parameter `{dataType}` that is used in the custom swagger file to allow annotation of data type schema