### PR TITLE
Add party object to instance owner in APIs returning instance

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -127,7 +127,7 @@ public class InstancesController : ControllerBase
     [Authorize]
     [HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
     [Produces("application/json")]
-    [ProducesResponseType(typeof(Instance), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(InstanceDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Get(
         [FromRoute] string org,
@@ -161,7 +161,11 @@ public class InstancesController : ControllerBase
                 await _instanceClient.UpdateReadStatus(instanceOwnerPartyId, instanceGuid, "read");
             }
 
-            return Ok(instance);
+            var instanceOwnerParty = await _altinnPartyClientClient.GetParty(instanceOwnerPartyId);
+
+            var dto = InstanceDto.From(instance, instanceOwnerParty);
+
+            return Ok(dto);
         }
         catch (Exception exception)
         {
@@ -183,10 +187,10 @@ public class InstancesController : ControllerBase
     [HttpPost]
     [DisableFormValueModelBinding]
     [Produces("application/json")]
-    [ProducesResponseType(typeof(Instance), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(InstanceDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [RequestSizeLimit(RequestSizeLimit)]
-    public async Task<ActionResult<Instance>> Post(
+    public async Task<ActionResult<InstanceDto>> Post(
         [FromRoute] string org,
         [FromRoute] string app,
         [FromQuery] int? instanceOwnerPartyId,
@@ -381,7 +385,9 @@ public class InstancesController : ControllerBase
         SelfLinkHelper.SetInstanceAppSelfLinks(instance, Request);
         string url = instance.SelfLinks.Apps;
 
-        return Created(url, instance);
+        var dto = InstanceDto.From(instance, party);
+
+        return Created(url, dto);
     }
 
     private ObjectResult? VerifyInstantiationPermissions(
@@ -417,10 +423,10 @@ public class InstancesController : ControllerBase
     [HttpPost("create")]
     [DisableFormValueModelBinding]
     [Produces("application/json")]
-    [ProducesResponseType(typeof(Instance), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(InstanceDto), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [RequestSizeLimit(RequestSizeLimit)]
-    public async Task<ActionResult<Instance>> PostSimplified(
+    public async Task<ActionResult<InstanceDto>> PostSimplified(
         [FromRoute] string org,
         [FromRoute] string app,
         [FromBody] InstansiationInstance instansiationInstance
@@ -592,7 +598,9 @@ public class InstancesController : ControllerBase
         SelfLinkHelper.SetInstanceAppSelfLinks(instance, Request);
         string url = instance.SelfLinks.Apps;
 
-        return Created(url, instance);
+        var dto = InstanceDto.From(instance, party);
+
+        return Created(url, dto);
     }
 
     /// <summary>

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -127,7 +127,7 @@ public class InstancesController : ControllerBase
     [Authorize]
     [HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
     [Produces("application/json")]
-    [ProducesResponseType(typeof(InstanceDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(InstanceResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Get(
         [FromRoute] string org,
@@ -163,7 +163,7 @@ public class InstancesController : ControllerBase
 
             var instanceOwnerParty = await _altinnPartyClientClient.GetParty(instanceOwnerPartyId);
 
-            var dto = InstanceDto.From(instance, instanceOwnerParty);
+            var dto = InstanceResponse.From(instance, instanceOwnerParty);
 
             return Ok(dto);
         }
@@ -187,10 +187,10 @@ public class InstancesController : ControllerBase
     [HttpPost]
     [DisableFormValueModelBinding]
     [Produces("application/json")]
-    [ProducesResponseType(typeof(InstanceDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(InstanceResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [RequestSizeLimit(RequestSizeLimit)]
-    public async Task<ActionResult<InstanceDto>> Post(
+    public async Task<ActionResult<InstanceResponse>> Post(
         [FromRoute] string org,
         [FromRoute] string app,
         [FromQuery] int? instanceOwnerPartyId,
@@ -385,7 +385,7 @@ public class InstancesController : ControllerBase
         SelfLinkHelper.SetInstanceAppSelfLinks(instance, Request);
         string url = instance.SelfLinks.Apps;
 
-        var dto = InstanceDto.From(instance, party);
+        var dto = InstanceResponse.From(instance, party);
 
         return Created(url, dto);
     }
@@ -423,10 +423,10 @@ public class InstancesController : ControllerBase
     [HttpPost("create")]
     [DisableFormValueModelBinding]
     [Produces("application/json")]
-    [ProducesResponseType(typeof(InstanceDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(InstanceResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [RequestSizeLimit(RequestSizeLimit)]
-    public async Task<ActionResult<InstanceDto>> PostSimplified(
+    public async Task<ActionResult<InstanceResponse>> PostSimplified(
         [FromRoute] string org,
         [FromRoute] string app,
         [FromBody] InstansiationInstance instansiationInstance
@@ -598,7 +598,7 @@ public class InstancesController : ControllerBase
         SelfLinkHelper.SetInstanceAppSelfLinks(instance, Request);
         string url = instance.SelfLinks.Apps;
 
-        var dto = InstanceDto.From(instance, party);
+        var dto = InstanceResponse.From(instance, party);
 
         return Created(url, dto);
     }

--- a/src/Altinn.App.Api/Models/InstanceDto.cs
+++ b/src/Altinn.App.Api/Models/InstanceDto.cs
@@ -1,0 +1,189 @@
+#nullable disable
+using Altinn.Platform.Register.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Newtonsoft.Json;
+
+namespace Altinn.App.Api.Models;
+
+/// <summary>
+/// Represents the response from an API endpoint providing a list of key-value properties.
+/// </summary>
+[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+public sealed class InstanceDto
+{
+    /// <summary>
+    /// Gets or sets the unique id of the instance {instanceOwnerId}/{instanceGuid}.
+    /// </summary>
+    [JsonProperty(PropertyName = "id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the instance owner information.
+    /// </summary>
+    [JsonProperty(PropertyName = "instanceOwner")]
+    public required InstanceOwnerDto InstanceOwner { get; init; }
+
+    /// <summary>
+    /// Gets or sets the id of the application this is an instance of, e.g. {org}/{app22}.
+    /// </summary>
+    [JsonProperty(PropertyName = "appId")]
+    public required string AppId { get; init; }
+
+    /// <summary>
+    /// Gets or sets application owner identifier, usually a abbreviation of organisation name. All in lower case.
+    /// </summary>
+    [JsonProperty(PropertyName = "org")]
+    public required string Org { get; init; }
+
+    /// <summary>
+    /// Gets or sets a set of URLs to access the instance metadata resource.
+    /// </summary>
+    [JsonProperty(PropertyName = "selfLinks")]
+    public required ResourceLinks SelfLinks { get; init; }
+
+    /// <summary>
+    /// Gets or sets the due date to submit the instance to application owner.
+    /// </summary>
+    [JsonProperty(PropertyName = "dueBefore")]
+    public required DateTime? DueBefore { get; init; }
+
+    /// <summary>
+    /// Gets or sets date and time for when the instance should first become visible for the instance owner.
+    /// </summary>
+    [JsonProperty(PropertyName = "visibleAfter")]
+    public required DateTime? VisibleAfter { get; init; }
+
+    /// <summary>
+    /// Gets or sets an object containing the instance process state.
+    /// </summary>
+    [JsonProperty(PropertyName = "process")]
+    public required ProcessState Process { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of finished status of the instance.
+    /// </summary>
+    [JsonProperty(PropertyName = "status")]
+    public required InstanceStatus Status { get; init; }
+
+    /// <summary>
+    /// Gets or sets a list of <see cref="CompleteConfirmation"/> elements.
+    /// </summary>
+    [JsonProperty(PropertyName = "completeConfirmations")]
+    public required IReadOnlyList<CompleteConfirmation> CompleteConfirmations { get; init; }
+
+    /// <summary>
+    /// Gets or sets a list of data elements associated with the instance
+    /// </summary>
+    [JsonProperty(PropertyName = "data")]
+    public required IReadOnlyList<DataElement> Data { get; init; }
+
+    /// <summary>
+    /// Gets or sets the presentation texts for the instance.
+    /// </summary>
+    [JsonProperty(PropertyName = "presentationTexts")]
+    public required IReadOnlyDictionary<string, string> PresentationTexts { get; init; }
+
+    /// <summary>
+    /// Gets or sets the data values for the instance.
+    /// </summary>
+    [JsonProperty(PropertyName = "dataValues")]
+    public required IReadOnlyDictionary<string, string> DataValues { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date and time for when the element was created.
+    /// </summary>
+    [JsonProperty(PropertyName = "created")]
+    public required DateTime? Created { get; init; }
+
+    /// <summary>
+    /// Gets or sets the id of the user who created this element.
+    /// </summary>
+    [JsonProperty(PropertyName = "createdBy")]
+    public required string CreatedBy { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date and time for when the element was last edited.
+    /// </summary>
+    [JsonProperty(PropertyName = "lastChanged")]
+    public required DateTime? LastChanged { get; init; }
+
+    /// <summary>
+    /// Gets or sets the id of the user who last changed this element.
+    /// </summary>
+    [JsonProperty(PropertyName = "lastChangedBy")]
+    public required string LastChangedBy { get; init; }
+
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+
+    internal static InstanceDto From(Instance instance, Party instanceOwnerParty)
+    {
+        return new InstanceDto
+        {
+            Id = instance.Id,
+            InstanceOwner = new InstanceOwnerDto
+            {
+                PartyId = instance.InstanceOwner.PartyId,
+                PersonNumber = instance.InstanceOwner.PersonNumber,
+                OrganisationNumber = instance.InstanceOwner.OrganisationNumber,
+                Username = instance.InstanceOwner.Username,
+                Party = instanceOwnerParty,
+            },
+            AppId = instance.AppId,
+            Org = instance.Org,
+            SelfLinks = instance.SelfLinks,
+            DueBefore = instance.DueBefore,
+            VisibleAfter = instance.VisibleAfter,
+            Process = instance.Process,
+            Status = instance.Status,
+            CompleteConfirmations = instance.CompleteConfirmations,
+            Data = instance.Data,
+            DataValues = instance.DataValues,
+            PresentationTexts = instance.PresentationTexts,
+            Created = instance.Created,
+            CreatedBy = instance.CreatedBy,
+            LastChanged = instance.LastChanged,
+            LastChangedBy = instance.LastChangedBy,
+        };
+    }
+}
+
+/// <summary>
+/// Represents information to identify the owner of an instance.
+/// </summary>
+[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+public class InstanceOwnerDto
+{
+    /// <summary>
+    /// Gets or sets the party id of the instance owner (also called instance owner party id).
+    /// </summary>
+    [JsonProperty(PropertyName = "partyId")]
+    public required string PartyId { get; init; }
+
+    /// <summary>
+    /// Gets or sets person number (national identification number) of the party. Null if the party is not a person.
+    /// </summary>
+    [JsonProperty(PropertyName = "personNumber")]
+    public required string PersonNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the organisation number of the party. Null if the party is not an organisation.
+    /// </summary>
+    [JsonProperty(PropertyName = "organisationNumber")]
+    public required string OrganisationNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the username of the party. Null if the party is not self identified.
+    /// </summary>
+    [JsonProperty(PropertyName = "username")]
+    public required string Username { get; init; }
+
+    /// <summary>
+    /// Party information for the instance owner.
+    /// </summary>
+    [JsonProperty(PropertyName = "party")]
+    public required Party Party { get; init; }
+}

--- a/src/Altinn.App.Api/Models/InstanceResponse.cs
+++ b/src/Altinn.App.Api/Models/InstanceResponse.cs
@@ -8,109 +8,91 @@ namespace Altinn.App.Api.Models;
 /// <summary>
 /// Represents the response from an API endpoint providing a list of key-value properties.
 /// </summary>
-[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
-public sealed class InstanceDto
+public sealed class InstanceResponse
 {
     /// <summary>
     /// Gets or sets the unique id of the instance {instanceOwnerId}/{instanceGuid}.
     /// </summary>
-    [JsonProperty(PropertyName = "id")]
     public required string Id { get; init; }
 
     /// <summary>
     /// Gets or sets the instance owner information.
     /// </summary>
-    [JsonProperty(PropertyName = "instanceOwner")]
-    public required InstanceOwnerDto InstanceOwner { get; init; }
+    public required InstanceOwnerResponse InstanceOwner { get; init; }
 
     /// <summary>
     /// Gets or sets the id of the application this is an instance of, e.g. {org}/{app22}.
     /// </summary>
-    [JsonProperty(PropertyName = "appId")]
     public required string AppId { get; init; }
 
     /// <summary>
     /// Gets or sets application owner identifier, usually a abbreviation of organisation name. All in lower case.
     /// </summary>
-    [JsonProperty(PropertyName = "org")]
     public required string Org { get; init; }
 
     /// <summary>
     /// Gets or sets a set of URLs to access the instance metadata resource.
     /// </summary>
-    [JsonProperty(PropertyName = "selfLinks")]
     public required ResourceLinks SelfLinks { get; init; }
 
     /// <summary>
     /// Gets or sets the due date to submit the instance to application owner.
     /// </summary>
-    [JsonProperty(PropertyName = "dueBefore")]
     public required DateTime? DueBefore { get; init; }
 
     /// <summary>
     /// Gets or sets date and time for when the instance should first become visible for the instance owner.
     /// </summary>
-    [JsonProperty(PropertyName = "visibleAfter")]
     public required DateTime? VisibleAfter { get; init; }
 
     /// <summary>
     /// Gets or sets an object containing the instance process state.
     /// </summary>
-    [JsonProperty(PropertyName = "process")]
     public required ProcessState Process { get; init; }
 
     /// <summary>
     /// Gets or sets the type of finished status of the instance.
     /// </summary>
-    [JsonProperty(PropertyName = "status")]
     public required InstanceStatus Status { get; init; }
 
     /// <summary>
     /// Gets or sets a list of <see cref="CompleteConfirmation"/> elements.
     /// </summary>
-    [JsonProperty(PropertyName = "completeConfirmations")]
     public required IReadOnlyList<CompleteConfirmation> CompleteConfirmations { get; init; }
 
     /// <summary>
     /// Gets or sets a list of data elements associated with the instance
     /// </summary>
-    [JsonProperty(PropertyName = "data")]
     public required IReadOnlyList<DataElement> Data { get; init; }
 
     /// <summary>
     /// Gets or sets the presentation texts for the instance.
     /// </summary>
-    [JsonProperty(PropertyName = "presentationTexts")]
     public required IReadOnlyDictionary<string, string> PresentationTexts { get; init; }
 
     /// <summary>
     /// Gets or sets the data values for the instance.
     /// </summary>
-    [JsonProperty(PropertyName = "dataValues")]
     public required IReadOnlyDictionary<string, string> DataValues { get; init; }
 
     /// <summary>
     /// Gets or sets the date and time for when the element was created.
     /// </summary>
-    [JsonProperty(PropertyName = "created")]
     public required DateTime? Created { get; init; }
 
     /// <summary>
     /// Gets or sets the id of the user who created this element.
     /// </summary>
-    [JsonProperty(PropertyName = "createdBy")]
     public required string CreatedBy { get; init; }
 
     /// <summary>
     /// Gets or sets the date and time for when the element was last edited.
     /// </summary>
-    [JsonProperty(PropertyName = "lastChanged")]
     public required DateTime? LastChanged { get; init; }
 
     /// <summary>
     /// Gets or sets the id of the user who last changed this element.
     /// </summary>
-    [JsonProperty(PropertyName = "lastChangedBy")]
     public required string LastChangedBy { get; init; }
 
     /// <inheritdoc/>
@@ -119,12 +101,12 @@ public sealed class InstanceDto
         return JsonConvert.SerializeObject(this);
     }
 
-    internal static InstanceDto From(Instance instance, Party instanceOwnerParty)
+    internal static InstanceResponse From(Instance instance, Party instanceOwnerParty)
     {
-        return new InstanceDto
+        return new InstanceResponse
         {
             Id = instance.Id,
-            InstanceOwner = new InstanceOwnerDto
+            InstanceOwner = new InstanceOwnerResponse
             {
                 PartyId = instance.InstanceOwner.PartyId,
                 PersonNumber = instance.InstanceOwner.PersonNumber,
@@ -154,36 +136,30 @@ public sealed class InstanceDto
 /// <summary>
 /// Represents information to identify the owner of an instance.
 /// </summary>
-[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
-public class InstanceOwnerDto
+public class InstanceOwnerResponse
 {
     /// <summary>
     /// Gets or sets the party id of the instance owner (also called instance owner party id).
     /// </summary>
-    [JsonProperty(PropertyName = "partyId")]
     public required string PartyId { get; init; }
 
     /// <summary>
     /// Gets or sets person number (national identification number) of the party. Null if the party is not a person.
     /// </summary>
-    [JsonProperty(PropertyName = "personNumber")]
     public required string PersonNumber { get; init; }
 
     /// <summary>
     /// Gets or sets the organisation number of the party. Null if the party is not an organisation.
     /// </summary>
-    [JsonProperty(PropertyName = "organisationNumber")]
     public required string OrganisationNumber { get; init; }
 
     /// <summary>
     /// Gets or sets the username of the party. Null if the party is not self identified.
     /// </summary>
-    [JsonProperty(PropertyName = "username")]
     public required string Username { get; init; }
 
     /// <summary>
     /// Party information for the instance owner.
     /// </summary>
-    [JsonProperty(PropertyName = "party")]
     public required Party Party { get; init; }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
@@ -34,7 +34,7 @@ internal sealed record InstancesControllerFixture(IServiceProvider ServiceProvid
     public Mock<T> Mock<T>()
         where T : class => Moq.Mock.Get(ServiceProvider.GetRequiredService<T>());
 
-    public static async Task<(InstanceDto Instance, string Response)> CreateInstanceSimplified(
+    public static async Task<(InstanceResponse Instance, string Response)> CreateInstanceSimplified(
         string org,
         string app,
         int instanceOwnerPartyId,
@@ -63,7 +63,7 @@ internal sealed record InstancesControllerFixture(IServiceProvider ServiceProvid
         var createResponseContent = await createResponse.Content.ReadAsStringAsync();
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createResponseContent);
 
-        var createResponseParsed = JsonSerializer.Deserialize<InstanceDto>(
+        var createResponseParsed = JsonSerializer.Deserialize<InstanceResponse>(
             createResponseContent,
             ApiTestBase.JsonSerializerOptions
         );

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
@@ -1,5 +1,10 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
 using Altinn.App.Api.Controllers;
 using Altinn.App.Api.Helpers.Patch;
+using Altinn.App.Api.Models;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers.Serialization;
@@ -13,6 +18,7 @@ using Altinn.App.Core.Internal.Profile;
 using Altinn.App.Core.Internal.Registers;
 using Altinn.App.Core.Internal.Validation;
 using Altinn.Common.PEP.Interfaces;
+using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -27,6 +33,47 @@ internal sealed record InstancesControllerFixture(IServiceProvider ServiceProvid
 {
     public Mock<T> Mock<T>()
         where T : class => Moq.Mock.Get(ServiceProvider.GetRequiredService<T>());
+
+    public static async Task<(InstanceDto Instance, string Response)> CreateInstanceSimplified(
+        string org,
+        string app,
+        int instanceOwnerPartyId,
+        HttpClient client,
+        string token,
+        Dictionary<string, string>? prefill = null
+    )
+    {
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        prefill ??= new();
+
+        // Create instance data
+        var body = $$"""
+                {
+                    "prefill": {{JsonSerializer.Serialize(prefill)}},
+                    "instanceOwner": {
+                        "partyId": "{{instanceOwnerPartyId}}"
+                    }
+                }
+            """;
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        // Create instance
+        using var createResponse = await client.PostAsync($"{org}/{app}/instances/create", content);
+        var createResponseContent = await createResponse.Content.ReadAsStringAsync();
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createResponseContent);
+
+        var createResponseParsed = JsonSerializer.Deserialize<InstanceDto>(
+            createResponseContent,
+            ApiTestBase.JsonSerializerOptions
+        );
+        Assert.NotNull(createResponseParsed);
+
+        // Verify Data id
+        var instanceId = createResponseParsed.Id;
+        instanceId.Should().NotBeNullOrWhiteSpace();
+        return (createResponseParsed, createResponseContent);
+    }
 
     public void VerifyNoOtherCalls(
         bool verifyDataClient = true,

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.ReturnsOkResult_Deserialized.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.ReturnsOkResult_Deserialized.verified.txt
@@ -1,0 +1,105 @@
+﻿{
+  CreatedInstance: {
+    Id: <instancOwnerPartyId>/<instanceGuid>,
+    InstanceOwner: {
+      PartyId: 501337,
+      PersonNumber: 01039012345,
+      Party: {
+        PartyId: 501337,
+        PartyTypeName: Person,
+        SSN: 01039012345,
+        Name: Sophie Salt,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false
+      }
+    },
+    AppId: tdd/contributer-restriction,
+    Org: tdd,
+    SelfLinks: {
+      Apps: https://localhost/tdd/contributer-restriction/instances/<instancOwnerPartyId>/<instanceGuid>
+    },
+    Process: {
+      Started: DateTime_1,
+      StartEvent: StartEvent_1,
+      CurrentTask: {
+        Flow: 2,
+        Started: DateTime_2,
+        ElementId: Task_1,
+        Name: Utfylling,
+        AltinnTaskType: data,
+        FlowType: CompleteCurrentMoveToNext
+      }
+    },
+    Status: {
+      IsArchived: false,
+      IsSoftDeleted: false,
+      IsHardDeleted: false,
+      ReadStatus: Read
+    },
+    Data: [
+      {
+        Id: Guid_1,
+        InstanceGuid: Guid_2,
+        DataType: default,
+        ContentType: application/xml,
+        SelfLinks: {
+          Apps: https://localhost/tdd/contributer-restriction/instances/<instancOwnerPartyId>/<instanceGuid>/data/<dataId>
+        },
+        Locked: false,
+        IsRead: true
+      }
+    ]
+  },
+  ReadInstance: {
+    Id: <instancOwnerPartyId>/<instanceGuid>,
+    InstanceOwner: {
+      PartyId: 501337,
+      PersonNumber: 01039012345,
+      Party: {
+        PartyId: 501337,
+        PartyTypeName: Person,
+        SSN: 01039012345,
+        Name: Sophie Salt,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false
+      }
+    },
+    AppId: tdd/contributer-restriction,
+    Org: tdd,
+    SelfLinks: {
+      Apps: https://localhost/tdd/contributer-restriction/instances/<instancOwnerPartyId>/<instanceGuid>
+    },
+    Process: {
+      Started: DateTime_1,
+      StartEvent: StartEvent_1,
+      CurrentTask: {
+        Flow: 2,
+        Started: DateTime_2,
+        ElementId: Task_1,
+        Name: Utfylling,
+        AltinnTaskType: data,
+        FlowType: CompleteCurrentMoveToNext
+      }
+    },
+    Status: {
+      IsArchived: false,
+      IsSoftDeleted: false,
+      IsHardDeleted: false,
+      ReadStatus: Read
+    },
+    Data: [
+      {
+        Id: Guid_1,
+        InstanceGuid: Guid_2,
+        DataType: default,
+        ContentType: application/xml,
+        SelfLinks: {
+          Apps: https://localhost/tdd/contributer-restriction/instances/<instancOwnerPartyId>/<instanceGuid>/data/<dataId>
+        },
+        Locked: false,
+        IsRead: true
+      }
+    ],
+    LastChanged: DateTime_3
+  }
+}

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.ReturnsOkResult_Raw.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.ReturnsOkResult_Raw.verified.txt
@@ -1,0 +1,186 @@
+﻿{
+  createdResponse: {
+    id: <instancOwnerPartyId>/<instanceGuid>,
+    instanceOwner: {
+      partyId: 501337,
+      personNumber: 01039012345,
+      organisationNumber: null,
+      username: null,
+      party: {
+        partyId: 501337,
+        partyUuid: null,
+        partyTypeName: 1,
+        orgNumber: null,
+        ssn: 01039012345,
+        unitType: null,
+        name: Sophie Salt,
+        isDeleted: false,
+        onlyHierarchyElementWithNoAccess: false,
+        person: null,
+        organization: null,
+        childParties: null
+      }
+    },
+    appId: tdd/contributer-restriction,
+    org: tdd,
+    selfLinks: {
+      apps: https://localhost/tdd/contributer-restriction/instances/<instancOwnerPartyId>/<instanceGuid>,
+      platform: null
+    },
+    dueBefore: null,
+    visibleAfter: null,
+    process: {
+      started: DateTimeOffset_1,
+      startEvent: StartEvent_1,
+      currentTask: {
+        flow: 2,
+        started: DateTimeOffset_2,
+        elementId: Task_1,
+        name: Utfylling,
+        altinnTaskType: data,
+        ended: null,
+        validated: null,
+        flowType: CompleteCurrentMoveToNext
+      },
+      ended: null,
+      endEvent: null
+    },
+    status: {
+      isArchived: false,
+      archived: null,
+      isSoftDeleted: false,
+      softDeleted: null,
+      isHardDeleted: false,
+      hardDeleted: null,
+      readStatus: 1,
+      substatus: null
+    },
+    completeConfirmations: null,
+    data: [
+      {
+        id: Guid_1,
+        instanceGuid: Guid_2,
+        dataType: default,
+        filename: null,
+        contentType: application/xml,
+        blobStoragePath: null,
+        selfLinks: {
+          apps: https://localhost/tdd/contributer-restriction/instances/<instancOwnerPartyId>/<instanceGuid>/data/<dataId>,
+          platform: null
+        },
+        size: 0,
+        contentHash: null,
+        locked: false,
+        refs: null,
+        isRead: true,
+        userDefinedMetadata: null,
+        metadata: null,
+        deleteStatus: null,
+        fileScanResult: NotApplicable,
+        references: null,
+        created: null,
+        createdBy: null,
+        lastChanged: null,
+        lastChangedBy: null
+      }
+    ],
+    presentationTexts: null,
+    dataValues: null,
+    created: null,
+    createdBy: null,
+    lastChanged: null,
+    lastChangedBy: null
+  },
+  readResponse: {
+    id: <instancOwnerPartyId>/<instanceGuid>,
+    instanceOwner: {
+      partyId: 501337,
+      personNumber: 01039012345,
+      organisationNumber: null,
+      username: null,
+      party: {
+        partyId: 501337,
+        partyUuid: null,
+        partyTypeName: 1,
+        orgNumber: null,
+        ssn: 01039012345,
+        unitType: null,
+        name: Sophie Salt,
+        isDeleted: false,
+        onlyHierarchyElementWithNoAccess: false,
+        person: null,
+        organization: null,
+        childParties: null
+      }
+    },
+    appId: tdd/contributer-restriction,
+    org: tdd,
+    selfLinks: {
+      apps: https://localhost/tdd/contributer-restriction/instances/<instancOwnerPartyId>/<instanceGuid>,
+      platform: null
+    },
+    dueBefore: null,
+    visibleAfter: null,
+    process: {
+      started: DateTimeOffset_1,
+      startEvent: StartEvent_1,
+      currentTask: {
+        flow: 2,
+        started: DateTimeOffset_2,
+        elementId: Task_1,
+        name: Utfylling,
+        altinnTaskType: data,
+        ended: null,
+        validated: null,
+        flowType: CompleteCurrentMoveToNext
+      },
+      ended: null,
+      endEvent: null
+    },
+    status: {
+      isArchived: false,
+      archived: null,
+      isSoftDeleted: false,
+      softDeleted: null,
+      isHardDeleted: false,
+      hardDeleted: null,
+      readStatus: 1,
+      substatus: null
+    },
+    completeConfirmations: null,
+    data: [
+      {
+        id: Guid_1,
+        instanceGuid: Guid_2,
+        dataType: default,
+        filename: null,
+        contentType: application/xml,
+        blobStoragePath: null,
+        selfLinks: {
+          apps: https://localhost/tdd/contributer-restriction/instances/<instancOwnerPartyId>/<instanceGuid>/data/<dataId>,
+          platform: null
+        },
+        size: 0,
+        contentHash: null,
+        locked: false,
+        refs: null,
+        isRead: true,
+        userDefinedMetadata: null,
+        metadata: null,
+        deleteStatus: null,
+        fileScanResult: NotApplicable,
+        references: null,
+        created: null,
+        createdBy: null,
+        lastChanged: null,
+        lastChangedBy: null
+      }
+    ],
+    presentationTexts: null,
+    dataValues: null,
+    created: null,
+    createdBy: null,
+    lastChanged: DateTimeOffset_3,
+    lastChangedBy: null
+  }
+}

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.cs
@@ -39,7 +39,7 @@ public class InstancesController_GetTests : ApiTestBase, IClassFixture<WebApplic
         using var readResponse = await client.GetAsync($"{org}/{app}/instances/{createdInstance.Id}");
         Assert.Equal(HttpStatusCode.OK, readResponse.StatusCode);
         var readResponseContent = await readResponse.Content.ReadAsStringAsync();
-        var readInstance = JsonSerializer.Deserialize<InstanceDto>(
+        var readInstance = JsonSerializer.Deserialize<InstanceResponse>(
             readResponseContent,
             ApiTestBase.JsonSerializerOptions
         );
@@ -85,7 +85,7 @@ public class InstancesController_GetTests : ApiTestBase, IClassFixture<WebApplic
         using var readResponse = await client.GetAsync($"{org}/{app}/instances/{createdInstance.Id}");
         Assert.Equal(HttpStatusCode.OK, readResponse.StatusCode);
         var readResponseContent = await readResponse.Content.ReadAsStringAsync();
-        var readInstance = JsonSerializer.Deserialize<InstanceDto>(
+        var readInstance = JsonSerializer.Deserialize<InstanceResponse>(
             readResponseContent,
             ApiTestBase.JsonSerializerOptions
         );

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Altinn.App.Api.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit.Abstractions;
+
+namespace Altinn.App.Api.Tests.Controllers;
+
+public class InstancesController_GetTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
+{
+    public InstancesController_GetTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+        : base(factory, outputHelper)
+    {
+        OverrideServicesForAllTests = (services) => { };
+    }
+
+    [Fact]
+    public async Task ReturnsOkResult_Raw()
+    {
+        // Arrange
+        string org = "tdd";
+        string app = "contributer-restriction";
+        var userId = 1337;
+        int instanceOwnerPartyId = 501337;
+
+        using HttpClient client = GetRootedClient(org, app, includeTraceContext: true);
+        string token = TestAuthentication.GetUserToken(userId: userId, partyId: instanceOwnerPartyId);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var (createdInstance, createdResponse) = await InstancesControllerFixture.CreateInstanceSimplified(
+            org,
+            app,
+            instanceOwnerPartyId,
+            client,
+            token
+        );
+
+        using var readResponse = await client.GetAsync($"{org}/{app}/instances/{createdInstance.Id}");
+        Assert.Equal(HttpStatusCode.OK, readResponse.StatusCode);
+        var readResponseContent = await readResponse.Content.ReadAsStringAsync();
+        var readInstance = JsonSerializer.Deserialize<InstanceDto>(
+            readResponseContent,
+            ApiTestBase.JsonSerializerOptions
+        );
+
+        await VerifyJson(
+                $$"""
+                    {
+                        "createdResponse": {{createdResponse}},
+                        "readResponse": {{readResponseContent}},
+                    }
+                """
+            )
+            .ScrubLinesWithReplace(line =>
+            {
+                line = line.Replace(createdInstance.Id, "<instancOwnerPartyId>/<instanceGuid>");
+                foreach (var data in createdInstance.Data)
+                    line = line.Replace(data.Id, "<dataId>");
+                return line;
+            });
+    }
+
+    [Fact]
+    public async Task ReturnsOkResult_Deserialized()
+    {
+        // Arrange
+        string org = "tdd";
+        string app = "contributer-restriction";
+        var userId = 1337;
+        int instanceOwnerPartyId = 501337;
+
+        using HttpClient client = GetRootedClient(org, app, includeTraceContext: true);
+        string token = TestAuthentication.GetUserToken(userId: userId, partyId: instanceOwnerPartyId);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var (createdInstance, createdResponse) = await InstancesControllerFixture.CreateInstanceSimplified(
+            org,
+            app,
+            instanceOwnerPartyId,
+            client,
+            token
+        );
+
+        using var readResponse = await client.GetAsync($"{org}/{app}/instances/{createdInstance.Id}");
+        Assert.Equal(HttpStatusCode.OK, readResponse.StatusCode);
+        var readResponseContent = await readResponse.Content.ReadAsStringAsync();
+        var readInstance = JsonSerializer.Deserialize<InstanceDto>(
+            readResponseContent,
+            ApiTestBase.JsonSerializerOptions
+        );
+
+        await Verify(new { CreatedInstance = createdInstance, ReadInstance = readInstance })
+            .ScrubLinesWithReplace(line =>
+            {
+                line = line.Replace(createdInstance.Id, "<instancOwnerPartyId>/<instanceGuid>");
+                foreach (var data in createdInstance.Data)
+                    line = line.Replace(data.Id, "<dataId>");
+                return line;
+            });
+    }
+}

--- a/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
+++ b/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
@@ -26,7 +26,7 @@ namespace Altinn.App.Api.Tests;
 
 public class ApiTestBase
 {
-    protected static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
+    internal static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         PropertyNameCaseInsensitive = true,

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -2303,7 +2303,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InstanceDto"
+                  "$ref": "#/components/schemas/InstanceResponse"
                 }
               }
             }
@@ -2434,7 +2434,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InstanceDto"
+                  "$ref": "#/components/schemas/InstanceResponse"
                 }
               }
             }
@@ -2504,7 +2504,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/InstanceDto"
+                  "$ref": "#/components/schemas/InstanceResponse"
                 }
               }
             }
@@ -6930,7 +6930,91 @@
         },
         "additionalProperties": false
       },
-      "InstanceDto": {
+      "InstanceFileScanResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Instance id",
+            "nullable": true,
+            "readOnly": true
+          },
+          "fileScanResult": {
+            "$ref": "#/components/schemas/FileScanResult"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataElementFileScanResult"
+            },
+            "description": "File scan result for individual data elements.",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Light weight model representing an instance and it's file scan result status."
+      },
+      "InstanceOwner": {
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "string",
+            "nullable": true
+          },
+          "personNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "organisationNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InstanceOwnerResponse": {
+        "required": [
+          "organisationNumber",
+          "party",
+          "partyId",
+          "personNumber",
+          "username"
+        ],
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "string",
+            "description": "Gets or sets the party id of the instance owner (also called instance owner party id).",
+            "nullable": true
+          },
+          "personNumber": {
+            "type": "string",
+            "description": "Gets or sets person number (national identification number) of the party. Null if the party is not a person.",
+            "nullable": true
+          },
+          "organisationNumber": {
+            "type": "string",
+            "description": "Gets or sets the organisation number of the party. Null if the party is not an organisation.",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Gets or sets the username of the party. Null if the party is not self identified.",
+            "nullable": true
+          },
+          "party": {
+            "$ref": "#/components/schemas/Party"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents information to identify the owner of an instance."
+      },
+      "InstanceResponse": {
         "required": [
           "appId",
           "completeConfirmations",
@@ -6958,7 +7042,7 @@
             "nullable": true
           },
           "instanceOwner": {
-            "$ref": "#/components/schemas/InstanceOwnerDto"
+            "$ref": "#/components/schemas/InstanceOwnerResponse"
           },
           "appId": {
             "type": "string",
@@ -7050,90 +7134,6 @@
         },
         "additionalProperties": false,
         "description": "Represents the response from an API endpoint providing a list of key-value properties."
-      },
-      "InstanceFileScanResult": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Instance id",
-            "nullable": true,
-            "readOnly": true
-          },
-          "fileScanResult": {
-            "$ref": "#/components/schemas/FileScanResult"
-          },
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DataElementFileScanResult"
-            },
-            "description": "File scan result for individual data elements.",
-            "nullable": true,
-            "readOnly": true
-          }
-        },
-        "additionalProperties": false,
-        "description": "Light weight model representing an instance and it's file scan result status."
-      },
-      "InstanceOwner": {
-        "type": "object",
-        "properties": {
-          "partyId": {
-            "type": "string",
-            "nullable": true
-          },
-          "personNumber": {
-            "type": "string",
-            "nullable": true
-          },
-          "organisationNumber": {
-            "type": "string",
-            "nullable": true
-          },
-          "username": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "InstanceOwnerDto": {
-        "required": [
-          "organisationNumber",
-          "party",
-          "partyId",
-          "personNumber",
-          "username"
-        ],
-        "type": "object",
-        "properties": {
-          "partyId": {
-            "type": "string",
-            "description": "Gets or sets the party id of the instance owner (also called instance owner party id).",
-            "nullable": true
-          },
-          "personNumber": {
-            "type": "string",
-            "description": "Gets or sets person number (national identification number) of the party. Null if the party is not a person.",
-            "nullable": true
-          },
-          "organisationNumber": {
-            "type": "string",
-            "description": "Gets or sets the organisation number of the party. Null if the party is not an organisation.",
-            "nullable": true
-          },
-          "username": {
-            "type": "string",
-            "description": "Gets or sets the username of the party. Null if the party is not self identified.",
-            "nullable": true
-          },
-          "party": {
-            "$ref": "#/components/schemas/Party"
-          }
-        },
-        "additionalProperties": false,
-        "description": "Represents information to identify the owner of an instance."
       },
       "InstanceSelection": {
         "type": "object",

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -2303,7 +2303,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Instance"
+                  "$ref": "#/components/schemas/InstanceDto"
                 }
               }
             }
@@ -2434,7 +2434,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Instance"
+                  "$ref": "#/components/schemas/InstanceDto"
                 }
               }
             }
@@ -2504,7 +2504,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Instance"
+                  "$ref": "#/components/schemas/InstanceDto"
                 }
               }
             }
@@ -6930,6 +6930,127 @@
         },
         "additionalProperties": false
       },
+      "InstanceDto": {
+        "required": [
+          "appId",
+          "completeConfirmations",
+          "created",
+          "createdBy",
+          "data",
+          "dataValues",
+          "dueBefore",
+          "id",
+          "instanceOwner",
+          "lastChanged",
+          "lastChangedBy",
+          "org",
+          "presentationTexts",
+          "process",
+          "selfLinks",
+          "status",
+          "visibleAfter"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Gets or sets the unique id of the instance {instanceOwnerId}/{instanceGuid}.",
+            "nullable": true
+          },
+          "instanceOwner": {
+            "$ref": "#/components/schemas/InstanceOwnerDto"
+          },
+          "appId": {
+            "type": "string",
+            "description": "Gets or sets the id of the application this is an instance of, e.g. {org}/{app22}.",
+            "nullable": true
+          },
+          "org": {
+            "type": "string",
+            "description": "Gets or sets application owner identifier, usually a abbreviation of organisation name. All in lower case.",
+            "nullable": true
+          },
+          "selfLinks": {
+            "$ref": "#/components/schemas/ResourceLinks"
+          },
+          "dueBefore": {
+            "type": "string",
+            "description": "Gets or sets the due date to submit the instance to application owner.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "visibleAfter": {
+            "type": "string",
+            "description": "Gets or sets date and time for when the instance should first become visible for the instance owner.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "process": {
+            "$ref": "#/components/schemas/ProcessState"
+          },
+          "status": {
+            "$ref": "#/components/schemas/InstanceStatus"
+          },
+          "completeConfirmations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompleteConfirmation"
+            },
+            "description": "Gets or sets a list of Altinn.Platform.Storage.Interface.Models.CompleteConfirmation elements.",
+            "nullable": true
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataElement"
+            },
+            "description": "Gets or sets a list of data elements associated with the instance",
+            "nullable": true
+          },
+          "presentationTexts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets the presentation texts for the instance.",
+            "nullable": true
+          },
+          "dataValues": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": "Gets or sets the data values for the instance.",
+            "nullable": true
+          },
+          "created": {
+            "type": "string",
+            "description": "Gets or sets the date and time for when the element was created.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Gets or sets the id of the user who created this element.",
+            "nullable": true
+          },
+          "lastChanged": {
+            "type": "string",
+            "description": "Gets or sets the date and time for when the element was last edited.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastChangedBy": {
+            "type": "string",
+            "description": "Gets or sets the id of the user who last changed this element.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents the response from an API endpoint providing a list of key-value properties."
+      },
       "InstanceFileScanResult": {
         "type": "object",
         "properties": {
@@ -6976,6 +7097,43 @@
           }
         },
         "additionalProperties": false
+      },
+      "InstanceOwnerDto": {
+        "required": [
+          "organisationNumber",
+          "party",
+          "partyId",
+          "personNumber",
+          "username"
+        ],
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "string",
+            "description": "Gets or sets the party id of the instance owner (also called instance owner party id).",
+            "nullable": true
+          },
+          "personNumber": {
+            "type": "string",
+            "description": "Gets or sets person number (national identification number) of the party. Null if the party is not a person.",
+            "nullable": true
+          },
+          "organisationNumber": {
+            "type": "string",
+            "description": "Gets or sets the organisation number of the party. Null if the party is not an organisation.",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "description": "Gets or sets the username of the party. Null if the party is not self identified.",
+            "nullable": true
+          },
+          "party": {
+            "$ref": "#/components/schemas/Party"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Represents information to identify the owner of an instance."
       },
       "InstanceSelection": {
         "type": "object",
@@ -7328,6 +7486,136 @@
         "additionalProperties": false,
         "description": "Contains details about an organisation"
       },
+      "Organization": {
+        "type": "object",
+        "properties": {
+          "orgNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "unitType": {
+            "type": "string",
+            "nullable": true
+          },
+          "telephoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "mobileNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "faxNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "eMailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "internetAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "mailingAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "mailingPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "mailingPostalCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "businessAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "businessPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "businessPostalCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "unitStatus": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Party": {
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "partyUuid": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "partyTypeName": {
+            "$ref": "#/components/schemas/PartyType"
+          },
+          "orgNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssn": {
+            "type": "string",
+            "nullable": true
+          },
+          "unitType": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "onlyHierarchyElementWithNoAccess": {
+            "type": "boolean"
+          },
+          "person": {
+            "$ref": "#/components/schemas/Person"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/Organization"
+          },
+          "childParties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Party"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PartyType": {
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
       "PartyTypesAllowed": {
         "type": "object",
         "properties": {
@@ -7596,6 +7884,85 @@
           "Skipped"
         ],
         "type": "string"
+      },
+      "Person": {
+        "type": "object",
+        "properties": {
+          "ssn": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "middleName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "telephoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "mobileNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "mailingAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "mailingPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "mailingPostalCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressMunicipalNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressMunicipalName": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressStreetName": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressHouseNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressHouseLetter": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "dateOfDeath": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       },
       "PersonDetails": {
         "required": [


### PR DESCRIPTION
## Description
This is to enable frontend in using information about the party in e.g. appheader.

APIs:
* Create instance
* Get instance

APIs not touched
* Patching
* User actions
* ...etc

## Related Issue(s)
-  https://github.com/Altinn/altinn-support-private/issues/4177

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
