### PR TITLE
Filtering app text files

### DIFF
--- a/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
@@ -22,7 +22,6 @@ public class ApplicationLanguage : IApplicationLanguage
         TimeSpan.FromMilliseconds(10)
     );
 
-
     private readonly AppSettings _settings;
     private readonly Telemetry? _telemetry;
 

--- a/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
+++ b/src/Altinn.App.Core/Internal/Language/ApplicationLanguage.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Microsoft.Extensions.Options;
@@ -14,6 +15,13 @@ public class ApplicationLanguage : IApplicationLanguage
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
+
+    private static readonly Regex _fileNameRegex = new(
+        @"^resource\.[a-z]{2}\.json$",
+        RegexOptions.Compiled,
+        TimeSpan.FromMilliseconds(10)
+    );
+
 
     private readonly AppSettings _settings;
     private readonly Telemetry? _telemetry;
@@ -44,6 +52,11 @@ public class ApplicationLanguage : IApplicationLanguage
 
         foreach (var fileInfo in textResourceFilesInDirectory)
         {
+            if (!_fileNameRegex.IsMatch(fileInfo.Name))
+            {
+                continue;
+            }
+
             await using (FileStream fileStream = new(fileInfo.FullName, FileMode.Open, FileAccess.Read))
             {
                 // ! TODO: find a better way to deal with deserialization errors here, rather than adding nulls to the list


### PR DESCRIPTION
## Description

I found this weirdness in app-frontend:

![20250320_09h23m27s_grim](https://github.com/user-attachments/assets/447827e3-54de-427e-92d9-4b627b408807)

Turns out `/api/v1/applicationlanguages` was returning this:
```json
[
	{ "language": "nn" },
	{ "language": "nb" },
	{ "language": "nn" }
]
```

Because the app had these files in the folder:
- `ignore.nn.json` <- hmm!
- `resource.nb.json`
- `resource.nn.json`

And when fetching a specific language that 'ignore' approach seems to be working the way it was supposed to:
https://github.com/Altinn/app-lib-dotnet/blob/bfb143099faf7ca29e1a87a4b8256efa496e9250/src/Altinn.App.Core/Implementation/AppResourcesSI.cs#L72

So, this fixes the `/api/v1/applicationlanguages` endpoint so it doesn't return languages you cannot ever fetch from the `/api/v1/texts/{language}` endpoint.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
