### PR TITLE
Update nuget depencencies

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.405",
+        "version": "8.0.407",
         "rollForward": "latestFeature",
         "allowPrerelease": false
     }

--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="4.1.2" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.7" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.6" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />

--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -15,17 +15,17 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Common.PEP" Version="4.1.2" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.6" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.7" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.23" />
   </ItemGroup>
 

--- a/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
+++ b/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
@@ -13,7 +13,6 @@ using Altinn.App.Core.Internal.Process;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using Microsoft.OpenApi;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
@@ -42,14 +41,16 @@ public class CustomOpenApiController : Controller
         IAppModel appModel,
         IAppMetadata appMetadata,
         ISerializerDataContractResolver dataContractResolver,
-        IOptions<MvcOptions> mvcOptions,
         IProcessReader processReader
     )
     {
         _appModel = appModel;
         _appMetadata = appMetadata;
         _processReader = processReader;
-        _schemaGenerator = new SchemaGenerator(new SchemaGeneratorOptions(), dataContractResolver, mvcOptions);
+        _schemaGenerator = new SchemaGenerator(
+            new SchemaGeneratorOptions() { SupportNonNullableReferenceTypes = true },
+            dataContractResolver
+        );
         _schemaRepository = new SchemaRepository();
     }
 

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.3.3" />
     <PackageReference Include="Altinn.Common.PEP" Version="4.1.2" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.6.1" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.7" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.6" />
     <PackageReference Include="JsonPatch.Net" Version="3.3.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <!-- The follwoing are depencencies for JWTCookieAuthentication, but we need newer versions-->

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -11,26 +11,26 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="8.0.1" />
+    <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.2.1" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.5" />
     <PackageReference Include="Altinn.Common.EFormidlingClient" Version="1.3.3" />
     <PackageReference Include="Altinn.Common.PEP" Version="4.1.2" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.6.1" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.6" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="4.0.7" />
     <PackageReference Include="JsonPatch.Net" Version="3.3.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <!-- The follwoing are depencencies for JWTCookieAuthentication, but we need newer versions-->
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.3.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.7.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.19" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <!-- End JWTCookieAuthentication deps -->
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="[9.0.0-preview.9.24556.5]" NoWarn="NU5104" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.3.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta11" PrivateAssets="all" ExcludeAssets="runtime" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -108,9 +108,7 @@ public static class ServiceCollectionExtensions
 #pragma warning restore CS0618 // Type or member is obsolete
         services.AddHttpClient<IProcessClient, ProcessClient>();
         services.AddHttpClient<IPersonClient, PersonClient>();
-#pragma warning disable EXTEXP0018 // is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         services.AddHybridCache();
-#pragma warning restore EXTEXP0018
 
         services.TryAddTransient<IUserTokenProvider, UserTokenProvider>();
         services.TryAddTransient<IAccessTokenGenerator, AccessTokenGenerator>();

--- a/src/Altinn.App.Internal.Analyzers/Altinn.App.Internal.Analyzers.csproj
+++ b/src/Altinn.App.Internal.Analyzers/Altinn.App.Internal.Analyzers.csproj
@@ -24,17 +24,17 @@
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
-  <!-- 
+  <!--
     NOTE:
     InternalsVisibleTo messes with PolySharp, which we use to support newer C# features in analyzer code (such as records)
-    So it is disabled currently and relevant members in analyzer code are public instead 
+    So it is disabled currently and relevant members in analyzer code are public instead
    -->
   <!-- <ItemGroup>
     <InternalsVisibleTo Include="Altinn.App.Analyzers.Tests" />
   </ItemGroup> -->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" Version="4.1.0" />
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 </Project>

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -11,9 +11,8 @@
     <PackageReference Include="FluentAssertions" Version="7.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.12" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Altinn.App.Api.Tests/Data/TestData.cs
+++ b/test/Altinn.App.Api.Tests/Data/TestData.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Models;
@@ -16,11 +17,16 @@ public static class TestData
 
     public static string GetTestDataRootDirectory()
     {
-        var assemblyPath = new Uri(typeof(TestData).Assembly.Location).LocalPath;
-        var assemblyFolder = Path.GetDirectoryName(assemblyPath);
-
-        return Path.Combine(assemblyFolder!, @"../../../Data/");
+        var file = GetCallerFilePath();
+        return (
+                Path.GetDirectoryName(file)
+                ?? throw new DirectoryNotFoundException(
+                    $"Could not find directory for file {file}. Please check the test data root directory."
+                )
+            ) + '/';
     }
+
+    private static string GetCallerFilePath([CallerFilePath] string file = "") => file;
 
     public static string GetApplicationDirectory(string org, string app)
     {

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
@@ -2631,11 +2631,6 @@
           "autoDeleteOnProcessEnd": {
             "type": "boolean"
           },
-          "preventInstanceDeletionForDays": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
           "presentationFields": {
             "type": "array",
             "items": {

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
@@ -2559,8 +2559,7 @@
             "nullable": true
           },
           "size": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -2632,6 +2631,11 @@
           "autoDeleteOnProcessEnd": {
             "type": "boolean"
           },
+          "preventInstanceDeletionForDays": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
           "presentationFields": {
             "type": "array",
             "items": {
@@ -2680,8 +2684,7 @@
             "$ref": "#/components/schemas/Logo"
           },
           "altinnNugetVersion": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "externalApiIds": {
             "type": "array",

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -1513,6 +1513,7 @@
             "name": "queryParams",
             "in": "query",
             "description": "Query parameteres supplied",
+            "style": "deepObject",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -1592,6 +1593,7 @@
             "name": "queryParams",
             "in": "query",
             "description": "Query parameters supplied",
+            "style": "deepObject",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -1987,6 +1989,7 @@
             "name": "queryParams",
             "in": "query",
             "description": "The query parameters to pass to the external api endpoint",
+            "style": "deepObject",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -2901,6 +2904,7 @@
             "name": "queryParams",
             "in": "query",
             "description": "Query parameters supplied",
+            "style": "deepObject",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -3006,6 +3010,7 @@
             "name": "queryParams",
             "in": "query",
             "description": "Query parameteres supplied",
+            "style": "deepObject",
             "schema": {
               "type": "object",
               "additionalProperties": {
@@ -6007,6 +6012,11 @@
           },
           "autoDeleteOnProcessEnd": {
             "type": "boolean"
+          },
+          "preventInstanceDeletionForDays": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           },
           "presentationFields": {
             "type": "array",

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -6013,11 +6013,6 @@
           "autoDeleteOnProcessEnd": {
             "type": "boolean"
           },
-          "preventInstanceDeletionForDays": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
           "presentationFields": {
             "type": "array",
             "items": {

--- a/test/Altinn.App.Api.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/test/Altinn.App.Api.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -188,49 +188,6 @@ public class TelemetryConfigurationTests
     }
 
     [Fact]
-    public async Task KeyedServices_Produces_Error_Diagnostics()
-    {
-        // This test just verifies that we rootcaused the issues re: https://github.com/Altinn/app-lib-dotnet/pull/594
-
-        using var listener = new AppInsightsListener();
-
-        var services = new ServiceCollection();
-        var env = new FakeWebHostEnvironment { EnvironmentName = "Development" };
-
-        services.AddSingleton<IWebHostEnvironment>(env);
-        services.AddSingleton<IHostingEnvironment>(env);
-
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(
-                [new KeyValuePair<string, string?>("ApplicationInsights:InstrumentationKey", "test")]
-            )
-            .Build();
-
-        // AppInsights SDK currently can't handle keyed services in the container
-        // Hopefully we can remove all this soon
-        services.AddKeyedSingleton<ITelemetryProcessor, TelemetryProcessor>("test");
-
-        Altinn.App.Api.Extensions.ServiceCollectionExtensions.AddAltinnAppServices(services, config, env);
-        services.Configure<ApplicationInsightsServiceOptions>(options =>
-            options.RequestCollectionOptions.InjectResponseHeaders = false
-        );
-
-        // Don't use BuildStrictServiceProvider here since we only want to test parts of the container that
-        // `AddAltinnAppServices` brings in
-        await using (var sp = services.BuildServiceProvider())
-        {
-            var client = sp.GetService<TelemetryClient>();
-            Assert.Null(client);
-        }
-
-        await Task.Yield();
-
-        EventLevel[] errorLevels = [EventLevel.Error, EventLevel.Critical];
-        var events = listener.Events;
-        Assert.Contains(events, e => errorLevels.Contains(e.Level));
-    }
-
-    [Fact]
     public async Task OpenTelemetry_Registers_Correctly_When_Enabled()
     {
         List<KeyValuePair<string, string?>> configData =

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -16,20 +16,14 @@
       CS0618: This is a test project, so we usually continue testing [Obsolete] apis
     -->
   </PropertyGroup>
-  <ItemGroup>
-    <!--
-    Temporary ignore a security advisory from a WireMock.Net dependency without any fix
-     (it does not matter in a test project anyway, because we don't process unsafe data)
-      -->
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-4cv2-4hjh-77rx" />
-  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
-    <PackageReference Include="Verify.Xunit" Version="28.9.0" />
+    <PackageReference Include="Verify.Xunit" Version="28.16.0" />
     <PackageReference Include="FluentAssertions" Version="7.1.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
@@ -40,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.6.11" />
+    <PackageReference Include="WireMock.Net" Version="1.7.4" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMetadataTest.GetApplicationMetadata_deserialize_serialize_unmapped_properties.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMetadataTest.GetApplicationMetadata_deserialize_serialize_unmapped_properties.verified.txt
@@ -71,6 +71,7 @@
     "SubUnit": true
   },
   "AutoDeleteOnProcessEnd": false,
+  "PreventInstanceDeletionForDays": null,
   "PresentationFields": null,
   "DataFields": null,
   "EFormidling": null,

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMetadataTest.GetApplicationMetadata_deserialize_serialize_unmapped_properties.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMetadataTest.GetApplicationMetadata_deserialize_serialize_unmapped_properties.verified.txt
@@ -71,7 +71,6 @@
     "SubUnit": true
   },
   "AutoDeleteOnProcessEnd": false,
-  "PreventInstanceDeletionForDays": null,
   "PresentationFields": null,
   "DataFields": null,
   "EFormidling": null,

--- a/test/Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj
+++ b/test/Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj
@@ -16,9 +16,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" />
-    <PackageReference Include="Verify.Xunit" Version="28.9.0" />
+    <PackageReference Include="Verify.Xunit" Version="28.16.0" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
-    <PackageReference Include="OpenTelemetry" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.11.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Notable changes
* Changed from Microsoft.CodeAnalysis.Workspaces to Microsoft.CodeAnalysis.CSharp, in Inernal.Analyzers because of a compiller warning see: https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1038.md
* Updated SDK reference in global.json
* Updated Applicationinsights package and removed the test from https://github.com/Altinn/app-lib-dotnet/pull/594
* Updated to released version of HybridCache and remove #pragma waring disable for preview
* Used [CallerFilePath] intead of assemly location to find test data folder. (tests failed)

## Replaces
* https://github.com/Altinn/app-lib-dotnet/pull/1216
* https://github.com/Altinn/app-lib-dotnet/pull/1212
* https://github.com/Altinn/app-lib-dotnet/pull/1071

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
