### PR TITLE
Tolerate duplicate 'AllowedContentTypes' items in custom OpenAPI spec generation

### DIFF
--- a/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
+++ b/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
@@ -192,7 +192,7 @@ public class CustomOpenApiController : Controller
             sb.Append('|');
             if (dataType.AllowedContentTypes is not null)
             {
-                sb.Append(string.Join(", ", dataType.AllowedContentTypes));
+                sb.Append(string.Join(", ", dataType.AllowedContentTypes.Distinct()));
             }
             else
             {
@@ -756,7 +756,7 @@ public class CustomOpenApiController : Controller
         }
         else
         {
-            AddRoutsForAttachmentDataType(doc, tags, dataType, appMetadata);
+            AddRoutesForAttachmentDataType(doc, tags, dataType, appMetadata);
         }
     }
 
@@ -898,7 +898,7 @@ public class CustomOpenApiController : Controller
         );
     }
 
-    private static void AddRoutsForAttachmentDataType(
+    private static void AddRoutesForAttachmentDataType(
         OpenApiDocument doc,
         OpenApiTag[] tags,
         DataType dataType,
@@ -960,10 +960,9 @@ public class CustomOpenApiController : Controller
                         {
                             Required = true,
                             Content =
-                                dataType.AllowedContentTypes?.ToDictionary(
-                                    contentType => contentType,
-                                    contentType => new OpenApiMediaType()
-                                )
+                                dataType
+                                    .AllowedContentTypes?.Distinct()
+                                    .ToDictionary(contentType => contentType, contentType => new OpenApiMediaType())
                                 ?? new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/octet-stream"] = new OpenApiMediaType(),


### PR DESCRIPTION
## Description
Users may specify [duplicate content types](https://altinn.studio/repos/ttd/signering-brukerstyrt/src/commit/34b8a6dec22a1bd8dee747044efe29bfae06a36a/App/config/applicationmetadata.json#L61-L62) in `dataType.allowedContentTypes`. This fix ensures we don't crash when that happens when generating custom OpenAPI spec

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
