### PR TITLE
When task type doesn't have specific mapping to actions that allow process next...

### DIFF
--- a/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngineAuthorizer.cs
@@ -103,7 +103,7 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
     /// Get all actions that allow process next for the given task type. Meant to be used to authorize the process next when no action is provided.
     /// </summary>
     /// <remarks>To allow process next for a custom action, user needs to have access to an action with the same name as the task type, or alternatively 'write', in the policy.</remarks>
-    private static string[] GetActionsThatAllowProcessNextForTaskType(string taskType)
+    public static string[] GetActionsThatAllowProcessNextForTaskType(string taskType)
     {
         return taskType switch
         {
@@ -111,7 +111,7 @@ internal sealed class ProcessEngineAuthorizer : IProcessEngineAuthorizer
             "payment" => ["pay", "write"],
             "confirmation" => ["confirm"],
             "signing" => ["sign", "write"],
-            _ => [taskType, "write"],
+            _ => [taskType],
         };
     }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineAuthorizerTests.cs
@@ -265,6 +265,25 @@ public class ProcessEngineAuthorizerTests
         );
     }
 
+    [Theory]
+    [InlineData("data", new[] { "write" })]
+    [InlineData("feedback", new[] { "write" })]
+    [InlineData("payment", new[] { "pay", "write" })]
+    [InlineData("confirmation", new[] { "confirm" })]
+    [InlineData("signing", new[] { "sign", "write" })]
+    [InlineData("customTask", new[] { "customTask" })]
+    public void GetActionsThatAllowProcessNextForTaskType_ReturnsExpectedActions(
+        string taskType,
+        string[] expectedActions
+    )
+    {
+        // Act
+        string[] result = ProcessEngineAuthorizer.GetActionsThatAllowProcessNextForTaskType(taskType);
+
+        // Assert
+        Assert.Equal(expectedActions, result);
+    }
+
     private static Instance CreateInstance(string? taskId, string? taskType = null)
     {
         var instance = new Instance


### PR DESCRIPTION
When task type doesn't have specific mapping to actions that allow process next, use task type as default. Ment to be used for custom task types.

Based on this feedback: https://github.com/Altinn/altinn-storage/pull/676#discussion_r2041684386