### PR TITLE
Chore: Replace hardcoded header keys with constants

### DIFF
--- a/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
+++ b/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
@@ -1,3 +1,5 @@
+using Altinn.App.Core.Constants;
+
 namespace Altinn.App.Api.Controllers;
 
 using System.Collections.Generic;
@@ -1268,10 +1270,10 @@ public static class Snippets
     /// <summary>
     /// Security scheme for Altinn token
     /// </summary>
-    public static readonly OpenApiSecurityScheme AltinnTokenSecurityScheme = new OpenApiSecurityScheme()
+    public static readonly OpenApiSecurityScheme AltinnTokenSecurityScheme = new()
     {
-        Reference = new OpenApiReference() { Id = "AltinnToken", Type = ReferenceType.SecurityScheme },
-        Scheme = "Bearer",
+        Reference = new OpenApiReference() { Id = General.AppTokenName, Type = ReferenceType.SecurityScheme },
+        Scheme = AuthorizationSchemes.Bearer,
         BearerFormat = "JWT",
         In = ParameterLocation.Header,
         Type = SecuritySchemeType.Http,

--- a/src/Altinn.App.Core/Constants/AuthorizationSchemes.cs
+++ b/src/Altinn.App.Core/Constants/AuthorizationSchemes.cs
@@ -1,0 +1,12 @@
+namespace Altinn.App.Core.Constants;
+
+/// <summary>
+/// Constants related to http authentication schemes.
+/// </summary>
+internal static class AuthorizationSchemes
+{
+    /// <summary>
+    /// The name of the authentication scheme used for bearer tokens.
+    /// </summary>
+    public const string Bearer = "Bearer";
+}

--- a/src/Altinn.App.Core/Constants/General.cs
+++ b/src/Altinn.App.Core/Constants/General.cs
@@ -1,12 +1,12 @@
 namespace Altinn.App.Core.Constants;
 
 /// <summary>
-/// app token
+/// Misc constants, mostly related to HTTP headers and cookies.
 /// </summary>
 public static class General
 {
     /// <summary>
-    /// app token name
+    /// App token name
     /// </summary>
     public const string AppTokenName = "AltinnToken";
 
@@ -26,12 +26,17 @@ public static class General
     public const string DesignerCookieName = "AltinnStudioDesigner";
 
     /// <summary>
-    /// Header key for API management subscription key
+    /// Header name for API management subscription key
     /// </summary>
     public const string SubscriptionKeyHeaderName = "Ocp-Apim-Subscription-Key";
 
     /// <summary>
-    /// Header key for access token for eFormidling Integration Point
+    /// Header name for eFormidling Integration Point access token
     /// </summary>
     public const string EFormidlingAccessTokenHeaderName = "AltinnIntegrationPointToken";
+
+    /// <summary>
+    /// Header name for platform access token
+    /// </summary>
+    internal const string PlatformAccessTokenHeaderName = "PlatformAccessToken";
 }

--- a/src/Altinn.App.Core/EFormidling/Implementation/DefaultEFormidlingService.cs
+++ b/src/Altinn.App.Core/EFormidling/Implementation/DefaultEFormidlingService.cs
@@ -91,7 +91,7 @@ public class DefaultEFormidlingService : IEFormidlingService
 
         var requestHeaders = new Dictionary<string, string>
         {
-            { "Authorization", $"Bearer {authzToken}" },
+            { "Authorization", $"{AuthorizationSchemes.Bearer} {authzToken}" },
             { General.EFormidlingAccessTokenHeaderName, accessToken },
             { General.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey },
         };

--- a/src/Altinn.App.Core/Extensions/HttpClientExtension.cs
+++ b/src/Altinn.App.Core/Extensions/HttpClientExtension.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Headers;
+
 namespace Altinn.App.Core.Extensions;
 
 /// <summary>
@@ -22,12 +24,15 @@ public static class HttpClientExtension
         string? platformAccessToken = null
     )
     {
-        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
-        request.Headers.Add("Authorization", "Bearer " + authorizationToken);
+        HttpRequestMessage request = new(HttpMethod.Post, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            Constants.AuthorizationSchemes.Bearer,
+            authorizationToken
+        );
         request.Content = content;
         if (!string.IsNullOrEmpty(platformAccessToken))
         {
-            request.Headers.Add("PlatformAccessToken", platformAccessToken);
+            request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
         }
 
         return httpClient.SendAsync(request, CancellationToken.None);
@@ -50,12 +55,15 @@ public static class HttpClientExtension
         string? platformAccessToken = null
     )
     {
-        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Put, requestUri);
-        request.Headers.Add("Authorization", "Bearer " + authorizationToken);
+        HttpRequestMessage request = new(HttpMethod.Put, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            Constants.AuthorizationSchemes.Bearer,
+            authorizationToken
+        );
         request.Content = content;
         if (!string.IsNullOrEmpty(platformAccessToken))
         {
-            request.Headers.Add("PlatformAccessToken", platformAccessToken);
+            request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
         }
 
         return httpClient.SendAsync(request, CancellationToken.None);
@@ -76,11 +84,14 @@ public static class HttpClientExtension
         string? platformAccessToken = null
     )
     {
-        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-        request.Headers.Add("Authorization", "Bearer " + authorizationToken);
+        HttpRequestMessage request = new(HttpMethod.Get, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            Constants.AuthorizationSchemes.Bearer,
+            authorizationToken
+        );
         if (!string.IsNullOrEmpty(platformAccessToken))
         {
-            request.Headers.Add("PlatformAccessToken", platformAccessToken);
+            request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
         }
 
         return httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
@@ -101,11 +112,14 @@ public static class HttpClientExtension
         string? platformAccessToken = null
     )
     {
-        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Delete, requestUri);
-        request.Headers.Add("Authorization", "Bearer " + authorizationToken);
+        HttpRequestMessage request = new(HttpMethod.Delete, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            Constants.AuthorizationSchemes.Bearer,
+            authorizationToken
+        );
         if (!string.IsNullOrEmpty(platformAccessToken))
         {
-            request.Headers.Add("PlatformAccessToken", platformAccessToken);
+            request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
         }
 
         return httpClient.SendAsync(request, CancellationToken.None);

--- a/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
@@ -6,7 +6,6 @@ using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features.Correspondence.Exceptions;
 using Altinn.App.Core.Features.Correspondence.Models;
-using Altinn.App.Core.Features.Maskinporten.Constants;
 using Altinn.App.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
@@ -144,7 +144,7 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
         _logger.LogDebug("Constructing authorized http request for target uri {TargetEndpoint}", uri);
         HttpRequestMessage request = new(method, uri) { Content = content };
 
-        request.Headers.Authorization = new AuthenticationHeaderValue(TokenTypes.Bearer, accessToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, accessToken);
         request.Headers.TryAddWithoutValidation(General.SubscriptionKeyHeaderName, _platformSettings.SubscriptionKey);
 
         return request;

--- a/src/Altinn.App.Core/Features/Maskinporten/Constants/TokenTypes.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/Constants/TokenTypes.cs
@@ -1,6 +1,0 @@
-namespace Altinn.App.Core.Features.Maskinporten.Constants;
-
-internal static class TokenTypes
-{
-    public const string Bearer = "Bearer";
-}

--- a/src/Altinn.App.Core/Features/Maskinporten/Delegates/MaskinportenDelegatingHandler.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/Delegates/MaskinportenDelegatingHandler.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features.Maskinporten.Constants;
 using Altinn.App.Core.Features.Maskinporten.Exceptions;
 using Microsoft.Extensions.Logging;
@@ -54,7 +55,7 @@ internal sealed class MaskinportenDelegatingHandler : DelegatingHandler
             _ => throw new MaskinportenAuthenticationException($"Unknown authority `{Authorities}`"),
         };
 
-        request.Headers.Authorization = new AuthenticationHeaderValue(TokenTypes.Bearer, token.Value);
+        request.Headers.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token.Value);
 
         return await base.SendAsync(request, cancellationToken);
     }

--- a/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
@@ -277,7 +277,10 @@ internal sealed class MaskinportenClient : IMaskinportenClient
                 General.SubscriptionKeyHeaderName,
                 _platformSettings.SubscriptionKey
             );
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", maskinportenToken.Value);
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                AuthorizationSchemes.Bearer,
+                maskinportenToken.Value
+            );
 
             using HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
             response.EnsureSuccessStatusCode();

--- a/src/Altinn.App.Core/Features/Notifications/Email/EmailNotificationClient.cs
+++ b/src/Altinn.App.Core/Features/Notifications/Email/EmailNotificationClient.cs
@@ -56,7 +56,7 @@ internal sealed class EmailNotificationClient : IEmailNotificationClient
             };
             httpRequestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             httpRequestMessage.Headers.Add(
-                "PlatformAccessToken",
+                Constants.General.PlatformAccessTokenHeaderName,
                 _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App)
             );
 

--- a/src/Altinn.App.Core/Features/Notifications/Sms/SmsNotificationClient.cs
+++ b/src/Altinn.App.Core/Features/Notifications/Sms/SmsNotificationClient.cs
@@ -56,7 +56,7 @@ internal sealed class SmsNotificationClient : ISmsNotificationClient
             };
             httpRequestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             httpRequestMessage.Headers.Add(
-                "PlatformAccessToken",
+                Constants.General.PlatformAccessTokenHeaderName,
                 _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App)
             );
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/AccessManagement/AccessManagementClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/AccessManagement/AccessManagementClient.cs
@@ -124,7 +124,7 @@ internal sealed class AccessManagementClient(
         };
         httpRequestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ApplicationJsonMediaType));
         httpRequestMessage.Headers.Add(
-            "PlatformAccessToken",
+            Constants.General.PlatformAccessTokenHeaderName,
             accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App)
         );
         return httpRequestMessage;

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -111,10 +111,10 @@ public class AltinnPartyClient : IAltinnPartyClient
             Content = content,
         };
 
-        request.Headers.Add("Authorization", "Bearer " + token);
+        request.Headers.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
         request.Headers.Add(
-            "PlatformAccessToken",
+            General.PlatformAccessTokenHeaderName,
             _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App)
         );
 

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/PersonClient.cs
@@ -80,8 +80,14 @@ public class PersonClient : IPersonClient
         ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
         string issuer = application.Org;
         string appName = application.AppIdentifier.App;
-        request.Headers.Add("PlatformAccessToken", _accessTokenGenerator.GenerateAccessToken(issuer, appName));
-        request.Headers.Add("Authorization", "Bearer " + _userTokenProvider.GetUserToken());
+        request.Headers.Add(
+            General.PlatformAccessTokenHeaderName,
+            _accessTokenGenerator.GenerateAccessToken(issuer, appName)
+        );
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            AuthorizationSchemes.Bearer,
+            _userTokenProvider.GetUserToken()
+        );
     }
 
     private static async Task<Person?> ReadResponse(HttpResponseMessage response, CancellationToken ct)

--- a/src/Altinn.App.Core/Internal/Registers/RegisterClient.cs
+++ b/src/Altinn.App.Core/Internal/Registers/RegisterClient.cs
@@ -104,8 +104,8 @@ internal sealed class RegisterClient : IRegisterClient
             application.AppIdentifier.App
         );
         using var request = new HttpRequestMessage(HttpMethod.Post, endpointUrl);
-        request.Headers.Add("Authorization", "Bearer " + token);
-        request.Headers.Add("PlatformAccessToken", platformAccessToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
+        request.Headers.Add(General.PlatformAccessTokenHeaderName, platformAccessToken);
 
         request.Content = new StringContent(JsonSerializer.Serialize(partyIds), Encoding.UTF8, "application/json");
 

--- a/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ActionsControllerTests.cs
@@ -7,6 +7,7 @@ using Altinn.App.Api.Controllers;
 using Altinn.App.Api.Models;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Data.apps.tdd.task_action.config.models;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Models.Process;
@@ -42,7 +43,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef41");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(1000, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var content = new StringContent(
             "{\"action\":\"lookup_unauthorized\"}",
             Encoding.UTF8,
@@ -117,7 +118,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef41");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(1000, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var content = new StringContent("{\"action\":null}", Encoding.UTF8, "application/json");
         using HttpResponseMessage response = await client.PostAsync(
             $"/{org}/{app}/instances/1337/{guid}/actions",
@@ -138,7 +139,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef43");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var content = new StringContent("{\"action\":\"lookup\"}", Encoding.UTF8, "application/json");
         using HttpResponseMessage response = await client.PostAsync(
             $"/{org}/{app}/instances/1337/{guid}/actions",
@@ -159,7 +160,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef42");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(1000, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var content = new StringContent("{\"action\":\"lookup\"}", Encoding.UTF8, "application/json");
         using HttpResponseMessage response = await client.PostAsync(
             $"/{org}/{app}/instances/1337/{guid}/actions",
@@ -184,7 +185,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef41");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(1000, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var requestContent = new StringContent("{\"action\":\"lookup\"}", Encoding.UTF8, "application/json");
         using HttpResponseMessage response = await client.PostAsync(
             $"/{org}/{app}/instances/1337/{guid}/actions",
@@ -236,7 +237,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef41");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(400, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var content = new StringContent("{\"action\":\"lookup\"}", Encoding.UTF8, "application/json");
         using HttpResponseMessage response = await client.PostAsync(
             $"/{org}/{app}/instances/1337/{guid}/actions",
@@ -261,7 +262,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef41");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(userId: 401, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var content = new StringContent("{\"action\":\"lookup\"}", Encoding.UTF8, "application/json");
         using HttpResponseMessage response = await client.PostAsync(
             $"/{org}/{app}/instances/1337/{guid}/actions",
@@ -286,7 +287,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef41");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(userId: 409, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var content = new StringContent("{\"action\":\"lookup\"}", Encoding.UTF8, "application/json");
         using HttpResponseMessage response = await client.PostAsync(
             $"/{org}/{app}/instances/1337/{guid}/actions",
@@ -311,7 +312,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef41");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(userId: 500, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var content = new StringContent("{\"action\":\"lookup\"}", Encoding.UTF8, "application/json");
         using HttpResponseMessage response = await client.PostAsync(
             $"/{org}/{app}/instances/1337/{guid}/actions",
@@ -336,7 +337,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         Guid guid = new Guid("b1135209-628e-4a6e-9efd-e4282068ef41");
         TestData.PrepareInstance(org, app, 1337, guid);
         string token = TestAuthentication.GetUserToken(userId: 1001, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var content = new StringContent("{\"action\":\"notfound\"}", Encoding.UTF8, "application/json");
         using HttpResponseMessage response = await client.PostAsync(
             $"/{org}/{app}/instances/1337/{guid}/actions",
@@ -362,7 +363,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         };
         var client = GetRootedUserClient(org, app, 1337);
         string token = TestAuthentication.GetUserToken(userId: 1001, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         // Run buttonId "add"
         using var content = JsonContent.Create(new { action = "fill", buttonId = "add" });
@@ -486,7 +487,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         };
         var client = GetRootedUserClient(org, app, 1337);
         string token = TestAuthentication.GetUserToken(userId: 1001, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         // run buttonId "getClientActions"
         using var getClientActionsContent = JsonContent.Create(new { action = "fill", buttonId = "getClientActions" });
@@ -518,7 +519,7 @@ public class ActionsControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         };
         var client = GetRootedUserClient(org, app, 1337);
         string token = TestAuthentication.GetUserToken(userId: 1001, authenticationLevel: 3);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         // Run buttonId "fail"
         using var failContent = JsonContent.Create(new { action = "fill", buttonId = "fail" });

--- a/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataControllerTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using Altinn.App.Api.Tests.Data;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features.FileAnalysis;
 using Altinn.App.Core.Features.Validation;
 using Altinn.App.Core.Models.Validation;
@@ -27,7 +28,7 @@ public class DataControllerTests : ApiTestBase, IClassFixture<WebApplicationFact
         Guid guid = new Guid("0fc98a23-fe31-4ef5-8fb9-dd3f479354cd");
         HttpClient client = GetRootedClient(org, app);
         string token = TestAuthentication.GetServiceOwnerToken("405003309", org: "nav");
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         TestData.PrepareInstance(org, app, instanceOwnerPartyId, guid);
 
@@ -49,7 +50,7 @@ public class DataControllerTests : ApiTestBase, IClassFixture<WebApplicationFact
         Guid guid = new Guid("0fc98a23-fe31-4ef5-8fb9-dd3f479354cd");
         HttpClient client = GetRootedClient(org, app);
         string token = TestAuthentication.GetServiceOwnerToken("405003309", org: "nav");
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         TestData.PrepareInstance(org, app, instanceOwnerPartyId, guid);
 
@@ -94,7 +95,7 @@ public class DataControllerTests : ApiTestBase, IClassFixture<WebApplicationFact
 
         // Setup the request
         string token = TestAuthentication.GetServiceOwnerToken("405003309", org: "nav");
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         ByteArrayContent fileContent = await CreateBinaryContent(org, app, "example.pdf", "application/pdf");
         string url = $"/{org}/{app}/instances/1337/{guid}/data?dataType=specificFileType";
         var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = fileContent };
@@ -127,7 +128,7 @@ public class DataControllerTests : ApiTestBase, IClassFixture<WebApplicationFact
 
         // Setup the request
         string token = TestAuthentication.GetServiceOwnerToken("405003309", org: "nav");
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         ByteArrayContent fileContent = await CreateBinaryContent(org, app, "zero.pdf", "application/pdf");
         string url = $"/{org}/{app}/instances/1337/{guid}/data?dataType=specificFileType";
         var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = fileContent };
@@ -162,7 +163,7 @@ public class DataControllerTests : ApiTestBase, IClassFixture<WebApplicationFact
 
         // Setup the request
         string token = TestAuthentication.GetServiceOwnerToken("405003309", org: "nav");
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         ByteArrayContent fileContent = await CreateBinaryContent(org, app, "example.jpg.pdf", "application/pdf");
         string url = $"/{org}/{app}/instances/1337/{guid}/data?dataType=specificFileType";
         var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = fileContent };

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PatchTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 using Altinn.App.Api.Models;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Models;
@@ -90,7 +91,10 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
         OutputHelper.WriteLine($"Calling PATCH {url}");
         using var httpClient = GetRootedClient(Org, App);
         string token = TestAuthentication.GetUserToken(userId: 1337);
-        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            AuthorizationSchemes.Bearer,
+            token
+        );
         var serializedPatch = JsonSerializer.Serialize(
             new DataPatchRequest() { Patch = patch, IgnoredValidators = ignoredValidators },
             _jsonSerializerOptions
@@ -856,7 +860,10 @@ public class DataControllerPatchTests : ApiTestBase, IClassFixture<WebApplicatio
         OutputHelper.WriteLine($"Calling GET {url}");
         using var httpClient = GetRootedClient(Org, App);
         string token = TestAuthentication.GetUserToken(userId: UserId, InstanceOwnerPartyId);
-        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            AuthorizationSchemes.Bearer,
+            token
+        );
         var response = await httpClient.GetAsync(url);
         var responseString = await response.Content.ReadAsStringAsync();
         using var responseParsedRaw = JsonDocument.Parse(responseString);

--- a/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/DataController_PutTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -37,7 +38,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         int instanceOwnerPartyId = 501337;
         HttpClient client = GetRootedClient(org, app);
         string token = TestAuthentication.GetUserToken(1337, instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         _dataProcessor
             .Setup(p =>
@@ -178,7 +179,7 @@ public class DataController_PutTests : ApiTestBase, IClassFixture<WebApplication
         int instanceOwnerPartyId = 501337;
         HttpClient client = GetRootedClient(org, app);
         string token = TestAuthentication.GetUserToken(1337, instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         // Create instance
         var createResponse = await client.PostAsync(

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesControllerFixture.cs
@@ -6,6 +6,7 @@ using Altinn.App.Api.Controllers;
 using Altinn.App.Api.Helpers.Patch;
 using Altinn.App.Api.Models;
 using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Helpers.Serialization;
@@ -45,7 +46,7 @@ internal sealed record InstancesControllerFixture(IServiceProvider ServiceProvid
         Dictionary<string, string>? prefill = null
     )
     {
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         prefill ??= new();
 

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using Altinn.App.Api.Models;
+using Altinn.App.Core.Constants;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit.Abstractions;
 
@@ -26,7 +27,7 @@ public class InstancesController_GetTests : ApiTestBase, IClassFixture<WebApplic
 
         using HttpClient client = GetRootedClient(org, app, includeTraceContext: true);
         string token = TestAuthentication.GetUserToken(userId: userId, partyId: instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         var (createdInstance, createdResponse) = await InstancesControllerFixture.CreateInstanceSimplified(
             org,
@@ -48,7 +49,7 @@ public class InstancesController_GetTests : ApiTestBase, IClassFixture<WebApplic
                 $$"""
                     {
                         "createdResponse": {{createdResponse}},
-                        "readResponse": {{readResponseContent}},
+                        "readResponse": {{readResponseContent}}
                     }
                 """
             )
@@ -72,7 +73,7 @@ public class InstancesController_GetTests : ApiTestBase, IClassFixture<WebApplic
 
         using HttpClient client = GetRootedClient(org, app, includeTraceContext: true);
         string token = TestAuthentication.GetUserToken(userId: userId, partyId: instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         var (createdInstance, createdResponse) = await InstancesControllerFixture.CreateInstanceSimplified(
             org,

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using Altinn.App.Api.Models;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Pdf;
 using Altinn.Platform.Storage.Interface.Models;
@@ -47,7 +48,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         int instanceOwnerPartyId = 501337;
         HttpClient client = GetRootedClient(org, app);
         string token = TestAuthentication.GetUserToken(userId: 1337, partyId: instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         // Create instance data
         using var content = new MultipartFormDataContent();
@@ -204,7 +205,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         int instanceOwnerPartyId = 501337;
         HttpClient client = GetRootedClient(org, app);
         string token = TestAuthentication.GetUserToken(userId: 1337, partyId: instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         // Create instance data
         using var content = new MultipartFormDataContent();
@@ -230,7 +231,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         int instanceOwnerPartyId = 501337;
         HttpClient client = GetRootedClient(org, app);
         string token = TestAuthentication.GetUserToken(userId: 1337, partyId: instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         // Create instance data
         using var content = new MultipartFormDataContent();
@@ -267,7 +268,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
             services.AddSingleton(new AppMetadataMutationHook(app => app.DisallowUserInstantiation = true));
         HttpClient client = GetRootedClient(org, app);
         string token = TestAuthentication.GetUserToken(userId: 1337, partyId: instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         // Create instance data
         using var content = new MultipartFormDataContent();
@@ -395,7 +396,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
             services.AddSingleton(new AppMetadataMutationHook(app => app.DisallowUserInstantiation = true));
         HttpClient client = GetRootedClient(org, app);
         string token = TestAuthentication.GetUserToken(userId: 1337, partyId: instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         // Create instance data
         var body = $$"""
@@ -456,7 +457,10 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         var sourceInstanceId = sourceInstance.Id;
 
         // Copy instance
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", userToken);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            AuthorizationSchemes.Bearer,
+            userToken
+        );
 
         // Create instance data
         var body = $$"""
@@ -494,7 +498,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         JsonPatch patch
     )
     {
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         var serializedPatch = JsonSerializer.Serialize(
             new DataPatchRequest() { Patch = patch, IgnoredValidators = [] },
@@ -511,7 +515,7 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
 
     private async Task CompleteInstance(string org, string app, HttpClient client, string token, string instanceId)
     {
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         using var nextResponse = await client.PutAsync($"{org}/{app}/instances/{instanceId}/process/next", null);
         var nextResponseContent = await nextResponse.Content.ReadAsStringAsync();

--- a/test/Altinn.App.Api.Tests/Controllers/LookupOrganisationControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/LookupOrganisationControllerTests.cs
@@ -4,6 +4,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Api.Models;
+using Altinn.App.Core.Constants;
 using Altinn.Platform.Register.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -160,7 +161,7 @@ public class LookupOrganisationControllerTests : ApiTestBase, IClassFixture<WebA
     {
         HttpClient client = GetRootedClient(Org, App);
         string token = TestAuthentication.GetUserToken(1337);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         return client;
     }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/LookupPersonControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/LookupPersonControllerTests.cs
@@ -4,6 +4,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Api.Models;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Helpers;
 using Altinn.Platform.Register.Models;
 using FluentAssertions;
@@ -281,7 +282,7 @@ public class LookupPersonControllerTests : ApiTestBase, IClassFixture<WebApplica
     {
         HttpClient client = GetRootedClient(Org, App);
         string token = TestAuthentication.GetUserToken(1337);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         return client;
     }
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ProfileControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ProfileControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.Registers;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -28,7 +29,7 @@ public class ProfileControllerTests(WebApplicationFactory<Program> factory, ITes
 
         using HttpClient client = GetRootedClient(org, app, includeTraceContext: true);
         string token = TestAuthentication.GetUserToken(userId: userId, partyId: instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         using var response = await client.GetAsync($"{org}/{app}/api/v1/profile/user");
 
@@ -60,7 +61,7 @@ public class ProfileControllerTests(WebApplicationFactory<Program> factory, ITes
 
         using HttpClient client = GetRootedClient(org, app, includeTraceContext: true);
         string token = TestAuthentication.GetUserToken(userId: userId, partyId: instanceOwnerPartyId);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, $"{org}/{app}/api/v1/profile/user");
         request.Headers.Add("Cookie", $"AltinnPartyId={selectedPartyId}");

--- a/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/StatelessDataControllerTests.cs
@@ -146,7 +146,7 @@ public class StatelessDataControllerTests
 
         var client = factory.CreateClient();
         string token = TestAuthentication.GetUserToken(1337);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var request = new HttpRequestMessage(HttpMethod.Get, "/tdd/demo-app/v1/data?dataType=xml");
         request.Headers.Add("party", new string[] { "partyid:234", "partyid:234" }); // Double header
 
@@ -174,7 +174,7 @@ public class StatelessDataControllerTests
 
         var client = factory.CreateClient();
         string token = TestAuthentication.GetUserToken(1337);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         using var request = new HttpRequestMessage(HttpMethod.Get, "/tdd/demo-app/v1/data?dataType=xml");
         request.Headers.Add("party", new string[] { "partyid:234" });
 

--- a/test/Altinn.App.Api.Tests/Controllers/ValidateController_ValidateInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ValidateController_ValidateInstanceTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Data.apps.tdd.contributer_restriction.models;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
@@ -56,7 +57,10 @@ public class ValidateControllerValidateInstanceTests : ApiTestBase, IClassFixtur
     {
         using var httpClient = GetRootedClient(Org, App);
         string token = TestAuthentication.GetUserToken(userId: 1337);
-        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            AuthorizationSchemes.Bearer,
+            token
+        );
         return await httpClient.GetAsync($"/{Org}/{App}/instances/{InstanceId}/validate");
     }
 
@@ -64,7 +68,10 @@ public class ValidateControllerValidateInstanceTests : ApiTestBase, IClassFixtur
     {
         using var httpClient = GetRootedClient(Org, App);
         string token = TestAuthentication.GetUserToken(userId: 1337);
-        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            AuthorizationSchemes.Bearer,
+            token
+        );
         var response = await httpClient.GetAsync($"/{Org}/{App}/instances/{InstanceId}/data/{DataGuid}/validate");
         var responseString = await LogResponse(response);
         return (response, responseString);

--- a/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
+++ b/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Altinn.App.Api.Tests.Data;
 using Altinn.App.Api.Tests.Utils;
 using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Constants;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -98,7 +99,7 @@ public class ApiTestBase
     {
         var client = GetRootedClient(org, app);
         string token = TestAuthentication.GetUserToken(userId, partyId, authenticationLevel);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         return client;
     }
 
@@ -112,7 +113,7 @@ public class ApiTestBase
     {
         var client = GetRootedClient(org, app);
         string token = TestAuthentication.GetServiceOwnerToken(orgNumber, org: serviceOwnerOrg, scope: scope);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         return client;
     }
 

--- a/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.cs
+++ b/test/Altinn.App.Api.Tests/Middleware/TelemetryEnrichingMiddlewareTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net.Http.Headers;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,7 +33,7 @@ public class TelemetryEnrichingMiddlewareTests : ApiTestBase, IClassFixture<WebA
         HttpClient client = GetRootedClient(org, app, includeTraceContext);
         var telemetry = this.Services.GetRequiredService<TelemetrySink>();
 
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
         if (includePdfHeader)
             client.DefaultRequestHeaders.Add("X-Altinn-IsPdf", "true");
 

--- a/test/Altinn.App.Core.Tests/Extensions/HttpClientExtensionTest.cs
+++ b/test/Altinn.App.Core.Tests/Extensions/HttpClientExtensionTest.cs
@@ -1,0 +1,169 @@
+using Altinn.App.Core.Extensions;
+using Moq;
+using Moq.Protected;
+
+namespace Altinn.App.Core.Tests.Extensions;
+
+public class HttpClientExtensionTest
+{
+    private const string RequestUri = "https://unit.test/api";
+    private const string AuthorizationToken = "not-a-real-token";
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("test", null)]
+    [InlineData("test", "platform-access-token")]
+    public async Task PostAsync_AddsRequiredHeaders(string? content, string? platformAccessToken)
+    {
+        // Arrange
+        HttpRequestMessage? capturedHttpRequestMessage = null;
+        var httpContent = content is not null ? new StringContent(content) : null;
+        using var fixture = CreateMockedHttpClient(request =>
+        {
+            capturedHttpRequestMessage = request;
+        });
+
+        // Act
+        var result = await fixture.HttpClient.PostAsync(
+            AuthorizationToken,
+            RequestUri,
+            httpContent,
+            platformAccessToken
+        );
+
+        // Assert
+        Assert.NotNull(capturedHttpRequestMessage);
+        Assert.Equal(System.Net.HttpStatusCode.NoContent, result.StatusCode);
+        Assert.Equal(RequestUri, capturedHttpRequestMessage.RequestUri!.ToString());
+        Assert.Equal(httpContent, capturedHttpRequestMessage.Content);
+        Assert.Equal(HttpMethod.Post, capturedHttpRequestMessage.Method);
+
+        AssertHeaders(capturedHttpRequestMessage, AuthorizationToken, platformAccessToken);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("test", null)]
+    [InlineData("test", "platform-access-token")]
+    public async Task PutAsync_AddsRequiredHeaders(string? content, string? platformAccessToken)
+    {
+        // Arrange
+        HttpRequestMessage? capturedHttpRequestMessage = null;
+        var httpContent = content is not null ? new StringContent(content) : null;
+        using var fixture = CreateMockedHttpClient(request =>
+        {
+            capturedHttpRequestMessage = request;
+        });
+
+        // Act
+        var result = await fixture.HttpClient.PutAsync(
+            AuthorizationToken,
+            RequestUri,
+            httpContent,
+            platformAccessToken
+        );
+
+        // Assert
+        Assert.NotNull(capturedHttpRequestMessage);
+        Assert.Equal(System.Net.HttpStatusCode.NoContent, result.StatusCode);
+        Assert.Equal(RequestUri, capturedHttpRequestMessage!.RequestUri!.ToString());
+        Assert.Equal(httpContent, capturedHttpRequestMessage.Content);
+        Assert.Equal(HttpMethod.Put, capturedHttpRequestMessage.Method);
+
+        AssertHeaders(capturedHttpRequestMessage, AuthorizationToken, platformAccessToken);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("platform-access-token")]
+    public async Task GetAsync_AddsRequiredHeaders(string? platformAccessToken)
+    {
+        // Arrange
+        HttpRequestMessage? capturedHttpRequestMessage = null;
+        using var fixture = CreateMockedHttpClient(request =>
+        {
+            capturedHttpRequestMessage = request;
+        });
+
+        // Act
+        var result = await fixture.HttpClient.GetAsync(AuthorizationToken, RequestUri, platformAccessToken);
+
+        // Assert
+        Assert.NotNull(capturedHttpRequestMessage);
+        Assert.Equal(System.Net.HttpStatusCode.NoContent, result.StatusCode);
+        Assert.Equal(RequestUri, capturedHttpRequestMessage!.RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Get, capturedHttpRequestMessage.Method);
+
+        AssertHeaders(capturedHttpRequestMessage, AuthorizationToken, platformAccessToken);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("platform-access-token")]
+    public async Task DeleteAsync_AddsRequiredHeaders(string? platformAccessToken)
+    {
+        // Arrange
+        HttpRequestMessage? capturedHttpRequestMessage = null;
+        using var fixture = CreateMockedHttpClient(request =>
+        {
+            capturedHttpRequestMessage = request;
+        });
+
+        // Act
+        var result = await fixture.HttpClient.DeleteAsync(AuthorizationToken, RequestUri, platformAccessToken);
+
+        // Assert
+        Assert.NotNull(capturedHttpRequestMessage);
+        Assert.Equal(System.Net.HttpStatusCode.NoContent, result.StatusCode);
+        Assert.Equal(RequestUri, capturedHttpRequestMessage!.RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Delete, capturedHttpRequestMessage.Method);
+
+        AssertHeaders(capturedHttpRequestMessage, AuthorizationToken, platformAccessToken);
+    }
+
+    private static void AssertHeaders(
+        HttpRequestMessage request,
+        string expectedAuthorizationToken,
+        string? expectedPlatformAccessToken = null
+    )
+    {
+        Assert.Equal($"Bearer {expectedAuthorizationToken}", request.Headers.GetValues("Authorization").Single());
+
+        if (expectedPlatformAccessToken is not null)
+        {
+            Assert.Equal(expectedPlatformAccessToken, request.Headers.GetValues("PlatformAccessToken").Single());
+        }
+    }
+
+    private static MockedHttpClient CreateMockedHttpClient(Action<HttpRequestMessage>? sendCallback = null)
+    {
+        var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+        var httpClient = new HttpClient(httpMessageHandlerMock.Object);
+
+        httpMessageHandlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Callback<HttpRequestMessage, CancellationToken>(
+                (request, ct) =>
+                {
+                    sendCallback?.Invoke(request);
+                }
+            )
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = System.Net.HttpStatusCode.NoContent });
+
+        return new MockedHttpClient(httpClient, httpMessageHandlerMock);
+    }
+
+    private sealed record MockedHttpClient(HttpClient HttpClient, Mock<HttpMessageHandler> MockHttpMessageHandler)
+        : IDisposable
+    {
+        public void Dispose()
+        {
+            HttpClient.Dispose();
+        }
+    }
+}

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/Delegates/MaskinportenDelegatingHandlerTest.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/Delegates/MaskinportenDelegatingHandlerTest.cs
@@ -1,3 +1,4 @@
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features.Maskinporten.Constants;
 using FluentAssertions;
 using Moq;
@@ -26,7 +27,7 @@ public class MaskinportenDelegatingHandlerTest
         // Assert
         client.Verify(c => c.GetAccessToken(scopes, It.IsAny<CancellationToken>()), Times.Once);
         Assert.NotNull(request.Headers.Authorization);
-        request.Headers.Authorization.Scheme.Should().Be("Bearer");
+        request.Headers.Authorization.Scheme.Should().Be(AuthorizationSchemes.Bearer);
         request.Headers.Authorization.Parameter.Should().Be(accessToken.ToStringUnmasked());
     }
 }

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/Models/MaskinportenTokenResponseTest.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/Models/MaskinportenTokenResponseTest.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features.Maskinporten.Models;
 using Altinn.App.Core.Models;
 using FluentAssertions;
@@ -15,7 +16,7 @@ public class MaskinportenTokenResponseTest
         var json = $$"""
             {
                 "access_token": "{{encodedToken.AccessToken}}",
-                "token_type": "Bearer",
+                "token_type": "{{AuthorizationSchemes.Bearer}}",
                 "expires_in": 120,
                 "scope": "anything"
             }
@@ -27,7 +28,7 @@ public class MaskinportenTokenResponseTest
         // Assert
         Assert.NotNull(tokenResponse);
         tokenResponse.AccessToken.Should().Be(JwtToken.Parse(encodedToken.AccessToken));
-        tokenResponse.TokenType.Should().Be("Bearer");
+        tokenResponse.TokenType.Should().Be(AuthorizationSchemes.Bearer);
         tokenResponse.Scope.Should().Be("anything");
         tokenResponse.ExpiresIn.Should().Be(120);
     }
@@ -43,7 +44,7 @@ public class MaskinportenTokenResponseTest
         {
             AccessToken = JwtToken.Parse(encodedToken.AccessToken),
             Scope = "yep",
-            TokenType = "Bearer",
+            TokenType = AuthorizationSchemes.Bearer,
             ExpiresIn = 120,
         };
 

--- a/test/Altinn.App.Tests.Common/Auth/TestAuthentication.cs
+++ b/test/Altinn.App.Tests.Common/Auth/TestAuthentication.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text.Json;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Features.Maskinporten.Constants;
 using Altinn.App.Core.Features.Maskinporten.Models;
@@ -363,7 +364,7 @@ public static class TestAuthentication
         Claim[] claims =
         [
             new(JwtClaimTypes.Scope, scope, ClaimValueTypes.String, iss),
-            new("token_type", "Bearer", ClaimValueTypes.String, iss),
+            new("token_type", AuthorizationSchemes.Bearer, ClaimValueTypes.String, iss),
             new("client_id", Guid.NewGuid().ToString(), ClaimValueTypes.String, iss),
             new("consumer", consumer, ClaimValueTypes.String, iss),
             new(AltinnCoreClaimTypes.OrgNumber, orgNumber, ClaimValueTypes.String, iss),
@@ -443,7 +444,7 @@ public static class TestAuthentication
         Claim[] claims =
         [
             new(JwtClaimTypes.Scope, scope, ClaimValueTypes.String, iss),
-            new("token_type", "Bearer", ClaimValueTypes.String, iss),
+            new("token_type", AuthorizationSchemes.Bearer, ClaimValueTypes.String, iss),
             new("client_id", Guid.NewGuid().ToString(), ClaimValueTypes.String, iss),
             new("consumer", consumer, ClaimValueTypes.String, iss),
             new(AltinnCoreClaimTypes.Org, org, ClaimValueTypes.String, iss),
@@ -522,7 +523,7 @@ public static class TestAuthentication
         var payload = new JwtPayload
         {
             { JwtClaimTypes.Issuer, iss },
-            { "token_type", "Bearer" },
+            { "token_type", AuthorizationSchemes.Bearer },
             { JwtClaimTypes.Scope, scope },
             { "client_id", Guid.NewGuid().ToString() },
             { "jti", Guid.NewGuid().ToString() },
@@ -649,7 +650,7 @@ public static class TestAuthentication
             AccessToken = JwtToken.Parse(accessToken),
             ExpiresIn = (int)expiry.Value.TotalSeconds,
             Scope = scope,
-            TokenType = "Bearer",
+            TokenType = AuthorizationSchemes.Bearer,
         };
     }
 }


### PR DESCRIPTION
## Description
This PR simply replaces the hard coded use of "PlatformAccessToken" header names with a newly created constant. It also moves `Maskinporten.TokenTypes` to `Constants.AuthorizationSchemes` and replaces hardcoded occurances of "Bearer" with `AuthorizationSchemes.Bearer`.

Lastly, the PR replaces manual definition of `Authorization` HTTP headers with the `request.Headers.Authorization = AuthenticationHeaderValue` implementation.