### PR TITLE
Fix various issues related to disposal in integration tests

### DIFF
--- a/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
+++ b/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
@@ -23,7 +23,7 @@ public class BasicAppTests(ITestOutputHelper _output)
             new InstansiationInstance { InstanceOwner = new InstanceOwner { PartyId = "501337" } }
         );
 
-        var readResponse = await response.Read<Instance>();
+        using var readResponse = await response.Read<Instance>();
         await verifier.Verify(
             readResponse,
             snapshotName: "Instantiation",
@@ -50,8 +50,8 @@ public class BasicAppTests(ITestOutputHelper _output)
             }
         );
 
-        var readInstantiationResponse = await instantiationResponse.Read<Instance>();
-        var download = await fixture.Instances.Download(token, readInstantiationResponse);
+        using var readInstantiationResponse = await instantiationResponse.Read<Instance>();
+        using var download = await fixture.Instances.Download(token, readInstantiationResponse);
         await download.Verify(verifier);
 
         await verifier.Verify(await fixture.GetSnapshotAppLogs(), snapshotName: "Logs");
@@ -73,7 +73,7 @@ public class BasicAppTests(ITestOutputHelper _output)
                 Prefill = new() { { "property1", "1" } },
             }
         );
-        var readInstantiationResponse = await instantiationResponse.Read<Instance>();
+        using var readInstantiationResponse = await instantiationResponse.Read<Instance>();
         await verifier.Verify(
             readInstantiationResponse,
             snapshotName: "Instantiation",
@@ -111,7 +111,7 @@ public class BasicAppTests(ITestOutputHelper _output)
         using var readProcessNextResponse = await processNextResponse.Read<AppProcessState>();
         await verifier.Verify(readProcessNextResponse, snapshotName: "ProcessNext", scrubber: scrubber);
 
-        var download = await fixture.Instances.Download(token, readInstantiationResponse);
+        using var download = await fixture.Instances.Download(token, readInstantiationResponse);
         await download.Verify(verifier);
 
         await verifier.Verify(await fixture.GetSnapshotAppLogs(), snapshotName: "Logs");

--- a/test/Altinn.App.Integration.Tests/PartyTypesAllowed/SubunitOnlyAppTests.cs
+++ b/test/Altinn.App.Integration.Tests/PartyTypesAllowed/SubunitOnlyAppTests.cs
@@ -23,7 +23,7 @@ public class SubunitOnlyAppTests(ITestOutputHelper _output)
             new InstansiationInstance { InstanceOwner = new InstanceOwner { PartyId = partyId } }
         );
 
-        var data = await response.Read<Instance>();
+        using var data = await response.Read<Instance>();
         await verifier.Verify(
             data,
             parameters: new { partyId },
@@ -43,7 +43,7 @@ public class SubunitOnlyAppTests(ITestOutputHelper _output)
         using var response = await fixture.ApplicationMetadata.Get();
 
         Assert.True(response.Response.IsSuccessStatusCode);
-        var applicationMetadata = await response.Read<ApplicationMetadata>();
+        using var applicationMetadata = await response.Read<ApplicationMetadata>();
         await verifier.Verify<ApplicationMetadata>(applicationMetadata);
 
         await verifier.Verify(await fixture.GetSnapshotAppLogs(), snapshotName: "Logs");


### PR DESCRIPTION
## Description
Had a test failure here: https://github.com/Altinn/app-lib-dotnet/actions/runs/16773826021/job/47495065236?pr=1413

Have som issues here related to disposal.
Some disposal might be happening multiple times but all the .NET HTTP stuff handle that

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
