### PR TITLE
Fix issue where request message is disposed before fully processed

### DIFF
--- a/src/Altinn.App.Core/Extensions/HttpClientExtension.cs
+++ b/src/Altinn.App.Core/Extensions/HttpClientExtension.cs
@@ -16,7 +16,7 @@ public static class HttpClientExtension
     /// <param name="content">The http content</param>
     /// <param name="platformAccessToken">The platformAccess tokens</param>
     /// <returns>A HttpResponseMessage</returns>
-    public static Task<HttpResponseMessage> PostAsync(
+    public static async Task<HttpResponseMessage> PostAsync(
         this HttpClient httpClient,
         string authorizationToken,
         string requestUri,
@@ -37,7 +37,7 @@ public static class HttpClientExtension
             request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
         }
 
-        return httpClient.SendAsync(request, CancellationToken.None);
+        return await httpClient.SendAsync(request, CancellationToken.None);
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public static class HttpClientExtension
     /// <param name="content">The http content</param>
     /// <param name="platformAccessToken">The platformAccess tokens</param>
     /// <returns>A HttpResponseMessage</returns>
-    public static Task<HttpResponseMessage> PutAsync(
+    public static async Task<HttpResponseMessage> PutAsync(
         this HttpClient httpClient,
         string authorizationToken,
         string requestUri,
@@ -70,7 +70,7 @@ public static class HttpClientExtension
             request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
         }
 
-        return httpClient.SendAsync(request, CancellationToken.None);
+        return await httpClient.SendAsync(request, CancellationToken.None);
     }
 
     /// <summary>
@@ -81,7 +81,7 @@ public static class HttpClientExtension
     /// <param name="requestUri">The request Uri</param>
     /// <param name="platformAccessToken">The platformAccess tokens</param>
     /// <returns>A HttpResponseMessage</returns>
-    public static Task<HttpResponseMessage> GetAsync(
+    public static async Task<HttpResponseMessage> GetAsync(
         this HttpClient httpClient,
         string authorizationToken,
         string requestUri,
@@ -100,7 +100,7 @@ public static class HttpClientExtension
             request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
         }
 
-        return httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+        return await httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
     }
 
     /// <summary>
@@ -111,7 +111,7 @@ public static class HttpClientExtension
     /// <param name="requestUri">The request Uri</param>
     /// <param name="platformAccessToken">The platformAccess tokens</param>
     /// <returns>A HttpResponseMessage</returns>
-    public static Task<HttpResponseMessage> DeleteAsync(
+    public static async Task<HttpResponseMessage> DeleteAsync(
         this HttpClient httpClient,
         string authorizationToken,
         string requestUri,
@@ -130,6 +130,6 @@ public static class HttpClientExtension
             request.Headers.Add(Constants.General.PlatformAccessTokenHeaderName, platformAccessToken);
         }
 
-        return httpClient.SendAsync(request, CancellationToken.None);
+        return await httpClient.SendAsync(request, CancellationToken.None);
     }
 }

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -107,7 +107,7 @@ public class AltinnPartyClient : IAltinnPartyClient
 
         using StringContent content = new(JsonSerializerPermissive.Serialize(partyLookup));
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
-        using HttpResponseMessage response = await _client.PostAsync(
+        HttpResponseMessage response = await _client.PostAsync(
             token,
             endpointUrl,
             content,


### PR DESCRIPTION
## Description
* `await` sending of request before disposing it
* don't dispose `HttpResponseMessage` when it is captured by `PlatformHttpException`

Recent commit so no need to backport

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
