### PR TITLE
Unobsolete GET instance copy endpoint, copy based on `Authenticated`

### DIFF
--- a/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
@@ -7,6 +7,7 @@ using Altinn.App.Api.Helpers.Patch;
 using Altinn.App.Api.Models;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
+using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
@@ -103,7 +104,7 @@ internal sealed record InstancesControllerFixture(IServiceProvider ServiceProvid
 
     public void Dispose() => (ServiceProvider as IDisposable)?.Dispose();
 
-    internal static InstancesControllerFixture Create()
+    internal static InstancesControllerFixture Create(Authenticated? auth = null)
     {
         var services = new ServiceCollection();
         services.AddLogging(logging => logging.AddProvider(NullLoggerProvider.Instance));
@@ -135,6 +136,11 @@ internal sealed record InstancesControllerFixture(IServiceProvider ServiceProvid
         services.AddTransient<InternalPatchService>();
         services.AddTransient<ModelSerializationService>();
         services.AddTransient<InstanceDataUnitOfWorkInitializer>();
+
+        Mock<IAuthenticationContext> authenticationContextMock = new();
+        services.AddSingleton(authenticationContextMock.Object);
+        if (auth is not null)
+            authenticationContextMock.Setup(m => m.Current).Returns(auth);
 
         services.AddTransient(sp =>
         {

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
@@ -24,7 +24,8 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_CopyInstanceNotDefined_ReturnsBadRequest()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: 343234);
+        using var fixture = InstancesControllerFixture.Create(auth);
         ApplicationMetadata application = new("ttd/copy-instance") { };
         fixture.Mock<IAppMetadata>().Setup(a => a.GetApplicationMetadata()).ReturnsAsync(application);
 
@@ -45,7 +46,8 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_CopyInstanceNotEnabled_ReturnsBadRequest()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: 343234);
+        using var fixture = InstancesControllerFixture.Create(auth);
         const string Org = "ttd";
         const string AppName = "copy-instance";
         fixture
@@ -70,7 +72,8 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_AsAppOwner_ReturnsForbidResult()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
+        var auth = TestAuthentication.GetServiceOwnerAuthentication(org: "ttd");
+        using var fixture = InstancesControllerFixture.Create(auth);
         fixture
             .Mock<HttpContext>()
             .Setup(httpContext => httpContext.User)
@@ -91,13 +94,14 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_AsUnauthorized_ReturnsForbidden()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
-        const string Org = "ttd";
-        const string AppName = "copy-instance";
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: 65434312);
+        using var fixture = InstancesControllerFixture.Create(auth);
         fixture
             .Mock<HttpContext>()
             .Setup(httpContext => httpContext.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337));
+            .Returns(TestAuthentication.GetUserPrincipal(65434312));
+        const string Org = "ttd";
+        const string AppName = "copy-instance";
         fixture
             .Mock<IAppMetadata>()
             .Setup(a => a.GetApplicationMetadata())
@@ -125,7 +129,6 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_InstanceNotArchived_ReturnsBadRequest()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
         const string Org = "ttd";
         const string AppName = "copy-instance";
         int instanceOwnerPartyId = 343234;
@@ -135,11 +138,13 @@ public class InstancesController_CopyInstanceTests
             Id = $"{instanceOwnerPartyId}/{instanceGuid}",
             Status = new InstanceStatus() { IsArchived = false },
         };
-
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: instanceOwnerPartyId);
+        using var fixture = InstancesControllerFixture.Create(auth);
         fixture
             .Mock<HttpContext>()
             .Setup(httpContext => httpContext.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337, instanceOwnerPartyId));
+            .Returns(TestAuthentication.GetUserPrincipal(partyId: instanceOwnerPartyId));
+
         fixture
             .Mock<IAppMetadata>()
             .Setup(a => a.GetApplicationMetadata())
@@ -172,11 +177,12 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_InstanceDoesNotExists_ReturnsBadRequest()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
         const string Org = "ttd";
         const string AppName = "copy-instance";
         int instanceOwnerPartyId = 343234;
         Guid instanceGuid = Guid.NewGuid();
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: instanceOwnerPartyId);
+        using var fixture = InstancesControllerFixture.Create(auth);
 
         // Storage returns Forbidden if the given instance id is wrong.
         PlatformHttpException platformHttpException = await PlatformHttpException.CreateAsync(
@@ -186,7 +192,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<HttpContext>()
             .Setup(httpContext => httpContext.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337, instanceOwnerPartyId));
+            .Returns(TestAuthentication.GetUserPrincipal(partyId: instanceOwnerPartyId));
         fixture
             .Mock<IAppMetadata>()
             .Setup(a => a.GetApplicationMetadata())
@@ -219,11 +225,12 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_PlatformReturnsError_ThrowsException()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
         const string Org = "ttd";
         const string AppName = "copy-instance";
         int instanceOwnerPartyId = 343234;
         Guid instanceGuid = Guid.NewGuid();
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: instanceOwnerPartyId);
+        using var fixture = InstancesControllerFixture.Create(auth);
 
         // Simulate a BadGateway respons from Platform
         PlatformHttpException platformHttpException = await PlatformHttpException.CreateAsync(
@@ -233,7 +240,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<HttpContext>()
             .Setup(httpContext => httpContext.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337, instanceOwnerPartyId));
+            .Returns(TestAuthentication.GetUserPrincipal(partyId: instanceOwnerPartyId));
         fixture
             .Mock<IAppMetadata>()
             .Setup(a => a.GetApplicationMetadata())
@@ -247,22 +254,13 @@ public class InstancesController_CopyInstanceTests
             .Setup(i => i.GetInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Guid>()))
             .ThrowsAsync(platformHttpException);
 
-        PlatformHttpException? actual = null;
-
         // Act
-        try
-        {
-            var controller = fixture.ServiceProvider.GetRequiredService<InstancesController>();
-            await controller.CopyInstance("ttd", "copy-instance", instanceOwnerPartyId, instanceGuid);
-        }
-        catch (PlatformHttpException phe)
-        {
-            actual = phe;
-        }
+        var controller = fixture.ServiceProvider.GetRequiredService<InstancesController>();
+        var actual = await Assert.ThrowsAsync<PlatformHttpException>(async () =>
+            await controller.CopyInstance("ttd", "copy-instance", instanceOwnerPartyId, instanceGuid)
+        );
 
         // Assert
-        Assert.NotNull(actual);
-
         fixture.Mock<IAppMetadata>().VerifyAll();
         fixture.Mock<IPDP>().VerifyAll();
         fixture.Mock<IInstanceClient>().VerifyAll();
@@ -273,7 +271,6 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_InstantiationValidationFails_ReturnsForbidden()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
         const string Org = "ttd";
         const string AppName = "copy-instance";
         int instanceOwnerPartyId = 343234;
@@ -284,11 +281,13 @@ public class InstancesController_CopyInstanceTests
             Status = new InstanceStatus() { IsArchived = true },
         };
         InstantiationValidationResult? instantiationValidationResult = new() { Valid = false };
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: instanceOwnerPartyId);
+        using var fixture = InstancesControllerFixture.Create(auth);
 
         fixture
             .Mock<HttpContext>()
             .Setup(httpContext => httpContext.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337, instanceOwnerPartyId));
+            .Returns(TestAuthentication.GetUserPrincipal(partyId: instanceOwnerPartyId));
         fixture
             .Mock<IAppMetadata>()
             .Setup(a => a.GetApplicationMetadata())
@@ -327,18 +326,17 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_EverythingIsFine_ReturnsRedirect()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
         const string Org = "ttd";
         const string AppName = "copy-instance";
-        const int InstanceOwnerPartyId = 343234;
+        const int instanceOwnerPartyId = 343234;
         Guid instanceGuid = Guid.NewGuid();
         Guid dataGuid = Guid.NewGuid();
         const string dataTypeId = "data_type_1";
         Instance instance = new()
         {
-            Id = $"{InstanceOwnerPartyId}/{instanceGuid}",
+            Id = $"{instanceOwnerPartyId}/{instanceGuid}",
             AppId = $"{Org}/{AppName}",
-            InstanceOwner = new InstanceOwner() { PartyId = InstanceOwnerPartyId.ToString() },
+            InstanceOwner = new InstanceOwner() { PartyId = instanceOwnerPartyId.ToString() },
             Status = new InstanceStatus() { IsArchived = true },
             Process = new ProcessState() { CurrentTask = new ProcessElementInfo() { ElementId = "First" } },
             Data = new List<DataElement>
@@ -347,11 +345,13 @@ public class InstancesController_CopyInstanceTests
             },
         };
         InstantiationValidationResult? instantiationValidationResult = new() { Valid = true };
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: instanceOwnerPartyId);
+        using var fixture = InstancesControllerFixture.Create(auth);
 
         fixture
             .Mock<HttpContext>()
-            .Setup(hc => hc.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337, InstanceOwnerPartyId));
+            .Setup(httpContext => httpContext.User)
+            .Returns(TestAuthentication.GetUserPrincipal(partyId: instanceOwnerPartyId));
         fixture.Mock<HttpContext>().Setup(hc => hc.Request).Returns(Mock.Of<HttpRequest>());
         fixture
             .Mock<IAppMetadata>()
@@ -392,7 +392,7 @@ public class InstancesController_CopyInstanceTests
             );
         fixture
             .Mock<IDataClient>()
-            .Setup(p => p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, InstanceOwnerPartyId, dataGuid))
+            .Setup(p => p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, instanceOwnerPartyId, dataGuid))
             .ReturnsAsync(new { test = "test" });
         fixture
             .Mock<IDataClient>()
@@ -403,7 +403,7 @@ public class InstancesController_CopyInstanceTests
                     It.IsAny<Type?>()!,
                     Org,
                     AppName,
-                    InstanceOwnerPartyId,
+                    instanceOwnerPartyId,
                     dataTypeId
                 )
             )
@@ -411,12 +411,12 @@ public class InstancesController_CopyInstanceTests
 
         // Act
         var controller = fixture.ServiceProvider.GetRequiredService<InstancesController>();
-        ActionResult actual = await controller.CopyInstance(Org, AppName, InstanceOwnerPartyId, instanceGuid);
+        ActionResult actual = await controller.CopyInstance(Org, AppName, instanceOwnerPartyId, instanceGuid);
 
         // Assert
         Assert.IsType<RedirectResult>(actual);
         RedirectResult objectResult = (RedirectResult)actual;
-        Assert.Contains($"/#/instance/{InstanceOwnerPartyId}/", objectResult.Url);
+        Assert.Contains($"/#/instance/{instanceOwnerPartyId}/", objectResult.Url);
 
         fixture.Mock<IAppMetadata>().VerifyAll();
         fixture.Mock<IPDP>().VerifyAll();

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
@@ -256,7 +256,7 @@ public class InstancesController_CopyInstanceTests
 
         // Act
         var controller = fixture.ServiceProvider.GetRequiredService<InstancesController>();
-        var actual = await Assert.ThrowsAsync<PlatformHttpException>(async () =>
+        await Assert.ThrowsAsync<PlatformHttpException>(async () =>
             await controller.CopyInstance("ttd", "copy-instance", instanceOwnerPartyId, instanceGuid)
         );
 

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_CopyInstanceTests.cs
@@ -429,10 +429,11 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_WithBinaryData_CopiesBothFormAndBinaryData()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
+        const int instanceOwnerPartyId = 343234;
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: instanceOwnerPartyId);
+        using var fixture = InstancesControllerFixture.Create(auth);
         const string Org = "ttd";
         const string AppName = "copy-instance";
-        const int InstanceOwnerPartyId = 343234;
         Guid instanceGuid = Guid.NewGuid();
         Guid formDataGuid = Guid.NewGuid();
         Guid binaryDataGuid = Guid.NewGuid();
@@ -443,9 +444,9 @@ public class InstancesController_CopyInstanceTests
 
         Instance instance = new()
         {
-            Id = $"{InstanceOwnerPartyId}/{instanceGuid}",
+            Id = $"{instanceOwnerPartyId}/{instanceGuid}",
             AppId = $"{Org}/{AppName}",
-            InstanceOwner = new InstanceOwner() { PartyId = InstanceOwnerPartyId.ToString() },
+            InstanceOwner = new InstanceOwner() { PartyId = instanceOwnerPartyId.ToString() },
             Status = new InstanceStatus() { IsArchived = true },
             Process = new ProcessState() { CurrentTask = new ProcessElementInfo() { ElementId = "First" } },
             Data = new List<DataElement>
@@ -468,7 +469,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<HttpContext>()
             .Setup(hc => hc.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337, InstanceOwnerPartyId));
+            .Returns(TestAuthentication.GetUserPrincipal(1337, instanceOwnerPartyId));
         fixture.Mock<HttpContext>().Setup(hc => hc.Request).Returns(Mock.Of<HttpRequest>());
         // Create app metadata with IncludeAttachments = true to enable binary data copying
         var appMetadata = CreateApplicationMetadata(Org, AppName, true);
@@ -509,7 +510,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<IDataClient>()
             .Setup(p =>
-                p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, InstanceOwnerPartyId, formDataGuid)
+                p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, instanceOwnerPartyId, formDataGuid)
             )
             .ReturnsAsync(new { test = "test" });
         fixture
@@ -521,7 +522,7 @@ public class InstancesController_CopyInstanceTests
                     It.IsAny<Type?>()!,
                     Org,
                     AppName,
-                    InstanceOwnerPartyId,
+                    instanceOwnerPartyId,
                     formDataTypeId
                 )
             )
@@ -529,7 +530,7 @@ public class InstancesController_CopyInstanceTests
 
         fixture
             .Mock<IDataClient>()
-            .Setup(p => p.GetBinaryData(Org, AppName, InstanceOwnerPartyId, instanceGuid, binaryDataGuid))
+            .Setup(p => p.GetBinaryData(Org, AppName, instanceOwnerPartyId, instanceGuid, binaryDataGuid))
             .ReturnsAsync(new MemoryStream(binaryDataBytes));
         fixture
             .Mock<IDataClient>()
@@ -547,7 +548,7 @@ public class InstancesController_CopyInstanceTests
 
         // Act
         var controller = fixture.ServiceProvider.GetRequiredService<InstancesController>();
-        ActionResult actual = await controller.CopyInstance(Org, AppName, InstanceOwnerPartyId, instanceGuid);
+        ActionResult actual = await controller.CopyInstance(Org, AppName, instanceOwnerPartyId, instanceGuid);
 
         // Assert
         Assert.IsType<RedirectResult>(actual);
@@ -556,7 +557,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<IDataClient>()
             .Verify(
-                p => p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, InstanceOwnerPartyId, formDataGuid),
+                p => p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, instanceOwnerPartyId, formDataGuid),
                 Times.Once
             );
         fixture
@@ -569,7 +570,7 @@ public class InstancesController_CopyInstanceTests
                         It.IsAny<Type?>()!,
                         Org,
                         AppName,
-                        InstanceOwnerPartyId,
+                        instanceOwnerPartyId,
                         formDataTypeId
                     ),
                 Times.Once
@@ -578,7 +579,7 @@ public class InstancesController_CopyInstanceTests
         // Verify binary data was copied (this should FAIL until we implement it)
         fixture
             .Mock<IDataClient>()
-            .Verify(p => p.GetBinaryData(Org, AppName, InstanceOwnerPartyId, instanceGuid, binaryDataGuid), Times.Once);
+            .Verify(p => p.GetBinaryData(Org, AppName, instanceOwnerPartyId, instanceGuid, binaryDataGuid), Times.Once);
         fixture
             .Mock<IDataClient>()
             .Verify(
@@ -599,10 +600,11 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_WithExcludedBinaryDataType_SkipsExcludedType()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
+        const int instanceOwnerPartyId = 343234;
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: instanceOwnerPartyId);
+        using var fixture = InstancesControllerFixture.Create(auth);
         const string Org = "ttd";
         const string AppName = "copy-instance";
-        const int InstanceOwnerPartyId = 343234;
         Guid instanceGuid = Guid.NewGuid();
         Guid formDataGuid = Guid.NewGuid();
         Guid binaryDataGuid = Guid.NewGuid();
@@ -613,9 +615,9 @@ public class InstancesController_CopyInstanceTests
 
         Instance instance = new()
         {
-            Id = $"{InstanceOwnerPartyId}/{instanceGuid}",
+            Id = $"{instanceOwnerPartyId}/{instanceGuid}",
             AppId = $"{Org}/{AppName}",
-            InstanceOwner = new InstanceOwner() { PartyId = InstanceOwnerPartyId.ToString() },
+            InstanceOwner = new InstanceOwner() { PartyId = instanceOwnerPartyId.ToString() },
             Status = new InstanceStatus() { IsArchived = true },
             Process = new ProcessState() { CurrentTask = new ProcessElementInfo() { ElementId = "First" } },
             Data = new List<DataElement>
@@ -640,7 +642,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<HttpContext>()
             .Setup(hc => hc.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337, InstanceOwnerPartyId));
+            .Returns(TestAuthentication.GetUserPrincipal(1337, instanceOwnerPartyId));
         fixture.Mock<HttpContext>().Setup(hc => hc.Request).Returns(Mock.Of<HttpRequest>());
         fixture.Mock<IAppMetadata>().Setup(a => a.GetApplicationMetadata()).ReturnsAsync(appMetadata);
         fixture
@@ -678,7 +680,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<IDataClient>()
             .Setup(p =>
-                p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, InstanceOwnerPartyId, formDataGuid)
+                p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, instanceOwnerPartyId, formDataGuid)
             )
             .ReturnsAsync(new { test = "test" });
         fixture
@@ -690,7 +692,7 @@ public class InstancesController_CopyInstanceTests
                     It.IsAny<Type?>()!,
                     Org,
                     AppName,
-                    InstanceOwnerPartyId,
+                    instanceOwnerPartyId,
                     formDataTypeId
                 )
             )
@@ -699,7 +701,7 @@ public class InstancesController_CopyInstanceTests
         // Binary data mocks (should NOT be called - type is excluded)
         fixture
             .Mock<IDataClient>()
-            .Setup(p => p.GetBinaryData(Org, AppName, InstanceOwnerPartyId, instanceGuid, binaryDataGuid))
+            .Setup(p => p.GetBinaryData(Org, AppName, instanceOwnerPartyId, instanceGuid, binaryDataGuid))
             .ReturnsAsync(new MemoryStream(binaryDataBytes));
         fixture
             .Mock<IDataClient>()
@@ -717,7 +719,7 @@ public class InstancesController_CopyInstanceTests
 
         // Act
         var controller = fixture.ServiceProvider.GetRequiredService<InstancesController>();
-        ActionResult actual = await controller.CopyInstance(Org, AppName, InstanceOwnerPartyId, instanceGuid);
+        ActionResult actual = await controller.CopyInstance(Org, AppName, instanceOwnerPartyId, instanceGuid);
 
         // Assert
         Assert.IsType<RedirectResult>(actual);
@@ -726,7 +728,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<IDataClient>()
             .Verify(
-                p => p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, InstanceOwnerPartyId, formDataGuid),
+                p => p.GetFormData(instanceGuid, It.IsAny<Type?>()!, Org, AppName, instanceOwnerPartyId, formDataGuid),
                 Times.Once
             );
         fixture
@@ -739,7 +741,7 @@ public class InstancesController_CopyInstanceTests
                         It.IsAny<Type?>()!,
                         Org,
                         AppName,
-                        InstanceOwnerPartyId,
+                        instanceOwnerPartyId,
                         formDataTypeId
                     ),
                 Times.Once
@@ -749,7 +751,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<IDataClient>()
             .Verify(
-                p => p.GetBinaryData(Org, AppName, InstanceOwnerPartyId, instanceGuid, binaryDataGuid),
+                p => p.GetBinaryData(Org, AppName, instanceOwnerPartyId, instanceGuid, binaryDataGuid),
                 Times.Never
             );
         fixture
@@ -772,10 +774,11 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_IncludeAttachmentsIsTrue_CopiesBinaryData()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
+        const int instanceOwnerPartyId = 343234;
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: instanceOwnerPartyId);
+        using var fixture = InstancesControllerFixture.Create(auth);
         const string Org = "ttd";
         const string AppName = "copy-instance";
-        const int InstanceOwnerPartyId = 343234;
         Guid instanceGuid = Guid.NewGuid();
         Guid binaryDataGuid = Guid.NewGuid();
         const string binaryDataTypeId = "attachment";
@@ -784,9 +787,9 @@ public class InstancesController_CopyInstanceTests
 
         Instance instance = new()
         {
-            Id = $"{InstanceOwnerPartyId}/{instanceGuid}",
+            Id = $"{instanceOwnerPartyId}/{instanceGuid}",
             AppId = $"{Org}/{AppName}",
-            InstanceOwner = new InstanceOwner() { PartyId = InstanceOwnerPartyId.ToString() },
+            InstanceOwner = new InstanceOwner() { PartyId = instanceOwnerPartyId.ToString() },
             Status = new InstanceStatus() { IsArchived = true },
             Process = new ProcessState() { CurrentTask = new ProcessElementInfo() { ElementId = "First" } },
             Data = new List<DataElement>
@@ -811,7 +814,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<HttpContext>()
             .Setup(hc => hc.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337, InstanceOwnerPartyId));
+            .Returns(TestAuthentication.GetUserPrincipal(1337, instanceOwnerPartyId));
         fixture.Mock<HttpContext>().Setup(hc => hc.Request).Returns(Mock.Of<HttpRequest>());
         fixture.Mock<IAppMetadata>().Setup(a => a.GetApplicationMetadata()).ReturnsAsync(appMetadata);
         fixture
@@ -848,7 +851,7 @@ public class InstancesController_CopyInstanceTests
         // Binary data mocks (should be called)
         fixture
             .Mock<IDataClient>()
-            .Setup(p => p.GetBinaryData(Org, AppName, InstanceOwnerPartyId, instanceGuid, binaryDataGuid))
+            .Setup(p => p.GetBinaryData(Org, AppName, instanceOwnerPartyId, instanceGuid, binaryDataGuid))
             .ReturnsAsync(new MemoryStream(binaryDataBytes));
         fixture
             .Mock<IDataClient>()
@@ -866,7 +869,7 @@ public class InstancesController_CopyInstanceTests
 
         // Act
         var controller = fixture.ServiceProvider.GetRequiredService<InstancesController>();
-        ActionResult actual = await controller.CopyInstance(Org, AppName, InstanceOwnerPartyId, instanceGuid);
+        ActionResult actual = await controller.CopyInstance(Org, AppName, instanceOwnerPartyId, instanceGuid);
 
         // Assert
         Assert.IsType<RedirectResult>(actual);
@@ -874,7 +877,7 @@ public class InstancesController_CopyInstanceTests
         // Verify binary data was copied
         fixture
             .Mock<IDataClient>()
-            .Verify(p => p.GetBinaryData(Org, AppName, InstanceOwnerPartyId, instanceGuid, binaryDataGuid), Times.Once);
+            .Verify(p => p.GetBinaryData(Org, AppName, instanceOwnerPartyId, instanceGuid, binaryDataGuid), Times.Once);
         fixture
             .Mock<IDataClient>()
             .Verify(
@@ -926,10 +929,11 @@ public class InstancesController_CopyInstanceTests
     public async Task CopyInstance_OnlyBinaryData_NotCopiedByDefault()
     {
         // Arrange
-        using var fixture = InstancesControllerFixture.Create();
+        const int instanceOwnerPartyId = 343234;
+        var auth = TestAuthentication.GetUserAuthentication(userPartyId: instanceOwnerPartyId);
+        using var fixture = InstancesControllerFixture.Create(auth);
         const string Org = "ttd";
         const string AppName = "copy-instance";
-        const int InstanceOwnerPartyId = 343234;
         Guid instanceGuid = Guid.NewGuid();
         Guid binaryDataGuid = Guid.NewGuid();
         const string binaryDataTypeId = "attachment";
@@ -938,9 +942,9 @@ public class InstancesController_CopyInstanceTests
 
         Instance instance = new()
         {
-            Id = $"{InstanceOwnerPartyId}/{instanceGuid}",
+            Id = $"{instanceOwnerPartyId}/{instanceGuid}",
             AppId = $"{Org}/{AppName}",
-            InstanceOwner = new InstanceOwner() { PartyId = InstanceOwnerPartyId.ToString() },
+            InstanceOwner = new InstanceOwner() { PartyId = instanceOwnerPartyId.ToString() },
             Status = new InstanceStatus() { IsArchived = true },
             Process = new ProcessState() { CurrentTask = new ProcessElementInfo() { ElementId = "First" } },
             Data = new List<DataElement>
@@ -961,7 +965,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<HttpContext>()
             .Setup(hc => hc.User)
-            .Returns(TestAuthentication.GetUserPrincipal(1337, InstanceOwnerPartyId));
+            .Returns(TestAuthentication.GetUserPrincipal(1337, instanceOwnerPartyId));
         fixture.Mock<HttpContext>().Setup(hc => hc.Request).Returns(Mock.Of<HttpRequest>());
         fixture
             .Mock<IAppMetadata>()
@@ -1001,7 +1005,7 @@ public class InstancesController_CopyInstanceTests
         // Binary data mocks (should be called)
         fixture
             .Mock<IDataClient>()
-            .Setup(p => p.GetBinaryData(Org, AppName, InstanceOwnerPartyId, instanceGuid, binaryDataGuid))
+            .Setup(p => p.GetBinaryData(Org, AppName, instanceOwnerPartyId, instanceGuid, binaryDataGuid))
             .ReturnsAsync(new MemoryStream(binaryDataBytes));
         fixture
             .Mock<IDataClient>()
@@ -1019,7 +1023,7 @@ public class InstancesController_CopyInstanceTests
 
         // Act
         var controller = fixture.ServiceProvider.GetRequiredService<InstancesController>();
-        ActionResult actual = await controller.CopyInstance(Org, AppName, InstanceOwnerPartyId, instanceGuid);
+        ActionResult actual = await controller.CopyInstance(Org, AppName, instanceOwnerPartyId, instanceGuid);
 
         // Assert
         Assert.IsType<RedirectResult>(actual);
@@ -1028,7 +1032,7 @@ public class InstancesController_CopyInstanceTests
         fixture
             .Mock<IDataClient>()
             .Verify(
-                p => p.GetBinaryData(Org, AppName, InstanceOwnerPartyId, instanceGuid, binaryDataGuid),
+                p => p.GetBinaryData(Org, AppName, instanceOwnerPartyId, instanceGuid, binaryDataGuid),
                 Times.Never
             );
         fixture


### PR DESCRIPTION
## Description
* Unobsolete GET instance copy endpoint that is going to be used by Arbeidsflate
* Do the auth checks based on `Authenticated`

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
