### PR TITLE
Enrich `http.server.request.duration` metric, add client ID during enrichment

### DIFF
--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.cs
@@ -189,6 +189,11 @@ public sealed partial class Telemetry : IDisposable
         public const string UserAuthenticationTokenIsExchanged = "user.authentication.token.isExchanged";
 
         /// <summary>
+        /// Label for the authentication token clientId claim.
+        /// </summary>
+        public const string UserAuthenticationTokenClientId = "user.authentication.token.clientId";
+
+        /// <summary>
         /// Label for the authentication token is issued from Altinn portal.
         /// </summary>
         public const string UserAuthenticationInAltinnPortal = "user.authentication.inAltinnPortal";

--- a/src/Altinn.App.Core/Features/Telemetry/TelemetryActivityExtensions.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/TelemetryActivityExtensions.cs
@@ -360,6 +360,8 @@ public static class TelemetryActivityExtensions
         activity.SetTag(Labels.UserAuthenticationType, currentAuth.GetType().Name);
         activity.SetTag(Labels.UserAuthenticationTokenIssuer, currentAuth.TokenIssuer);
         activity.SetTag(Labels.UserAuthenticationTokenIsExchanged, currentAuth.TokenIsExchanged);
+        if (currentAuth.ClientId is not null)
+            activity.SetTag(Labels.UserAuthenticationTokenClientId, currentAuth.ClientId);
         switch (currentAuth)
         {
             case Authenticated.None:

--- a/test/Altinn.App.Api.Tests/Controllers/DataControllerPatchTests.InvalidTestValue_ReturnsConflict.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/DataControllerPatchTests.InvalidTestValue_ReturnsConflict.verified.txt
@@ -1,16 +1,19 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Data.Patch,
+      Name: Data.Patch,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: PATCH {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/data/{dataGuid:guid},
+      Name: PATCH {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/data/{dataGuid:guid},
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: PATCH
@@ -49,7 +52,7 @@
           url.scheme: http
         },
         {
-          user.authentication.inAltinnPortal: True
+          user.authentication.inAltinnPortal: true
         },
         {
           user.authentication.level: 2
@@ -58,7 +61,7 @@
           user.authentication.method: BankID
         },
         {
-          user.authentication.token.isExchanged: False
+          user.authentication.token.isExchanged: false
         },
         {
           user.authentication.token.issuer: Altinn
@@ -73,18 +76,17 @@
           user.party.id: 500600
         }
       ],
-      IdFormat: W3C,
-      Kind: Server
+      HasParent: false
     },
     {
-      ActivityName: SerializationService.DeserializeXml,
+      Name: SerializationService.DeserializeXml,
+      IdFormat: W3C,
       Tags: [
         {
           Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_SelfIdentifiedUser.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_SelfIdentifiedUser.verified.txt
@@ -1,7 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: POST {org}/{app}/instances/create,
+      Name: POST {org}/{app}/instances/create,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: POST
@@ -28,7 +30,7 @@
           url.scheme: http
         },
         {
-          user.authentication.inAltinnPortal: True
+          user.authentication.inAltinnPortal: true
         },
         {
           user.authentication.level: 0
@@ -37,7 +39,7 @@
           user.authentication.method: Mock
         },
         {
-          user.authentication.token.isExchanged: False
+          user.authentication.token.isExchanged: false
         },
         {
           user.authentication.token.issuer: Altinn
@@ -52,9 +54,77 @@
           user.party.id: 501337
         }
       ],
-      IdFormat: W3C,
-      Kind: Server
+      HasParent: false
     }
   ],
-  Metrics: []
+  Metrics: [
+    {
+      Name: http.server.request.duration,
+      MeterName: Microsoft.AspNetCore.Hosting,
+      Measurements: [
+        {
+          Tags: [
+            {
+              http.request.method: POST
+            },
+            {
+              http.response.status_code: 201
+            },
+            {
+              http.route: {org}/{app}/instances/create
+            },
+            {
+              network.protocol.version: 1.1
+            },
+            {
+              TestId: Guid_1
+            },
+            {
+              url.scheme: http
+            },
+            {
+              user.authentication.token.isExchanged: false
+            },
+            {
+              user.authentication.token.issuer: Altinn
+            },
+            {
+              user.authentication.type: User
+            }
+          ]
+        },
+        {
+          Tags: [
+            {
+              http.request.method: GET
+            },
+            {
+              http.response.status_code: 200
+            },
+            {
+              http.route: {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/data/{dataGuid:guid}
+            },
+            {
+              network.protocol.version: 1.1
+            },
+            {
+              TestId: Guid_1
+            },
+            {
+              url.scheme: http
+            },
+            {
+              user.authentication.token.isExchanged: false
+            },
+            {
+              user.authentication.token.issuer: Altinn
+            },
+            {
+              user.authentication.type: User
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_ServiceOwner.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_ServiceOwner.verified.txt
@@ -1,7 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: POST {org}/{app}/instances/create,
+      Name: POST {org}/{app}/instances/create,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: POST
@@ -40,7 +42,10 @@
           user.authentication.method: maskinporten
         },
         {
-          user.authentication.token.isExchanged: True
+          user.authentication.token.clientId: Guid_2
+        },
+        {
+          user.authentication.token.isExchanged: true
         },
         {
           user.authentication.token.issuer: Maskinporten
@@ -49,9 +54,83 @@
           user.authentication.type: ServiceOwner
         }
       ],
-      IdFormat: W3C,
-      Kind: Server
+      HasParent: false
     }
   ],
-  Metrics: []
+  Metrics: [
+    {
+      Name: http.server.request.duration,
+      MeterName: Microsoft.AspNetCore.Hosting,
+      Measurements: [
+        {
+          Tags: [
+            {
+              http.request.method: POST
+            },
+            {
+              http.response.status_code: 201
+            },
+            {
+              http.route: {org}/{app}/instances/create
+            },
+            {
+              network.protocol.version: 1.1
+            },
+            {
+              TestId: Guid_1
+            },
+            {
+              url.scheme: http
+            },
+            {
+              user.authentication.token.clientId: Guid_2
+            },
+            {
+              user.authentication.token.isExchanged: true
+            },
+            {
+              user.authentication.token.issuer: Maskinporten
+            },
+            {
+              user.authentication.type: ServiceOwner
+            }
+          ]
+        },
+        {
+          Tags: [
+            {
+              http.request.method: GET
+            },
+            {
+              http.response.status_code: 200
+            },
+            {
+              http.route: {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/data/{dataGuid:guid}
+            },
+            {
+              network.protocol.version: 1.1
+            },
+            {
+              TestId: Guid_1
+            },
+            {
+              url.scheme: http
+            },
+            {
+              user.authentication.token.clientId: Guid_2
+            },
+            {
+              user.authentication.token.isExchanged: true
+            },
+            {
+              user.authentication.token.issuer: Maskinporten
+            },
+            {
+              user.authentication.type: ServiceOwner
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_SystemUser.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_SystemUser.verified.txt
@@ -1,7 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: POST {org}/{app}/instances/create,
+      Name: POST {org}/{app}/instances/create,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: POST
@@ -40,7 +42,10 @@
           user.authentication.method: maskinporten
         },
         {
-          user.authentication.token.isExchanged: True
+          user.authentication.token.clientId: Guid_3
+        },
+        {
+          user.authentication.token.isExchanged: true
         },
         {
           user.authentication.token.issuer: Maskinporten
@@ -49,9 +54,83 @@
           user.authentication.type: SystemUser
         }
       ],
-      IdFormat: W3C,
-      Kind: Server
+      HasParent: false
     }
   ],
-  Metrics: []
+  Metrics: [
+    {
+      Name: http.server.request.duration,
+      MeterName: Microsoft.AspNetCore.Hosting,
+      Measurements: [
+        {
+          Tags: [
+            {
+              http.request.method: POST
+            },
+            {
+              http.response.status_code: 201
+            },
+            {
+              http.route: {org}/{app}/instances/create
+            },
+            {
+              network.protocol.version: 1.1
+            },
+            {
+              TestId: Guid_2
+            },
+            {
+              url.scheme: http
+            },
+            {
+              user.authentication.token.clientId: Guid_3
+            },
+            {
+              user.authentication.token.isExchanged: true
+            },
+            {
+              user.authentication.token.issuer: Maskinporten
+            },
+            {
+              user.authentication.type: SystemUser
+            }
+          ]
+        },
+        {
+          Tags: [
+            {
+              http.request.method: GET
+            },
+            {
+              http.response.status_code: 200
+            },
+            {
+              http.route: {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/data/{dataGuid:guid}
+            },
+            {
+              network.protocol.version: 1.1
+            },
+            {
+              TestId: Guid_2
+            },
+            {
+              url.scheme: http
+            },
+            {
+              user.authentication.token.clientId: Guid_3
+            },
+            {
+              user.authentication.token.isExchanged: true
+            },
+            {
+              user.authentication.token.issuer: Maskinporten
+            },
+            {
+              user.authentication.type: SystemUser
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_User.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.PostNewInstance_Simplified_User.verified.txt
@@ -1,7 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: POST {org}/{app}/instances/create,
+      Name: POST {org}/{app}/instances/create,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: POST
@@ -28,7 +30,7 @@
           url.scheme: http
         },
         {
-          user.authentication.inAltinnPortal: True
+          user.authentication.inAltinnPortal: true
         },
         {
           user.authentication.level: 2
@@ -37,7 +39,7 @@
           user.authentication.method: BankID
         },
         {
-          user.authentication.token.isExchanged: False
+          user.authentication.token.isExchanged: false
         },
         {
           user.authentication.token.issuer: Altinn
@@ -52,9 +54,77 @@
           user.party.id: 501337
         }
       ],
-      IdFormat: W3C,
-      Kind: Server
+      HasParent: false
     }
   ],
-  Metrics: []
+  Metrics: [
+    {
+      Name: http.server.request.duration,
+      MeterName: Microsoft.AspNetCore.Hosting,
+      Measurements: [
+        {
+          Tags: [
+            {
+              http.request.method: POST
+            },
+            {
+              http.response.status_code: 201
+            },
+            {
+              http.route: {org}/{app}/instances/create
+            },
+            {
+              network.protocol.version: 1.1
+            },
+            {
+              TestId: Guid_1
+            },
+            {
+              url.scheme: http
+            },
+            {
+              user.authentication.token.isExchanged: false
+            },
+            {
+              user.authentication.token.issuer: Altinn
+            },
+            {
+              user.authentication.type: User
+            }
+          ]
+        },
+        {
+          Tags: [
+            {
+              http.request.method: GET
+            },
+            {
+              http.response.status_code: 200
+            },
+            {
+              http.route: {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/data/{dataGuid:guid}
+            },
+            {
+              network.protocol.version: 1.1
+            },
+            {
+              TestId: Guid_1
+            },
+            {
+              url.scheme: http
+            },
+            {
+              user.authentication.token.isExchanged: false
+            },
+            {
+              user.authentication.token.issuer: Altinn
+            },
+            {
+              user.authentication.type: User
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.cs
@@ -158,6 +158,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         TestData.DeleteInstanceAndData(org, app, instanceId);
 
         var telemetry = this.Services.GetRequiredService<TelemetrySink>();
+        await Task.Delay(100); // For some reason metric telemetry is not captured immediately, waiting a bit
         await telemetry.Snapshot(settings => settings.UseTextForParameters(token.Type.ToString()));
     }
 

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.cs
@@ -128,8 +128,11 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         {
             services.AddTelemetrySink(
                 shouldAlsoListenToActivities: (_, source) => source.Name == "Microsoft.AspNetCore",
+                shouldAlsoListenToMetrics: (_, source) => source.Name == "Microsoft.AspNetCore.Hosting",
                 activityFilter: (_, activity) =>
-                    this.ActivityFilter(_, activity) && activity.DisplayName == "POST {org}/{app}/instances/create"
+                    this.ActivityFilter(_, activity) && activity.DisplayName == "POST {org}/{app}/instances/create",
+                metricFilter: (_, metric) =>
+                    this.MetricFilter(_, metric) && metric.Name == "http.server.request.duration"
             );
         };
 
@@ -155,7 +158,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         TestData.DeleteInstanceAndData(org, app, instanceId);
 
         var telemetry = this.Services.GetRequiredService<TelemetrySink>();
-        await telemetry.SnapshotActivities(settings => settings.UseTextForParameters(token.Type.ToString()));
+        await telemetry.Snapshot(settings => settings.UseTextForParameters(token.Type.ToString()));
     }
 
     [Fact]

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_Reject_ReturnsOk.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_Reject_ReturnsOk.verified.txt
@@ -1,7 +1,8 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Authorization.Service.AuthorizeAction,
+      Name: Authorization.Service.AuthorizeAction,
+      IdFormat: W3C,
       Tags: [
         {
           authorization.action: reject
@@ -16,10 +17,12 @@
           task.id: Task_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,
+      Name: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: PUT
@@ -49,7 +52,7 @@
           url.scheme: http
         },
         {
-          user.authentication.inAltinnPortal: True
+          user.authentication.inAltinnPortal: true
         },
         {
           user.authentication.level: 2
@@ -58,7 +61,7 @@
           user.authentication.method: BankID
         },
         {
-          user.authentication.token.isExchanged: False
+          user.authentication.token.isExchanged: false
         },
         {
           user.authentication.token.issuer: Altinn
@@ -73,29 +76,32 @@
           user.party.id: 500600
         }
       ],
+      HasParent: false
+    },
+    {
+      Name: Process.End,
       IdFormat: W3C,
-      Kind: Server
-    },
-    {
-      ActivityName: Process.End,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.HandleEvents,
+      Name: Process.HandleEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.Next,
+      Name: Process.Next,
+      IdFormat: W3C,
+      Status: Ok,
       Tags: [
         {
           instance.guid: Guid_1
@@ -104,8 +110,6 @@
           process.action: reject
         }
       ],
-      IdFormat: W3C,
-      Status: Ok,
       Events: [
         {
           Name: change,
@@ -130,101 +134,123 @@
             }
           ]
         }
-      ]
+      ],
+      HasParent: true
     },
     {
-      ActivityName: Process.StoreEvents,
+      Name: Process.StoreEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: ProcessClient.GetProcessDefinition,
-      IdFormat: W3C
+      Name: ProcessClient.GetProcessDefinition,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetAllFlowElements,
-      IdFormat: W3C
+      Name: ProcessReader.GetAllFlowElements,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetAllFlowElements,
-      IdFormat: W3C
+      Name: ProcessReader.GetAllFlowElements,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetAltinnTaskExtension,
-      IdFormat: W3C
+      Name: ProcessReader.GetAltinnTaskExtension,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetEndEventIds,
-      IdFormat: W3C
+      Name: ProcessReader.GetEndEventIds,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetEndEvents,
-      IdFormat: W3C
+      Name: ProcessReader.GetEndEvents,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetEndEvents,
-      IdFormat: W3C
+      Name: ProcessReader.GetEndEvents,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetEndEvents,
-      IdFormat: W3C
+      Name: ProcessReader.GetEndEvents,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetExclusiveGateways,
-      IdFormat: W3C
+      Name: ProcessReader.GetExclusiveGateways,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetExclusiveGateways,
-      IdFormat: W3C
+      Name: ProcessReader.GetExclusiveGateways,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetFlowElement,
-      IdFormat: W3C
+      Name: ProcessReader.GetFlowElement,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetNextElements,
-      IdFormat: W3C
+      Name: ProcessReader.GetNextElements,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetProcessTaskIds,
-      IdFormat: W3C
+      Name: ProcessReader.GetProcessTaskIds,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetProcessTasks,
-      IdFormat: W3C
+      Name: ProcessReader.GetProcessTasks,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetProcessTasks,
-      IdFormat: W3C
+      Name: ProcessReader.GetProcessTasks,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetProcessTasks,
-      IdFormat: W3C
+      Name: ProcessReader.GetProcessTasks,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetSequenceFlows,
-      IdFormat: W3C
+      Name: ProcessReader.GetSequenceFlows,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetStartEvents,
-      IdFormat: W3C
+      Name: ProcessReader.GetStartEvents,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetStartEvents,
-      IdFormat: W3C
+      Name: ProcessReader.GetStartEvents,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.IsEndEvent,
-      IdFormat: W3C
+      Name: ProcessReader.IsEndEvent,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.IsProcessTask,
-      IdFormat: W3C
+      Name: ProcessReader.IsProcessTask,
+      IdFormat: W3C,
+      HasParent: true
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
@@ -1,79 +1,98 @@
 ﻿{
   Activities: [
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutModel,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutModel,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutModel,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutModel,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSetsForTask,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSetsForTask,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSetsForTask,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSetsForTask,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSettingsForSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSettingsForSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetValidationConfiguration,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetValidationConfiguration,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: Authorization.Service.AuthorizeAction,
+      Name: Authorization.Service.AuthorizeAction,
+      IdFormat: W3C,
       Tags: [
         {
           authorization.action: write
@@ -88,10 +107,12 @@
           task.id: Task_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,
+      Name: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: PUT
@@ -127,7 +148,7 @@
           url.scheme: http
         },
         {
-          user.authentication.inAltinnPortal: True
+          user.authentication.inAltinnPortal: true
         },
         {
           user.authentication.level: 2
@@ -136,7 +157,7 @@
           user.authentication.method: BankID
         },
         {
-          user.authentication.token.isExchanged: False
+          user.authentication.token.isExchanged: false
         },
         {
           user.authentication.token.issuer: Altinn
@@ -151,32 +172,36 @@
           user.party.id: 500600
         }
       ],
+      HasParent: false
+    },
+    {
+      Name: ProcessClient.GetProcessDefinition,
       IdFormat: W3C,
-      Kind: Server
+      HasParent: true
     },
     {
-      ActivityName: ProcessClient.GetProcessDefinition,
-      IdFormat: W3C
+      Name: ProcessReader.GetAltinnTaskExtension,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetAltinnTaskExtension,
-      IdFormat: W3C
+      Name: ProcessReader.GetFlowElement,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetFlowElement,
-      IdFormat: W3C
-    },
-    {
-      ActivityName: SerializationService.DeserializeXml,
+      Name: SerializationService.DeserializeXml,
+      IdFormat: W3C,
       Tags: [
         {
           Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -188,10 +213,11 @@
           validator.type: RequiredLayoutValidator
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -203,10 +229,11 @@
           validator.type: ExpressionValidator
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -218,10 +245,11 @@
           validator.type: TaskValidatorWrapper
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -233,10 +261,11 @@
           validator.type: DataElementValidatorWrapper
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -248,10 +277,11 @@
           validator.type: FormDataValidatorWrapper
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -263,10 +293,11 @@
           validator.type: FormDataValidatorWrapper
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 1
@@ -278,10 +309,11 @@
           validator.type: FormDataValidatorWrapper
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.ValidateInstanceAtTask,
+      Name: Validation.ValidateInstanceAtTask,
+      IdFormat: W3C,
       Tags: [
         {
           task.id: Task_1
@@ -290,8 +322,7 @@
           validation.total_issue_count: 1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -1,87 +1,108 @@
 ﻿{
   Activities: [
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutModel,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutModel,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutModel,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutModel,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSets,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSetsForTask,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSetsForTask,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSetsForTask,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSetsForTask,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSettingsForSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetLayoutSettingsForSet,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetLayoutSettingsForSet,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetTexts,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetTexts,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetTexts,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetTexts,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetValidationConfiguration,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ApplicationMetadata.Service.GetValidationConfiguration,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Service.GetValidationConfiguration,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: Authorization.Service.AuthorizeAction,
+      Name: Authorization.Service.AuthorizeAction,
+      IdFormat: W3C,
       Tags: [
         {
           authorization.action: write
@@ -96,10 +117,13 @@
           task.id: Task_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,
+      Name: PUT {org}/{app}/instances/{instanceOwnerPartyId:int}/{instanceGuid:guid}/process/next,
+      Kind: Server,
+      IdFormat: W3C,
+      Status: Error,
       Tags: [
         {
           http.request.method: PUT
@@ -135,7 +159,7 @@
           url.scheme: http
         },
         {
-          user.authentication.inAltinnPortal: True
+          user.authentication.inAltinnPortal: true
         },
         {
           user.authentication.level: 2
@@ -144,7 +168,7 @@
           user.authentication.method: BankID
         },
         {
-          user.authentication.token.isExchanged: False
+          user.authentication.token.isExchanged: false
         },
         {
           user.authentication.token.issuer: Altinn
@@ -159,16 +183,16 @@
           user.party.id: 500600
         }
       ],
+      HasParent: false
+    },
+    {
+      Name: PdfGeneratorClient.GeneratePdf,
       IdFormat: W3C,
-      Status: Error,
-      Kind: Server
+      HasParent: true
     },
     {
-      ActivityName: PdfGeneratorClient.GeneratePdf,
-      IdFormat: W3C
-    },
-    {
-      ActivityName: PdfService.GenerateAndStorePdf,
+      Name: PdfService.GenerateAndStorePdf,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
@@ -177,28 +201,31 @@
           task.id: Task_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.End,
+      Name: Process.End,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.HandleEvents,
+      Name: Process.HandleEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.Next,
+      Name: Process.Next,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
@@ -207,110 +234,131 @@
           process.action: write
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: ProcessClient.GetProcessDefinition,
-      IdFormat: W3C
+      Name: ProcessClient.GetProcessDefinition,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetAllFlowElements,
-      IdFormat: W3C
+      Name: ProcessReader.GetAllFlowElements,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetAltinnTaskExtension,
-      IdFormat: W3C
+      Name: ProcessReader.GetAltinnTaskExtension,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetEndEventIds,
-      IdFormat: W3C
+      Name: ProcessReader.GetEndEventIds,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetEndEvents,
-      IdFormat: W3C
+      Name: ProcessReader.GetEndEvents,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetEndEvents,
-      IdFormat: W3C
+      Name: ProcessReader.GetEndEvents,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetExclusiveGateways,
-      IdFormat: W3C
+      Name: ProcessReader.GetExclusiveGateways,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetFlowElement,
-      IdFormat: W3C
+      Name: ProcessReader.GetFlowElement,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetNextElements,
-      IdFormat: W3C
+      Name: ProcessReader.GetNextElements,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetProcessTaskIds,
-      IdFormat: W3C
+      Name: ProcessReader.GetProcessTaskIds,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetProcessTasks,
-      IdFormat: W3C
+      Name: ProcessReader.GetProcessTasks,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetProcessTasks,
-      IdFormat: W3C
+      Name: ProcessReader.GetProcessTasks,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetSequenceFlows,
-      IdFormat: W3C
+      Name: ProcessReader.GetSequenceFlows,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetStartEvents,
-      IdFormat: W3C
+      Name: ProcessReader.GetStartEvents,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.IsEndEvent,
-      IdFormat: W3C
+      Name: ProcessReader.IsEndEvent,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.IsProcessTask,
-      IdFormat: W3C
+      Name: ProcessReader.IsProcessTask,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: SerializationService.DeserializeXml,
+      Name: SerializationService.DeserializeXml,
+      IdFormat: W3C,
       Tags: [
         {
           Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: SerializationService.DeserializeXml,
+      Name: SerializationService.DeserializeXml,
+      IdFormat: W3C,
       Tags: [
         {
           Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: SerializationService.DeserializeXml,
+      Name: SerializationService.DeserializeXml,
+      IdFormat: W3C,
       Tags: [
         {
           Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: SerializationService.SerializeXml,
+      Name: SerializationService.SerializeXml,
+      IdFormat: W3C,
       Tags: [
         {
           Type: Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -322,10 +370,11 @@
           validator.type: RequiredLayoutValidator
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -337,10 +386,11 @@
           validator.type: ExpressionValidator
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -352,10 +402,11 @@
           validator.type: TaskValidatorWrapper
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -367,10 +418,11 @@
           validator.type: DataElementValidatorWrapper
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -382,10 +434,11 @@
           validator.type: FormDataValidatorWrapper
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.RunValidator,
+      Name: Validation.RunValidator,
+      IdFormat: W3C,
       Tags: [
         {
           validation.issue_count: 0
@@ -397,10 +450,11 @@
           validator.type: FormDataValidatorWrapper
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Validation.ValidateInstanceAtTask,
+      Name: Validation.ValidateInstanceAtTask,
+      IdFormat: W3C,
       Tags: [
         {
           task.id: Task_1
@@ -409,8 +463,7 @@
           validation.total_issue_count: 0
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
+++ b/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
@@ -52,6 +52,17 @@ public class ApiTestBase
         return false;
     };
 
+    protected readonly Func<TestId?, MetricMeasurement, bool> MetricFilter = static (thisTestId, metric) =>
+    {
+        Assert.NotNull(thisTestId);
+        if (metric.Tags.TryGetValue(nameof(TestId), out var testId) && testId is Guid id && id == thisTestId.Value)
+        {
+            return true;
+        }
+
+        return false;
+    };
+
     protected ApiTestBase(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
     {
         _factory = factory;
@@ -92,6 +103,11 @@ public class ApiTestBase
             if (activity is not null)
             {
                 activity.AddTag(nameof(TestId), _testId);
+            }
+            var metrics = httpContext.Features.Get<IHttpMetricsTagsFeature>();
+            if (metrics is not null)
+            {
+                metrics.Tags.Add(new KeyValuePair<string, object?>(nameof(TestId), _testId));
             }
             return _next(httpContext);
         }

--- a/test/Altinn.App.Api.Tests/Helpers/Patch/PatchServiceTests.Test_Ok.verified.txt
+++ b/test/Altinn.App.Api.Tests/Helpers/Patch/PatchServiceTests.Test_Ok.verified.txt
@@ -1,18 +1,19 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Data.Patch,
+      Name: Data.Patch,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     },
     {
-      ActivityName: Data.ProcessWrite.IDataProcessorProxy,
-      IdFormat: W3C
+      Name: Data.ProcessWrite.IDataProcessorProxy,
+      IdFormat: W3C,
+      HasParent: true
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Always_Be_A_Root_Trace.verified.txt
+++ b/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Always_Be_A_Root_Trace.verified.txt
@@ -1,7 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: GET {org}/{app}/api/v1/applicationmetadata,
+      Name: GET {org}/{app}/api/v1/applicationmetadata,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: GET
@@ -28,7 +30,7 @@
           url.scheme: http
         },
         {
-          user.authentication.inAltinnPortal: True
+          user.authentication.inAltinnPortal: true
         },
         {
           user.authentication.level: 4
@@ -37,7 +39,7 @@
           user.authentication.method: BankID
         },
         {
-          user.authentication.token.isExchanged: False
+          user.authentication.token.isExchanged: false
         },
         {
           user.authentication.token.issuer: Altinn
@@ -52,9 +54,7 @@
           user.party.id: Scrubbed
         }
       ],
-      IdFormat: W3C,
-      Kind: Server
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Always_Be_A_Root_Trace_Unless_Pdf.verified.txt
+++ b/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Always_Be_A_Root_Trace_Unless_Pdf.verified.txt
@@ -1,7 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: GET {org}/{app}/api/v1/applicationmetadata,
+      Name: GET {org}/{app}/api/v1/applicationmetadata,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: GET
@@ -28,7 +30,7 @@
           url.scheme: http
         },
         {
-          user.authentication.inAltinnPortal: True
+          user.authentication.inAltinnPortal: true
         },
         {
           user.authentication.level: 4
@@ -37,7 +39,7 @@
           user.authentication.method: BankID
         },
         {
-          user.authentication.token.isExchanged: False
+          user.authentication.token.isExchanged: false
         },
         {
           user.authentication.token.issuer: Altinn
@@ -52,9 +54,7 @@
           user.party.id: Scrubbed
         }
       ],
-      IdFormat: W3C,
-      Kind: Server
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Always_Be_A_Root_Trace_Unless_Pdf.verified.txt
+++ b/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Always_Be_A_Root_Trace_Unless_Pdf.verified.txt
@@ -54,7 +54,7 @@
           user.party.id: Scrubbed
         }
       ],
-      HasParent: false
+      HasParent: true
     }
   ]
 }

--- a/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Have_Root_AspNetCore_Trace_Org.verified.txt
+++ b/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Have_Root_AspNetCore_Trace_Org.verified.txt
@@ -1,7 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: GET {org}/{app}/api/v1/applicationmetadata,
+      Name: GET {org}/{app}/api/v1/applicationmetadata,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: GET
@@ -40,7 +42,10 @@
           user.authentication.method: maskinporten
         },
         {
-          user.authentication.token.isExchanged: True
+          user.authentication.token.clientId: Guid_2
+        },
+        {
+          user.authentication.token.isExchanged: true
         },
         {
           user.authentication.token.issuer: Maskinporten
@@ -49,9 +54,7 @@
           user.authentication.type: ServiceOwner
         }
       ],
-      IdFormat: W3C,
-      Kind: Server
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Have_Root_AspNetCore_Trace_User.verified.txt
+++ b/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.Should_Have_Root_AspNetCore_Trace_User.verified.txt
@@ -1,7 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: GET {org}/{app}/api/v1/applicationmetadata,
+      Name: GET {org}/{app}/api/v1/applicationmetadata,
+      Kind: Server,
+      IdFormat: W3C,
       Tags: [
         {
           http.request.method: GET
@@ -28,7 +30,7 @@
           url.scheme: http
         },
         {
-          user.authentication.inAltinnPortal: True
+          user.authentication.inAltinnPortal: true
         },
         {
           user.authentication.level: 4
@@ -37,7 +39,7 @@
           user.authentication.method: BankID
         },
         {
-          user.authentication.token.isExchanged: False
+          user.authentication.token.isExchanged: false
         },
         {
           user.authentication.token.issuer: Altinn
@@ -52,9 +54,7 @@
           user.party.id: Scrubbed
         }
       ],
-      IdFormat: W3C,
-      Kind: Server
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Email/EmailNotificationClientTests.Order_VerifyHttpCall.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Email/EmailNotificationClientTests.Order_VerifyHttpCall.verified.txt
@@ -1,24 +1,31 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Notifications.Order,
+      Name: Notifications.Order,
+      IdFormat: W3C,
       Tags: [
         {
           type: email
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
   ],
   Metrics: [
     {
-      altinn_app_lib_notification_orders: [
+      Name: altinn_app_lib_notification_orders,
+      MeterName: test,
+      Measurements: [
         {
-          Value: 1,
-          Tags: {
-            result: success,
-            type: email
-          }
+          Value: 1.0,
+          Tags: [
+            {
+              result: success
+            },
+            {
+              type: email
+            }
+          ]
         }
       ]
     }

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Sms/SmsNotificationClientTests.Order_VerifyHttpCall.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Sms/SmsNotificationClientTests.Order_VerifyHttpCall.verified.txt
@@ -1,24 +1,31 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Notifications.Order,
+      Name: Notifications.Order,
+      IdFormat: W3C,
       Tags: [
         {
           type: sms
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
   ],
   Metrics: [
     {
-      altinn_app_lib_notification_orders: [
+      Name: altinn_app_lib_notification_orders,
+      MeterName: test,
+      Measurements: [
         {
-          Value: 1,
-          Tags: {
-            result: success,
-            type: sms
-          }
+          Value: 1.0,
+          Tags: [
+            {
+              result: success
+            },
+            {
+              type: sms
+            }
+          ]
         }
       ]
     }

--- a/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.GenericFormDataValidator_serviceModelIsString_CallsValidatorFunctionForIncremental.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.GenericFormDataValidator_serviceModelIsString_CallsValidatorFunctionForIncremental.verified.txt
@@ -2,13 +2,14 @@
   telemetry: {
     Activities: [
       {
-        ActivityName: Validation.RunValidator,
+        Name: Validation.RunValidator,
+        IdFormat: W3C,
         Tags: [
           {
             validation.issue_count: 1
           },
           {
-            validator.has_relevant_changes: True
+            validator.has_relevant_changes: true
           },
           {
             validator.source: Altinn.App.Core.Tests.Features.Validators.ValidationServiceTests+GenericValidatorFake-default
@@ -17,10 +18,11 @@
             validator.type: FormDataValidatorWrapper
           }
         ],
-        IdFormat: W3C
+        HasParent: true
       },
       {
-        ActivityName: Validation.ValidateIncremental,
+        Name: Validation.ValidateIncremental,
+        IdFormat: W3C,
         Tags: [
           {
             task.id: Task_1
@@ -29,7 +31,6 @@
             validation.total_issue_count: 1
           }
         ],
-        IdFormat: W3C,
         Events: [
           {
             Name: ChangedDataElements,
@@ -46,10 +47,10 @@
               }
             ]
           }
-        ]
+        ],
+        HasParent: false
       }
-    ],
-    Metrics: []
+    ]
   },
   issues: [
     {

--- a/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.GenericFormDataValidator_serviceModelIsString_CallsValidatorFunctionForTask.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.GenericFormDataValidator_serviceModelIsString_CallsValidatorFunctionForTask.verified.txt
@@ -2,7 +2,8 @@
   telemetry: {
     Activities: [
       {
-        ActivityName: Validation.RunValidator,
+        Name: Validation.RunValidator,
+        IdFormat: W3C,
         Tags: [
           {
             validation.issue_count: 1
@@ -14,10 +15,11 @@
             validator.type: FormDataValidatorWrapper
           }
         ],
-        IdFormat: W3C
+        HasParent: true
       },
       {
-        ActivityName: Validation.ValidateInstanceAtTask,
+        Name: Validation.ValidateInstanceAtTask,
+        IdFormat: W3C,
         Tags: [
           {
             task.id: Task_1
@@ -26,10 +28,9 @@
             validation.total_issue_count: 1
           }
         ],
-        IdFormat: W3C
+        HasParent: false
       }
-    ],
-    Metrics: []
+    ]
   },
   issues: [
     {

--- a/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.ValidateIncrementalFormData_WithNoData_ShouldReturnNoIssues.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.ValidateIncrementalFormData_WithNoData_ShouldReturnNoIssues.verified.txt
@@ -1,7 +1,8 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Validation.ValidateIncremental,
+      Name: Validation.ValidateIncremental,
+      IdFormat: W3C,
       Tags: [
         {
           task.id: Task_1
@@ -10,7 +11,6 @@
           validation.total_issue_count: 0
         }
       ],
-      IdFormat: W3C,
       Events: [
         {
           Name: ChangedDataElements,
@@ -21,8 +21,8 @@
             }
           ]
         }
-      ]
+      ],
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.ValidateInstanceAtTask_WithNoData_ShouldReturnNoIssues.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Validators/ValidationServiceTests.ValidateInstanceAtTask_WithNoData_ShouldReturnNoIssues.verified.txt
@@ -1,7 +1,8 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Validation.ValidateInstanceAtTask,
+      Name: Validation.ValidateInstanceAtTask,
+      IdFormat: W3C,
       Tags: [
         {
           task.id: Task_1
@@ -10,8 +11,7 @@
           validation.total_issue_count: 0
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Implementation/EventsClientTest.AddEvent_RegisterEventWithInstanceOwnerOrganisation_CloudEventInRequestContainOrganisationNumber.verified.txt
+++ b/test/Altinn.App.Core.Tests/Implementation/EventsClientTest.AddEvent_RegisterEventWithInstanceOwnerOrganisation_CloudEventInRequestContainOrganisationNumber.verified.txt
@@ -1,9 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: EventClient.GetAsyncWithId,
-      IdFormat: W3C
+      Name: EventClient.GetAsyncWithId,
+      IdFormat: W3C,
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Implementation/InstanceClientTests.AddCompleteConfirmation_SuccessfulCallToStorage.verified.txt
+++ b/test/Altinn.App.Core.Tests/Implementation/InstanceClientTests.AddCompleteConfirmation_SuccessfulCallToStorage.verified.txt
@@ -1,7 +1,8 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Instance.CompleteConfirmation,
+      Name: Instance.CompleteConfirmation,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
@@ -10,14 +11,16 @@
           instance.owner.party.id: 1337
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
   ],
   Metrics: [
     {
-      altinn_app_lib_instances_completed: [
+      Name: altinn_app_lib_instances_completed,
+      MeterName: test,
+      Measurements: [
         {
-          Value: 1
+          Value: 1.0
         }
       ]
     }

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.AuthorizeActions_returns_dictionary_with_one_action_denied.verified.txt
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Authorization/AuthorizationClientTests.AuthorizeActions_returns_dictionary_with_one_action_denied.verified.txt
@@ -1,14 +1,14 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Authorization.Client.AuthorizeActions,
+      Name: Authorization.Client.AuthorizeActions,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Profile/ProfileClientTests.Returns_Test_Profile.verified.txt
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Profile/ProfileClientTests.Returns_Test_Profile.verified.txt
@@ -1,14 +1,14 @@
 ﻿{
   Activities: [
     {
-      ActivityName: ProfileClient.GetUserProfile,
+      Name: ProfileClient.GetUserProfile,
+      IdFormat: W3C,
       Tags: [
         {
           user.id: 1234
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.InsertBinaryData_MethodProduceValidPlatformRequest.verified.txt
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.InsertBinaryData_MethodProduceValidPlatformRequest.verified.txt
@@ -1,14 +1,14 @@
 ﻿{
   Activities: [
     {
-      ActivityName: DataClient.InsertBinaryData,
+      Name: DataClient.InsertBinaryData,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMetadataTest.GetApplicationMetadata_desrializes_file_from_disk.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMetadataTest.GetApplicationMetadata_desrializes_file_from_disk.verified.txt
@@ -1,9 +1,9 @@
 ﻿{
   Activities: [
     {
-      ActivityName: ApplicationMetadata.Client.Get,
-      IdFormat: W3C
+      Name: ApplicationMetadata.Client.Get,
+      IdFormat: W3C,
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Internal/Auth/AuthorizationServiceTests.GetPartyList_returns_party_list_from_AuthorizationClient.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Auth/AuthorizationServiceTests.GetPartyList_returns_party_list_from_AuthorizationClient.verified.txt
@@ -1,14 +1,14 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Authorization.Service.GetPartyList,
+      Name: Authorization.Service.GetPartyList,
+      IdFormat: W3C,
       Tags: [
         {
           user.id: 1337
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.GenerateAndStorePdf.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.GenerateAndStorePdf.verified.txt
@@ -1,7 +1,8 @@
 ﻿{
   Activities: [
     {
-      ActivityName: PdfService.GenerateAndStorePdf,
+      Name: PdfService.GenerateAndStorePdf,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
@@ -10,8 +11,7 @@
           task.id: Task_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task_SelfIdentifiedUser.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task_SelfIdentifiedUser.verified.txt
@@ -1,23 +1,24 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Process.HandleEvents,
+      Name: Process.HandleEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     },
     {
-      ActivityName: Process.Start,
+      Name: Process.Start,
+      IdFormat: W3C,
+      Status: Ok,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C,
-      Status: Ok,
       Events: [
         {
           Name: change,
@@ -37,23 +38,27 @@
             }
           ]
         }
-      ]
+      ],
+      HasParent: false
     },
     {
-      ActivityName: Process.StoreEvents,
+      Name: Process.StoreEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
   ],
   Metrics: [
     {
-      altinn_app_lib_processes_started: [
+      Name: altinn_app_lib_processes_started,
+      MeterName: test,
+      Measurements: [
         {
-          Value: 1
+          Value: 1.0
         }
       ]
     }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task_ServiceOwner.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task_ServiceOwner.verified.txt
@@ -1,23 +1,24 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Process.HandleEvents,
+      Name: Process.HandleEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     },
     {
-      ActivityName: Process.Start,
+      Name: Process.Start,
+      IdFormat: W3C,
+      Status: Ok,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C,
-      Status: Ok,
       Events: [
         {
           Name: change,
@@ -37,23 +38,27 @@
             }
           ]
         }
-      ]
+      ],
+      HasParent: false
     },
     {
-      ActivityName: Process.StoreEvents,
+      Name: Process.StoreEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
   ],
   Metrics: [
     {
-      altinn_app_lib_processes_started: [
+      Name: altinn_app_lib_processes_started,
+      MeterName: test,
+      Measurements: [
         {
-          Value: 1
+          Value: 1.0
         }
       ]
     }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task_SystemUser.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task_SystemUser.verified.txt
@@ -1,23 +1,24 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Process.HandleEvents,
+      Name: Process.HandleEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     },
     {
-      ActivityName: Process.Start,
+      Name: Process.Start,
+      IdFormat: W3C,
+      Status: Ok,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C,
-      Status: Ok,
       Events: [
         {
           Name: change,
@@ -37,23 +38,27 @@
             }
           ]
         }
-      ]
+      ],
+      HasParent: false
     },
     {
-      ActivityName: Process.StoreEvents,
+      Name: Process.StoreEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
   ],
   Metrics: [
     {
-      altinn_app_lib_processes_started: [
+      Name: altinn_app_lib_processes_started,
+      MeterName: test,
+      Measurements: [
         {
-          Value: 1
+          Value: 1.0
         }
       ]
     }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task_User.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.StartProcess_starts_process_and_moves_to_first_task_User.verified.txt
@@ -1,23 +1,24 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Process.HandleEvents,
+      Name: Process.HandleEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     },
     {
-      ActivityName: Process.Start,
+      Name: Process.Start,
+      IdFormat: W3C,
+      Status: Ok,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C,
-      Status: Ok,
       Events: [
         {
           Name: change,
@@ -37,23 +38,27 @@
             }
           ]
         }
-      ]
+      ],
+      HasParent: false
     },
     {
-      ActivityName: Process.StoreEvents,
+      Name: Process.StoreEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: false
     }
   ],
   Metrics: [
     {
-      altinn_app_lib_processes_started: [
+      Name: altinn_app_lib_processes_started,
+      MeterName: test,
+      Measurements: [
         {
-          Value: 1
+          Value: 1.0
         }
       ]
     }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.Telemetry.IProcessEnd_not_registered.json.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.Telemetry.IProcessEnd_not_registered.json.verified.txt
@@ -1,32 +1,34 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Process.End,
+      Name: Process.End,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.HandleEvents,
+      Name: Process.HandleEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.Next,
-      Tags: [
-        {
-          instance.guid: Guid_1
-        }
-      ],
+      Name: Process.Next,
       IdFormat: W3C,
       Status: Ok,
+      Tags: [
+        {
+          instance.guid: Guid_1
+        }
+      ],
       Events: [
         {
           Name: change,
@@ -45,17 +47,18 @@
             {}
           ]
         }
-      ]
+      ],
+      HasParent: false
     },
     {
-      ActivityName: Process.StoreEvents,
+      Name: Process.StoreEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.Telemetry.IProcessEnd_registered.json.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.Telemetry.IProcessEnd_registered.json.verified.txt
@@ -1,50 +1,54 @@
 ﻿{
   Activities: [
     {
-      ActivityName: Process.End,
+      Name: Process.End,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.EndHandler.Castle.Proxies.IProcessEndProxy,
+      Name: Process.EndHandler.Castle.Proxies.IProcessEndProxy,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.EndHandlers,
+      Name: Process.EndHandlers,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.HandleEvents,
+      Name: Process.HandleEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     },
     {
-      ActivityName: Process.Next,
-      Tags: [
-        {
-          instance.guid: Guid_1
-        }
-      ],
+      Name: Process.Next,
       IdFormat: W3C,
       Status: Ok,
+      Tags: [
+        {
+          instance.guid: Guid_1
+        }
+      ],
       Events: [
         {
           Name: change,
@@ -63,17 +67,18 @@
             {}
           ]
         }
-      ]
+      ],
+      HasParent: false
     },
     {
-      ActivityName: Process.StoreEvents,
+      Name: Process.StoreEvents,
+      IdFormat: W3C,
       Tags: [
         {
           instance.guid: Guid_1
         }
       ],
-      IdFormat: W3C
+      HasParent: true
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessReaderTests.IsStartEvent_returns_true_when_element_is_StartEvent.verified.txt
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessReaderTests.IsStartEvent_returns_true_when_element_is_StartEvent.verified.txt
@@ -1,17 +1,19 @@
 ﻿{
   Activities: [
     {
-      ActivityName: ProcessReader.GetStartEventIds,
-      IdFormat: W3C
+      Name: ProcessReader.GetStartEventIds,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.GetStartEvents,
-      IdFormat: W3C
+      Name: ProcessReader.GetStartEvents,
+      IdFormat: W3C,
+      HasParent: true
     },
     {
-      ActivityName: ProcessReader.IsStartEvent,
-      IdFormat: W3C
+      Name: ProcessReader.IsStartEvent,
+      IdFormat: W3C,
+      HasParent: false
     }
-  ],
-  Metrics: []
+  ]
 }

--- a/test/Altinn.App.Tests.Common/TelemetrySink.cs
+++ b/test/Altinn.App.Tests.Common/TelemetrySink.cs
@@ -149,6 +149,7 @@ public sealed record TelemetrySink : IDisposable
         Assert.NotNull(meterProvider);
         Assert.NotNull(traceProvider);
 
+        await Task.Yield();
         Assert.True(meterProvider.ForceFlush(1_000));
         Assert.True(traceProvider.ForceFlush(1_000));
         await Task.Yield();

--- a/test/Altinn.App.Tests.Common/TelemetrySink.cs
+++ b/test/Altinn.App.Tests.Common/TelemetrySink.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
-using static Altinn.App.Tests.Common.TelemetrySink;
 
 namespace Altinn.App.Tests.Common;
 
@@ -22,7 +21,8 @@ public static class TelemetrySinkDI
         string version = "v1",
         Func<TestId?, ActivitySource, bool>? shouldAlsoListenToActivities = null,
         Func<TestId?, Meter, bool>? shouldAlsoListenToMetrics = null,
-        Func<TestId?, Activity, bool>? activityFilter = null
+        Func<TestId?, Activity, bool>? activityFilter = null,
+        Func<TestId?, MetricMeasurement, bool>? metricFilter = null
     )
     {
         var telemetryRegistration = services.FirstOrDefault(s => s.ServiceType == typeof(Telemetry));
@@ -37,7 +37,8 @@ public static class TelemetrySinkDI
             telemetry: null,
             shouldAlsoListenToActivities,
             shouldAlsoListenToMetrics,
-            activityFilter
+            activityFilter,
+            metricFilter
         ));
         services.AddSingleton<Telemetry>(sp => sp.GetRequiredService<TelemetrySink>().Object);
 
@@ -61,26 +62,38 @@ public sealed record TelemetrySink : IDisposable
     private bool _waitForServerActivity = true;
     private readonly TaskCompletionSource _serverActivityTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+    Func<TestId?, Activity, bool>? _activityFilter;
+    Func<TestId?, MetricMeasurement, bool>? _metricFilter;
+    private readonly TestId? _testId;
+
     public async Task WaitForServerActivity() => await _serverActivityTcs.Task;
 
     private readonly ConcurrentBag<Activity> _activities = [];
-    private readonly ConcurrentDictionary<string, IReadOnlyList<MetricMeasurement>> _metricValues = [];
+    private readonly ConcurrentDictionary<
+        (string Name, string Meter),
+        IReadOnlyList<MetricMeasurement>
+    > _metricValues = [];
     private readonly IServiceProvider? _serviceProvider;
-
-    public readonly record struct MetricMeasurement(long Value, IReadOnlyDictionary<string, object?> Tags);
 
     public IEnumerable<Activity> CapturedActivities =>
         _activities.OrderBy(a => a.OperationName).ThenBy(a => a.StartTimeUtc).ToArray();
 
-    public IReadOnlyDictionary<string, IReadOnlyList<MetricMeasurement>> CapturedMetrics => _metricValues;
+    public IReadOnlyDictionary<(string Name, string Meter), IReadOnlyList<MetricMeasurement>> CapturedMetrics =>
+        _metricValues;
 
     public TelemetrySnapshot GetSnapshot() => new(CapturedActivities, CapturedMetrics);
 
     public TelemetrySnapshot GetSnapshot(Activity activity) =>
-        new([activity], new Dictionary<string, IReadOnlyList<MetricMeasurement>>());
+        new([activity], new Dictionary<(string Name, string Meter), IReadOnlyList<MetricMeasurement>>());
 
     public TelemetrySnapshot GetSnapshot(IEnumerable<Activity> activities) =>
-        new(activities, new Dictionary<string, IReadOnlyList<MetricMeasurement>>());
+        new(activities, new Dictionary<(string Name, string Meter), IReadOnlyList<MetricMeasurement>>());
+
+    public async Task Snapshot(
+        Func<SettingsTask, SettingsTask>? configure = null,
+        VerifySettings? settings = null,
+        [CallerFilePath] string sourceFile = ""
+    ) => await SnapshotInternal(configure, settings, sourceFile);
 
     public async Task Snapshot(
         Activity activity,
@@ -114,6 +127,19 @@ public sealed record TelemetrySink : IDisposable
         await task;
     }
 
+    private async Task SnapshotInternal(
+        Func<SettingsTask, SettingsTask>? configure = null,
+        VerifySettings? settings = null,
+        [CallerFilePath] string sourceFile = ""
+    )
+    {
+        TryFlush();
+        var task = Verify(GetSnapshot(), settings: settings, sourceFile: sourceFile);
+        if (configure is not null)
+            task = configure(task);
+        await task;
+    }
+
     public void TryFlush()
     {
         Assert.NotNull(_serviceProvider);
@@ -135,7 +161,8 @@ public sealed record TelemetrySink : IDisposable
         Telemetry? telemetry = null,
         Func<TestId?, ActivitySource, bool>? shouldAlsoListenToActivities = null,
         Func<TestId?, Meter, bool>? shouldAlsoListenToMetrics = null,
-        Func<TestId?, Activity, bool>? activityFilter = null
+        Func<TestId?, Activity, bool>? activityFilter = null,
+        Func<TestId?, MetricMeasurement, bool>? metricFilter = null
     )
     {
         _serviceProvider = serviceProvider;
@@ -145,8 +172,13 @@ public sealed record TelemetrySink : IDisposable
             Assert.NotNull(_serviceProvider);
         if (activityFilter is not null)
             Assert.NotNull(_serviceProvider);
+        if (metricFilter is not null)
+            Assert.NotNull(_serviceProvider);
 
-        var testId = serviceProvider?.GetService<TestId>();
+        _activityFilter = activityFilter;
+        _metricFilter = metricFilter;
+
+        _testId = serviceProvider?.GetService<TestId>();
 
         var appId = new AppIdentifier(org, name);
         var options = new AppSettings { AppVersion = version };
@@ -160,7 +192,7 @@ public sealed record TelemetrySink : IDisposable
                 if (IsDisposed)
                     return false;
                 var sameSource = ReferenceEquals(activitySource, Object.ActivitySource);
-                return sameSource || (shouldAlsoListenToActivities?.Invoke(testId, activitySource) ?? false);
+                return sameSource || (shouldAlsoListenToActivities?.Invoke(_testId, activitySource) ?? false);
             },
             Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
             {
@@ -173,7 +205,7 @@ public sealed record TelemetrySink : IDisposable
                 if (IsDisposed)
                     return;
 
-                if (activityFilter is not null && !activityFilter(testId, activity))
+                if (_activityFilter is not null && !_activityFilter(_testId, activity))
                     return;
                 _activities.Add(activity);
                 if (activity.Kind == ActivityKind.Server)
@@ -191,40 +223,57 @@ public sealed record TelemetrySink : IDisposable
                 var sameSource = ReferenceEquals(instrument.Meter, Object.Meter);
                 if (
                     !sameSource
-                    && (shouldAlsoListenToMetrics is null || !shouldAlsoListenToMetrics(testId, instrument.Meter))
+                    && (shouldAlsoListenToMetrics is null || !shouldAlsoListenToMetrics(_testId, instrument.Meter))
                 )
                 {
                     return;
                 }
 
-                _metricValues.TryAdd(instrument.Name, new List<MetricMeasurement>());
+                var key = (instrument.Name, instrument.Meter.Name);
+                _metricValues.TryAdd(key, new List<MetricMeasurement>());
                 listener.EnableMeasurementEvents(instrument, this);
             },
         };
-        MeterListener.SetMeasurementEventCallback<long>(
-            static (instrument, measurement, tagSpan, state) =>
-            {
-                Debug.Assert(state is not null);
-                var self = (TelemetrySink)state!;
-                if (self.IsDisposed)
-                    return;
-                Debug.Assert(self._metricValues[instrument.Name] is List<MetricMeasurement>);
-                var measurements = (List<MetricMeasurement>)self._metricValues[instrument.Name];
-                var tags = new Dictionary<string, object?>(tagSpan.Length);
-                for (int i = 0; i < tagSpan.Length; i++)
-                {
-                    tags.Add(tagSpan[i].Key, tagSpan[i].Value);
-                }
+        MeterListener.SetMeasurementEventCallback<double>(MeasurementRecordedDouble);
+        MeterListener.SetMeasurementEventCallback<float>(static (i, m, t, s) => MeasurementRecordedDouble(i, m, t, s));
 
-                foreach (var t in instrument.Tags ?? [])
-                {
-                    tags.Add(t.Key, t.Value);
-                }
-
-                measurements.Add(new(measurement, tags));
-            }
-        );
+        MeterListener.SetMeasurementEventCallback<long>(static (i, m, t, s) => MeasurementRecordedDouble(i, m, t, s));
+        MeterListener.SetMeasurementEventCallback<int>(static (i, m, t, s) => MeasurementRecordedDouble(i, m, t, s));
+        MeterListener.SetMeasurementEventCallback<short>(static (i, m, t, s) => MeasurementRecordedDouble(i, m, t, s));
+        MeterListener.SetMeasurementEventCallback<byte>(static (i, m, t, s) => MeasurementRecordedDouble(i, m, t, s));
         MeterListener.Start();
+    }
+
+    private static void MeasurementRecordedDouble(
+        Instrument instrument,
+        double measurement,
+        ReadOnlySpan<KeyValuePair<string, object?>> tagSpan,
+        object? state
+    )
+    {
+        Debug.Assert(state is not null);
+        var self = (TelemetrySink)state!;
+        if (self.IsDisposed)
+            return;
+        var key = (instrument.Name, instrument.Meter.Name);
+        Debug.Assert(self._metricValues[key] is List<MetricMeasurement>);
+        var measurements = (List<MetricMeasurement>)self._metricValues[key];
+        var tags = new Dictionary<string, object?>(tagSpan.Length);
+        for (int i = 0; i < tagSpan.Length; i++)
+        {
+            tags.Add(tagSpan[i].Key, tagSpan[i].Value);
+        }
+
+        foreach (var t in instrument.Tags ?? [])
+        {
+            tags.Add(t.Key, t.Value);
+        }
+
+        MetricMeasurement record = new(instrument.Name, instrument.Meter.Name, measurement, tags);
+        if (self._metricFilter is not null && !self._metricFilter(self._testId, record))
+            return;
+
+        measurements.Add(record);
     }
 
     public void Dispose()
@@ -257,26 +306,55 @@ public sealed record TelemetrySink : IDisposable
     }
 }
 
+public sealed record MetricMeasurement(
+    string Name,
+    string MeterName,
+    double Value,
+    IReadOnlyDictionary<string, object?> Tags
+);
+
 public class TelemetrySnapshot(
     IEnumerable<Activity>? activities,
-    IReadOnlyDictionary<string, IReadOnlyList<MetricMeasurement>>? metrics
+    IReadOnlyDictionary<(string Name, string Meter), IReadOnlyList<MetricMeasurement>>? metrics
 )
 {
     // Properties must be public to be accessible for Verify.Xunit
-    public readonly IEnumerable<object>? Activities = activities?.Select(a => new
-    {
-        ActivityName = a.DisplayName,
-        Tags = a
-            .TagObjects.Select(tag => new KeyValuePair<string, string?>(tag.Key, tag.Value?.ToString()))
-            .Where(tag => tag.Key != "_MS.ProcessedByMetricExtractors")
-            .OrderBy(tag => tag.Key)
-            .ToList(),
-        a.IdFormat,
-        a.Status,
-        a.Events,
-        a.Kind,
-    });
-    public readonly IEnumerable<KeyValuePair<string, IReadOnlyList<MetricMeasurement>>>? Metrics = metrics
-        ?.Select(m => new KeyValuePair<string, IReadOnlyList<MetricMeasurement>>(m.Key, m.Value))
-        .Where(x => x.Value.Count != 0);
+    public readonly IReadOnlyList<ActivityInfo>? Activities = activities
+        ?.Select(a => new ActivityInfo(
+            a.DisplayName,
+            a.Kind,
+            a.IdFormat,
+            a.Status,
+            a.TagObjects.OrderBy(t => t.Key).ToArray(),
+            a.Events.OrderBy(e => e.Name).ToArray(),
+            a.Parent is not null
+        ))
+        .ToArray();
+    public readonly IReadOnlyList<MetricInfo>? Metrics = metrics
+        ?.Select(m => new MetricInfo(
+            m.Key.Name,
+            m.Key.Meter,
+            m.Value.Where(m => m.Value != 0)
+                .Select(measurement => new MetricMeasurementInfo(
+                    double.IsInteger(measurement.Value) ? measurement.Value : null,
+                    measurement.Tags.OrderBy(t => t.Key).ToArray()
+                ))
+                .ToArray()
+        ))
+        .Where(m => m.Measurements.Count > 0)
+        .ToArray();
 }
+
+public sealed record ActivityInfo(
+    string Name,
+    ActivityKind Kind,
+    ActivityIdFormat IdFormat,
+    ActivityStatusCode Status,
+    IReadOnlyList<KeyValuePair<string, object?>> Tags,
+    IReadOnlyList<ActivityEvent> Events,
+    bool HasParent
+);
+
+public sealed record MetricInfo(string Name, string MeterName, IReadOnlyList<MetricMeasurementInfo> Measurements);
+
+public sealed record MetricMeasurementInfo(double? Value, IReadOnlyList<KeyValuePair<string, object?>> Tags);

--- a/test/Altinn.App.Tests.Common/TelemetrySink.cs
+++ b/test/Altinn.App.Tests.Common/TelemetrySink.cs
@@ -60,8 +60,8 @@ public sealed record TelemetrySink : IDisposable
     private bool _waitForServerActivity = true;
     private readonly TaskCompletionSource _serverActivityTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    Func<TestId?, Activity, bool>? _activityFilter;
-    Func<TestId?, MetricMeasurement, bool>? _metricFilter;
+    private readonly Func<TestId?, Activity, bool>? _activityFilter;
+    private readonly Func<TestId?, MetricMeasurement, bool>? _metricFilter;
     private readonly TestId? _testId;
 
     public async Task WaitForServerActivity() => await _serverActivityTcs.Task;

--- a/test/Altinn.App.Tests.Common/TelemetrySink.cs
+++ b/test/Altinn.App.Tests.Common/TelemetrySink.cs
@@ -334,7 +334,7 @@ public class TelemetrySnapshot(
         ?.Select(m => new MetricInfo(
             m.Key.Name,
             m.Key.Meter,
-            m.Value.Where(m => m.Value != 0)
+            m.Value.Where(m => Math.Abs(m.Value) > double.Epsilon)
                 .Select(measurement => new MetricMeasurementInfo(
                     double.IsInteger(measurement.Value) ? measurement.Value : null,
                     measurement.Tags.OrderBy(t => t.Key).ToArray()

--- a/test/Altinn.App.Tests.Common/TelemetrySink.cs
+++ b/test/Altinn.App.Tests.Common/TelemetrySink.cs
@@ -310,7 +310,7 @@ public class TelemetrySnapshot(
             a.Status,
             a.TagObjects.OrderBy(t => t.Key).ToArray(),
             a.Events.OrderBy(e => e.Name).ToArray(),
-            a.Parent is not null
+            a.ParentId is not null
         ))
         .ToArray();
     public readonly IReadOnlyList<MetricInfo>? Metrics = metrics


### PR DESCRIPTION
## Description
Enriches the `http.server.request.duration` metric and adds the token client ID as well.

Background for this is giving service owners ability to do some basic aggregation based on metrics.
Not adding party IDs, org numbers and such to metric tags as that could lead to high cardinality which is something to consider when it comes to metrics.

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
