### PR TITLE
Fix flakyness in tests caused by App Insights 'HostingDiagnosticListener'

### DIFF
--- a/test/Altinn.App.Api.Tests/Program.cs
+++ b/test/Altinn.App.Api.Tests/Program.cs
@@ -19,6 +19,7 @@ using Altinn.App.Core.Internal.Profile;
 using Altinn.App.Core.Internal.Registers;
 using AltinnCore.Authentication.JwtCookie;
 using App.IntegrationTests.Mocks.Services;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -58,6 +59,9 @@ builder.Configuration.AddJsonFile(
 );
 builder.Configuration.GetSection("MetricsSettings:Enabled").Value = "false";
 builder.Configuration.GetSection("AppSettings:UseOpenTelemetry").Value = "true";
+builder.Services.Configure<ApplicationInsightsServiceOptions>(options =>
+    options.RequestCollectionOptions.InjectResponseHeaders = false
+);
 builder.Services.Configure<GeneralSettings>(settings => settings.DisableLocaltestValidation = true);
 builder.Services.Configure<GeneralSettings>(settings => settings.DisableAppConfigurationCache = true);
 builder.Services.Configure<GeneralSettings>(settings => settings.IsTest = true);

--- a/test/Altinn.App.Api.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/test/Altinn.App.Api.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Altinn.App.Api.Tests.TestUtils;
 using Altinn.App.Core.Features;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -152,6 +153,9 @@ public class TelemetryConfigurationTests
 
         Altinn.App.Api.Extensions.ServiceCollectionExtensions.AddAltinnAppServices(services, config, env);
         services.AddApplicationInsightsTelemetryProcessor<TelemetryProcessor>();
+        services.Configure<ApplicationInsightsServiceOptions>(options =>
+            options.RequestCollectionOptions.InjectResponseHeaders = false
+        );
 
         // Don't use BuildStrictServiceProvider here since we only want to test parts of the container that
         // `AddAltinnAppServices` brings in
@@ -208,6 +212,9 @@ public class TelemetryConfigurationTests
         services.AddKeyedSingleton<ITelemetryProcessor, TelemetryProcessor>("test");
 
         Altinn.App.Api.Extensions.ServiceCollectionExtensions.AddAltinnAppServices(services, config, env);
+        services.Configure<ApplicationInsightsServiceOptions>(options =>
+            options.RequestCollectionOptions.InjectResponseHeaders = false
+        );
 
         // Don't use BuildStrictServiceProvider here since we only want to test parts of the container that
         // `AddAltinnAppServices` brings in

--- a/test/Altinn.App.Api.Tests/TestUtils/AppBuilder.cs
+++ b/test/Altinn.App.Api.Tests/TestUtils/AppBuilder.cs
@@ -1,3 +1,4 @@
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +38,9 @@ public static class AppBuilder
             builder.Services,
             builder.Configuration,
             builder.Environment
+        );
+        builder.Services.Configure<ApplicationInsightsServiceOptions>(options =>
+            options.RequestCollectionOptions.InjectResponseHeaders = false
         );
 
         // 4. OverrideAltinnAppServices


### PR DESCRIPTION
## Description
Some `HomeControllerTest_SetQueryParams` tests are snapshotting API responses including headers.
Application Insights will by default inject a `Request-Context` header in API responses through its [HostingDiagnosticListener](https://github.com/microsoft/ApplicationInsights-dotnet/blob/18ffbf6427ee705179052bfc94356c593621db85/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs#L708) which runs globally in process. So if these tests run parallel to other tests which used the App Insights SDK, this would trigger the linked function to append the response header. I'm not sure why it didn't do it every time, maybe it's related to sampling

This PR just disabled response injection during tests, as it is not important...

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
