### PR TITLE
Fix content include for testdata files in Altinn.App.Core.Tests which made build buggy

### DIFF
--- a/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
+++ b/test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj
@@ -58,9 +58,7 @@
     <Content Include="Features/Validators/**/*.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
     <Content Include="Models/**/*.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
     <Content Include="secrets.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
-    <Content Include="**/TestData/**">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <Content Include="**/TestData/**" Exclude="bin/**;obj/**" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
From the error messages I've seen thus far for failing builds after merging #1215, the build has failed to copy files where `TestData` was in the path within `bin` when building `Altinn.App.Core.Tests`, so I think my "simplified" include is the culprit. VS Code solution explorer also showed the bin folder disappearing after adding this exclude clause, so this gives me some confidence.

Of course I haven't been able to reproduce this error on my machines, so hopefully someone else can test this 

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
