### PR TITLE
Process next: Use AuthorizeAction multiple times instead of AuthorizeActions

### DIFF
--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -349,10 +349,10 @@ public class ProcessController : ControllerBase
             }
 
             _logger.LogDebug(
-                $"User successfully authorized to perform process next. Task ID: {currentTaskId}. Task type: {altinnTaskType}. Action: {processNext?.Action ?? "none"}.",
+                "User successfully authorized to perform process next. Task ID: {currentTaskId}. Task type: {altinnTaskType}. Action: {processNextAction}.",
                 currentTaskId,
                 altinnTaskType,
-                LogSanitizer.Sanitize(processNext?.Action)
+                LogSanitizer.Sanitize(processNext?.Action ?? "none")
             );
 
             string checkedAction = processNext?.Action ?? ConvertTaskTypeToAction(altinnTaskType);

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -342,17 +342,17 @@ public class ProcessController : ControllerBase
                     {
                         Status = StatusCodes.Status403Forbidden,
                         Detail =
-                            $"User is not authorized to perform process next with action '{processNext?.Action}' on task {currentTaskId} with task type {altinnTaskType}.",
+                            $"User is not authorized to perform process next. Task ID: {currentTaskId}. Task type: {altinnTaskType}. Action: {processNext?.Action ?? "none"}.",
                         Title = "Unauthorized",
                     }
                 );
             }
 
             _logger.LogDebug(
-                "User successfully authorized to perform process next with action '{Action}' on task {CurrentTaskId} with task type {AltinnTaskType}.",
-                LogSanitizer.Sanitize(processNext?.Action),
+                $"User successfully authorized to perform process next. Task ID: {currentTaskId}. Task type: {altinnTaskType}. Action: {processNext?.Action ?? "none"}.",
                 currentTaskId,
-                altinnTaskType
+                altinnTaskType,
+                LogSanitizer.Sanitize(processNext?.Action)
             );
 
             string checkedAction = processNext?.Action ?? ConvertTaskTypeToAction(altinnTaskType);

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -349,7 +349,7 @@ public class ProcessController : ControllerBase
             }
 
             _logger.LogDebug(
-                "User successfully authorized to perform process next. Task ID: {currentTaskId}. Task type: {altinnTaskType}. Action: {processNextAction}.",
+                "User successfully authorized to perform process next. Task ID: {CurrentTaskId}. Task type: {AltinnTaskType}. Action: {ProcessNextAction}.",
                 currentTaskId,
                 altinnTaskType,
                 LogSanitizer.Sanitize(processNext?.Action ?? "none")

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
@@ -46,13 +46,19 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
         // When an action is provided we only allow process next if that action is allowed.
         if (action is not null)
         {
-            return await _authorizationService.AuthorizeAction(
+            bool isPerformedActionAuthorized = await _authorizationService.AuthorizeAction(
                 new AppIdentifier(instance.Org, instance.AppId),
                 new InstanceIdentifier(instance),
                 _httpContext.User,
                 action,
                 currentTaskId
             );
+
+            _logger.LogInformation(
+                $"Process next was performed with action: {action}. Authorization result: {isPerformedActionAuthorized}."
+            );
+
+            return isPerformedActionAuthorized;
         }
 
         // When no action is provided we check if the user is authorized for at least one of the actions that allow process next for the current task type.
@@ -76,7 +82,9 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
             }
         }
 
-        _logger.LogInformation($"Process next authorization check: {isAnyActionAuthorized}.");
+        _logger.LogInformation(
+            $"Process next performed without an action. Authorizing based on task type. Result: {isAnyActionAuthorized}."
+        );
 
         return isAnyActionAuthorized;
     }

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
@@ -83,7 +83,7 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
         }
 
         _logger.LogInformation(
-            $"Process next performed without an action. Authorizing based on task type. Result: {isAnyActionAuthorized}."
+            $"Process next performed without an action. Authorizing based on task type {altinnTaskType}, which means using action(s) [{string.Join(",", actionsThatAllowProcessNextForTaskType)}]. Authorization result: {isAnyActionAuthorized}."
         );
 
         return isAnyActionAuthorized;

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
@@ -47,7 +47,7 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
         if (action is not null)
         {
             bool isPerformedActionAuthorized = await _authorizationService.AuthorizeAction(
-                new AppIdentifier(instance.Org, instance.AppId),
+                new AppIdentifier(instance.AppId),
                 new InstanceIdentifier(instance),
                 _httpContext.User,
                 action,
@@ -68,7 +68,7 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
         foreach (string actionToAuthorize in actionsThatAllowProcessNextForTaskType)
         {
             bool isActionAuthorized = await _authorizationService.AuthorizeAction(
-                new AppIdentifier(instance.Org, instance.AppId),
+                new AppIdentifier(instance.AppId),
                 new InstanceIdentifier(instance),
                 _httpContext.User,
                 actionToAuthorize,

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
@@ -58,27 +58,27 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
         // When no action is provided we check if the user is authorized for at least one of the actions that allow process next for the current task type.
         string[] actionsThatAllowProcessNextForTaskType = GetActionsThatAllowProcessNextForTaskType(altinnTaskType);
 
-        var atLeastOneActionAuthorized = false;
-        foreach (string actionToBeChecked in actionsThatAllowProcessNextForTaskType)
+        var isAnyActionAuthorized = false;
+        foreach (string actionToAuthorize in actionsThatAllowProcessNextForTaskType)
         {
-            bool actionIsAuthorized = await _authorizationService.AuthorizeAction(
+            bool isActionAuthorized = await _authorizationService.AuthorizeAction(
                 new AppIdentifier(instance.Org, instance.AppId),
                 new InstanceIdentifier(instance),
                 _httpContext.User,
-                actionToBeChecked,
+                actionToAuthorize,
                 currentTaskId
             );
 
-            if (actionIsAuthorized)
+            if (isActionAuthorized)
             {
-                atLeastOneActionAuthorized = true;
+                isAnyActionAuthorized = true;
                 break;
             }
         }
 
-        _logger.LogInformation($"Process next authorization check: {atLeastOneActionAuthorized}.");
+        _logger.LogInformation($"Process next authorization check: {isAnyActionAuthorized}.");
 
-        return atLeastOneActionAuthorized;
+        return isAnyActionAuthorized;
     }
 
     private HttpContext _httpContext =>

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
@@ -36,7 +36,8 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
         if (instance.Process.CurrentTask is null)
         {
             _logger.LogError(
-                $"Instance {instance.Id} has no current task. The process must be started before process next can be authorized."
+                "Instance {InstanceId} has no current task. The process must be started before process next can be authorized.",
+                instance.Id
             );
             return false;
         }
@@ -56,7 +57,9 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
             );
 
             _logger.LogInformation(
-                $"Process next was performed with action: {LogSanitizer.Sanitize(action)}. Authorization result: {isPerformedActionAuthorized}."
+                "Process next was performed with action: {SanitizedAction}. Authorization result: {IsPerformedActionAuthorized}.",
+                LogSanitizer.Sanitize(action),
+                isPerformedActionAuthorized
             );
 
             return isPerformedActionAuthorized;
@@ -84,7 +87,10 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
         }
 
         _logger.LogInformation(
-            $"Process next performed without an action. Authorizing based on task type {altinnTaskType}, which means using action(s) [{string.Join(",", actionsThatAllowProcessNextForTaskType)}]. Authorization result: {isAnyActionAuthorized}."
+            "Process next performed without an action. Authorizing based on task type {AltinnTaskType}, which means using action(s) [{Actions}]. Authorization result: {IsAnyActionAuthorized}.",
+            altinnTaskType,
+            string.Join(",", actionsThatAllowProcessNextForTaskType),
+            isAnyActionAuthorized
         );
 
         return isAnyActionAuthorized;

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.App.Core.Features.Auth;
+using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.Auth;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -55,7 +56,7 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
             );
 
             _logger.LogInformation(
-                $"Process next was performed with action: {action}. Authorization result: {isPerformedActionAuthorized}."
+                $"Process next was performed with action: {LogSanitizer.Sanitize(action)}. Authorization result: {isPerformedActionAuthorized}."
             );
 
             return isPerformedActionAuthorized;

--- a/src/Altinn.App.Core/Internal/Process/ProcessSequenceFlowType.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessSequenceFlowType.cs
@@ -13,6 +13,7 @@ public enum ProcessSequenceFlowType
     /// <summary>
     /// Abandon the current task and return to next process element.
     /// </summary>
+    [Obsolete("Never used in our process engine code.")]
     AbandonCurrentReturnToNext = 1,
 
     /// <summary>

--- a/src/Altinn.App.Core/Models/AppIdentifier.cs
+++ b/src/Altinn.App.Core/Models/AppIdentifier.cs
@@ -35,6 +35,13 @@ public sealed class AppIdentifier : IEquatable<AppIdentifier>
             throw new ArgumentNullException(nameof(app));
         }
 
+        if (app.Contains('/'))
+        {
+            throw new ArgumentException(
+                $"The '{nameof(app)}' parameter should not contain any forward slashes. You likely passed the full AppId instead of just the app name."
+            );
+        }
+
         Org = org;
         App = app;
     }

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
@@ -73,30 +73,22 @@
       IdFormat: W3C
     },
     {
-      ActivityName: Authorization.Service.AuthorizeActions,
+      ActivityName: Authorization.Service.AuthorizeAction,
       Tags: [
         {
+          authorization.action: write
+        },
+        {
           instance.guid: Guid_1
+        },
+        {
+          instance.owner.party.id: 500600
+        },
+        {
+          task.id: Task_1
         }
       ],
-      IdFormat: W3C,
-      Events: [
-        {
-          Name: actions,
-          Timestamp: DateTimeOffset_1,
-          Tags: [
-            {
-              actions.count: 1
-            },
-            {
-              actions.0.value: write
-            },
-            {
-              actions.0.type: ProcessAction
-            }
-          ]
-        }
-      ]
+      IdFormat: W3C
     },
     {
       ActivityName: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -81,30 +81,22 @@
       IdFormat: W3C
     },
     {
-      ActivityName: Authorization.Service.AuthorizeActions,
+      ActivityName: Authorization.Service.AuthorizeAction,
       Tags: [
         {
+          authorization.action: write
+        },
+        {
           instance.guid: Guid_1
+        },
+        {
+          instance.owner.party.id: 500600
+        },
+        {
+          task.id: Task_1
         }
       ],
-      IdFormat: W3C,
-      Events: [
-        {
-          Name: actions,
-          Timestamp: DateTimeOffset_1,
-          Tags: [
-            {
-              actions.count: 1
-            },
-            {
-              actions.0.value: write
-            },
-            {
-              actions.0.type: ProcessAction
-            }
-          ]
-        }
-      ]
+      IdFormat: W3C
     },
     {
       ActivityName: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
@@ -271,7 +271,7 @@ public class ProcessEngineAuthorizerTests
         {
             Id = "1337/12df57b6-cecf-4e7d-9415-857d93a817b3",
             InstanceOwner = new InstanceOwner { PartyId = "1337" },
-            AppId = "app",
+            AppId = "org/app",
             Org = "org",
             Process = new ProcessState(),
         };

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
@@ -24,9 +24,14 @@ public class ProcessEngineAuthorizerTests
     private readonly ProcessEngineAuthorizer _authorizer;
     private readonly ClaimsPrincipal _user;
 
+    private const string WriteAction = "write";
+    private const string ConfirmAction = "confirm";
+    private const string SignAction = "sign";
+    private const string PayAction = "pay";
+
     public ProcessEngineAuthorizerTests()
     {
-        _authServiceMock = new Mock<IAuthorizationService>();
+        _authServiceMock = new Mock<IAuthorizationService>(MockBehavior.Strict);
         _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
         var loggerMock = new Mock<ILogger<ProcessEngineAuthorizer>>();
 
@@ -66,7 +71,6 @@ public class ProcessEngineAuthorizerTests
     {
         // Arrange
         Instance instance = CreateInstance("task1", "data");
-        const string action = "write";
 
         _authServiceMock
             .Setup(x =>
@@ -74,28 +78,19 @@ public class ProcessEngineAuthorizerTests
                     It.IsAny<AppIdentifier>(),
                     It.IsAny<InstanceIdentifier>(),
                     It.IsAny<ClaimsPrincipal>(),
-                    action,
-                    "task1"
+                    WriteAction,
+                    instance.Process.CurrentTask.ElementId
                 )
             )
-            .ReturnsAsync(true);
+            .ReturnsAsync(true)
+            .Verifiable();
 
         // Act
-        bool result = await _authorizer.AuthorizeProcessNext(instance, action);
+        bool result = await _authorizer.AuthorizeProcessNext(instance, WriteAction);
 
         // Assert
         Assert.True(result);
-        _authServiceMock.Verify(
-            x =>
-                x.AuthorizeAction(
-                    It.IsAny<AppIdentifier>(),
-                    It.IsAny<InstanceIdentifier>(),
-                    It.IsAny<ClaimsPrincipal>(),
-                    action,
-                    "task1"
-                ),
-            Times.Once
-        );
+        _authServiceMock.Verify();
     }
 
     [Fact]
@@ -103,35 +98,26 @@ public class ProcessEngineAuthorizerTests
     {
         // Arrange
         Instance instance = CreateInstance("task1", "data");
-        var authorizeActionsResult = new List<UserAction>
-        {
-            new() { Id = "write", Authorized = true },
-        };
 
         _authServiceMock
             .Setup(x =>
-                x.AuthorizeActions(
-                    It.IsAny<Instance>(),
+                x.AuthorizeAction(
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<InstanceIdentifier>(),
                     It.IsAny<ClaimsPrincipal>(),
-                    It.Is<List<AltinnAction>>(a => a.Any(action => action.Value == "write"))
+                    WriteAction,
+                    instance.Process.CurrentTask.ElementId
                 )
             )
-            .ReturnsAsync(authorizeActionsResult);
+            .ReturnsAsync(true)
+            .Verifiable();
 
         // Act
         bool result = await _authorizer.AuthorizeProcessNext(instance);
 
         // Assert
         Assert.True(result);
-        _authServiceMock.Verify(
-            x =>
-                x.AuthorizeActions(
-                    instance,
-                    It.IsAny<ClaimsPrincipal>(),
-                    It.Is<List<AltinnAction>>(a => a.Count == 1 && a[0].Value == "write")
-                ),
-            Times.Once
-        );
+        _authServiceMock.Verify();
     }
 
     [Fact]
@@ -139,40 +125,39 @@ public class ProcessEngineAuthorizerTests
     {
         // Arrange
         Instance instance = CreateInstance("task1", "payment");
-        var authorizeActionsResult = new List<UserAction>
-        {
-            new() { Id = "pay", Authorized = false },
-            new() { Id = "write", Authorized = true },
-        };
 
         _authServiceMock
             .Setup(x =>
-                x.AuthorizeActions(
-                    It.IsAny<Instance>(),
+                x.AuthorizeAction(
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<InstanceIdentifier>(),
                     It.IsAny<ClaimsPrincipal>(),
-                    It.Is<List<AltinnAction>>(a =>
-                        a.Any(action => action.Value == "pay") && a.Any(action => action.Value == "write")
-                    )
+                    PayAction,
+                    instance.Process.CurrentTask.ElementId
                 )
             )
-            .ReturnsAsync(authorizeActionsResult);
+            .ReturnsAsync(false)
+            .Verifiable();
+
+        _authServiceMock
+            .Setup(x =>
+                x.AuthorizeAction(
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<InstanceIdentifier>(),
+                    It.IsAny<ClaimsPrincipal>(),
+                    WriteAction,
+                    instance.Process.CurrentTask.ElementId
+                )
+            )
+            .ReturnsAsync(true)
+            .Verifiable();
 
         // Act
         bool result = await _authorizer.AuthorizeProcessNext(instance);
 
         // Assert
         Assert.True(result);
-        _authServiceMock.Verify(
-            x =>
-                x.AuthorizeActions(
-                    instance,
-                    It.IsAny<ClaimsPrincipal>(),
-                    It.Is<List<AltinnAction>>(a =>
-                        a.Count == 2 && a.Any(act => act.Value == "pay") && a.Any(act => act.Value == "write")
-                    )
-                ),
-            Times.Once
-        );
+        _authServiceMock.Verify();
     }
 
     [Fact]
@@ -180,35 +165,26 @@ public class ProcessEngineAuthorizerTests
     {
         // Arrange
         Instance instance = CreateInstance("task1", "confirmation");
-        var authorizeActionsResult = new List<UserAction>
-        {
-            new() { Id = "confirm", Authorized = true },
-        };
 
         _authServiceMock
             .Setup(x =>
-                x.AuthorizeActions(
-                    It.IsAny<Instance>(),
+                x.AuthorizeAction(
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<InstanceIdentifier>(),
                     It.IsAny<ClaimsPrincipal>(),
-                    It.Is<List<AltinnAction>>(a => a.Any(action => action.Value == "confirm"))
+                    ConfirmAction,
+                    instance.Process.CurrentTask.ElementId
                 )
             )
-            .ReturnsAsync(authorizeActionsResult);
+            .ReturnsAsync(true)
+            .Verifiable();
 
         // Act
         bool result = await _authorizer.AuthorizeProcessNext(instance);
 
         // Assert
         Assert.True(result);
-        _authServiceMock.Verify(
-            x =>
-                x.AuthorizeActions(
-                    instance,
-                    It.IsAny<ClaimsPrincipal>(),
-                    It.Is<List<AltinnAction>>(a => a.Count == 1 && a[0].Value == "confirm")
-                ),
-            Times.Once
-        );
+        _authServiceMock.Verify();
     }
 
     [Fact]
@@ -216,40 +192,39 @@ public class ProcessEngineAuthorizerTests
     {
         // Arrange
         Instance instance = CreateInstance("task1", "signing");
-        var authorizeActionsResult = new List<UserAction>
-        {
-            new() { Id = "sign", Authorized = false },
-            new() { Id = "write", Authorized = true },
-        };
 
         _authServiceMock
             .Setup(x =>
-                x.AuthorizeActions(
-                    It.IsAny<Instance>(),
+                x.AuthorizeAction(
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<InstanceIdentifier>(),
                     It.IsAny<ClaimsPrincipal>(),
-                    It.Is<List<AltinnAction>>(a =>
-                        a.Any(action => action.Value == "sign") && a.Any(action => action.Value == "write")
-                    )
+                    SignAction,
+                    instance.Process.CurrentTask.ElementId
                 )
             )
-            .ReturnsAsync(authorizeActionsResult);
+            .ReturnsAsync(false)
+            .Verifiable();
+
+        _authServiceMock
+            .Setup(x =>
+                x.AuthorizeAction(
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<InstanceIdentifier>(),
+                    It.IsAny<ClaimsPrincipal>(),
+                    WriteAction,
+                    instance.Process.CurrentTask.ElementId
+                )
+            )
+            .ReturnsAsync(true)
+            .Verifiable();
 
         // Act
         bool result = await _authorizer.AuthorizeProcessNext(instance);
 
         // Assert
         Assert.True(result);
-        _authServiceMock.Verify(
-            x =>
-                x.AuthorizeActions(
-                    It.IsAny<Instance>(),
-                    It.IsAny<ClaimsPrincipal>(),
-                    It.Is<List<AltinnAction>>(a =>
-                        a.Count == 2 && a.Any(act => act.Value == "sign") && a.Any(act => act.Value == "write")
-                    )
-                ),
-            Times.Once
-        );
+        _authServiceMock.Verify();
     }
 
     [Fact]
@@ -257,16 +232,18 @@ public class ProcessEngineAuthorizerTests
     {
         // Arrange
         Instance instance = CreateInstance("task1", "data");
-        var authorizeActionsResult = new List<UserAction>
-        {
-            new() { Id = "write", Authorized = false },
-        };
 
         _authServiceMock
             .Setup(x =>
-                x.AuthorizeActions(It.IsAny<Instance>(), It.IsAny<ClaimsPrincipal>(), It.IsAny<List<AltinnAction>>())
+                x.AuthorizeAction(
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<InstanceIdentifier>(),
+                    It.IsAny<ClaimsPrincipal>(),
+                    WriteAction,
+                    instance.Process.CurrentTask.ElementId
+                )
             )
-            .ReturnsAsync(authorizeActionsResult);
+            .ReturnsAsync(false);
 
         // Act
         bool result = await _authorizer.AuthorizeProcessNext(instance);


### PR DESCRIPTION
Use AuthorizeAction multiple times instead of AuthorizeActions because of risk of behaviour change if we don't send taskId. Allow using task type in policy xml as an action, to allow use of custom task types.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
