### PR TITLE
Renames Maskinporten extension methods

### DIFF
--- a/src/Altinn.App.Api/Extensions/HttpClientBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/HttpClientBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class HttpClientBuilderExtensions
         params string[] additionalScopes
     )
     {
-        return builder.AddMaskinportenHttpMessageHandler(scope, additionalScopes, TokenAuthorities.Maskinporten);
+        return builder.AddMaskinportenHttpMessageHandler(scope, additionalScopes, TokenAuthority.Maskinporten);
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public static class HttpClientBuilderExtensions
         params string[] additionalScopes
     )
     {
-        return builder.AddMaskinportenHttpMessageHandler(scope, additionalScopes, TokenAuthorities.AltinnTokenExchange);
+        return builder.AddMaskinportenHttpMessageHandler(scope, additionalScopes, TokenAuthority.AltinnTokenExchange);
     }
 
     /// <inheritdoc cref="UseMaskinportenAuthorization"/>

--- a/src/Altinn.App.Api/Extensions/HttpClientBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/HttpClientBuilderExtensions.cs
@@ -18,7 +18,7 @@ public static class HttpClientBuilderExtensions
     /// <param name="builder">The Http client builder</param>
     /// <param name="scope">The scope to claim authorization for with Maskinporten</param>
     /// <param name="additionalScopes">Additional scopes as required</param>
-    public static IHttpClientBuilder UseMaskinportenAuthorisation(
+    public static IHttpClientBuilder UseMaskinportenAuthorization(
         this IHttpClientBuilder builder,
         string scope,
         params string[] additionalScopes
@@ -37,7 +37,7 @@ public static class HttpClientBuilderExtensions
     /// <param name="builder">The Http client builder</param>
     /// <param name="scope">The scope to claim authorization for with Maskinporten</param>
     /// <param name="additionalScopes">Additional scopes as required</param>
-    public static IHttpClientBuilder UseMaskinportenAltinnAuthorisation(
+    public static IHttpClientBuilder UseMaskinportenAltinnAuthorization(
         this IHttpClientBuilder builder,
         string scope,
         params string[] additionalScopes
@@ -45,4 +45,20 @@ public static class HttpClientBuilderExtensions
     {
         return builder.AddMaskinportenHttpMessageHandler(scope, additionalScopes, TokenAuthorities.AltinnTokenExchange);
     }
+
+    /// <inheritdoc cref="UseMaskinportenAuthorization"/>
+    [Obsolete("Use UseMaskinportenAuthorization instead")]
+    public static IHttpClientBuilder UseMaskinportenAuthorisation(
+        this IHttpClientBuilder builder,
+        string scope,
+        params string[] additionalScopes
+    ) => UseMaskinportenAuthorization(builder, scope, additionalScopes);
+
+    /// <inheritdoc cref="UseMaskinportenAltinnAuthorization"/>
+    [Obsolete("Use UseMaskinportenAltinnAuthorization instead")]
+    public static IHttpClientBuilder UseMaskinportenAltinnAuthorisation(
+        this IHttpClientBuilder builder,
+        string scope,
+        params string[] additionalScopes
+    ) => UseMaskinportenAltinnAuthorization(builder, scope, additionalScopes);
 }

--- a/src/Altinn.App.Core/Features/Maskinporten/Constants/TokenAuthority.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/Constants/TokenAuthority.cs
@@ -3,7 +3,7 @@ namespace Altinn.App.Core.Features.Maskinporten.Constants;
 /// <summary>
 /// Supported token authorities.
 /// </summary>
-internal enum TokenAuthorities
+internal enum TokenAuthority
 {
     /// <summary>
     /// Maskinporten.

--- a/src/Altinn.App.Core/Features/Maskinporten/Delegates/MaskinportenDelegatingHandler.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/Delegates/MaskinportenDelegatingHandler.cs
@@ -12,7 +12,7 @@ namespace Altinn.App.Core.Features.Maskinporten.Delegates;
 internal sealed class MaskinportenDelegatingHandler : DelegatingHandler
 {
     public IEnumerable<string> Scopes { get; init; }
-    internal readonly TokenAuthorities Authorities;
+    internal readonly TokenAuthority Authority;
 
     private readonly ILogger<MaskinportenDelegatingHandler> _logger;
     private readonly IMaskinportenClient _maskinportenClient;
@@ -20,12 +20,12 @@ internal sealed class MaskinportenDelegatingHandler : DelegatingHandler
     /// <summary>
     /// Creates a new instance of <see cref="MaskinportenDelegatingHandler"/>.
     /// </summary>
-    /// <param name="authorities">The token authority to authorise with</param>
+    /// <param name="authority">The token authority to authorise with</param>
     /// <param name="scopes">A list of scopes to claim authorisation for</param>
     /// <param name="maskinportenClient">A <see cref="MaskinportenClient"/> instance</param>
     /// <param name="logger">Optional logger interface</param>
     public MaskinportenDelegatingHandler(
-        TokenAuthorities authorities,
+        TokenAuthority authority,
         IEnumerable<string> scopes,
         IMaskinportenClient maskinportenClient,
         ILogger<MaskinportenDelegatingHandler> logger
@@ -34,7 +34,7 @@ internal sealed class MaskinportenDelegatingHandler : DelegatingHandler
         Scopes = scopes;
         _logger = logger;
         _maskinportenClient = maskinportenClient;
-        Authorities = authorities;
+        Authority = authority;
     }
 
     /// <inheritdoc/>
@@ -45,14 +45,14 @@ internal sealed class MaskinportenDelegatingHandler : DelegatingHandler
     {
         _logger.LogDebug("Executing custom `SendAsync` method; injecting authentication headers");
 
-        var token = Authorities switch
+        var token = Authority switch
         {
-            TokenAuthorities.Maskinporten => await _maskinportenClient.GetAccessToken(Scopes, cancellationToken),
-            TokenAuthorities.AltinnTokenExchange => await _maskinportenClient.GetAltinnExchangedToken(
+            TokenAuthority.Maskinporten => await _maskinportenClient.GetAccessToken(Scopes, cancellationToken),
+            TokenAuthority.AltinnTokenExchange => await _maskinportenClient.GetAltinnExchangedToken(
                 Scopes,
                 cancellationToken
             ),
-            _ => throw new MaskinportenAuthenticationException($"Unknown authority `{Authorities}`"),
+            _ => throw new MaskinportenAuthenticationException($"Unknown authority `{Authority}`"),
         };
 
         request.Headers.Authorization = new AuthenticationHeaderValue(AuthorizationSchemes.Bearer, token.Value);

--- a/src/Altinn.App.Core/Features/Maskinporten/Extensions/HttpClientBuilderExtensions.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/Extensions/HttpClientBuilderExtensions.cs
@@ -10,13 +10,13 @@ internal static class HttpClientBuilderExtensions
         this IHttpClientBuilder builder,
         string scope,
         IEnumerable<string> additionalScopes,
-        TokenAuthorities authorities
+        TokenAuthority authority
     )
     {
         var scopes = new[] { scope }.Concat(additionalScopes);
         var factory = ActivatorUtilities.CreateFactory<MaskinportenDelegatingHandler>(
-            [typeof(TokenAuthorities), typeof(IEnumerable<string>)]
+            [typeof(TokenAuthority), typeof(IEnumerable<string>)]
         );
-        return builder.AddHttpMessageHandler(provider => factory(provider, [authorities, scopes]));
+        return builder.AddHttpMessageHandler(provider => factory(provider, [authority, scopes]));
     }
 }

--- a/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
+++ b/test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj
@@ -5,6 +5,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+    <!--
+      CS0618: This is a test project, so we usually continue testing [Obsolete] apis
+    -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/Delegates/MaskinportenDelegatingHandlerTest.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/Delegates/MaskinportenDelegatingHandlerTest.cs
@@ -14,7 +14,7 @@ public class MaskinportenDelegatingHandlerTest
         var scopes = new[] { "scope1", "scope2" };
         var accessToken = TestAuthentication.GetMaskinportenToken(scope: "-").AccessToken;
         var (client, handler) = TestHelpers.MockMaskinportenDelegatingHandlerFactory(
-            TokenAuthorities.Maskinporten,
+            TokenAuthority.Maskinporten,
             scopes,
             accessToken
         );

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/Delegates/MaskinportenDelegatingHandlerTest.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/Delegates/MaskinportenDelegatingHandlerTest.cs
@@ -1,33 +1,67 @@
 using Altinn.App.Core.Constants;
+using Altinn.App.Core.Features.Maskinporten;
 using Altinn.App.Core.Features.Maskinporten.Constants;
-using FluentAssertions;
+using Altinn.App.Core.Models;
 using Moq;
 
-namespace Altinn.App.Core.Tests.Features.Maskinporten.Tests.Delegates;
+namespace Altinn.App.Core.Tests.Features.Maskinporten.Delegates;
 
 public class MaskinportenDelegatingHandlerTest
 {
-    [Fact]
-    public async Task SendAsync_AddsAuthorizationHeader()
+    [Theory]
+    [InlineData(nameof(TokenAuthority.Maskinporten))]
+    [InlineData(nameof(TokenAuthority.AltinnTokenExchange))]
+    public async Task SendAsync_AddsAuthorizationHeader(string tokenAuthority)
     {
         // Arrange
-        var scopes = new[] { "scope1", "scope2" };
-        var accessToken = TestAuthentication.GetMaskinportenToken(scope: "-").AccessToken;
+        Enum.TryParse(tokenAuthority, false, out TokenAuthority actualTokenAuthority);
+        string[] scopes = ["scope1", "scope2"];
+        var maskinportenToken = scopes.GetMaskinportenToken();
+        var altinnToken = scopes.GetAltinnExchangedToken();
+
         var (client, handler) = TestHelpers.MockMaskinportenDelegatingHandlerFactory(
-            TokenAuthority.Maskinporten,
+            actualTokenAuthority,
             scopes,
-            accessToken
+            maskinportenToken,
+            altinnToken
         );
-        var httpClient = new HttpClient(handler);
-        var request = new HttpRequestMessage(HttpMethod.Get, "https://some-maskinporten-url/token");
+
+        using var httpClient = new HttpClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://some-maskinporten-url/token");
 
         // Act
         await httpClient.SendAsync(request);
 
         // Assert
-        client.Verify(c => c.GetAccessToken(scopes, It.IsAny<CancellationToken>()), Times.Once);
         Assert.NotNull(request.Headers.Authorization);
-        request.Headers.Authorization.Scheme.Should().Be(AuthorizationSchemes.Bearer);
-        request.Headers.Authorization.Parameter.Should().Be(accessToken.ToStringUnmasked());
+        Assert.Equal(AuthorizationSchemes.Bearer, request.Headers.Authorization.Scheme);
+
+        if (actualTokenAuthority == TokenAuthority.Maskinporten)
+        {
+            client.Verify(c => c.GetAccessToken(scopes, It.IsAny<CancellationToken>()), Times.Once);
+            client.Verify(c => c.GetAltinnExchangedToken(scopes, It.IsAny<CancellationToken>()), Times.Never);
+            Assert.Equal(maskinportenToken.ToStringUnmasked(), request.Headers.Authorization.Parameter);
+        }
+        else
+        {
+            client.Verify(c => c.GetAccessToken(scopes, It.IsAny<CancellationToken>()), Times.Never);
+            client.Verify(c => c.GetAltinnExchangedToken(scopes, It.IsAny<CancellationToken>()), Times.Once);
+            Assert.Equal(altinnToken.ToStringUnmasked(), request.Headers.Authorization.Parameter);
+        }
+    }
+}
+
+public static class MaskinportenDelegatingHandlerTestExtensions
+{
+    public static JwtToken GetMaskinportenToken(this IEnumerable<string> scopes)
+    {
+        return TestAuthentication.GetMaskinportenToken(scope: MaskinportenClient.FormattedScopes(scopes)).AccessToken;
+    }
+
+    public static JwtToken GetAltinnExchangedToken(this IEnumerable<string> scopes)
+    {
+        var token = TestAuthentication.GetOrgAuthentication(scope: MaskinportenClient.FormattedScopes(scopes)).Token;
+
+        return JwtToken.Parse(token);
     }
 }

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/TestHelpers.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/TestHelpers.cs
@@ -64,7 +64,8 @@ internal static class TestHelpers
     ) MockMaskinportenDelegatingHandlerFactory(
         TokenAuthority authority,
         IEnumerable<string> scopes,
-        JwtToken accessToken
+        JwtToken maskinportenToken,
+        JwtToken altinnToken
     )
     {
         var mockProvider = new Mock<IServiceProvider>();
@@ -88,7 +89,10 @@ internal static class TestHelpers
 
         mockMaskinportenClient
             .Setup(c => c.GetAccessToken(scopes, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(accessToken);
+            .ReturnsAsync(maskinportenToken);
+        mockMaskinportenClient
+            .Setup(c => c.GetAltinnExchangedToken(scopes, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(altinnToken);
 
         var handler = new MaskinportenDelegatingHandler(
             authority,

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/TestHelpers.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/TestHelpers.cs
@@ -62,7 +62,7 @@ internal static class TestHelpers
         Mock<IMaskinportenClient> client,
         MaskinportenDelegatingHandler handler
     ) MockMaskinportenDelegatingHandlerFactory(
-        TokenAuthorities authorities,
+        TokenAuthority authority,
         IEnumerable<string> scopes,
         JwtToken accessToken
     )
@@ -91,7 +91,7 @@ internal static class TestHelpers
             .ReturnsAsync(accessToken);
 
         var handler = new MaskinportenDelegatingHandler(
-            authorities,
+            authority,
             scopes,
             mockMaskinportenClient.Object,
             mockLogger.Object


### PR DESCRIPTION
## Description
As part of the ongoing attempt to unify the language of public API components, this PR renames the following methods from British spelling to American:
- UseMaskinportenAuthorization
- UseMaskinportenAltinnAuthorization

The `TokenAuthorities` enum has also been renamed to `TokenAuthority`, which is more in line with other enum namings.

The old spelling is still available as aliases, which will generate a compiler warning due to the  `Obsolete` annotation.