### PR TITLE
Treating null as empty string in `stringReplace`

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -594,7 +594,7 @@ public static class ExpressionEvaluator
         string? search = ToStringForEquals(args[1]);
         string? replace = ToStringForEquals(args[2]);
 
-        if (subject is null || search is null || replace is null || subject == "" || search == "")
+        if (subject is null || search is null || subject == "" || search == "")
         {
             return null;
         }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/stringReplace/replace-with-null.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/stringReplace/replace-with-null.json
@@ -1,0 +1,5 @@
+{
+  "name": "Should allow replacing with null (as empty string)",
+  "expression": ["stringReplace", "Hello, {0}!", "{0}", null],
+  "expects": "Hello, !"
+}


### PR DESCRIPTION
## Description

This should have been the behaviour when this was released, but that was not the case. [When searching](https://altinn.studio/repos/explore/code?q=replace&l=JSON&fuzzy=false), it seems this expression is still only used in the app developed by Ronny (who reported the issue).

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/3151
- https://github.com/Altinn/app-frontend-react/pull/3202

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
