### PR TITLE
Minor telemetry improvements

### DIFF
--- a/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
@@ -91,7 +91,7 @@ internal sealed class MaskinportenClient : IMaskinportenClient
         DateTimeOffset referenceTime = _timeProvider.GetUtcNow();
 
         _logger.LogDebug("Retrieving Maskinporten token for scopes: {Scopes}", formattedScopes);
-        _telemetry?.StartGetAccessTokenActivity(Variant, Settings.ClientId, formattedScopes);
+        using var activity = _telemetry?.StartGetAccessTokenActivity(Variant, Settings.ClientId, formattedScopes);
 
         var result = await _tokenCache.GetOrCreateAsync(
             cacheKey,
@@ -149,7 +149,11 @@ internal sealed class MaskinportenClient : IMaskinportenClient
         string cacheKey = $"{_altinnCacheKeySalt}_{formattedScopes}";
 
         _logger.LogDebug("Retrieving Altinn token for scopes: {Scopes}", formattedScopes);
-        _telemetry?.StartGetAltinnExchangedAccessTokenActivity(Variant, Settings.ClientId, formattedScopes);
+        using var activity = _telemetry?.StartGetAltinnExchangedAccessTokenActivity(
+            Variant,
+            Settings.ClientId,
+            formattedScopes
+        );
 
         var result = await _tokenCache.GetOrCreateAsync(
             cacheKey,

--- a/src/Altinn.App.Core/Features/Telemetry/Telemetry.DataClient.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Telemetry.DataClient.cs
@@ -21,19 +21,19 @@ partial class Telemetry
         return activity;
     }
 
-    internal Activity? StartUpdateDataActivity(Guid? instanceId, int? partyId)
+    internal Activity? StartUpdateDataActivity(Guid instanceId, Guid dataElementId)
     {
         var activity = ActivitySource.StartActivity($"{Prefix}.UpdateData");
         activity?.SetInstanceId(instanceId);
-        activity?.SetInstanceOwnerPartyId(partyId);
+        activity?.SetDataElementId(dataElementId);
         return activity;
     }
 
-    internal Activity? StartGetBinaryDataActivity(Guid? instanceId, int? partyId)
+    internal Activity? StartGetBinaryDataActivity(Guid instanceId, Guid dataElementId)
     {
         var activity = ActivitySource.StartActivity($"{Prefix}.GetBinaryData");
         activity?.SetInstanceId(instanceId);
-        activity?.SetInstanceOwnerPartyId(partyId);
+        activity?.SetDataElementId(dataElementId);
         return activity;
     }
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Storage/DataClient.cs
@@ -138,7 +138,7 @@ public class DataClient : IDataClient
     )
         where T : notnull
     {
-        using var activity = _telemetry?.StartUpdateDataActivity(instanceGuid, instanceOwnerPartyId);
+        using var activity = _telemetry?.StartUpdateDataActivity(instanceGuid, dataId);
         string instanceIdentifier = $"{instanceOwnerPartyId}/{instanceGuid}";
         string apiUrl = $"instances/{instanceIdentifier}/data/{dataId}";
         string token = _userTokenProvider.GetUserToken();
@@ -173,7 +173,7 @@ public class DataClient : IDataClient
         Guid dataId
     )
     {
-        using var activity = _telemetry?.StartGetBinaryDataActivity(instanceGuid, instanceOwnerPartyId);
+        using var activity = _telemetry?.StartGetBinaryDataActivity(instanceGuid, dataId);
         string instanceIdentifier = $"{instanceOwnerPartyId}/{instanceGuid}";
         string apiUrl = $"instances/{instanceIdentifier}/data/{dataId}";
 
@@ -240,7 +240,7 @@ public class DataClient : IDataClient
         Guid dataId
     )
     {
-        using var activity = _telemetry?.StartGetBinaryDataActivity(instanceGuid, instanceOwnerPartyId);
+        using var activity = _telemetry?.StartGetBinaryDataActivity(instanceGuid, dataId);
         string instanceIdentifier = $"{instanceOwnerPartyId}/{instanceGuid}";
         string apiUrl = $"instances/{instanceIdentifier}/data/{dataId}";
 


### PR DESCRIPTION
We have the instanceOwnerPartyId in surrounding scopes, but the actual element that is updated is more relevant to track from dataClient

In addition I discovered that some spans were not in a `using` block, but they need to be (right?)