### PR TITLE
Initialize altinn row id for stateless apps when requested in url

### DIFF
--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -5825,6 +5825,15 @@
             }
           },
           {
+            "name": "includeRowId",
+            "in": "query",
+            "description": "Whether to initialize or remove AltinnRowId fields in the model",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
             "name": "language",
             "in": "query",
             "description": "Currently selected language by the user (if available)",
@@ -5937,6 +5946,15 @@
             }
           },
           {
+            "name": "includeRowId",
+            "in": "query",
+            "description": "Whether to initialize or remove AltinnRowId fields in the model",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
             "name": "language",
             "in": "query",
             "description": "The language selected by the user.",
@@ -5992,6 +6010,15 @@
             "description": "The data type id",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "includeRowId",
+            "in": "query",
+            "description": "Whether to initialize or remove AltinnRowId fields in the model",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
           },
           {
@@ -6064,6 +6091,15 @@
             "description": "The data type id",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "includeRowId",
+            "in": "query",
+            "description": "Whether to initialize or remove AltinnRowId fields in the model",
+            "schema": {
+              "type": "boolean",
+              "default": false
             }
           },
           {

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -611,27 +611,27 @@ namespace Altinn.App.Api.Controllers
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(Altinn.Platform.Storage.Interface.Models.DataElement), 200)]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(Microsoft.AspNetCore.Mvc.ProblemDetails), 400)]
         [Microsoft.AspNetCore.Mvc.RequestSizeLimit(2097152000)]
-        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult> Get([Microsoft.AspNetCore.Mvc.FromRoute] string org, [Microsoft.AspNetCore.Mvc.FromRoute] string app, [Microsoft.AspNetCore.Mvc.FromQuery] string dataType, [Microsoft.AspNetCore.Mvc.FromHeader(Name="party")] string partyFromHeader, [Microsoft.AspNetCore.Mvc.FromQuery] string? prefill, [Microsoft.AspNetCore.Mvc.FromQuery] string? language = null) { }
+        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult> Get([Microsoft.AspNetCore.Mvc.FromRoute] string org, [Microsoft.AspNetCore.Mvc.FromRoute] string app, [Microsoft.AspNetCore.Mvc.FromQuery] string dataType, [Microsoft.AspNetCore.Mvc.FromHeader(Name="party")] string partyFromHeader, [Microsoft.AspNetCore.Mvc.FromQuery] string? prefill, [Microsoft.AspNetCore.Mvc.FromQuery] bool includeRowId = false, [Microsoft.AspNetCore.Mvc.FromQuery] string? language = null) { }
         [Altinn.App.Api.Controllers.DisableFormValueModelBinding]
         [Microsoft.AspNetCore.Authorization.AllowAnonymous]
         [Microsoft.AspNetCore.Mvc.HttpGet]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(Altinn.Platform.Storage.Interface.Models.DataElement), 200)]
         [Microsoft.AspNetCore.Mvc.RequestSizeLimit(2097152000)]
         [Microsoft.AspNetCore.Mvc.Route("anonymous")]
-        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult> GetAnonymous([Microsoft.AspNetCore.Mvc.FromQuery] string dataType, [Microsoft.AspNetCore.Mvc.FromQuery] string? language = null) { }
+        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult> GetAnonymous([Microsoft.AspNetCore.Mvc.FromQuery] string dataType, [Microsoft.AspNetCore.Mvc.FromQuery] bool includeRowId = false, [Microsoft.AspNetCore.Mvc.FromQuery] string? language = null) { }
         [Altinn.App.Api.Controllers.DisableFormValueModelBinding]
         [Microsoft.AspNetCore.Authorization.Authorize]
         [Microsoft.AspNetCore.Mvc.HttpPost]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(Altinn.Platform.Storage.Interface.Models.DataElement), 200)]
         [Microsoft.AspNetCore.Mvc.RequestSizeLimit(2097152000)]
-        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult> Post([Microsoft.AspNetCore.Mvc.FromRoute] string org, [Microsoft.AspNetCore.Mvc.FromRoute] string app, [Microsoft.AspNetCore.Mvc.FromQuery] string dataType, [Microsoft.AspNetCore.Mvc.FromHeader(Name="party")] string partyFromHeader, [Microsoft.AspNetCore.Mvc.FromQuery] string? language = null) { }
+        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult> Post([Microsoft.AspNetCore.Mvc.FromRoute] string org, [Microsoft.AspNetCore.Mvc.FromRoute] string app, [Microsoft.AspNetCore.Mvc.FromQuery] string dataType, [Microsoft.AspNetCore.Mvc.FromHeader(Name="party")] string partyFromHeader, [Microsoft.AspNetCore.Mvc.FromQuery] bool includeRowId = false, [Microsoft.AspNetCore.Mvc.FromQuery] string? language = null) { }
         [Altinn.App.Api.Controllers.DisableFormValueModelBinding]
         [Microsoft.AspNetCore.Authorization.AllowAnonymous]
         [Microsoft.AspNetCore.Mvc.HttpPost]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(Altinn.Platform.Storage.Interface.Models.DataElement), 200)]
         [Microsoft.AspNetCore.Mvc.RequestSizeLimit(2097152000)]
         [Microsoft.AspNetCore.Mvc.Route("anonymous")]
-        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult> PostAnonymous([Microsoft.AspNetCore.Mvc.FromQuery] string dataType, [Microsoft.AspNetCore.Mvc.FromQuery] string? language = null) { }
+        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult> PostAnonymous([Microsoft.AspNetCore.Mvc.FromQuery] string dataType, [Microsoft.AspNetCore.Mvc.FromQuery] bool includeRowId = false, [Microsoft.AspNetCore.Mvc.FromQuery] string? language = null) { }
     }
     [Microsoft.AspNetCore.Authorization.AllowAnonymous]
     [Microsoft.AspNetCore.Mvc.ApiController]


### PR DESCRIPTION
Frontend needs `altinnRowId` to be initialised in data models in order to properly render.

## Related Issue(s)
- #1414 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
