### PR TITLE
ITranslationService don't throw on missing text resource

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -1340,10 +1340,13 @@ public class InstancesController : ControllerBase
     {
         if (String.IsNullOrEmpty(validationResult.Message) && !String.IsNullOrEmpty(validationResult.CustomTextKey))
         {
-            validationResult.Message = await _translationService.TranslateTextKey(
-                validationResult.CustomTextKey,
-                language
-            );
+            if (
+                await _translationService.TranslateTextKey(validationResult.CustomTextKey, language)
+                is string translated
+            )
+            {
+                validationResult.Message = translated;
+            }
         }
     }
 }

--- a/src/Altinn.App.Core/Internal/Texts/ITranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/ITranslationService.cs
@@ -11,5 +11,5 @@ public interface ITranslationService
     /// <param name="key">Id of the text resource</param>
     /// <param name="language">Language for the text. If omitted, 'nb' will be used</param>
     /// <returns>The value of the text resource in the specified language</returns>
-    Task<string> TranslateTextKey(string key, string? language);
+    Task<string?> TranslateTextKey(string key, string? language);
 }

--- a/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
@@ -28,7 +28,7 @@ internal class TranslationService : ITranslationService
     /// <param name="key">Id of the text resource</param>
     /// <param name="language">Language for the text. If omitted, 'nb' will be used</param>
     /// <returns>The value of the text resource in the specified language</returns>
-    public async Task<string> TranslateTextKey(string key, string? language)
+    public async Task<string?> TranslateTextKey(string key, string? language)
     {
         language = language ?? LanguageConst.Nb;
         TextResource? textResource = await _appResources.GetTexts(_org, _app, language);
@@ -40,14 +40,14 @@ internal class TranslationService : ITranslationService
 
         if (textResource == null)
         {
-            throw new ArgumentException($"Could not locate text resource file with language = \"{language}\"");
+            return null;
         }
 
         var value = textResource.Resources.Find(resource => resource.Id == key)?.Value;
 
         if (value == null)
         {
-            throw new ArgumentException($"Text resource with id = {key} does not exist");
+            return null;
         }
 
         return value;

--- a/src/Altinn.App.Core/Internal/Validation/ValidationService.cs
+++ b/src/Altinn.App.Core/Internal/Validation/ValidationService.cs
@@ -175,7 +175,10 @@ public class ValidationService : IValidationService
         {
             if (String.IsNullOrEmpty(issue.Description) && !String.IsNullOrEmpty(issue.CustomTextKey))
             {
-                issue.Description = await _translationService.TranslateTextKey(issue.CustomTextKey, language);
+                if (await _translationService.TranslateTextKey(issue.CustomTextKey, language) is string translated)
+                {
+                    issue.Description = translated;
+                }
             }
         }
     }

--- a/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceTests.cs
@@ -75,8 +75,7 @@ public class TranslationServiceTests
     [Fact]
     public async Task Fail_Missing()
     {
-        await Assert.ThrowsAsync<ArgumentException>(async () =>
-            await _translationService.TranslateTextKey("missing", "nb")
-        );
+        var result = await _translationService.TranslateTextKey("missing", "nb");
+        Assert.Null(result);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Throwing when a text resource is missing wasn't the best idea, as this affects all existing validation messages and is breaking. Instead, the `ITranslationService` returns `null` when the textresource/language is missing and this is handled by not setting anything if that is the case.

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/pull/1226

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
