### PR TITLE
move ct to useractioncontext

### DIFF
--- a/src/Altinn.App.Api/Controllers/ActionsController.cs
+++ b/src/Altinn.App.Api/Controllers/ActionsController.cs
@@ -137,7 +137,8 @@ public class ActionsController : ControllerBase
             actionRequest.Metadata,
             language,
             currentAuth,
-            actionRequest.OnBehalfOf
+            actionRequest.OnBehalfOf,
+            cancellationToken: ct
         );
         IUserAction? actionHandler = _userActionService.GetActionHandler(action);
         if (actionHandler is null)
@@ -155,7 +156,7 @@ public class ActionsController : ControllerBase
             );
         }
 
-        UserActionResult result = await actionHandler.HandleAction(userActionContext, ct);
+        UserActionResult result = await actionHandler.HandleAction(userActionContext);
 
         if (result.ResultType is ResultType.Failure)
         {

--- a/src/Altinn.App.Core/Features/Action/PaymentUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/PaymentUserAction.cs
@@ -37,7 +37,7 @@ internal class PaymentUserAction : IUserAction
     public string Id => "pay";
 
     /// <inheritdoc />
-    public async Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+    public async Task<UserActionResult> HandleAction(UserActionContext context)
     {
         if (
             _processReader.GetFlowElement(context.Instance.Process.CurrentTask.ElementId) is not ProcessTask currentTask

--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -64,8 +64,10 @@ internal class SigningUserAction : IUserAction
     /// <inheritdoc />
     /// <exception cref="PlatformHttpException"></exception>
     /// <exception cref="ApplicationConfigException"></exception>
-    public async Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct = default)
+    public async Task<UserActionResult> HandleAction(UserActionContext context)
     {
+        var ct = context.CancellationToken;
+
         if (context.Authentication is not Authenticated.User and not Authenticated.SystemUser)
         {
             return UserActionResult.FailureResult(

--- a/src/Altinn.App.Core/Features/IUserAction.cs
+++ b/src/Altinn.App.Core/Features/IUserAction.cs
@@ -17,7 +17,6 @@ public interface IUserAction
     /// Method for handling the user action
     /// </summary>
     /// <param name="context">The user action context</param>
-    /// <param name="ct">Cancellation token. Optional</param>
     /// <returns>If the handling of the action was a success</returns>
-    Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct = default);
+    Task<UserActionResult> HandleAction(UserActionContext context);
 }

--- a/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEngine.cs
@@ -151,9 +151,9 @@ public class ProcessEngine : IProcessEngine
                 userId,
                 language: request.Language,
                 authentication: currentAuth,
-                onBehalfOf: request.ActionOnBehalfOf
-            ),
-            ct
+                onBehalfOf: request.ActionOnBehalfOf,
+                cancellationToken: ct
+            )
         );
 
         if (actionResult.ResultType == ResultType.Failure)

--- a/src/Altinn.App.Core/Models/UserAction/UserActionContext.cs
+++ b/src/Altinn.App.Core/Models/UserAction/UserActionContext.cs
@@ -20,6 +20,7 @@ public class UserActionContext
     /// <param name="language">The currently used language by the user (or null if not available)</param>
     /// <param name="authentication">Information about the authenticated party</param>
     /// <param name="onBehalfOf">The organisation number of the party the user is acting on behalf of</param>
+    /// <param name="cancellationToken">The cancellation token</param>
     public UserActionContext(
         IInstanceDataMutator dataMutator,
         int? userId,
@@ -27,7 +28,8 @@ public class UserActionContext
         Dictionary<string, string>? actionMetadata = null,
         string? language = null,
         Authenticated? authentication = null,
-        string? onBehalfOf = null
+        string? onBehalfOf = null,
+        CancellationToken? cancellationToken = null
     )
     {
         Instance = dataMutator.Instance;
@@ -38,6 +40,7 @@ public class UserActionContext
         ButtonId = buttonId;
         ActionMetadata = actionMetadata ?? [];
         Language = language;
+        CancellationToken = cancellationToken ?? default;
     }
 
     /// <summary>
@@ -116,6 +119,11 @@ public class UserActionContext
     /// The language that will be used for the action
     /// </summary>
     public string? Language { get; }
+
+    /// <summary>
+    /// The cancellation token associated with the action
+    /// </summary>
+    public CancellationToken CancellationToken { get; }
 
     internal IAltinnCdnClient? AltinnCdnClient { get; set; }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
@@ -663,7 +663,7 @@ public class FillAction : IUserAction
         _dataClient = dataClient;
     }
 
-    public async Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+    public async Task<UserActionResult> HandleAction(UserActionContext context)
     {
         _logger.LogInformation("FillAction triggered, with button id: {buttonId}", context.ButtonId);
 
@@ -737,7 +737,7 @@ public class LookupAction : IUserAction
 {
     public string Id => "lookup";
 
-    public async Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+    public async Task<UserActionResult> HandleAction(UserActionContext context)
     {
         await Task.CompletedTask;
         if (context.UserId == 400)

--- a/test/Altinn.App.Core.Tests/Features/Action/PaymentUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/PaymentUserActionTests.cs
@@ -50,7 +50,7 @@ public class PaymentUserActionTests
 
         // Act
         PaymentUserAction userAction = CreatePaymentUserAction();
-        UserActionResult result = await userAction.HandleAction(userActionContext, CancellationToken.None);
+        UserActionResult result = await userAction.HandleAction(userActionContext);
 
         // Assert
         result
@@ -88,7 +88,7 @@ public class PaymentUserActionTests
 
         // Act
         PaymentUserAction userAction = CreatePaymentUserAction();
-        UserActionResult result = await userAction.HandleAction(userActionContext, CancellationToken.None);
+        UserActionResult result = await userAction.HandleAction(userActionContext);
 
         // Assert
         result.Should().BeEquivalentTo(UserActionResult.SuccessResult());
@@ -124,7 +124,7 @@ public class PaymentUserActionTests
 
         // Act
         PaymentUserAction userAction = CreatePaymentUserAction();
-        UserActionResult result = await userAction.HandleAction(userActionContext, CancellationToken.None);
+        UserActionResult result = await userAction.HandleAction(userActionContext);
 
         // Assert
         result

--- a/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
@@ -154,8 +154,7 @@ public class SigningUserActionTests
 
         // Act
         var result = await fixture.SigningUserAction.HandleAction(
-            new UserActionContext(fixture.InstanceDataMutatorMock.Object, null),
-            CancellationToken.None
+            new UserActionContext(fixture.InstanceDataMutatorMock.Object, null)
         );
 
         // Assert
@@ -183,8 +182,7 @@ public class SigningUserActionTests
                 fixture.InstanceDataMutatorMock.Object,
                 1337,
                 authentication: TestAuthentication.GetUserAuthentication(1337)
-            ),
-            CancellationToken.None
+            )
         );
 
         // Assert
@@ -218,7 +216,7 @@ public class SigningUserActionTests
         // Act
 
         int dataElementCountBeforeSign = fixture.Instance.Data.Count;
-        var result = await fixture.SigningUserAction.HandleAction(userActionContext, CancellationToken.None);
+        var result = await fixture.SigningUserAction.HandleAction(userActionContext);
 
         // Assert
         Assert.Equal(JsonSerializer.Serialize(UserActionResult.SuccessResult()), JsonSerializer.Serialize(result));
@@ -241,7 +239,7 @@ public class SigningUserActionTests
         );
 
         // Act
-        var result = await fixture.SigningUserAction.HandleAction(userActionContext, CancellationToken.None);
+        var result = await fixture.SigningUserAction.HandleAction(userActionContext);
         var expected = UserActionResult.FailureResult(
             error: new ActionError() { Code = "SignDataElementsFailed", Message = "Failed to sign data elements." },
             errorType: ProcessErrorType.Internal
@@ -270,8 +268,7 @@ public class SigningUserActionTests
 
         // Act
         var result = await fixture.SigningUserAction.HandleAction(
-            new UserActionContext(fixture.InstanceDataMutatorMock.Object, 1337, authentication: token.Auth),
-            CancellationToken.None
+            new UserActionContext(fixture.InstanceDataMutatorMock.Object, 1337, authentication: token.Auth)
         );
 
         // Assert
@@ -359,8 +356,7 @@ public class SigningUserActionTests
                 fixture.InstanceDataMutatorMock.Object,
                 1337,
                 authentication: TestAuthentication.GetUserAuthentication(1337)
-            ),
-            CancellationToken.None
+            )
         );
 
         // Assert
@@ -392,7 +388,7 @@ public class SigningUserActionTests
             authentication: TestAuthentication.GetUserAuthentication(1337)
         );
         // Act
-        var result = await fixture.SigningUserAction.HandleAction(userActionContext, CancellationToken.None);
+        var result = await fixture.SigningUserAction.HandleAction(userActionContext);
         // Assert
         SignatureContext expected = new(
             new InstanceIdentifier(instance),
@@ -432,7 +428,7 @@ public class SigningUserActionTests
 
         // Act
         await Assert.ThrowsAsync<ApplicationConfigException>(async () =>
-            await fixture.SigningUserAction.HandleAction(userActionContext, CancellationToken.None)
+            await fixture.SigningUserAction.HandleAction(userActionContext)
         );
         fixture.SignClient.VerifyNoOtherCalls();
     }
@@ -452,7 +448,7 @@ public class SigningUserActionTests
 
         // Act
         await Assert.ThrowsAsync<ApplicationConfigException>(async () =>
-            await fixture.SigningUserAction.HandleAction(userActionContext, CancellationToken.None)
+            await fixture.SigningUserAction.HandleAction(userActionContext)
         );
         signClientMock.VerifyNoOtherCalls();
     }
@@ -473,7 +469,7 @@ public class SigningUserActionTests
 
         // Act
         await Assert.ThrowsAsync<ApplicationConfigException>(async () =>
-            await fixture.SigningUserAction.HandleAction(userActionContext, CancellationToken.None)
+            await fixture.SigningUserAction.HandleAction(userActionContext)
         );
         signClientMock.VerifyNoOtherCalls();
     }
@@ -505,7 +501,7 @@ public class SigningUserActionTests
 
         // Act
         await Assert.ThrowsAsync<ApplicationConfigException>(async () =>
-            await userAction.HandleAction(userActionContext, CancellationToken.None)
+            await userAction.HandleAction(userActionContext)
         );
         signClientMock.VerifyNoOtherCalls();
     }

--- a/test/Altinn.App.Core.Tests/Features/Action/UserActionServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/UserActionServiceTests.cs
@@ -80,7 +80,7 @@ public class UserActionServiceTests
     {
         public string Id => "dummy";
 
-        public Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+        public Task<UserActionResult> HandleAction(UserActionContext context)
         {
             return Task.FromResult(UserActionResult.SuccessResult());
         }
@@ -90,7 +90,7 @@ public class UserActionServiceTests
     {
         public string Id => "dummy";
 
-        public Task<UserActionResult> HandleAction(UserActionContext context, CancellationToken ct)
+        public Task<UserActionResult> HandleAction(UserActionContext context)
         {
             return Task.FromResult(
                 UserActionResult.SuccessResult(new List<ClientAction>() { ClientAction.NextPage() })

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessEngineTest.cs
@@ -444,7 +444,7 @@ public sealed class ProcessEngineTest
         Mock<IUserAction> userActionMock = new Mock<IUserAction>(MockBehavior.Strict);
         userActionMock.Setup(u => u.Id).Returns("sign");
         userActionMock
-            .Setup(u => u.HandleAction(It.IsAny<UserActionContext>(), It.IsAny<CancellationToken>()))
+            .Setup(u => u.HandleAction(It.IsAny<UserActionContext>()))
             .ReturnsAsync(UserActionResult.SuccessResult());
         using var fixture = Fixture.Create(updatedInstance: expectedInstance, userActions: [userActionMock.Object]);
         fixture
@@ -504,7 +504,7 @@ public sealed class ProcessEngineTest
         Mock<IUserAction> userActionMock = new Mock<IUserAction>(MockBehavior.Strict);
         userActionMock.Setup(u => u.Id).Returns("sign");
         userActionMock
-            .Setup(u => u.HandleAction(It.IsAny<UserActionContext>(), It.IsAny<CancellationToken>()))
+            .Setup(u => u.HandleAction(It.IsAny<UserActionContext>()))
             .ReturnsAsync(
                 UserActionResult.FailureResult(
                     error: new ActionError() { Code = "NoUserId", Message = "User id is missing in token" },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Revert IUserAction to not include CancellationToken in its definition.
Move CancellationToken to UserActionContext

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
