### PR TITLE
Add back some project references for JWTCookieAuthentication dependencies

### DIFF
--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -17,6 +17,12 @@
     <PackageReference Include="Altinn.ApiClients.Maskinporten"/>
 
     <PackageReference Include="JWTCookieAuthentication"/>
+    <!-- The follwoing are depencencies for JWTCookieAuthentication, but we need newer versions-->
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" />
+    <PackageReference Include="System.Text.RegularExpressions" />
+    <!-- End JWTCookieAuthentication deps -->
 
     <PackageReference Include="Altinn.Common.AccessTokenClient"/>
     <!-- End frozen versions -->


### PR DESCRIPTION
## Description

Before this diff, when running with local project references in an app:
```
/home/martin/.dotnet/sdk/9.0.202/Microsoft.Common.CurrentVersion.targets(2424,5): warning MSB3277: 
      Found conflicts between different versions of "System.IdentityModel.Tokens.Jwt" that could not be resolved.
      There was a conflict between "System.IdentityModel.Tokens.Jwt, Version=6.33.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "System.IdentityModel.Tokens.Jwt, Version=8.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35".
          "System.IdentityModel.Tokens.Jwt, Version=6.33.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" was chosen because it was primary and "System.IdentityModel.Tokens.Jwt, Version=8.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" was not.
          References which depend on "System.IdentityModel.Tokens.Jwt, Version=6.33.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" [/home/martin/.nuget/packages/system.identitymodel.tokens.jwt/6.33.0/lib/net6.0/System.IdentityModel.Tokens.Jwt.dll].
              /home/martin/.nuget/packages/system.identitymodel.tokens.jwt/6.33.0/lib/net6.0/System.IdentityModel.Tokens.Jwt.dll
                Project file item includes which caused reference "/home/martin/.nuget/packages/system.identitymodel.tokens.jwt/6.33.0/lib/net6.0/System.IdentityModel.Tokens.Jwt.dll".
                  /home/martin/.nuget/packages/system.identitymodel.tokens.jwt/6.33.0/lib/net6.0/System.IdentityModel.Tokens.Jwt.dll
          References which depend on or have been unified to "System.IdentityModel.Tokens.Jwt, Version=8.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" [].
              /home/martin/code/digdir/altinn/app-lib-dotnet/src/Altinn.App.Core/bin/Debug/net8.0/Altinn.App.Core.dll
                Project file item includes which caused reference "/home/martin/code/digdir/altinn/app-lib-dotnet/src/Altinn.App.Core/bin/Debug/net8.0/Altinn.App.Core.dll".
                  /home/martin/code/digdir/altinn/app-lib-dotnet/src/Altinn.App.Core/bin/Debug/net8.0/Altinn.App.Core.dll
                  /home/martin/code/digdir/altinn/app-lib-dotnet/src/Altinn.App.Api/bin/Debug/net8.0/Altinn.App.Api.dll
```

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/pull/1262

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
