### PR TITLE
Fix broken build

### DIFF
--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -27,6 +27,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="Altinn.App.Tests.Common" />
+    <Using Include="Altinn.App.Tests.Common.Auth" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../../src/Altinn.App.Api/Altinn.App.Api.csproj" />
 
     <!-- <ProjectReference Include="../../src/Altinn.App.Api/Altinn.App.Api.csproj">
@@ -35,7 +40,4 @@
     <ProjectReference Include="../Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="../Altinn.App.Tests.Common/ModuleInitializer.cs" />
-  </ItemGroup>
 </Project>

--- a/test/Altinn.App.Api.Tests/ModuleInitializer.cs
+++ b/test/Altinn.App.Api.Tests/ModuleInitializer.cs
@@ -1,6 +1,6 @@
 using System.Runtime.CompilerServices;
 
-namespace Altinn.App.Tests.Common;
+namespace Altinn.App.Api.Tests;
 
 internal static class ModuleInitializer
 {

--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -50,7 +50,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../Altinn.App.Tests.Common/ModuleInitializer.cs" />
+    <Using Include="Altinn.App.Tests.Common" />
+    <Using Include="Altinn.App.Tests.Common.Auth" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Altinn.App.Core.Tests/ModuleInitializer.cs
+++ b/test/Altinn.App.Core.Tests/ModuleInitializer.cs
@@ -1,0 +1,12 @@
+using System.Runtime.CompilerServices;
+
+namespace Altinn.App.Core.Tests;
+
+internal static class ModuleInitializer
+{
+    [ModuleInitializer]
+    public static void Init()
+    {
+        VerifierSettings.AutoVerify(includeBuildServer: false);
+    }
+}

--- a/test/Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj
+++ b/test/Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj
@@ -33,7 +33,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="ModuleInitializer.cs" />
     <Content Include="TestResources/**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <LinkBase>/</LinkBase>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -15,10 +15,4 @@
         CA1859: Use concrete types when possible for improved performance
     -->
   </PropertyGroup>
-
-  <ItemGroup>
-    <Using Include="Altinn.App.Tests.Common" />
-    <Using Include="Altinn.App.Tests.Common.Auth" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION

<img width="1049" alt="image" src="https://github.com/user-attachments/assets/a244e8ca-f7d1-410a-823c-6a048c80c491" />


The build is unreliable, so I'm not sure these issues will fix them, but in my limited testing I see the issue without the fix and not with the fix.

* Don't reference CS files outside of the folder (copy ModuleInitializer into every project).
* Move global usings for test projects to the individual test projects
  * The current layout means that the build fails when adding a new test project before referencing Altinn.App.Tests.Common

