### PR TITLE
Fix null pointer exception in obsolete single data element validation

### DIFF
--- a/src/Altinn.App.Api/Controllers/ValidateController.cs
+++ b/src/Altinn.App.Api/Controllers/ValidateController.cs
@@ -129,7 +129,9 @@ public class ValidateController : ControllerBase
             return NotFound();
         }
 
-        if (instance.Process?.CurrentTask?.ElementId == null)
+        var taskId = instance.Process?.CurrentTask?.ElementId;
+
+        if (taskId is null)
         {
             throw new ValidationException("Unable to validate instance without a started process.");
         }
@@ -152,10 +154,9 @@ public class ValidateController : ControllerBase
             throw new ValidationException("Unknown element type.");
         }
 
-        string taskId = instance.Process.CurrentTask.ElementId;
-
         // Should this be a BadRequest instead?
-        if (!dataType.TaskId.Equals(taskId, StringComparison.OrdinalIgnoreCase))
+        // The element will likely not be validated at all if the taskId is not the same as the one in the element
+        if (!taskId.Equals(dataType.TaskId, StringComparison.OrdinalIgnoreCase))
         {
             ValidationIssueWithSource message = new()
             {

--- a/src/Altinn.App.Api/Controllers/ValidateController.cs
+++ b/src/Altinn.App.Api/Controllers/ValidateController.cs
@@ -155,7 +155,7 @@ public class ValidateController : ControllerBase
         }
 
         // Should this be a BadRequest instead?
-        // The element will likely not be validated at all if the taskId is not the same as the one in the element
+        // The element will likely not be validated at all if the taskId is not the same as the one in the dataType
         if (!taskId.Equals(dataType.TaskId, StringComparison.OrdinalIgnoreCase))
         {
             ValidationIssueWithSource message = new()

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateControllerValidateDataTests.cs
@@ -45,7 +45,7 @@ public class TestScenariosData : IEnumerable<object[]>
         {
             ReceivedInstance = new Instance
             {
-                Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "1234" } },
+                Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "Task_1" } },
                 Data = new List<DataElement>(),
             },
             ExpectedExceptionMessage = "Unable to validate data element.",
@@ -55,8 +55,11 @@ public class TestScenariosData : IEnumerable<object[]>
             DataGuid = _dataGuid,
             ReceivedInstance = new Instance
             {
-                Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "1234" } },
-                Data = new List<DataElement> { new DataElement { Id = "0fc98a23-fe31-4ef5-8fb9-dd3f479354cd" } },
+                Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "Task_1" } },
+                Data = new List<DataElement>
+                {
+                    new DataElement { Id = "0fc98a23-fe31-4ef5-8fb9-dd3f479354cd", DataType = "dataType" },
+                },
             },
             ReceivedApplication = new ApplicationMetadata("ttd/test") { DataTypes = new List<DataType>() },
             ExpectedExceptionMessage = "Unknown element type.",
@@ -71,7 +74,7 @@ public class TestScenariosData : IEnumerable<object[]>
                 Org = ValidationControllerValidateDataTests.Org,
                 Id = $"{ValidationControllerValidateDataTests.InstanceOwnerId}/{_instanceId}",
                 InstanceOwner = new() { PartyId = ValidationControllerValidateDataTests.InstanceOwnerId.ToString() },
-                Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "1234" } },
+                Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "Task_1" } },
                 Data = new List<DataElement>
                 {
                     new DataElement
@@ -118,10 +121,7 @@ public class TestScenariosData : IEnumerable<object[]>
                 Org = ValidationControllerValidateDataTests.Org,
                 Id = $"{ValidationControllerValidateDataTests.InstanceOwnerId}/{_instanceId}",
                 InstanceOwner = new() { PartyId = ValidationControllerValidateDataTests.InstanceOwnerId.ToString() },
-                Process = new ProcessState
-                {
-                    CurrentTask = new ProcessElementInfo { ElementId = "0fc98a23-fe31-4ef5-8fb9-dd3f479354cd" },
-                },
+                Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "Task_1" } },
                 Data = new List<DataElement>
                 {
                     new DataElement


### PR DESCRIPTION
The previous code crashed when validating a `dataElement` where `dataType.TaskId` was `null`. I spent some time debugging, so it seems worth fixing even though it did not matter in the end.