### PR TITLE
Make sure 'IsValidContributor' is correct according to docs - only service owners are 'validContributors'

### DIFF
--- a/src/Altinn.App.Api/Helpers/DataElementAccessChecker.cs
+++ b/src/Altinn.App.Api/Helpers/DataElementAccessChecker.cs
@@ -1,5 +1,4 @@
 using Altinn.App.Core.Features.Auth;
-using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -22,9 +21,9 @@ internal static class DataElementAccessChecker
 
         var (org, orgNr) = auth switch
         {
-            Authenticated.Org a => (null, a.OrgNo),
+            // System users also have 'orgno',  but this feature was originally intended
+            // to let a service owner "own" a specific data type, so we haven't extended this
             Authenticated.ServiceOwner a => (a.Name, a.OrgNo),
-            Authenticated.SystemUser a => (null, a.SystemUserOrgNr.Get(OrganisationNumberFormat.Local)),
             _ => (null, null),
         };
 

--- a/test/Altinn.App.Api.Tests/Helpers/DataElementAccessCheckerTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/DataElementAccessCheckerTests.cs
@@ -10,29 +10,25 @@ namespace Altinn.App.Api.Tests.Helpers;
 public class DataElementAccessCheckerTests
 {
     [Theory]
-    [InlineData(null, null, null, false, true)] // No allowed contributors, should be true
-    [InlineData("org:altinn", "altinn", 370194483, false, true)] // Matching org
-    [InlineData("org:altinn", "Altinn", 370194483, false, true)] // Matching org, case insensitive
-    [InlineData("org:altinn", "notAltinn", 370194483, false, false)] // Non-matching org
-    [InlineData("orgno:370194483", "altinn", 370194483, false, true)] // Matching orgNr
-    [InlineData("orgno:370194483", "altinn", 556750777, false, false)] // Non-matching orgNr
-    [InlineData("orgno:370194483", null, 370194483, false, true)] // Matching orgNr (not serviceowner)
-    [InlineData("orgno:370194483", null, 556750777, false, false)] // Non-matching orgNr (not serviceowner)
-    [InlineData("orgno:370194483", null, null, false, false)] // orgNr is null
-    [InlineData("org:altinn,orgno:370194483", "altinn", 370194483, false, true)] // Matching both
-    [InlineData("org:altinn,orgno:370194483", "altinn", 556750777, false, true)] // Matching org only
-    [InlineData("org:altinn,orgno:370194483", "notAltinn", 370194483, false, true)] // Matching orgNr only
-    [InlineData("org:altinn,orgno:370194483", "notAltinn", 556750777, false, false)] // Non-matching both
-    [InlineData("org:altinn,orgno:556750777", null, 556750777, true, true)] // Matching second rule
-    [InlineData("org:altinn,orgno:556750777", null, 556750777, false, true)] // Matching second rule
-    [InlineData("orgno:370194483", null, 370194483, true, true)] // Matching orgNr (as systemuser)
-    [InlineData("orgno:370194483", null, 556750777, true, false)] // Non-matching orgNr (as systemuser)
-    [InlineData("org:altinn", null, 370194483, true, false)] // Org (as systemuser)
+    [InlineData(null, null, null, true)] // No allowed contributors, should be true
+    [InlineData("org:altinn", "altinn", 370194483, true)] // Matching service owner
+    [InlineData("org:altinn", "Altinn", 370194483, true)] // Matching service owner, case insensitive
+    [InlineData("org:altinn", null, null, false)] // No match
+    [InlineData("org:altinn", "notAltinn", 370194483, false)] // Different service owner
+    [InlineData("orgno:370194483", "altinn", 370194483, true)] // Matching service owner orgNr
+    [InlineData("orgno:370194483", "altinn", 556750777, false)] // Non-matching service owner orgNr
+    [InlineData("orgno:370194483", null, 370194483, false)] // Matching orgNr (not serviceowner)
+    [InlineData("orgno:370194483", null, 556750777, false)] // Non-matching orgNr (not serviceowner)
+    [InlineData("orgno:370194483", null, null, false)] // No match
+    [InlineData("org:altinn,orgno:370194483", "altinn", 370194483, true)] // Matches service owner name
+    [InlineData("org:altinn,orgno:370194483", "altinn", 556750777, true)] // Matches service owner name (different org nr, will not actually happen)
+    [InlineData("org:altinn,orgno:370194483", "notAltinn", 370194483, true)] // Different service owner name, but matching service owner org nr (should not actually happen)
+    [InlineData("org:altinn,orgno:370194483", "notAltinn", 556750777, false)] // Different service owner
+    [InlineData("org:altinn,orgno:556750777", null, 556750777, false)] // Matching orgNr (not serviceowner)
     public void IsValidContributor_ShouldReturnExpectedResult(
         string? allowedContributors,
         string? org,
         int? orgNr,
-        bool isSystemUser,
         bool expectedResult
     )
     {
@@ -41,18 +37,15 @@ public class DataElementAccessCheckerTests
         {
             AllowedContributers = allowedContributors?.Split(',')?.ToList() ?? new List<string>(),
         };
-        Authenticated auth = (org, orgNr, isSystemUser) switch
+        Authenticated auth = (org, orgNr) switch
         {
-            (null, null, _) => TestAuthentication.GetNoneAuthentication(),
-            (string orgName, int orgNo, _) => TestAuthentication.GetServiceOwnerAuthentication(
+            (null, null) => TestAuthentication.GetNoneAuthentication(),
+            (null, int orgNo) => TestAuthentication.GetOrgAuthentication(
+                orgNumber: orgNo.ToString(CultureInfo.InvariantCulture)
+            ),
+            (string orgName, int orgNo) => TestAuthentication.GetServiceOwnerAuthentication(
                 orgNumber: orgNo.ToString(CultureInfo.InvariantCulture),
                 org: orgName
-            ),
-            (null, int orgNumber, bool systemUser) when !systemUser => TestAuthentication.GetOrgAuthentication(
-                orgNumber.ToString(CultureInfo.InvariantCulture)
-            ),
-            (null, int orgNumber, bool systemUser) when systemUser => TestAuthentication.GetSystemUserAuthentication(
-                systemUserOrgNumber: orgNumber.ToString(CultureInfo.InvariantCulture)
             ),
             _ => throw new Exception("Unhandled case"),
         };


### PR DESCRIPTION
## Description
When implementing systemusers I included system users as valid 'orgno's, but the docs state that only service owners are supported (which was not strictly true before either). This change ensures that we only accept service owners as the authenticated part. This feature/format should probably be redesigned for v9

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
