### PR TITLE
Handle possible nulls when reading `RequestServices` in `IdentityTelemetryFilter`

### DIFF
--- a/src/Altinn.App.Api/Infrastructure/Telemetry/IdentityTelemetryFilter.cs
+++ b/src/Altinn.App.Api/Infrastructure/Telemetry/IdentityTelemetryFilter.cs
@@ -57,11 +57,15 @@ public class IdentityTelemetryFilter : ITelemetryProcessor
                     request.Properties.Add("orgNumber", orgNumber?.ToString(CultureInfo.InvariantCulture) ?? "");
                 }
 
-                var authContext = ctx.RequestServices.GetRequiredService<IAuthenticationContext>();
-                var auth = authContext.Current;
-                request.Properties.Add("tokenIssuer", auth.TokenIssuer.ToString());
-                request.Properties.Add("tokenIsExchanged", auth.TokenIsExchanged.ToString());
-                request.Properties.Add("authType", auth.GetType().Name);
+                var services = ctx.RequestServices;
+                if (services is not null)
+                {
+                    var authContext = services.GetRequiredService<IAuthenticationContext>();
+                    var auth = authContext.Current;
+                    request.Properties.Add("tokenIssuer", auth.TokenIssuer.ToString());
+                    request.Properties.Add("tokenIsExchanged", auth.TokenIsExchanged.ToString());
+                    request.Properties.Add("authType", auth.GetType().Name);
+                }
             }
         }
 


### PR DESCRIPTION
## Description
Discovered through debugging (the potential exception is swallowed) that `RequestServices` can be null here.
I suspect we would have seen this in exception rate metrics if we monitored that.

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
