### PR TITLE
Remove self identified users as a special case in `Authenticated`

### DIFF
--- a/src/Altinn.App.Api/Controllers/ActionsController.cs
+++ b/src/Altinn.App.Api/Controllers/ActionsController.cs
@@ -109,7 +109,6 @@ public class ActionsController : ControllerBase
         {
             case Authenticated.User:
             case Authenticated.SystemUser:
-            case Authenticated.SelfIdentifiedUser:
                 break;
             default:
                 return Unauthorized();

--- a/src/Altinn.App.Api/Controllers/AuthorizationController.cs
+++ b/src/Altinn.App.Api/Controllers/AuthorizationController.cs
@@ -79,16 +79,6 @@ public class AuthorizationController : Controller
                 }
                 return Ok(reportee.PartyId);
             }
-            case Authenticated.SelfIdentifiedUser selfIdentified:
-            {
-                var details = await selfIdentified.LoadDetails();
-                if (returnPartyObject)
-                {
-                    return Ok(details.Party);
-                }
-
-                return Ok(details.Party.PartyId);
-            }
             case Authenticated.Org org:
             {
                 var details = await org.LoadDetails();

--- a/src/Altinn.App.Api/Controllers/ProfileController.cs
+++ b/src/Altinn.App.Api/Controllers/ProfileController.cs
@@ -37,11 +37,6 @@ public class ProfileController : Controller
                 var details = await user.LoadDetails(validateSelectedParty: false);
                 return Ok(details.Profile);
             }
-            case Authenticated.SelfIdentifiedUser selfIdentifiedUser:
-            {
-                var details = await selfIdentifiedUser.LoadDetails();
-                return Ok(details.Profile);
-            }
             default:
                 return BadRequest($"Unknown authentication context: {context.GetType().Name}");
         }

--- a/src/Altinn.App.Api/Controllers/StatelessDataController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessDataController.cs
@@ -347,7 +347,6 @@ public class StatelessDataController : ControllerBase
             Party? party = currentAuth switch
             {
                 Authenticated.User auth => await auth.LookupSelectedParty(),
-                Authenticated.SelfIdentifiedUser auth => (await auth.LoadDetails()).Party,
                 Authenticated.Org auth => (await auth.LoadDetails()).Party,
                 Authenticated.ServiceOwner auth => (await auth.LoadDetails()).Party,
                 Authenticated.SystemUser auth => (await auth.LoadDetails()).Party,

--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -51,12 +51,7 @@ public class SigningUserAction : IUserAction
     /// <exception cref="ApplicationConfigException"></exception>
     public async Task<UserActionResult> HandleAction(UserActionContext context)
     {
-        if (
-            context.Authentication
-            is not Authenticated.User
-                and not Authenticated.SelfIdentifiedUser
-                and not Authenticated.SystemUser
-        )
+        if (context.Authentication is not Authenticated.User and not Authenticated.SystemUser)
         {
             return UserActionResult.FailureResult(
                 error: new ActionError() { Code = "NoUserId", Message = "User id is missing in token" },
@@ -157,8 +152,6 @@ public class SigningUserAction : IUserAction
                     OrganisationNumber = userProfile.Party.OrgNumber,
                 };
             }
-            case Authenticated.SelfIdentifiedUser selfIdentifiedUser:
-                return new Signee { UserId = selfIdentifiedUser.UserId.ToString(CultureInfo.InvariantCulture) };
             case Authenticated.SystemUser systemUser:
                 return new Signee
                 {

--- a/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
+++ b/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
@@ -83,8 +83,6 @@ public class UniqueSignatureAuthorizer : IUserActionAuthorizer
                 bool unauthorized = context.Authentication switch
                 {
                     Authenticated.User a => a.UserId.ToString(CultureInfo.InvariantCulture) == signee?.UserId,
-                    Authenticated.SelfIdentifiedUser a => a.UserId.ToString(CultureInfo.InvariantCulture)
-                        == signee?.UserId,
                     Authenticated.SystemUser a => a.SystemUserId[0] == signee?.SystemUserId,
                     _ => false,
                 };

--- a/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
-using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Features.Maskinporten.Constants;
@@ -106,6 +105,10 @@ public abstract class Authenticated
 
         /// <summary>
         /// The party the user has selected through party selection
+        /// If the current request is related to an active instance, this value is not relevant.
+        /// The selected party ID is always whatever the user has selected in the party selection screen.
+        /// Party selection is used for instantiating new instances. The selected party ID becomes the instance owner party ID
+        /// when instantiating.
         /// </summary>
         public int SelectedPartyId { get; }
 
@@ -867,7 +870,7 @@ public abstract class Authenticated
         return NewUser(ref context);
     }
 
-    static Authenticated NewUser(ref ParseContext context)
+    static Authenticated.User NewUser(ref ParseContext context)
     {
         if (!context.UserIdClaim.Exists)
             throw new AuthenticationContextException("Missing user ID claim for user token");

--- a/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Features.Maskinporten.Constants;
@@ -58,13 +59,12 @@ public abstract class Authenticated
     {
         string language = LanguageConst.Nb;
 
-        if (this is not User and not SelfIdentifiedUser)
+        if (this is not User)
             return language;
 
         var profile = this switch
         {
             User user => await user.LookupProfile(),
-            SelfIdentifiedUser selfIdentifiedUser => (await selfIdentifiedUser.LoadDetails()).Profile,
             _ => throw new InvalidOperationException($"Unexpected case: {this.GetType().Name}"),
         };
 
@@ -94,6 +94,12 @@ public abstract class Authenticated
         public int UserId { get; }
 
         /// <summary>
+        /// Username of the registered user, only relevant for self-identified/self-registered users.
+        /// E.g. BankID doesn't operate based on usernames, so this property would be null in that case.
+        /// </summary>
+        public string? Username { get; }
+
+        /// <summary>
         /// Party ID
         /// </summary>
         public int UserPartyId { get; }
@@ -118,6 +124,11 @@ public abstract class Authenticated
         /// </summary>
         public bool InAltinnPortal { get; }
 
+        /// <summary>
+        /// True if the user is self-identified/self-registered.
+        /// </summary>
+        public bool IsSelfIdentified => AuthenticationLevel == 0;
+
         private Details? _extra;
         private readonly Func<int, Task<UserProfile?>> _getUserProfile;
         private readonly Func<int, Task<Party?>> _lookupParty;
@@ -127,6 +138,7 @@ public abstract class Authenticated
 
         internal User(
             int userId,
+            string? username,
             int userPartyId,
             int authenticationLevel,
             string authenticationMethod,
@@ -136,6 +148,7 @@ public abstract class Authenticated
             : base(ref context)
         {
             UserId = userId;
+            Username = username;
             UserPartyId = userPartyId;
             SelectedPartyId = selectedPartyId;
             AuthenticationLevel = authenticationLevel;
@@ -303,90 +316,6 @@ public abstract class Authenticated
                 partiesAllowedToInstantiate,
                 canRepresent
             );
-            return _extra;
-        }
-    }
-
-    /// <summary>
-    /// The logged in client is a user (e.g. Altinn portal/ID-porten) with auth level 0.
-    /// This means that the user has authenticated with a username/password, which can happen using
-    /// * Altinn "self registered users"
-    /// * ID-porten through Ansattporten ("low"), MinID self registered eID
-    /// These have limited access to Altinn and can only represent themselves.
-    /// </summary>
-    public sealed class SelfIdentifiedUser : Authenticated
-    {
-        /// <summary>
-        /// Username
-        /// </summary>
-        public string Username { get; }
-
-        /// <summary>
-        /// User ID
-        /// </summary>
-        public int UserId { get; }
-
-        /// <summary>
-        /// Party ID
-        /// </summary>
-        public int PartyId { get; }
-
-        /// <summary>
-        /// Method of authentication, e.g. "idporten" or "maskinporten"
-        /// </summary>
-        public string AuthenticationMethod { get; }
-
-        private Details? _extra;
-        private readonly Func<int, Task<UserProfile?>> _getUserProfile;
-        private readonly ApplicationMetadata _appMetadata;
-
-        internal SelfIdentifiedUser(
-            string username,
-            int userId,
-            int partyId,
-            string authenticationMethod,
-            ref ParseContext context
-        )
-            : base(ref context)
-        {
-            Username = username;
-            UserId = userId;
-            PartyId = partyId;
-            AuthenticationMethod = authenticationMethod;
-            // Since they are self-identified, they are always 0
-            AuthenticationLevel = 0;
-            _getUserProfile = context.GetUserProfile;
-            _appMetadata = context.AppMetadata;
-        }
-
-        /// <summary>
-        /// Authentication level
-        /// </summary>
-        public int AuthenticationLevel { get; }
-
-        /// <summary>
-        /// Detailed information about a logged in user
-        /// </summary>
-        public sealed record Details(Party Party, UserProfile Profile, bool RepresentsSelf, bool CanInstantiate);
-
-        /// <summary>
-        /// Load the details for the current user.
-        /// </summary>
-        /// <returns></returns>
-        public async Task<Details> LoadDetails()
-        {
-            if (_extra is not null)
-                return _extra;
-
-            var userProfile =
-                await _getUserProfile(UserId)
-                ?? throw new AuthenticationContextException(
-                    $"Could not get user profile for logged in self identified user: {UserId}"
-                );
-
-            var party = userProfile.Party;
-            var canInstantiate = InstantiationHelper.IsPartyAllowedToInstantiate(party, _appMetadata.PartyTypesAllowed);
-            _extra = new Details(party, userProfile, RepresentsSelf: true, canInstantiate);
             return _extra;
         }
     }
@@ -690,13 +619,6 @@ public abstract class Authenticated
             throw new AuthenticationContextException("Missing party ID for user token");
 
         ParseAuthLevel(context.AuthLevelClaim, out authLevel);
-        if (authLevel == 0)
-        {
-            if (!context.UsernameClaim.IsValidString(out var usernameClaimValue))
-                throw new AuthenticationContextException("Missing username claim for self-identified user token");
-
-            return new SelfIdentifiedUser(usernameClaimValue, userId, partyId.Value, "localtest", ref context);
-        }
 
         int selectedPartyId = partyId.Value;
         if (getSelectedParty() is { } selectedPartyStr)
@@ -706,8 +628,17 @@ public abstract class Authenticated
 
             selectedPartyId = selectedParty;
         }
+        context.UsernameClaim.IsValidString(out var usernameClaimValue);
 
-        return new User(userId, partyId.Value, authLevel, "localtest", selectedPartyId, ref context);
+        return new User(
+            userId,
+            usernameClaimValue,
+            partyId.Value,
+            authLevel,
+            "localtest",
+            selectedPartyId,
+            ref context
+        );
     }
 
     internal record struct ParseContext(
@@ -959,19 +890,6 @@ public abstract class Authenticated
             throw new AuthenticationContextException("Missing or invalid authentication method claim for user token");
 
         ParseAuthLevel(context.AuthLevelClaim, out var authLevel);
-        if (authLevel == 0)
-        {
-            if (!context.UsernameClaim.IsValidString(out var usernameClaimValue))
-                throw new AuthenticationContextException("Missing username claim for self-identified user token");
-
-            return new SelfIdentifiedUser(
-                usernameClaimValue,
-                userId.Value,
-                partyId.Value,
-                authMethodClaimValue,
-                ref context
-            );
-        }
 
         int selectedPartyId = partyId.Value;
         if (context.GetSelectedParty() is { } selectedPartyStr)
@@ -982,7 +900,17 @@ public abstract class Authenticated
             selectedPartyId = selectedParty;
         }
 
-        return new User(userId.Value, partyId.Value, authLevel, authMethodClaimValue, selectedPartyId, ref context);
+        context.UsernameClaim.IsValidString(out var usernameClaimValue);
+
+        return new User(
+            userId.Value,
+            usernameClaimValue,
+            partyId.Value,
+            authLevel,
+            authMethodClaimValue,
+            selectedPartyId,
+            ref context
+        );
     }
 
     static Org NewOrg(ref ParseContext context)

--- a/src/Altinn.App.Core/Features/Telemetry/TelemetryActivityExtensions.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/TelemetryActivityExtensions.cs
@@ -373,14 +373,6 @@ public static class TelemetryActivityExtensions
                 activity.SetTag(Labels.UserAuthenticationInAltinnPortal, auth.InAltinnPortal);
                 break;
             }
-            case Authenticated.SelfIdentifiedUser auth:
-            {
-                activity.SetUserId(auth.UserId);
-                activity.SetUserPartyId(auth.PartyId);
-                activity.SetAuthenticationMethod(auth.AuthenticationMethod);
-                activity.SetAuthenticationLevel(auth.AuthenticationLevel);
-                break;
-            }
             case Authenticated.Org auth:
             {
                 activity.SetOrganisationNumber(auth.OrgNo);

--- a/src/Altinn.App.Core/Implementation/PrefillSI.cs
+++ b/src/Altinn.App.Core/Implementation/PrefillSI.cs
@@ -93,7 +93,6 @@ public class PrefillSI : IPrefill
         Party? party = currentAuth switch
         {
             Authenticated.User user when user.SelectedPartyId == partyIdNum => await user.LookupSelectedParty(),
-            Authenticated.SelfIdentifiedUser user when user.PartyId == partyIdNum => (await user.LoadDetails()).Party,
             Authenticated.SystemUser systemUser
                 when await systemUser.LoadDetails() is { } details && details.Party.PartyId == partyIdNum =>
                 details.Party,
@@ -123,12 +122,6 @@ public class PrefillSI : IPrefill
                     case Authenticated.User user:
                     {
                         var details = await user.LoadDetails(validateSelectedParty: false);
-                        userProfile = details.Profile;
-                        break;
-                    }
-                    case Authenticated.SelfIdentifiedUser user:
-                    {
-                        var details = await user.LoadDetails();
                         userProfile = details.Profile;
                         break;
                     }

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
@@ -161,7 +161,6 @@ public class ProcessEngine : IProcessEngine
         int? userId = currentAuth switch
         {
             Authenticated.User auth => auth.UserId,
-            Authenticated.SelfIdentifiedUser auth => auth.UserId,
             _ => null,
         };
         UserActionResult actionResult = actionHandler is null
@@ -377,17 +376,6 @@ public class ProcessEngine : IProcessEngine
                     UserId = auth.UserId,
                     AuthenticationLevel = auth.AuthenticationLevel,
                     NationalIdentityNumber = details.Profile.Party.SSN,
-                };
-                break;
-            }
-            case Authenticated.SelfIdentifiedUser auth:
-            {
-                var details = await auth.LoadDetails();
-                user = new PlatformUser
-                {
-                    UserId = auth.UserId,
-                    AuthenticationLevel = auth.AuthenticationLevel,
-                    NationalIdentityNumber = details.Profile.Party.SSN, // This is probably null?
                 };
                 break;
             }

--- a/src/Altinn.App.Core/Models/UserAction/UserActionContext.cs
+++ b/src/Altinn.App.Core/Models/UserAction/UserActionContext.cs
@@ -85,7 +85,6 @@ public class UserActionContext
         ?? Authentication switch
         {
             Authenticated.User user => user.UserId,
-            Authenticated.SelfIdentifiedUser selfIdentifiedUser => selfIdentifiedUser.UserId,
             _ => null,
         };
 

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_SelfIdentifiedUser.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_SelfIdentifiedUser.verified.txt
@@ -28,6 +28,9 @@
           url.scheme: http
         },
         {
+          user.authentication.inAltinnPortal: True
+        },
+        {
           user.authentication.level: 0
         },
         {
@@ -40,7 +43,7 @@
           user.authentication.token.issuer: Altinn
         },
         {
-          user.authentication.type: SelfIdentifiedUser
+          user.authentication.type: User
         },
         {
           user.id: 1337

--- a/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
@@ -76,30 +76,6 @@ public class SigningUserActionTests
                     signClientMock.VerifyNoOtherCalls();
                 }
                 break;
-            case Authenticated.SelfIdentifiedUser selfIdentifiedUser:
-                {
-                    SignatureContext expected = new SignatureContext(
-                        new InstanceIdentifier(instance),
-                        instance.Process.CurrentTask.ElementId,
-                        "signature",
-                        new Signee()
-                        {
-                            UserId = selfIdentifiedUser.UserId.ToString(CultureInfo.InvariantCulture),
-                            PersonNumber = null,
-                        },
-                        new DataElementSignature("a499c3ef-e88a-436b-8650-1c43e5037ada")
-                    );
-                    signClientMock.Verify(
-                        s =>
-                            s.SignDataElements(
-                                It.Is<SignatureContext>(sc => AssertSigningContextAsExpected(sc, expected))
-                            ),
-                        Times.Once
-                    );
-                    result.Should().BeEquivalentTo(UserActionResult.SuccessResult());
-                    signClientMock.VerifyNoOtherCalls();
-                }
-                break;
             case Authenticated.SystemUser systemUser:
                 {
                     SignatureContext expected = new SignatureContext(

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=SelfIdentifiedUser_ffv+.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=SelfIdentifiedUser_ffv+.verified.txt
@@ -1,11 +1,14 @@
 ﻿{
   Description: Altinn portal tt02 self identified, token extracted from AltinnStudioRuntime cookie,
-  AuthType: Altinn.App.Core.Features.Auth.Authenticated+SelfIdentifiedUser,
+  AuthType: Altinn.App.Core.Features.Auth.Authenticated+User,
   Auth: {
-    Username: martinothamar,
     UserId: 1428813,
-    PartyId: 53328660,
+    Username: martinothamar,
+    UserPartyId: 53328660,
+    SelectedPartyId: 53328660,
     AuthenticationMethod: SelfIdentified,
+    InAltinnPortal: true,
+    IsSelfIdentified: true,
     TokenIssuer: Altinn,
     TokenIsExchanged: false,
     Scopes: altinn:portal/enduser,
@@ -25,13 +28,23 @@
     urn:altinn:username: martinothamar
   },
   Details: {
-    Party: {
+    UserParty: {
       PartyId: 53328660,
       PartyTypeName: Person,
       SSN: 12345678901,
       Name: Test Testesen,
       IsDeleted: false,
-      OnlyHierarchyElementWithNoAccess: false
+      OnlyHierarchyElementWithNoAccess: false,
+      ChildParties: []
+    },
+    SelectedParty: {
+      PartyId: 53328660,
+      PartyTypeName: Person,
+      SSN: 12345678901,
+      Name: Test Testesen,
+      IsDeleted: false,
+      OnlyHierarchyElementWithNoAccess: false,
+      ChildParties: []
     },
     Profile: {
       UserId: 1428813,
@@ -43,10 +56,33 @@
         SSN: 12345678901,
         Name: Test Testesen,
         IsDeleted: false,
-        OnlyHierarchyElementWithNoAccess: false
+        OnlyHierarchyElementWithNoAccess: false,
+        ChildParties: []
       }
     },
     RepresentsSelf: true,
-    CanInstantiate: true
+    Parties: [
+      {
+        PartyId: 53328660,
+        PartyTypeName: Person,
+        SSN: 12345678901,
+        Name: Test Testesen,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false,
+        ChildParties: []
+      }
+    ],
+    PartiesAllowedToInstantiate: [
+      {
+        PartyId: 53328660,
+        PartyTypeName: Person,
+        SSN: 12345678901,
+        Name: Test Testesen,
+        IsDeleted: false,
+        OnlyHierarchyElementWithNoAccess: false,
+        ChildParties: []
+      }
+    ],
+    CanRepresent: true
   }
 }

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=User_T1OG.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=User_T1OG.verified.txt
@@ -3,11 +3,13 @@
   AuthType: Altinn.App.Core.Features.Auth.Authenticated+User,
   Auth: {
     UserId: 1004,
+    Username: SelvRegistrert,
     UserPartyId: 510004,
     SelectedPartyId: 510004,
     AuthenticationLevel: 2,
     AuthenticationMethod: localtest,
     InAltinnPortal: true,
+    IsSelfIdentified: false,
     TokenIssuer: Altinn,
     TokenIsExchanged: false,
     Token: eyJhbGciOiJSUzI1NiIsImtpZCI6IjQ4Q0VFNjAzMzEwMkYzMjQzMTk2NDc4QUYwNkZCNDNBMTc2NEQ4NDMiLCJ4NXQiOiJTTTdtQXpFQzh5UXhsa2VLOEctME9oZGsyRU0iLCJ0eXAiOiJKV1QifQ.eyJuYW1laWQiOiIxMDA0IiwidXJuOmFsdGlubjp1c2VyaWQiOiIxMDA0IiwidXJuOmFsdGlubjp1c2VybmFtZSI6IlNlbHZSZWdpc3RyZXJ0IiwidXJuOmFsdGlubjpwYXJ0eWlkIjo1MTAwMDQsInVybjphbHRpbm46YXV0aGxldmVsIjoyLCJuYmYiOjE3NDI5MDQxMjQsImV4cCI6MTc0Mjk2MTcyNCwiaWF0IjoxNzQyOTA0MTI0fQ.XxEHCiloqnZmn8gN83Cyde8OK7BrqAhpkxTXpTFrHoumaKA63sqvOZbxbr1pakj8iNWRI7D53R4tskHRxamuHk-6A5-UEpZv9i3lukOpaqtZhPO006VFTTxlRjp5gSrX4sG6DoDBTQrHfchiAleLEmGxxtzvtIlmaehz0HhJcCLZ3Ly1_3XepdSilSPAKin80Nkads7bjTqqI4UP1UZsDz4qyjF_xN7ganGZ5aEpGNbGszhsEcS-OW5QS4BrvSZh2YPpn2-LiO9iyasYR2CwY80_P1NgQZM6DTMggcE5nuYGP1jIuj7Fj2me0NOi-qzzEibD7SRvvUJuWAdJodBbzQ

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=User_csSy.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=User_csSy.verified.txt
@@ -8,6 +8,7 @@
     AuthenticationLevel: 3,
     AuthenticationMethod: IdportenTestId,
     InAltinnPortal: true,
+    IsSelfIdentified: false,
     TokenIssuer: Altinn,
     TokenIsExchanged: false,
     Scopes: altinn:portal/enduser,

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=User_fOrK.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=User_fOrK.verified.txt
@@ -8,6 +8,7 @@
     AuthenticationLevel: 3,
     AuthenticationMethod: NotDefined,
     InAltinnPortal: true,
+    IsSelfIdentified: false,
     TokenIssuer: Altinn,
     TokenIsExchanged: false,
     Scopes: altinn:instances.read altinn:instances.write,

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=User_sUK3.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=User_sUK3.verified.txt
@@ -8,6 +8,7 @@
     AuthenticationLevel: 3,
     AuthenticationMethod: NotDefined,
     InAltinnPortal: false,
+    IsSelfIdentified: false,
     TokenIssuer: IDporten,
     TokenIsExchanged: true,
     Scopes: altinn:instances.read openid profile,

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -121,8 +121,7 @@ public sealed class ProcessEngineTest
         using var fixture = Fixture.Create(withTelemetry: true, token: token);
         var instanceOwnerPartyId = token.Auth switch
         {
-            Authenticated.User auth when await auth.LoadDetails() is { } details => details.SelectedParty.PartyId,
-            Authenticated.SelfIdentifiedUser auth => auth.PartyId,
+            Authenticated.User auth => auth.SelectedPartyId,
             Authenticated.ServiceOwner => _instanceOwnerPartyId,
             Authenticated.SystemUser auth when await auth.LoadDetails() is { } details => details.Party.PartyId,
             _ => throw new NotImplementedException(),
@@ -171,11 +170,6 @@ public sealed class ProcessEngineTest
             {
                 UserId = auth.UserId,
                 NationalIdentityNumber = details.SelectedParty.SSN,
-                AuthenticationLevel = auth.AuthenticationLevel,
-            },
-            Authenticated.SelfIdentifiedUser auth => new()
-            {
-                UserId = auth.UserId,
                 AuthenticationLevel = auth.AuthenticationLevel,
             },
             Authenticated.ServiceOwner auth => new()

--- a/test/Altinn.App.Tests.Common/Auth/TestAuthentication.cs
+++ b/test/Altinn.App.Tests.Common/Auth/TestAuthentication.cs
@@ -286,7 +286,7 @@ public static class TestAuthentication
         return new ClaimsPrincipal(new ClaimsIdentity(claims, "mock"));
     }
 
-    public static SelfIdentifiedUser GetSelfIdentifiedUserAuthentication(
+    public static User GetSelfIdentifiedUserAuthentication(
         string username = DefaultUsername,
         int userId = DefaultUserId,
         int partyId = DefaultUserPartyId,
@@ -329,10 +329,19 @@ public static class TestAuthentication
                 return Task.FromResult<Party?>(party);
             },
             lookupOrgParty: _ => throw new NotImplementedException(),
-            getPartyList: _ => throw new NotImplementedException(),
-            validateSelectedParty: (_, __) => throw new NotImplementedException()
+            getPartyList: uid =>
+            {
+                Assert.Equal(userId, uid);
+                return Task.FromResult<List<Party>?>([party]);
+            },
+            validateSelectedParty: (uid, pid) =>
+            {
+                Assert.Equal(userId, uid);
+                Assert.Equal(partyId, pid);
+                return Task.FromResult<bool?>(true);
+            }
         );
-        return Assert.IsType<SelfIdentifiedUser>(auth);
+        return Assert.IsType<User>(auth);
     }
 
     public static ClaimsPrincipal GetOrgPrincipal(string orgNumber = DefaultOrgNumber, string scope = DefaultOrgScope)


### PR DESCRIPTION
## Description
There's less of a difference between users and self identified users than I originally thought

* Self identified users can be thought of as users where auth level = 0
* Self identified users can't have roles right now, but might in the future (so they can submit "on behalf of" orgs at some point, and there's nothing stopping them in localtest currently)

The only thing brought over from `SelfIdentified` is the username claim which is only there for selfgregistered users.

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
