### PR TITLE
Add CancellationToken to IUserAction.HandleAction in a backwards compatible way.

### DIFF
--- a/src/Altinn.App.Core/Features/Action/PaymentUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/PaymentUserAction.cs
@@ -37,7 +37,7 @@ internal class PaymentUserAction : IUserAction
     public string Id => "pay";
 
     /// <inheritdoc />
-    public async Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+    public async Task<UserActionResult> HandleAction(UserActionContext context)
     {
         if (
             _processReader.GetFlowElement(context.Instance.Process.CurrentTask.ElementId) is not ProcessTask currentTask

--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -64,7 +64,7 @@ internal class SigningUserAction : IUserAction
     /// <inheritdoc />
     /// <exception cref="PlatformHttpException"></exception>
     /// <exception cref="ApplicationConfigException"></exception>
-    public async Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct = default)
+    public async Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
     {
         if (context.Authentication is not Authenticated.User and not Authenticated.SystemUser)
         {
@@ -196,6 +196,11 @@ internal class SigningUserAction : IUserAction
         }
 
         return UserActionResult.SuccessResult();
+    }
+
+    public async Task<UserActionResult> HandleAction(UserActionContext context)
+    {
+        throw new NotImplementedException();
     }
 
     internal async Task<bool> HandleOnBehalfOf(

--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -198,9 +198,9 @@ internal class SigningUserAction : IUserAction
         return UserActionResult.SuccessResult();
     }
 
-    public async Task<UserActionResult> HandleAction(UserActionContext context)
+    public Task<UserActionResult> HandleAction(UserActionContext context)
     {
-        throw new NotImplementedException();
+        return Task.FromException<UserActionResult>(new NotImplementedException());
     }
 
     internal async Task<bool> HandleOnBehalfOf(

--- a/src/Altinn.App.Core/Features/IUserAction.cs
+++ b/src/Altinn.App.Core/Features/IUserAction.cs
@@ -17,7 +17,14 @@ public interface IUserAction
     /// Method for handling the user action
     /// </summary>
     /// <param name="context">The user action context</param>
-    /// <param name="ct">Cancellation token. Optional</param>
+    /// <param name="ct">Cancellation token</param>
     /// <returns>If the handling of the action was a success</returns>
-    Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct = default);
+    Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct) => HandleAction(context);
+
+    /// <summary>
+    /// Method for handling the user action
+    /// </summary>
+    /// <param name="context">The user action context</param>
+    /// <returns>If the handling of the action was a success</returns>
+    Task<UserActionResult> HandleAction(UserActionContext context);
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
@@ -663,7 +663,7 @@ public class FillAction : IUserAction
         _dataClient = dataClient;
     }
 
-    public async Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+    public async Task<UserActionResult> HandleAction(UserActionContext context)
     {
         _logger.LogInformation("FillAction triggered, with button id: {buttonId}", context.ButtonId);
 
@@ -737,7 +737,7 @@ public class LookupAction : IUserAction
 {
     public string Id => "lookup";
 
-    public async Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+    public async Task<UserActionResult> HandleAction(UserActionContext context)
     {
         await Task.CompletedTask;
         if (context.UserId == 400)

--- a/test/Altinn.App.Core.Tests/Features/Action/PaymentUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/PaymentUserActionTests.cs
@@ -1,8 +1,7 @@
-#nullable disable
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Action;
 using Altinn.App.Core.Features.Payment.Models;
 using Altinn.App.Core.Features.Payment.Services;
-using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Process;
 using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
 using Altinn.App.Core.Models.Process;
@@ -17,7 +16,6 @@ namespace Altinn.App.Core.Tests.Features.Action;
 
 public class PaymentUserActionTests
 {
-    private readonly Mock<IDataService> _dataServiceMock = new();
     private readonly Mock<IPaymentService> _paymentServiceMock = new();
 
     [Fact]
@@ -49,7 +47,7 @@ public class PaymentUserActionTests
             .ReturnsAsync((paymentInformation, false));
 
         // Act
-        PaymentUserAction userAction = CreatePaymentUserAction();
+        IUserAction userAction = CreatePaymentUserAction();
         UserActionResult result = await userAction.HandleAction(userActionContext, CancellationToken.None);
 
         // Assert
@@ -75,7 +73,7 @@ public class PaymentUserActionTests
                 OrderLines = [],
                 Receiver = new PaymentReceiver(),
             },
-            PaymentDetails = new PaymentDetails { PaymentId = null, RedirectUrl = null },
+            PaymentDetails = new PaymentDetails { PaymentId = "null", RedirectUrl = null },
         };
 
         var userActionContext = new UserActionContext(instance, 1337);
@@ -87,7 +85,7 @@ public class PaymentUserActionTests
             .ReturnsAsync((paymentInformation, false));
 
         // Act
-        PaymentUserAction userAction = CreatePaymentUserAction();
+        IUserAction userAction = CreatePaymentUserAction();
         UserActionResult result = await userAction.HandleAction(userActionContext, CancellationToken.None);
 
         // Assert
@@ -123,7 +121,7 @@ public class PaymentUserActionTests
             .ReturnsAsync((paymentInformation, true));
 
         // Act
-        PaymentUserAction userAction = CreatePaymentUserAction();
+        IUserAction userAction = CreatePaymentUserAction();
         UserActionResult result = await userAction.HandleAction(userActionContext, CancellationToken.None);
 
         // Assert
@@ -137,7 +135,7 @@ public class PaymentUserActionTests
             );
     }
 
-    private PaymentUserAction CreatePaymentUserAction(string testBpmnFilename = "payment-task-process.bpmn")
+    private IUserAction CreatePaymentUserAction(string testBpmnFilename = "payment-task-process.bpmn")
     {
         IProcessReader processReader = ProcessTestUtils.SetupProcessReader(
             testBpmnFilename,

--- a/test/Altinn.App.Core.Tests/Features/Action/UserActionServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/UserActionServiceTests.cs
@@ -80,7 +80,7 @@ public class UserActionServiceTests
     {
         public string Id => "dummy";
 
-        public Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+        public Task<UserActionResult> HandleAction(UserActionContext context)
         {
             return Task.FromResult(UserActionResult.SuccessResult());
         }
@@ -90,7 +90,7 @@ public class UserActionServiceTests
     {
         public string Id => "dummy";
 
-        public Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+        public Task<UserActionResult> HandleAction(UserActionContext context)
         {
             return Task.FromResult(
                 UserActionResult.SuccessResult(new List<ClientAction>() { ClientAction.NextPage() })


### PR DESCRIPTION
Add CancellationToken to IUserAction.HandleAction in a backwards compatible way.

Apps that update to 8.6 (signing release) and implements `IUserAction` currently needs to manually add the `CancellationToken` parameter to their implementation.

This adds a default implementation to the interface (as we have done in other instances)

Pros:
* Apps that upgrade don't need to make changes

Cons:
* Apps that want to use the cancellation token needs to implement the old method without token as a "dummy" method
* Apps that already have updated (and added the parameter) needs to remove the parameter or add the dummy method too.

### Alternative
Remove the `CancellationToken` parameter and let users that need cancellation token fetch it from `IHttpContextAccessor.HttpContext.RequestAborted`