### PR TITLE
Minor AltinnPartyClient refactoring

### DIFF
--- a/src/Altinn.App.Core/Extensions/HttpClientExtension.cs
+++ b/src/Altinn.App.Core/Extensions/HttpClientExtension.cs
@@ -24,12 +24,14 @@ public static class HttpClientExtension
         string? platformAccessToken = null
     )
     {
-        HttpRequestMessage request = new(HttpMethod.Post, requestUri);
+        using HttpRequestMessage request = new(HttpMethod.Post, requestUri);
+        request.Content = content;
+
         request.Headers.Authorization = new AuthenticationHeaderValue(
             Constants.AuthorizationSchemes.Bearer,
             authorizationToken
         );
-        request.Content = content;
+
         if (!string.IsNullOrEmpty(platformAccessToken))
         {
             request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
@@ -55,12 +57,14 @@ public static class HttpClientExtension
         string? platformAccessToken = null
     )
     {
-        HttpRequestMessage request = new(HttpMethod.Put, requestUri);
+        using HttpRequestMessage request = new(HttpMethod.Put, requestUri);
+        request.Content = content;
+
         request.Headers.Authorization = new AuthenticationHeaderValue(
             Constants.AuthorizationSchemes.Bearer,
             authorizationToken
         );
-        request.Content = content;
+
         if (!string.IsNullOrEmpty(platformAccessToken))
         {
             request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
@@ -84,11 +88,13 @@ public static class HttpClientExtension
         string? platformAccessToken = null
     )
     {
-        HttpRequestMessage request = new(HttpMethod.Get, requestUri);
+        using HttpRequestMessage request = new(HttpMethod.Get, requestUri);
+
         request.Headers.Authorization = new AuthenticationHeaderValue(
             Constants.AuthorizationSchemes.Bearer,
             authorizationToken
         );
+
         if (!string.IsNullOrEmpty(platformAccessToken))
         {
             request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
@@ -112,11 +118,13 @@ public static class HttpClientExtension
         string? platformAccessToken = null
     )
     {
-        HttpRequestMessage request = new(HttpMethod.Delete, requestUri);
+        using HttpRequestMessage request = new(HttpMethod.Delete, requestUri);
+
         request.Headers.Authorization = new AuthenticationHeaderValue(
             Constants.AuthorizationSchemes.Bearer,
             authorizationToken
         );
+
         if (!string.IsNullOrEmpty(platformAccessToken))
         {
             request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -63,25 +63,28 @@ public class AltinnPartyClient : IAltinnPartyClient
     public async Task<Party?> GetParty(int partyId)
     {
         using var activity = _telemetry?.StartGetPartyActivity(partyId);
-        Party? party = null;
 
+        ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
         string endpointUrl = $"parties/{partyId}";
         string token = _userTokenProvider.GetUserToken();
-        ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
-        HttpResponseMessage response = await _client.GetAsync(
+
+        using HttpResponseMessage response = await _client.GetAsync(
             token,
             endpointUrl,
             _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App)
         );
-        if (response.StatusCode == HttpStatusCode.OK)
+
+        Party? party = response.StatusCode switch
         {
-            party = await JsonSerializerPermissive.DeserializeAsync<Party>(response.Content);
-        }
-        else if (response.StatusCode == HttpStatusCode.Unauthorized)
-        {
-            throw new ServiceException(HttpStatusCode.Unauthorized, "Unauthorized for party");
-        }
-        else
+            HttpStatusCode.OK => await JsonSerializerPermissive.DeserializeAsync<Party>(response.Content),
+            HttpStatusCode.Unauthorized => throw new ServiceException(
+                HttpStatusCode.Unauthorized,
+                "Unauthorized for party"
+            ),
+            _ => null,
+        };
+
+        if (party is null)
         {
             _logger.LogError(
                 "// Getting party with partyID {PartyId} failed with statuscode {StatusCode}",
@@ -97,46 +100,33 @@ public class AltinnPartyClient : IAltinnPartyClient
     public async Task<Party> LookupParty(PartyLookup partyLookup)
     {
         using var activity = _telemetry?.StartLookupPartyActivity();
-        Party party;
 
+        ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
         string endpointUrl = "parties/lookup";
         string token = _userTokenProvider.GetUserToken();
 
-        StringContent content = new StringContent(JsonSerializerPermissive.Serialize(partyLookup));
+        using StringContent content = new(JsonSerializerPermissive.Serialize(partyLookup));
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-        HttpRequestMessage request = new HttpRequestMessage
-        {
-            RequestUri = new Uri(endpointUrl, UriKind.Relative),
-            Method = HttpMethod.Post,
-            Content = content,
-        };
-
-        request.Headers.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token);
-        ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
-        request.Headers.Add(
-            General.PlatformAccessTokenHeaderName,
+        using HttpResponseMessage response = await _client.PostAsync(
+            token,
+            endpointUrl,
+            content,
             _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App)
         );
 
-        HttpResponseMessage response = await _client.SendAsync(request);
         if (response.StatusCode == HttpStatusCode.OK)
         {
-            party = await JsonSerializerPermissive.DeserializeAsync<Party>(response.Content);
-        }
-        else
-        {
-            string reason = await response.Content.ReadAsStringAsync();
-            _logger.LogError(
-                "// Getting party with orgNo: {OrgNo} or ssn: {Ssn} failed with statuscode {StatusCode} - {Reason}",
-                partyLookup.OrgNo,
-                partyLookup.Ssn,
-                response.StatusCode,
-                reason
-            );
-
-            throw await PlatformHttpException.CreateAsync(response);
+            return await JsonSerializerPermissive.DeserializeAsync<Party>(response.Content);
         }
 
-        return party;
+        _logger.LogError(
+            "// Getting party with orgNo: {OrgNo} or ssn: {Ssn} failed with statuscode {StatusCode} - {Reason}",
+            partyLookup.OrgNo,
+            partyLookup.Ssn,
+            response.StatusCode,
+            await response.Content.ReadAsStringAsync()
+        );
+
+        throw await PlatformHttpException.CreateAsync(response);
     }
 }

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -49,14 +49,14 @@ public class AltinnPartyClient : IAltinnPartyClient
     )
     {
         _logger = logger;
-        httpClient.BaseAddress = new Uri(platformSettings.Value.ApiRegisterEndpoint);
-        httpClient.DefaultRequestHeaders.Add(General.SubscriptionKeyHeaderName, platformSettings.Value.SubscriptionKey);
-        httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        _client = httpClient;
         _appMetadata = appMetadata;
         _userTokenProvider = userTokenProvider;
         _accessTokenGenerator = accessTokenGenerator;
         _telemetry = telemetry;
+        _client = httpClient;
+        _client.BaseAddress = new Uri(platformSettings.Value.ApiRegisterEndpoint);
+        _client.DefaultRequestHeaders.Add(General.SubscriptionKeyHeaderName, platformSettings.Value.SubscriptionKey);
+        _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
     }
 
     /// <inheritdoc/>

--- a/test/Altinn.App.Core.Tests/Implementation/EventsClientTest.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/EventsClientTest.cs
@@ -57,7 +57,13 @@ public class EventsClientTest
         };
 
         HttpRequestMessage actualRequest = null;
-        void SetRequest(HttpRequestMessage request) => actualRequest = request;
+        CloudEvent actualEvent = null;
+        void SetRequest(HttpRequestMessage request)
+        {
+            actualRequest = request;
+            actualEvent = JsonSerializer.Deserialize<CloudEvent>(request.Content!.ReadAsStringAsync().Result);
+        }
+
         InitializeMocks(httpResponseMessage, SetRequest);
 
         HttpClient httpClient = new(handlerMock.Object);
@@ -79,10 +85,7 @@ public class EventsClientTest
         // Assert
         Assert.NotNull(actualRequest);
         Assert.Equal(HttpMethod.Post, actualRequest.Method);
-        Assert.EndsWith("app", actualRequest.RequestUri.OriginalString);
-
-        string requestContent = await actualRequest.Content.ReadAsStringAsync();
-        CloudEvent actualEvent = JsonSerializer.Deserialize<CloudEvent>(requestContent);
+        Assert.EndsWith("app", actualRequest.RequestUri!.OriginalString);
 
         Assert.NotNull(actualEvent);
         Assert.Equal("/party/123", actualEvent.Subject);
@@ -112,7 +115,13 @@ public class EventsClientTest
         };
 
         HttpRequestMessage actualRequest = null;
-        void SetRequest(HttpRequestMessage request) => actualRequest = request;
+        CloudEvent actualEvent = null;
+        void SetRequest(HttpRequestMessage request)
+        {
+            actualRequest = request;
+            actualEvent = JsonSerializer.Deserialize<CloudEvent>(request.Content!.ReadAsStringAsync().Result);
+        }
+
         InitializeMocks(httpResponseMessage, SetRequest);
 
         HttpClient httpClient = new HttpClient(handlerMock.Object);
@@ -133,10 +142,7 @@ public class EventsClientTest
         // Assert
         Assert.NotNull(actualRequest);
         Assert.Equal(HttpMethod.Post, actualRequest.Method);
-        Assert.EndsWith("app", actualRequest.RequestUri.OriginalString);
-
-        string requestContent = await actualRequest.Content.ReadAsStringAsync();
-        CloudEvent actualEvent = JsonSerializer.Deserialize<CloudEvent>(requestContent);
+        Assert.EndsWith("app", actualRequest.RequestUri!.OriginalString);
 
         Assert.NotNull(actualEvent);
         Assert.Equal("/party/321", actualEvent.Subject);

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Register/AltinnPartyClientTest.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Register/AltinnPartyClientTest.cs
@@ -1,0 +1,243 @@
+using System.Net;
+using System.Net.Http.Json;
+using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Constants;
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Infrastructure.Clients.Register;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Auth;
+using Altinn.App.Core.Models;
+using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Platform.Register.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+
+namespace Altinn.App.Core.Tests.Infrastructure.Clients.Register;
+
+public class AltinnPartyClientTest
+{
+    private const string UserToken = "user-token";
+    private const string PlatformAccessToken = "platform-access-token";
+    private const string SubscriptionKey = "subscription-key";
+    private const string ApiRegisterEndpoint = "https://localhost/api/v1/";
+
+    [Fact]
+    public async Task GetParty_OK_CallsCorrectUrl_SetsCorrectHeaders()
+    {
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+        const int partyId = 123;
+        var fixture = Fixture.Create(requestCallback: req => capturedRequest = req);
+
+        // Act
+        var result = await fixture.Client.GetParty(partyId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(partyId, result.PartyId);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(HttpMethod.Get, capturedRequest.Method);
+        Assert.Equal(SubscriptionKey, capturedRequest.GetHeader(General.SubscriptionKeyHeaderName));
+        Assert.Equal(PlatformAccessToken, capturedRequest.GetHeader(General.PlatformAccessTokenHeaderName));
+        Assert.Equal($"Bearer {UserToken}", capturedRequest.GetHeader("Authorization"));
+        Assert.Equal($"{ApiRegisterEndpoint}parties/123", capturedRequest.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task GetParty_Unauthorized_ThrowsException()
+    {
+        // Arrange
+        var fixture = Fixture.Create();
+        fixture
+            .HttpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Unauthorized));
+
+        // Act
+        var act = async () => await fixture.Client.GetParty(123);
+
+        // Assert
+        await Assert.ThrowsAsync<ServiceException>(act);
+    }
+
+    [Fact]
+    public async Task GetParty_UnknownError_LogsEventAndReturnsNull()
+    {
+        // Arrange
+        var fixture = Fixture.Create();
+        fixture
+            .HttpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadRequest));
+
+        // Act
+        var result = await fixture.Client.GetParty(123);
+
+        // Assert
+        Assert.Null(result);
+        fixture.LoggerMock.VerifyCall(LogLevel.Error, "failed with statuscode", Times.Once());
+    }
+
+    [Fact]
+    public async Task LookupParty_CallsCorrectUrl_SetsCorrectHeaders()
+    {
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+        const string orgNumber = "123456789";
+        var fixture = Fixture.Create(requestCallback: req => capturedRequest = req);
+
+        // Act
+        var result = await fixture.Client.LookupParty(new PartyLookup { OrgNo = orgNumber });
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(orgNumber, result.OrgNumber);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(HttpMethod.Post, capturedRequest.Method);
+        Assert.Equal(SubscriptionKey, capturedRequest.GetHeader(General.SubscriptionKeyHeaderName));
+        Assert.Equal(PlatformAccessToken, capturedRequest.GetHeader(General.PlatformAccessTokenHeaderName));
+        Assert.Equal($"Bearer {UserToken}", capturedRequest.GetHeader("Authorization"));
+        Assert.Equal($"{ApiRegisterEndpoint}parties/lookup", capturedRequest.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task LookupParty_AnyError_LogsEventAndThrowsException()
+    {
+        // Arrange
+        var fixture = Fixture.Create();
+        fixture
+            .HttpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadRequest));
+
+        // Act
+        var act = async () => await fixture.Client.LookupParty(new PartyLookup());
+
+        // Assert
+        await Assert.ThrowsAsync<PlatformHttpException>(act);
+        fixture.LoggerMock.VerifyCall(LogLevel.Error, "failed with statuscode", Times.Once());
+    }
+
+    private sealed record Fixture(
+        AltinnPartyClient Client,
+        Mock<HttpMessageHandler> HttpMessageHandlerMock,
+        Mock<ILogger<AltinnPartyClient>> LoggerMock
+    )
+    {
+        public static Fixture Create(
+            string userToken = UserToken,
+            string platformAccessToken = PlatformAccessToken,
+            string subscriptionKey = SubscriptionKey,
+            string apiRegisterEndpoint = ApiRegisterEndpoint,
+            Action<HttpRequestMessage>? requestCallback = null
+        )
+        {
+            var loggerMock = new Mock<ILogger<AltinnPartyClient>>();
+
+            var appMetadataMock = new Mock<IAppMetadata>();
+            appMetadataMock.Setup(m => m.GetApplicationMetadata()).ReturnsAsync(new ApplicationMetadata("org/app"));
+
+            var userTokenProviderMock = new Mock<IUserTokenProvider>();
+            userTokenProviderMock.Setup(m => m.GetUserToken()).Returns(userToken);
+
+            var accessTokenGeneratorMock = new Mock<IAccessTokenGenerator>();
+            accessTokenGeneratorMock
+                .Setup(m => m.GenerateAccessToken(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(platformAccessToken);
+
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            httpMessageHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => requestCallback?.Invoke(req))
+                .ReturnsAsync(
+                    (HttpRequestMessage request, CancellationToken ct) =>
+                    {
+                        return request.Method.Method switch
+                        {
+                            "GET" => new HttpResponseMessage(HttpStatusCode.OK)
+                            {
+                                Content = new StringContent($"{{\"partyId\": {request.RequestUri!.Segments.Last()} }}"),
+                            },
+                            "POST" => new HttpResponseMessage(HttpStatusCode.OK)
+                            {
+                                Content = new StringContent(
+                                    $"{{\"orgNumber\": \"{request.Content!.ReadFromJsonAsync<PartyLookup>(CancellationToken.None).Result!.OrgNo}\" }}"
+                                ),
+                            },
+                            _ => throw new InvalidOperationException("Unexpected HTTP method"),
+                        };
+                    }
+                );
+
+            var altinnPartyClient = new AltinnPartyClient(
+                Options.Create(
+                    new PlatformSettings
+                    {
+                        ApiRegisterEndpoint = apiRegisterEndpoint,
+                        SubscriptionKey = subscriptionKey,
+                    }
+                ),
+                loggerMock.Object,
+                new HttpClient(httpMessageHandlerMock.Object),
+                appMetadataMock.Object,
+                userTokenProviderMock.Object,
+                accessTokenGeneratorMock.Object
+            );
+
+            return new Fixture(altinnPartyClient, httpMessageHandlerMock, loggerMock);
+        }
+    }
+}
+
+internal static class AltinnPartyClientTestExtensions
+{
+    public static string GetHeader(this HttpRequestMessage request, string headerName)
+    {
+        return request.Headers.Contains(headerName)
+            ? request.Headers.GetValues(headerName).First()
+            : throw new InvalidOperationException($"Header '{headerName}' not found in request.");
+    }
+
+    public static void VerifyCall<T>(
+        this Mock<ILogger<T>> loggerMock,
+        LogLevel logLevel,
+        string? partialMessage = null,
+        Times? times = null
+    )
+    {
+        loggerMock.Verify(
+            logger =>
+                logger.Log(
+                    logLevel,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>(
+                        (value, _) => partialMessage == null || value.ToString()!.Contains(partialMessage)
+                    ),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                ),
+            times ?? Times.Once()
+        );
+    }
+}

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/SignClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/SignClientTests.cs
@@ -36,12 +36,17 @@ public class SignClientTests
         // Arrange
         InstanceIdentifier instanceIdentifier = new InstanceIdentifier(1337, Guid.NewGuid());
         HttpRequestMessage? platformRequest = null;
+        SignRequest? actualSignRequest = null;
         int callCount = 0;
         SignClient signClient = GetSignClient(
             (request, token) =>
             {
                 callCount++;
                 platformRequest = request;
+                actualSignRequest = JsonSerializerPermissive
+                    .DeserializeAsync<SignRequest>(platformRequest!.Content!)
+                    .Result;
+
                 return Task.FromResult(new HttpResponseMessage { StatusCode = HttpStatusCode.Created });
             }
         );
@@ -80,8 +85,7 @@ public class SignClientTests
             .Be(
                 $"{apiStorageEndpoint}instances/{instanceIdentifier.InstanceOwnerPartyId}/{instanceIdentifier.InstanceGuid}/sign"
             );
-        SignRequest actual = await JsonSerializerPermissive.DeserializeAsync<SignRequest>(platformRequest!.Content!);
-        actual.Should().BeEquivalentTo(expectedRequest);
+        actualSignRequest.Should().BeEquivalentTo(expectedRequest);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
The `AltinnPartyClient` was getting some CodeQL warnings after some tweaks in an unrelated PR, and is in general a bit inconsistent in how it deals with authorization headers and disposal of transient objects.

This PR refactors the client to address these concerns, as well as adding relevant unit tests.

## Notes
Because the new behaviour of request disposal in the HttpClientExtensions methods, a couple of tests which based their logic around capturing requests for later analysis needed to be refactored slightly.

This seems fair to me, since those test cases are _not_ indicative of normal lifecycle behaviour. However, it is possibly a point of contention which is worth discussing further.