### PR TITLE
Extend date verification regex timeout so that tests in CI are a little less flaky

### DIFF
--- a/benchmark/Altinn.App.Benchmarks/Expressions/DateVerificationRegexBenchmarks.cs
+++ b/benchmark/Altinn.App.Benchmarks/Expressions/DateVerificationRegexBenchmarks.cs
@@ -1,0 +1,31 @@
+using System.Text.RegularExpressions;
+using Altinn.App.Core.Internal.Expressions;
+
+namespace Altinn.App.Benchmarks.Expressions;
+
+[Config(typeof(Config))]
+public class DateVerificationRegexBenchmarks
+{
+    private sealed class Config : ManualConfig
+    {
+        public Config()
+        {
+            this.SummaryStyle = SummaryStyle.Default.WithRatioStyle(RatioStyle.Trend);
+            this.AddDiagnoser(MemoryDiagnoser.Default);
+            // this.AddDiagnoser(new DotTraceDiagnoser());
+            this.AddColumn(RankColumn.Arabic);
+            this.Orderer = new DefaultOrderer(SummaryOrderPolicy.SlowestToFastest, MethodOrderPolicy.Declared);
+        }
+    }
+
+    private Regex _dateVerificationRegex;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _dateVerificationRegex = UnicodeDateTimeTokenConverter.DateVerificationRegex();
+    }
+
+    [Benchmark]
+    public bool Verify() => _dateVerificationRegex.IsMatch("1963-06-19T08:30:06.28123+01:00Z");
+}

--- a/src/Altinn.App.Api/Altinn.App.Api.csproj
+++ b/src/Altinn.App.Api/Altinn.App.Api.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+    <InternalsVisibleTo Include="Altinn.App.Benchmarks" />
     <InternalsVisibleTo Include="Altinn.App.Tests.Common" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Altinn.App.Core/Altinn.App.Core.csproj
+++ b/src/Altinn.App.Core/Altinn.App.Core.csproj
@@ -71,6 +71,7 @@
 
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
     <InternalsVisibleTo Include="Altinn.App.Api.Tests" />
+    <InternalsVisibleTo Include="Altinn.App.Benchmarks" />
     <InternalsVisibleTo Include="Altinn.App.Tests.Common" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Altinn.App.Core/Internal/Expressions/UnicodeDateTimeTokenConverter.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/UnicodeDateTimeTokenConverter.cs
@@ -168,7 +168,7 @@ internal static partial class UnicodeDateTimeTokenConverter
         RegexOptions.CultureInvariant,
         matchTimeoutMilliseconds: 100
     )]
-    private static partial Regex DateVerificationRegex();
+    internal static partial Regex DateVerificationRegex();
 
     public static DateTimeOffset? Parse(string rawString, out bool hasTimeZone)
     {

--- a/src/Altinn.App.Core/Internal/Expressions/UnicodeDateTimeTokenConverter.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/UnicodeDateTimeTokenConverter.cs
@@ -166,7 +166,7 @@ internal static partial class UnicodeDateTimeTokenConverter
     [GeneratedRegex(
         @"^[0-9]{4}-[0-9]{2}-[0-9]{2}(?:[ Tt][0-9]{2}:[0-9]{2}(?::[0-9]{2}(?:\.[0-9]{1,9})?)?([Zz]|[+-][0-9]{2}:[0-9]{2})?)?$",
         RegexOptions.CultureInvariant,
-        matchTimeoutMilliseconds: 10
+        matchTimeoutMilliseconds: 100
     )]
     private static partial Regex DateVerificationRegex();
 


### PR DESCRIPTION
## Description
Extend date verification regex timeout so that tests in CI are a little less flaky
Added a benchmark to verify perf for a test case that failed in CI recently: https://github.com/Altinn/app-lib-dotnet/actions/runs/16798811181/job/47575101515?pr=1413

<img width="715" height="689" alt="image" src="https://github.com/user-attachments/assets/ff7fe76e-7c76-4b82-ab83-71c971a13196" />

Seems reasonable to me so it's probably just CI agent cpus being very busy and threads getting scheduled out sometimes

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
