### PR TITLE
Preserve empty issue list from validation on UserActions

### DIFF
--- a/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
@@ -553,32 +553,22 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
 
     [Theory]
     [MemberData(nameof(PartitionValidationIssuesByDataElement))]
-    public void TestPartitionCodeForCompatibility(
-        int index,
-        List<ValidationSourcePair> validationIssues,
-        string expectedJson
-    )
+    public void TestPartitionCodeForCompatibility(List<ValidationSourcePair> validationIssues, string expectedJson)
     {
         var partitionedIssues = ActionsController.PartitionValidationIssuesByDataElement(validationIssues);
         var json = JsonSerializer.Serialize(partitionedIssues);
         Assert.Equal(expectedJson, json);
     }
 
-    public static TheoryData<int, List<ValidationSourcePair>, string> PartitionValidationIssuesByDataElement =>
+    public static TheoryData<List<ValidationSourcePair>, string> PartitionValidationIssuesByDataElement =>
         new()
         {
+            { [new ValidationSourcePair("source", new List<ValidationIssueWithSource>())], """{"":{"source":[]}}""" },
             {
-                1,
-                [new ValidationSourcePair("source", new List<ValidationIssueWithSource>())],
-                """{"":{"source":[]}}"""
-            },
-            {
-                2,
                 [new ValidationSourcePair("source", []), new ValidationSourcePair("source2", [])],
                 """{"":{"source":[],"source2":[]}}"""
             },
             {
-                3,
                 [
                     new ValidationSourcePair(
                         "source",
@@ -597,7 +587,6 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
                 """{"123445":{"source":[{"severity":0,"dataElementId":"123445","field":null,"code":null,"description":null,"source":"null"}]}}"""
             },
             {
-                4,
                 [
                     new ValidationSourcePair(
                         "source",
@@ -629,7 +618,6 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
                 """{"123445":{"source":[{"severity":0,"dataElementId":"123445","field":null,"code":null,"description":null,"source":"null"}],"source2":[{"severity":0,"dataElementId":"123445","field":null,"code":null,"description":null,"source":"null"}]}}"""
             },
             {
-                5,
                 [
                     new ValidationSourcePair(
                         "source",

--- a/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using Altinn.App.Api.Controllers;
 using Altinn.App.Api.Models;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Data.apps.tdd.task_action.config.models;
@@ -10,6 +11,7 @@ using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Models.Process;
 using Altinn.App.Core.Models.UserAction;
+using Altinn.App.Core.Models.Validation;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -548,6 +550,116 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         mutator?.Invoke(expected);
         actual.Should().BeEquivalentTo(expected);
     }
+
+    [Theory]
+    [MemberData(nameof(PartitionValidationIssuesByDataElement))]
+    public void TestPartitionCodeForCompatibility(
+        int index,
+        List<ValidationSourcePair> validationIssues,
+        string expectedJson
+    )
+    {
+        var partitionedIssues = ActionsController.PartitionValidationIssuesByDataElement(validationIssues);
+        var json = JsonSerializer.Serialize(partitionedIssues);
+        Assert.Equal(expectedJson, json);
+    }
+
+    public static TheoryData<int, List<ValidationSourcePair>, string> PartitionValidationIssuesByDataElement =>
+        new()
+        {
+            {
+                1,
+                [new ValidationSourcePair("source", new List<ValidationIssueWithSource>())],
+                """{"":{"source":[]}}"""
+            },
+            {
+                2,
+                [new ValidationSourcePair("source", []), new ValidationSourcePair("source2", [])],
+                """{"":{"source":[],"source2":[]}}"""
+            },
+            {
+                3,
+                [
+                    new ValidationSourcePair(
+                        "source",
+                        [
+                            new()
+                            {
+                                DataElementId = "123445",
+                                Severity = ValidationIssueSeverity.Unspecified,
+                                Code = null,
+                                Description = null,
+                                Source = "null",
+                            },
+                        ]
+                    ),
+                ],
+                """{"123445":{"source":[{"severity":0,"dataElementId":"123445","field":null,"code":null,"description":null,"source":"null"}]}}"""
+            },
+            {
+                4,
+                [
+                    new ValidationSourcePair(
+                        "source",
+                        [
+                            new()
+                            {
+                                DataElementId = "123445",
+                                Severity = ValidationIssueSeverity.Unspecified,
+                                Code = null,
+                                Description = null,
+                                Source = "null",
+                            },
+                        ]
+                    ),
+                    new ValidationSourcePair(
+                        "source2",
+                        [
+                            new()
+                            {
+                                DataElementId = "123445",
+                                Severity = ValidationIssueSeverity.Unspecified,
+                                Code = null,
+                                Description = null,
+                                Source = "null",
+                            },
+                        ]
+                    ),
+                ],
+                """{"123445":{"source":[{"severity":0,"dataElementId":"123445","field":null,"code":null,"description":null,"source":"null"}],"source2":[{"severity":0,"dataElementId":"123445","field":null,"code":null,"description":null,"source":"null"}]}}"""
+            },
+            {
+                5,
+                [
+                    new ValidationSourcePair(
+                        "source",
+                        [
+                            new()
+                            {
+                                Severity = ValidationIssueSeverity.Unspecified,
+                                Code = null,
+                                Description = null,
+                                Source = "null",
+                            },
+                        ]
+                    ),
+                    new ValidationSourcePair(
+                        "source2",
+                        [
+                            new()
+                            {
+                                DataElementId = "123445",
+                                Severity = ValidationIssueSeverity.Unspecified,
+                                Code = null,
+                                Description = null,
+                                Source = "null",
+                            },
+                        ]
+                    ),
+                ],
+                """{"":{"source":[{"severity":0,"dataElementId":null,"field":null,"code":null,"description":null,"source":"null"}]},"123445":{"source2":[{"severity":0,"dataElementId":"123445","field":null,"code":null,"description":null,"source":"null"}]}}"""
+            },
+        };
 }
 
 public class FillAction : IUserAction


### PR DESCRIPTION
The user action endpoint returns validation issues grouped by dataElementId (it kind of made sense when issues always was tied to a single element) For backwards compatibility we kept the grouping when working with validation issues

In the first implementation there was a bug that we didn't add an empty list of issues to the response when an validator returned an empty list of issues.

This mostly works fine, unless a validator removes the last issue, wich the frontend will think is still valid.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
