### PR TITLE
Footer in generated pdf should use dd.MM.yyyy HH:mm:ss

### DIFF
--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -285,7 +285,7 @@ public class PdfService : IPdfService
 
         string title = GetTitleText(textResource) ?? "Altinn";
 
-        string dateGenerated = now.ToString("dd.MM.yyyy HH:mm:ss", new CultureInfo("nb-NO"));
+        string dateGenerated = now.ToString("dd.MM.yyyy HH:mm", new CultureInfo("nb-NO"));
         string altinnReferenceId = instance.Id.Split("/")[1].Split("-")[4];
 
         string footerTemplate =

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -134,7 +134,6 @@ public class PdfService : IPdfService
         else if (displayFooter)
         {
             footerContent = GetFooterContent(instance, textResource);
-            _logger.LogInformation($"Footer content: {footerContent}");
         }
 
         Stream pdfContent = await _pdfGeneratorClient.GeneratePdf(uri, footerContent, ct);
@@ -286,19 +285,7 @@ public class PdfService : IPdfService
 
         string title = GetTitleText(textResource) ?? "Altinn";
 
-        _logger.LogInformation("--------------------------------------------------------");
-        _logger.LogInformation($"Current culture: {CultureInfo.CurrentCulture.Name}");
-        _logger.LogInformation($"Current UI culture: {CultureInfo.CurrentUICulture.Name}");
-        _logger.LogInformation(
-            $"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: {Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT")}"
-        );
-
-        _logger.LogInformation($"Successfully created nb-NO culture");
-
-        // string dateGenerated = now.ToString("G", nbCulture);
         string dateGenerated = now.ToString("dd.MM.yyyy HH:mm:ss", new CultureInfo("nb-NO"));
-        _logger.LogInformation($"Generated date with nb-NO culture: {dateGenerated}");
-
         string altinnReferenceId = instance.Id.Split("/")[1].Split("-")[4];
 
         string footerTemplate =

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -127,7 +127,7 @@ public class PdfService : IPdfService
 
         string? footerContent = null;
 
-        if (isPreview == true)
+        if (isPreview)
         {
             footerContent = GetPreviewFooter(textResource);
         }

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -292,17 +292,8 @@ public class PdfService : IPdfService
             $"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: {Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT")}"
         );
 
-        CultureInfo nbCulture;
-        try
-        {
-            nbCulture = new CultureInfo("nb-NO");
-            _logger.LogInformation($"Successfully created nb-NO culture");
-        }
-        catch (CultureNotFoundException ex)
-        {
-            _logger.LogError($"Failed to create nb-NO culture: {ex.Message}");
-            nbCulture = CultureInfo.InvariantCulture;
-        }
+        CultureInfo nbCulture = new("nb-NO"); // Throws CulureNotFoundException if invariant globalization is not disabled.
+        _logger.LogInformation($"Successfully created nb-NO culture");
 
         string dateGenerated = now.ToString("G", nbCulture);
         string altinnReferenceId = instance.Id.Split("/")[1].Split("-")[4];

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -134,6 +134,7 @@ public class PdfService : IPdfService
         else if (displayFooter)
         {
             footerContent = GetFooterContent(instance, textResource);
+            _logger.LogInformation($"Footer content: {footerContent}");
         }
 
         Stream pdfContent = await _pdfGeneratorClient.GeneratePdf(uri, footerContent, ct);
@@ -292,10 +293,12 @@ public class PdfService : IPdfService
             $"DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: {Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT")}"
         );
 
-        CultureInfo nbCulture = new("nb-NO"); // Throws CulureNotFoundException if invariant globalization is not disabled.
         _logger.LogInformation($"Successfully created nb-NO culture");
 
-        string dateGenerated = now.ToString("G", nbCulture);
+        // string dateGenerated = now.ToString("G", nbCulture);
+        string dateGenerated = now.ToString("dd.MM.yyyy HH:mm:ss", new CultureInfo("nb-NO"));
+        _logger.LogInformation($"Generated date with nb-NO culture: {dateGenerated}");
+
         string altinnReferenceId = instance.Id.Split("/")[1].Split("-")[4];
 
         string footerTemplate =

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -284,7 +284,7 @@ public class PdfService : IPdfService
         DateTimeOffset now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, timeZone);
 
         string title = GetTitleText(textResource) ?? "Altinn";
-        string dateGenerated = now.ToString("G", new CultureInfo("nb-NO"));
+        string dateGenerated = now.ToString("G", GetCultureOrInvariant("nb-NO"));
         string altinnReferenceId = instance.Id.Split("/")[1].Split("-")[4];
 
         string footerTemplate =
@@ -306,5 +306,23 @@ public class PdfService : IPdfService
                 </div>
             </div>";
         return footerTemplate;
+    }
+
+    private static CultureInfo GetCultureOrInvariant(string? cultureName)
+    {
+        CultureInfo culture = CultureInfo.InvariantCulture;
+        if (cultureName is not null)
+        {
+            try
+            {
+                culture = new CultureInfo(cultureName);
+            }
+            catch (CultureNotFoundException)
+            {
+                // If the language is not recognized, we'll just use the invariant culture.
+            }
+        }
+
+        return culture;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The explicit format string "dd.MM.yyyy HH:mm:ss" bypasses the complex culture-dependent format resolution that the "G" specifier relies on. While the "G" format specifier is supposed to be culture-aware, it can fall back to system defaults when thread culture is not properly set, even when an explicit culture is provided to the method and DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: false

Another solution would be to update the docs on how to set up the dockerfile for pdf footer.

By adding default culture:

// Set .NET default culture
ENV DOTNET_DefaultCulture=nb-NO
ENV DOTNET_DefaultUICulture=nb-NO

This has not been tested though.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
