### PR TITLE
Use Register party lookup API that handles system users tokens as well

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -169,7 +169,7 @@ public class InstancesController : ControllerBase
                 await _instanceClient.UpdateReadStatus(instanceOwnerPartyId, instanceGuid, "read");
             }
 
-            var instanceOwnerParty = await _registerClient.GetParty(instanceOwnerPartyId, cancellationToken);
+            var instanceOwnerParty = await _registerClient.GetPartyUnchecked(instanceOwnerPartyId, cancellationToken);
 
             var dto = InstanceResponse.From(instance, instanceOwnerParty);
 
@@ -1089,7 +1089,7 @@ public class InstancesController : ControllerBase
         {
             try
             {
-                return await _registerClient.GetParty(
+                return await _registerClient.GetPartyUnchecked(
                     int.Parse(instanceOwner.PartyId, CultureInfo.InvariantCulture),
                     this.HttpContext.RequestAborted
                 );

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -55,7 +55,7 @@ public class InstancesController : ControllerBase
 
     private readonly IInstanceClient _instanceClient;
     private readonly IDataClient _dataClient;
-    private readonly IAltinnPartyClient _altinnPartyClientClient;
+    private readonly IAltinnPartyClient _altinnPartyClient;
     private readonly IRegisterClient _registerClient;
     private readonly IEventsClient _eventsClient;
     private readonly IProfileClient _profileClient;
@@ -104,7 +104,7 @@ public class InstancesController : ControllerBase
         _instanceClient = instanceClient;
         _dataClient = dataClient;
         _appMetadata = appMetadata;
-        _altinnPartyClientClient = altinnPartyClient;
+        _altinnPartyClient = altinnPartyClient;
         _registerClient = serviceProvider.GetRequiredService<IRegisterClient>();
         _appModel = appModel;
         _appImplementationFactory = serviceProvider.GetRequiredService<AppImplementationFactory>();
@@ -1113,14 +1113,12 @@ public class InstancesController : ControllerBase
                 if (!string.IsNullOrEmpty(instanceOwner.PersonNumber))
                 {
                     lookupNumber = "personNumber";
-                    return await _altinnPartyClientClient.LookupParty(
-                        new PartyLookup { Ssn = instanceOwner.PersonNumber }
-                    );
+                    return await _altinnPartyClient.LookupParty(new PartyLookup { Ssn = instanceOwner.PersonNumber });
                 }
                 else if (!string.IsNullOrEmpty(instanceOwner.OrganisationNumber))
                 {
                     lookupNumber = "organisationNumber";
-                    return await _altinnPartyClientClient.LookupParty(
+                    return await _altinnPartyClient.LookupParty(
                         new PartyLookup { OrgNo = instanceOwner.OrganisationNumber }
                     );
                 }

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -56,6 +56,7 @@ public class InstancesController : ControllerBase
     private readonly IInstanceClient _instanceClient;
     private readonly IDataClient _dataClient;
     private readonly IAltinnPartyClient _altinnPartyClientClient;
+    private readonly IRegisterClient _registerClient;
     private readonly IEventsClient _eventsClient;
     private readonly IProfileClient _profileClient;
 
@@ -80,7 +81,7 @@ public class InstancesController : ControllerBase
     /// </summary>
     public InstancesController(
         ILogger<InstancesController> logger,
-        IAltinnPartyClient altinnPartyClientClient,
+        IAltinnPartyClient altinnPartyClient,
         IInstanceClient instanceClient,
         IDataClient dataClient,
         IAppMetadata appMetadata,
@@ -103,7 +104,8 @@ public class InstancesController : ControllerBase
         _instanceClient = instanceClient;
         _dataClient = dataClient;
         _appMetadata = appMetadata;
-        _altinnPartyClientClient = altinnPartyClientClient;
+        _altinnPartyClientClient = altinnPartyClient;
+        _registerClient = serviceProvider.GetRequiredService<IRegisterClient>();
         _appModel = appModel;
         _appImplementationFactory = serviceProvider.GetRequiredService<AppImplementationFactory>();
         _pdp = pdp;
@@ -127,6 +129,7 @@ public class InstancesController : ControllerBase
     /// <param name="app">application identifier which is unique within an organisation</param>
     /// <param name="instanceOwnerPartyId">unique id of the party that is the owner of the instance</param>
     /// <param name="instanceGuid">unique id to identify the instance</param>
+    /// <param name="cancellationToken">cancellation token</param>
     /// <returns>the instance</returns>
     [Authorize]
     [HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
@@ -137,7 +140,8 @@ public class InstancesController : ControllerBase
         [FromRoute] string org,
         [FromRoute] string app,
         [FromRoute] int instanceOwnerPartyId,
-        [FromRoute] Guid instanceGuid
+        [FromRoute] Guid instanceGuid,
+        CancellationToken cancellationToken
     )
     {
         EnforcementResult enforcementResult = await AuthorizeAction(
@@ -165,7 +169,7 @@ public class InstancesController : ControllerBase
                 await _instanceClient.UpdateReadStatus(instanceOwnerPartyId, instanceGuid, "read");
             }
 
-            var instanceOwnerParty = await _altinnPartyClientClient.GetParty(instanceOwnerPartyId);
+            var instanceOwnerParty = await _registerClient.GetParty(instanceOwnerPartyId, cancellationToken);
 
             var dto = InstanceResponse.From(instance, instanceOwnerParty);
 
@@ -1085,8 +1089,9 @@ public class InstancesController : ControllerBase
         {
             try
             {
-                return await _altinnPartyClientClient.GetParty(
-                    int.Parse(instanceOwner.PartyId, CultureInfo.InvariantCulture)
+                return await _registerClient.GetParty(
+                    int.Parse(instanceOwner.PartyId, CultureInfo.InvariantCulture),
+                    this.HttpContext.RequestAborted
                 );
             }
             catch (Exception e) when (e is not ServiceException)

--- a/src/Altinn.App.Api/Controllers/StatelessDataController.cs
+++ b/src/Altinn.App.Api/Controllers/StatelessDataController.cs
@@ -31,7 +31,7 @@ public class StatelessDataController : ControllerBase
     private readonly IAppModel _appModel;
     private readonly IAppResources _appResourcesService;
     private readonly IPrefill _prefillService;
-    private readonly IAltinnPartyClient _altinnPartyClientClient;
+    private readonly IAltinnPartyClient _altinnPartyClient;
     private readonly IPDP _pdp;
     private readonly IAuthenticationContext _authenticationContext;
     private readonly AppImplementationFactory _appImplementationFactory;
@@ -50,7 +50,7 @@ public class StatelessDataController : ControllerBase
         IAppModel appModel,
         IAppResources appResourcesService,
         IPrefill prefillService,
-        IAltinnPartyClient altinnPartyClientClient,
+        IAltinnPartyClient altinnPartyClient,
         IPDP pdp,
         IAuthenticationContext authenticationContext,
         IServiceProvider serviceProvider
@@ -60,7 +60,7 @@ public class StatelessDataController : ControllerBase
         _appModel = appModel;
         _appResourcesService = appResourcesService;
         _prefillService = prefillService;
-        _altinnPartyClientClient = altinnPartyClientClient;
+        _altinnPartyClient = altinnPartyClient;
         _pdp = pdp;
         _authenticationContext = authenticationContext;
         _appImplementationFactory = serviceProvider.GetRequiredService<AppImplementationFactory>();
@@ -371,11 +371,11 @@ public class StatelessDataController : ControllerBase
             var idPrefix = headerParts[0].ToLowerInvariant();
             var party = idPrefix switch
             {
-                PartyPrefix => await _altinnPartyClientClient.GetParty(int.TryParse(id, out var partyId) ? partyId : 0),
+                PartyPrefix => await _altinnPartyClient.GetParty(int.TryParse(id, out var partyId) ? partyId : 0),
 
                 // Frontend seems to only use partyId, not orgnr or ssn.
-                PersonPrefix => await _altinnPartyClientClient.LookupParty(new PartyLookup { Ssn = id }),
-                OrgPrefix => await _altinnPartyClientClient.LookupParty(new PartyLookup { OrgNo = id }),
+                PersonPrefix => await _altinnPartyClient.LookupParty(new PartyLookup { Ssn = id }),
+                OrgPrefix => await _altinnPartyClient.LookupParty(new PartyLookup { OrgNo = id }),
                 _ => null,
             };
 

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -103,6 +103,7 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient<IEventsClient, EventsClient>();
         services.AddProfileClient();
         services.AddHttpClient<IAltinnPartyClient, AltinnPartyClient>();
+        services.AddRegisterClient();
 #pragma warning disable CS0618 // Type or member is obsolete
         services.AddHttpClient<IText, TextClient>();
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.RegisterClient.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.RegisterClient.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+
+namespace Altinn.App.Core.Features;
+
+partial class Telemetry
+{
+    internal Activity? StartGetPartyListForPartyIds(IReadOnlyList<int> partyIds)
+    {
+        var activity = ActivitySource.StartActivity("RegisterClient.GetPartyListForPartyIds");
+        if (activity is not null && partyIds is not null)
+        {
+            var now = DateTimeOffset.UtcNow;
+            ActivityTagsCollection tags = new([new("party_ids.count", partyIds.Count)]);
+            if (partyIds.Count <= 10)
+            {
+                for (int i = 0; i < partyIds.Count; i++)
+                {
+                    var partyId = partyIds[i];
+                    tags.Add(new($"party_ids.{i}.value", partyId));
+                }
+            }
+
+            activity.AddEvent(new ActivityEvent("data", now, tags));
+        }
+        return activity;
+    }
+}

--- a/src/Altinn.App.Core/Implementation/PrefillSI.cs
+++ b/src/Altinn.App.Core/Implementation/PrefillSI.cs
@@ -17,7 +17,7 @@ public class PrefillSI : IPrefill
 {
     private readonly ILogger _logger;
     private readonly IAppResources _appResourcesService;
-    private readonly IAltinnPartyClient _altinnPartyClientClient;
+    private readonly IAltinnPartyClient _altinnPartyClient;
     private readonly IAuthenticationContext _authenticationContext;
     private readonly Telemetry? _telemetry;
     private static readonly string _erKey = "ER";
@@ -31,20 +31,20 @@ public class PrefillSI : IPrefill
     /// </summary>
     /// <param name="logger">The logger</param>
     /// <param name="appResourcesService">The app's resource service</param>
-    /// <param name="altinnPartyClientClient">The register client</param>
+    /// <param name="altinnPartyClient">The register client</param>
     /// <param name="authenticationContext">The authentication context</param>
     /// <param name="telemetry">Telemetry for traces and metrics.</param>
     public PrefillSI(
         ILogger<PrefillSI> logger,
         IAppResources appResourcesService,
-        IAltinnPartyClient altinnPartyClientClient,
+        IAltinnPartyClient altinnPartyClient,
         IAuthenticationContext authenticationContext,
         Telemetry? telemetry = null
     )
     {
         _logger = logger;
         _appResourcesService = appResourcesService;
-        _altinnPartyClientClient = altinnPartyClientClient;
+        _altinnPartyClient = altinnPartyClient;
         _authenticationContext = authenticationContext;
         _telemetry = telemetry;
     }
@@ -96,7 +96,7 @@ public class PrefillSI : IPrefill
             Authenticated.SystemUser systemUser
                 when await systemUser.LoadDetails() is { } details && details.Party.PartyId == partyIdNum =>
                 details.Party,
-            _ => await _altinnPartyClientClient.GetParty(partyIdNum),
+            _ => await _altinnPartyClient.GetParty(partyIdNum),
         };
         if (party == null)
         {

--- a/src/Altinn.App.Core/Internal/Registers/RegisterClient.cs
+++ b/src/Altinn.App.Core/Internal/Registers/RegisterClient.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Http.Headers;
-using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
@@ -114,7 +113,10 @@ internal sealed class RegisterClient : IRegisterClient
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
-            return await response.Content.ReadFromJsonAsync<IReadOnlyList<Party>>(cancellationToken) ?? [];
+            return await JsonSerializerPermissive.DeserializeAsync<IReadOnlyList<Party>>(
+                    response.Content,
+                    cancellationToken
+                ) ?? [];
         }
         else if (response.StatusCode == HttpStatusCode.NotFound)
         {

--- a/src/Altinn.App.Core/Internal/Registers/RegisterClient.cs
+++ b/src/Altinn.App.Core/Internal/Registers/RegisterClient.cs
@@ -39,7 +39,7 @@ internal interface IRegisterClient
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns></returns>
     /// <exception cref="ServiceException"></exception>
-    Task<Party?> GetParty(int partyId, CancellationToken cancellationToken);
+    Task<Party?> GetPartyUnchecked(int partyId, CancellationToken cancellationToken);
 
     /// <summary>
     /// This API does not validate that the requestor (based on token)
@@ -49,7 +49,7 @@ internal interface IRegisterClient
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns></returns>
     /// <exception cref="ServiceException"></exception>
-    Task<IReadOnlyList<Party>> GetPartyList(IReadOnlyList<int> partyIds, CancellationToken cancellationToken);
+    Task<IReadOnlyList<Party>> GetPartyListUnchecked(IReadOnlyList<int> partyIds, CancellationToken cancellationToken);
 }
 
 internal sealed class RegisterClient : IRegisterClient
@@ -82,14 +82,14 @@ internal sealed class RegisterClient : IRegisterClient
         _telemetry = telemetry;
     }
 
-    public async Task<Party?> GetParty(int partyId, CancellationToken cancellationToken)
+    public async Task<Party?> GetPartyUnchecked(int partyId, CancellationToken cancellationToken)
     {
         int[] partyIds = [partyId];
-        var partyList = await GetPartyList(partyIds, cancellationToken);
+        var partyList = await GetPartyListUnchecked(partyIds, cancellationToken);
         return partyList.SingleOrDefault(p => p.PartyId == partyId);
     }
 
-    public async Task<IReadOnlyList<Party>> GetPartyList(
+    public async Task<IReadOnlyList<Party>> GetPartyListUnchecked(
         IReadOnlyList<int> partyIds,
         CancellationToken cancellationToken
     )

--- a/src/Altinn.App.Core/Internal/Registers/RegisterClient.cs
+++ b/src/Altinn.App.Core/Internal/Registers/RegisterClient.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Constants;
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Auth;
+using Altinn.App.Core.Models;
+using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Platform.Register.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.App.Core.Internal.Registers;
+
+internal static class RegisterClientDI
+{
+    public static void AddRegisterClient(this IServiceCollection services) =>
+        services.AddHttpClient<IRegisterClient, RegisterClient>();
+}
+
+/// <summary>
+/// Client for the Register API
+/// Contains methods that don't validate access to parties.
+/// I.e. the requestor (token) can't necessarily represent returned/given parties,
+/// So the methods should be used with caution
+/// </summary>
+internal interface IRegisterClient
+{
+    /// <summary>
+    /// This API does not validate that the requestor (based on token)
+    /// can represent the given/returned party. Use with caution
+    /// </summary>
+    /// <param name="partyId">Party ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    /// <exception cref="ServiceException"></exception>
+    Task<Party?> GetParty(int partyId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// This API does not validate that the requestor (based on token)
+    /// can represent the given/returned party. Use with caution
+    /// </summary>
+    /// <param name="partyIds">Party IDs</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns></returns>
+    /// <exception cref="ServiceException"></exception>
+    Task<IReadOnlyList<Party>> GetPartyList(IReadOnlyList<int> partyIds, CancellationToken cancellationToken);
+}
+
+internal sealed class RegisterClient : IRegisterClient
+{
+    private readonly ILogger _logger;
+    private readonly HttpClient _client;
+    private readonly IAppMetadata _appMetadata;
+    private readonly IUserTokenProvider _userTokenProvider;
+    private readonly IAccessTokenGenerator _accessTokenGenerator;
+    private readonly Telemetry? _telemetry;
+
+    public RegisterClient(
+        ILogger<RegisterClient> logger,
+        IOptions<PlatformSettings> platformSettings,
+        HttpClient client,
+        IAppMetadata appMetadata,
+        IUserTokenProvider userTokenProvider,
+        IAccessTokenGenerator accessTokenGenerator,
+        Telemetry? telemetry = null
+    )
+    {
+        _logger = logger;
+        client.BaseAddress = new Uri(platformSettings.Value.ApiRegisterEndpoint);
+        client.DefaultRequestHeaders.Add(General.SubscriptionKeyHeaderName, platformSettings.Value.SubscriptionKey);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        _client = client;
+        _appMetadata = appMetadata;
+        _userTokenProvider = userTokenProvider;
+        _accessTokenGenerator = accessTokenGenerator;
+        _telemetry = telemetry;
+    }
+
+    public async Task<Party?> GetParty(int partyId, CancellationToken cancellationToken)
+    {
+        int[] partyIds = [partyId];
+        var partyList = await GetPartyList(partyIds, cancellationToken);
+        return partyList.SingleOrDefault(p => p.PartyId == partyId);
+    }
+
+    public async Task<IReadOnlyList<Party>> GetPartyList(
+        IReadOnlyList<int> partyIds,
+        CancellationToken cancellationToken
+    )
+    {
+        using var activity = _telemetry?.StartGetPartyListForPartyIds(partyIds);
+
+        string endpointUrl = $"parties/partylist?fetchSubUnits=true";
+        string token = _userTokenProvider.GetUserToken();
+        ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
+        var platformAccessToken = _accessTokenGenerator.GenerateAccessToken(
+            application.Org,
+            application.AppIdentifier.App
+        );
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpointUrl);
+        request.Headers.Add("Authorization", "Bearer " + token);
+        request.Headers.Add("PlatformAccessToken", platformAccessToken);
+
+        request.Content = new StringContent(JsonSerializer.Serialize(partyIds), Encoding.UTF8, "application/json");
+
+        using var response = await _client.SendAsync(request, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.OK)
+        {
+            return await response.Content.ReadFromJsonAsync<IReadOnlyList<Party>>(cancellationToken) ?? [];
+        }
+        else if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return [];
+        }
+        else
+        {
+            var errorMessage = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError(
+                "Getting partylist from party IDs failed with statuscode {StatusCode} and error message: {ErrorMessage}",
+                response.StatusCode,
+                errorMessage
+            );
+            throw new ServiceException(HttpStatusCode.Unauthorized, "Unauthorized for party");
+        }
+    }
+}

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
@@ -111,6 +111,7 @@ internal sealed record InstancesControllerFixture(IServiceProvider ServiceProvid
         services.AddAppImplementationFactory();
 
         services.AddSingleton(new Mock<IAltinnPartyClient>().Object);
+        services.AddSingleton(new Mock<IRegisterClient>().Object);
         services.AddSingleton(new Mock<IInstanceClient>().Object);
         services.AddSingleton(new Mock<IDataClient>().Object);
         services.AddSingleton(new Mock<IAppMetadata>().Object);

--- a/test/Altinn.App.Api.Tests/Mocks/RegisterClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/RegisterClientMock.cs
@@ -15,13 +15,13 @@ public class RegisterClientMock : IRegisterClient
 
     private readonly string _partyFolder = TestData.GetAltinnProfilePath();
 
-    public async Task<Party?> GetParty(int partyId, CancellationToken cancellationToken)
+    public async Task<Party?> GetPartyUnchecked(int partyId, CancellationToken cancellationToken)
     {
-        var partyList = await GetPartyList([partyId], cancellationToken);
+        var partyList = await GetPartyListUnchecked([partyId], cancellationToken);
         return partyList.SingleOrDefault(p => p.PartyId == partyId);
     }
 
-    public async Task<IReadOnlyList<Party>> GetPartyList(
+    public async Task<IReadOnlyList<Party>> GetPartyListUnchecked(
         IReadOnlyList<int> partyIds,
         CancellationToken cancellationToken
     )

--- a/test/Altinn.App.Api.Tests/Mocks/RegisterClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/RegisterClientMock.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Altinn.App.Api.Tests.Data;
+using Altinn.App.Core.Internal.Registers;
+using Altinn.Platform.Register.Models;
+
+namespace Altinn.App.Api.Tests.Mocks;
+
+public class RegisterClientMock : IRegisterClient
+{
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly string _partyFolder = TestData.GetAltinnProfilePath();
+
+    public async Task<Party?> GetParty(int partyId, CancellationToken cancellationToken)
+    {
+        var partyList = await GetPartyList([partyId], cancellationToken);
+        return partyList.SingleOrDefault(p => p.PartyId == partyId);
+    }
+
+    public async Task<IReadOnlyList<Party>> GetPartyList(
+        IReadOnlyList<int> partyIds,
+        CancellationToken cancellationToken
+    )
+    {
+        List<Party> parties = [];
+        foreach (var partyId in partyIds)
+        {
+            var file = Path.Join(_partyFolder, $"{partyId}.json");
+            await using var fileHandle = File.OpenRead(file); // Throws exception if missing (helps with debugging tests)
+            var party = await JsonSerializer.DeserializeAsync<Party>(fileHandle, _jsonSerializerOptions);
+            parties.Add(party!);
+        }
+
+        return parties;
+    }
+}

--- a/test/Altinn.App.Api.Tests/Program.cs
+++ b/test/Altinn.App.Api.Tests/Program.cs
@@ -107,6 +107,7 @@ void ConfigureMockServices(IServiceCollection services, ConfigurationManager con
     services.AddSingleton<IAppConfigurationCache, AppConfigurationCacheMock>();
     services.AddTransient<IDataClient, DataClientMock>();
     services.AddTransient<IAltinnPartyClient, AltinnPartyClientMock>();
+    services.AddTransient<IRegisterClient, RegisterClientMock>();
     services.AddTransient<IProfileClient, ProfileClientMock>();
     services.AddTransient<IInstanceEventClient, InstanceEventClientMock>();
     services.AddTransient<IAppModel, AppModelMock<Program>>();


### PR DESCRIPTION
## Description
Some Register APIs are not ready for system users to use (one of which is the target of `IAltinnPartyClient.GetParty`): https://github.com/Altinn/altinn-authorization-tmp/issues/88

This PR makes use of a different Register API to get parties which doesn't validate based on access, it's just a straight lookup. I put it in a new internal client with doc comments describing the constraints.

We should probably also go through the rest of the use of `IAltinnPartyClient`, as there may be more issues with system users

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
