### PR TITLE
Configure renovate to split PRs for each major change, and separate grouped PRs for minor and patch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     "dependency"
   ],
   "separateMinorPatch": true,
+  "separateMultipleMajor": true,
   "baseBranchPatterns": [
     "main"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "labels": [
     "dependency"
   ],
+  "separateMinorPatch": true,
   "baseBranchPatterns": [
     "main"
   ],


### PR DESCRIPTION
## Description
Doc: https://docs.renovatebot.com/configuration-options/#separateminorpatch

The non-major PRs we get now tend to be pretty large and it seems like we manually split them up sometimes (which makes sense to me). See: https://github.com/Altinn/app-lib-dotnet/pull/1424

Also separates each major release

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
