### PR TITLE
Fixes broken DataController test

### DIFF
--- a/test/Altinn.App.Api.Tests/Controllers/DataController_UserAccessTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_UserAccessTests.cs
@@ -54,7 +54,7 @@ public class DataController_UserAccessTests : ApiTestBase, IClassFixture<WebAppl
     [Theory]
     [InlineData("userInteractionUnspecified", false, HttpStatusCode.OK)]
     [InlineData("userInteractionUnspecified", true, HttpStatusCode.OK)]
-    [InlineData("disallowUserDelete", false, HttpStatusCode.OK)]
+    [InlineData("disallowUserDelete", false, HttpStatusCode.BadRequest)]
     [InlineData("disallowUserDelete", true, HttpStatusCode.OK)]
     public async Task DeleteDataElement_ImplementsAndValidates_AllowUserDeleteProperty(
         string dataModelId,

--- a/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/config/applicationmetadata.json
+++ b/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/config/applicationmetadata.json
@@ -97,7 +97,7 @@
             "maxCount": 10,
             "appLogic": {
                 "ClassRef": "Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models.Skjema",
-                "diallowUserDelete": true
+                "disallowUserDelete": true
             },
             "taskId": "Task_1"
         }


### PR DESCRIPTION
## Description
A [previous commit](https://github.com/Altinn/app-lib-dotnet/commit/6d3fb4ec5c203f60d7a88db059e3e3199f10010a#diff-b41fc3f5813e59ea35b1dd14d402a111d141eddd6e619ca98da6cfe0cd4f4f6e) associated with the renaming of `DataType.UserDeleteEnabled` -> `DataType.DisallowUserDelete` introduced a typo in the test's applicationmetadata.json which accidentically caused the associated test to pass, even though the logic was now faulty.

This PR corrects both of these issues.

TL;DR A data type flagged with `disallowUserDelete` should trigger a 400 error if DEL is called with a user token.