### PR TITLE
Use Path.Join instead of Path.Combine to fix codeql issues

### DIFF
--- a/benchmark/Altinn.App.Benchmarks/Analyzers/AppImplementationFactoryAnalyzerBenchmarks.cs
+++ b/benchmark/Altinn.App.Benchmarks/Analyzers/AppImplementationFactoryAnalyzerBenchmarks.cs
@@ -26,7 +26,7 @@ public class AppImplementationFactoryAnalyzerBenchmarks
 
         var manager = new AnalyzerManager();
         var analyzer = manager.GetProject(
-            Path.Combine(dir.FullName, "..", "..", "src", "Altinn.App.Core", "Altinn.App.Core.csproj")
+            Path.Join(dir.FullName, "..", "..", "src", "Altinn.App.Core", "Altinn.App.Core.csproj")
         );
         _workspace = analyzer.GetWorkspace();
         var solution = _workspace.CurrentSolution;

--- a/benchmark/Altinn.App.Benchmarks/Analyzers/HttpContextAccessorUseAnalyzerBenchmarks.cs
+++ b/benchmark/Altinn.App.Benchmarks/Analyzers/HttpContextAccessorUseAnalyzerBenchmarks.cs
@@ -26,7 +26,7 @@ public class HttpContextAccessorUseAnalyzerBenchmarks
 
         var manager = new AnalyzerManager();
         var analyzer = manager.GetProject(
-            Path.Combine(dir.FullName, "..", "..", "test", "Altinn.App.Analyzers.Tests", "testapp", "App", "App.csproj")
+            Path.Join(dir.FullName, "..", "..", "test", "Altinn.App.Analyzers.Tests", "testapp", "App", "App.csproj")
         );
         _workspace = analyzer.GetWorkspace();
         var solution = _workspace.CurrentSolution;

--- a/src/Altinn.App.Api/Helpers/StartupHelper.cs
+++ b/src/Altinn.App.Api/Helpers/StartupHelper.cs
@@ -23,10 +23,10 @@ public static class StartupHelper
         try
         {
             string fileName = $"{Assembly.GetCallingAssembly().GetName().Name}.xml";
-            string fullFilePath = Path.Combine(AppContext.BaseDirectory, fileName);
+            string fullFilePath = Path.Join(AppContext.BaseDirectory, fileName);
             if (File.Exists(fullFilePath))
                 swaggerDelegate(fullFilePath, false);
-            string fullFilePathApi = Path.Combine(AppContext.BaseDirectory, "Altinn.App.Api.xml");
+            string fullFilePathApi = Path.Join(AppContext.BaseDirectory, "Altinn.App.Api.xml");
             if (File.Exists(fullFilePathApi))
                 swaggerDelegate(fullFilePathApi, false);
         }

--- a/src/Altinn.App.Core/Infrastructure/Clients/KeyVault/SecretsLocalClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/KeyVault/SecretsLocalClient.cs
@@ -61,7 +61,7 @@ public class SecretsLocalClient : ISecretsClient
 
     private static string? GetTokenFromLocalSecrets(string secretId)
     {
-        string path = Path.Combine(Directory.GetCurrentDirectory(), @"secrets.json");
+        string path = Path.Join(Directory.GetCurrentDirectory(), @"secrets.json");
         if (File.Exists(path))
         {
             string jsonString = File.ReadAllText(path);

--- a/test/Altinn.App.Analyzers.Tests/Fixtures/AltinnAppCoreFixture.cs
+++ b/test/Altinn.App.Analyzers.Tests/Fixtures/AltinnAppCoreFixture.cs
@@ -12,14 +12,7 @@ public sealed class AltinnAppCoreFixture : BaseFixture
     internal async Task Initialize()
     {
         await base.Init(
-            Path.Join(
-                Directory.GetCurrentDirectory(),
-                "..",
-                "..",
-                "src",
-                "Altinn.App.Core",
-                "Altinn.App.Core.csproj"
-            )
+            Path.Join(Directory.GetCurrentDirectory(), "..", "..", "src", "Altinn.App.Core", "Altinn.App.Core.csproj")
         );
     }
 

--- a/test/Altinn.App.Analyzers.Tests/Fixtures/AltinnAppCoreFixture.cs
+++ b/test/Altinn.App.Analyzers.Tests/Fixtures/AltinnAppCoreFixture.cs
@@ -12,7 +12,7 @@ public sealed class AltinnAppCoreFixture : BaseFixture
     internal async Task Initialize()
     {
         await base.Init(
-            Path.Combine(
+            Path.Join(
                 Directory.GetCurrentDirectory(),
                 "..",
                 "..",

--- a/test/Altinn.App.Analyzers.Tests/Fixtures/AltinnTestAppFixture.Contents.cs
+++ b/test/Altinn.App.Analyzers.Tests/Fixtures/AltinnTestAppFixture.Contents.cs
@@ -4,7 +4,7 @@ internal sealed record DocumentSelector
 {
     public DocumentSelector(params string[] path)
     {
-        FilePath = Path.Combine([Directory.GetCurrentDirectory(), "testapp", "App", .. path]);
+        FilePath = Path.Join([Directory.GetCurrentDirectory(), "testapp", "App", .. path]);
     }
 
     public string FilePath { get; }

--- a/test/Altinn.App.Analyzers.Tests/Fixtures/AltinnTestAppFixture.cs
+++ b/test/Altinn.App.Analyzers.Tests/Fixtures/AltinnTestAppFixture.cs
@@ -9,7 +9,7 @@ public sealed partial class AltinnTestAppFixture : BaseFixture
 {
     internal async Task Initialize()
     {
-        await base.Init(Path.Combine(Directory.GetCurrentDirectory(), "testapp", "App", "App.csproj"));
+        await base.Init(Path.Join(Directory.GetCurrentDirectory(), "testapp", "App", "App.csproj"));
     }
 
     public IDisposable WithRemovedModelClass()

--- a/test/Altinn.App.Analyzers.Tests/ModuleInitializer.cs
+++ b/test/Altinn.App.Analyzers.Tests/ModuleInitializer.cs
@@ -14,7 +14,7 @@ public class ModuleInitializer
     {
         var testProjectDir = GetTestProjectDirectory();
         Directory.SetCurrentDirectory(testProjectDir.FullName);
-        var path = Path.Combine(testProjectDir.FullName, "testapp", "App.sln");
+        var path = Path.Join(testProjectDir.FullName, "testapp", "App.sln");
         Assert.True(File.Exists(path));
         path = Path.GetFullPath(path);
         Assert.True(File.Exists(path));
@@ -40,7 +40,7 @@ public class ModuleInitializer
     private static DirectoryInfo GetTestProjectDirectory([CallerFilePath] string callerFilePath = "")
     {
         var projDir = Path.GetDirectoryName(callerFilePath) ?? "";
-        var projFile = Path.Combine(projDir, "Altinn.App.Analyzers.Tests.csproj");
+        var projFile = Path.Join(projDir, "Altinn.App.Analyzers.Tests.csproj");
         if (!File.Exists(projFile))
         {
             throw new FileNotFoundException(

--- a/test/Altinn.App.Api.Tests/Data/TestData.cs
+++ b/test/Altinn.App.Api.Tests/Data/TestData.cs
@@ -31,7 +31,7 @@ public static class TestData
     public static string GetApplicationDirectory(string org, string app)
     {
         string testDataDirectory = GetTestDataRootDirectory();
-        return Path.Combine(testDataDirectory, "apps", org, app);
+        return Path.Join(testDataDirectory, "apps", org, app);
     }
 
     public static string GetAppSpecificTestdataDirectory(string org, string app)
@@ -49,13 +49,13 @@ public static class TestData
     public static string GetApplicationMetadataPath(string org, string app)
     {
         string applicationMetadataPath = GetApplicationDirectory(org, app);
-        return Path.Combine(applicationMetadataPath, "config", "applicationmetadata.json");
+        return Path.Join(applicationMetadataPath, "config", "applicationmetadata.json");
     }
 
     public static string GetInstancesDirectory()
     {
         string? testDataDirectory = GetTestDataRootDirectory();
-        return Path.Combine(testDataDirectory!, @"Instances");
+        return Path.Join(testDataDirectory!, @"Instances");
     }
 
     public static string GetDataDirectory(string org, string app, int instanceOwnerId, Guid instanceGuid)
@@ -98,7 +98,7 @@ public static class TestData
     )
     {
         string dataDirectory = GetDataDirectory(org, app, instanceOwnerId, instanceGuid);
-        return Path.Combine(dataDirectory, $"{dataGuid}.json");
+        return Path.Join(dataDirectory, $"{dataGuid}.json");
     }
 
     public static string GetDataElementBlobContnet(
@@ -116,13 +116,13 @@ public static class TestData
     public static string GetDataBlobPath(string org, string app, int instanceOwnerId, Guid instanceGuid, Guid dataGuid)
     {
         string dataDirectory = GetDataDirectory(org, app, instanceOwnerId, instanceGuid);
-        return Path.Combine(dataDirectory, "blob", dataGuid.ToString());
+        return Path.Join(dataDirectory, "blob", dataGuid.ToString());
     }
 
     public static string GetTestDataRolesFolder(int userId, int resourcePartyId)
     {
         string testDataDirectory = GetTestDataRootDirectory();
-        return Path.Combine(
+        return Path.Join(
             testDataDirectory,
             "authorization",
             "roles",
@@ -135,26 +135,26 @@ public static class TestData
     public static string GetAltinnAppsPolicyPath(string org, string app)
     {
         string testDataDirectory = GetTestDataRootDirectory();
-        return Path.Combine(testDataDirectory, "apps", org, app, "config", "authorization")
+        return Path.Join(testDataDirectory, "apps", org, app, "config", "authorization")
             + Path.DirectorySeparatorChar;
     }
 
     public static string GetAltinnProfilePath()
     {
         string testDataDirectory = GetTestDataRootDirectory();
-        return Path.Combine(testDataDirectory, "Register", "Party");
+        return Path.Join(testDataDirectory, "Register", "Party");
     }
 
     public static string GetRegisterProfilePath()
     {
         string testDataDirectory = GetTestDataRootDirectory();
-        return Path.Combine(testDataDirectory, "Profile", "User");
+        return Path.Join(testDataDirectory, "Profile", "User");
     }
 
     public static string GetInstancePath(string org, string app, int instanceOwnerId, Guid instanceGuid)
     {
         string instancesDirectory = GetInstancesDirectory();
-        return Path.Combine(instancesDirectory, org, app, instanceOwnerId.ToString(), instanceGuid + @".json");
+        return Path.Join(instancesDirectory, org, app, instanceOwnerId.ToString(), instanceGuid + @".json");
     }
 
     public static void PrepareInstance(string org, string app, int instanceOwnerId, Guid instanceGuid)

--- a/test/Altinn.App.Api.Tests/Data/TestData.cs
+++ b/test/Altinn.App.Api.Tests/Data/TestData.cs
@@ -135,8 +135,7 @@ public static class TestData
     public static string GetAltinnAppsPolicyPath(string org, string app)
     {
         string testDataDirectory = GetTestDataRootDirectory();
-        return Path.Join(testDataDirectory, "apps", org, app, "config", "authorization")
-            + Path.DirectorySeparatorChar;
+        return Path.Join(testDataDirectory, "apps", org, app, "config", "authorization") + Path.DirectorySeparatorChar;
     }
 
     public static string GetAltinnProfilePath()

--- a/test/Altinn.App.Api.Tests/Mocks/AppMetadataMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/AppMetadataMock.cs
@@ -144,7 +144,7 @@ public class AppMetadataMock : IAppMetadata
 
     private static Application GetTestApplication(string org, string app)
     {
-        string applicationPath = Path.Combine(GetMetadataPath(), org, app, "applicationmetadata.json");
+        string applicationPath = Path.Join(GetMetadataPath(), org, app, "applicationmetadata.json");
         if (File.Exists(applicationPath))
         {
             string content =
@@ -174,6 +174,6 @@ public class AppMetadataMock : IAppMetadata
         string unitTestFolder =
             Path.GetDirectoryName(uri.LocalPath) ?? throw new Exception($"Unable to locate path {uri.LocalPath}");
 
-        return Path.Combine(unitTestFolder, @"../../../Data/Metadata");
+        return Path.Join(unitTestFolder, @"../../../Data/Metadata");
     }
 }

--- a/test/Altinn.App.Api.Tests/Mocks/DataClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/DataClientMock.cs
@@ -592,7 +592,7 @@ public class DataClientMock : IDataClient
 
         foreach (string file in files)
         {
-            string content = await File.ReadAllTextAsync(Path.Combine(path, file), cancellationToken);
+            string content = await File.ReadAllTextAsync(Path.Join(path, file), cancellationToken);
             DataElement? dataElement = JsonSerializer.Deserialize<DataElement>(content, _jsonSerializerOptions);
 
             if (dataElement != null)
@@ -622,7 +622,7 @@ public class DataClientMock : IDataClient
     )
     {
         string path = TestData.GetDataDirectory(org, app, instanceOwnerId, instanceId);
-        string content = await File.ReadAllTextAsync(Path.Combine(path, dataElementGuid + ".json"), cancellationToken);
+        string content = await File.ReadAllTextAsync(Path.Join(path, dataElementGuid + ".json"), cancellationToken);
         return JsonSerializer.Deserialize<DataElement>(content, _jsonSerializerOptions)
             ?? throw new JsonException("Returned null when deserializing data element");
     }

--- a/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
@@ -158,13 +158,7 @@ public class InstanceClientMockSi : IInstanceClient
 
     private static string GetInstancePath(string app, string org, int instanceOwnerId, Guid instanceId)
     {
-        return Path.Join(
-            TestData.GetInstancesDirectory(),
-            org,
-            app,
-            instanceOwnerId.ToString(),
-            instanceId + ".json"
-        );
+        return Path.Join(TestData.GetInstancesDirectory(), org, app, instanceOwnerId.ToString(), instanceId + ".json");
     }
 
     private static string GetDataPath(string org, string app, int instanceOwnerId, Guid instanceGuid)
@@ -196,7 +190,7 @@ public class InstanceClientMockSi : IInstanceClient
                 continue;
             }
 
-            string content = File.ReadAllText(Path.Join(path, file));
+            string content = File.ReadAllText(file);
             DataElement dataElement =
                 JsonConvert.DeserializeObject<DataElement>(content)
                 ?? throw new InvalidDataException($"Something went wrong deserializing json for data from path {file}");

--- a/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/InstanceClientMockSi.cs
@@ -158,7 +158,7 @@ public class InstanceClientMockSi : IInstanceClient
 
     private static string GetInstancePath(string app, string org, int instanceOwnerId, Guid instanceId)
     {
-        return Path.Combine(
+        return Path.Join(
             TestData.GetInstancesDirectory(),
             org,
             app,
@@ -169,7 +169,7 @@ public class InstanceClientMockSi : IInstanceClient
 
     private static string GetDataPath(string org, string app, int instanceOwnerId, Guid instanceGuid)
     {
-        return Path.Combine(
+        return Path.Join(
                 TestData.GetInstancesDirectory(),
                 org,
                 app,
@@ -196,7 +196,7 @@ public class InstanceClientMockSi : IInstanceClient
                 continue;
             }
 
-            string content = File.ReadAllText(Path.Combine(path, file));
+            string content = File.ReadAllText(Path.Join(path, file));
             DataElement dataElement =
                 JsonConvert.DeserializeObject<DataElement>(content)
                 ?? throw new InvalidDataException($"Something went wrong deserializing json for data from path {file}");

--- a/test/Altinn.App.Api.Tests/Mocks/PepWithPDPAuthorizationMockSI.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/PepWithPDPAuthorizationMockSI.cs
@@ -326,7 +326,7 @@ public class PepWithPDPAuthorizationMockSI : Altinn.Common.PEP.Interfaces.IPDP
     public static XacmlPolicy ParsePolicy(string policyDocumentTitle, string policyPath)
     {
         XmlDocument policyDocument = new();
-        policyDocument.Load(Path.Combine(policyPath, policyDocumentTitle));
+        policyDocument.Load(Path.Join(policyPath, policyDocumentTitle));
         XacmlPolicy policy;
         using (XmlReader reader = XmlReader.Create(new StringReader(policyDocument.OuterXml)))
         {

--- a/test/Altinn.App.Core.Tests/Features/Action/PaymentUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/PaymentUserActionTests.cs
@@ -141,7 +141,7 @@ public class PaymentUserActionTests
     {
         IProcessReader processReader = ProcessTestUtils.SetupProcessReader(
             testBpmnFilename,
-            Path.Combine("Features", "Action", "TestData")
+            Path.Join("Features", "Action", "TestData")
         );
         return new PaymentUserAction(processReader, _paymentServiceMock.Object, NullLogger<PaymentUserAction>.Instance);
     }

--- a/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
@@ -61,10 +61,7 @@ public class SigningUserActionTests
         {
             IProcessReader _processReader =
                 processReader
-                ?? ProcessTestUtils.SetupProcessReader(
-                    testBpmnFilename,
-                    Path.Join("Features", "Action", "TestData")
-                );
+                ?? ProcessTestUtils.SetupProcessReader(testBpmnFilename, Path.Join("Features", "Action", "TestData"));
             Instance _instance = instance ?? _defaultInstance;
 
             var signingReceiptService = new Mock<ISigningReceiptService>();

--- a/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/SigningUserActionTests.cs
@@ -63,7 +63,7 @@ public class SigningUserActionTests
                 processReader
                 ?? ProcessTestUtils.SetupProcessReader(
                     testBpmnFilename,
-                    Path.Combine("Features", "Action", "TestData")
+                    Path.Join("Features", "Action", "TestData")
                 );
             Instance _instance = instance ?? _defaultInstance;
 
@@ -514,7 +514,7 @@ public class SigningUserActionTests
     {
         IProcessReader processReader = ProcessTestUtils.SetupProcessReader(
             testBpmnfilename,
-            Path.Combine("Features", "Action", "TestData")
+            Path.Join("Features", "Action", "TestData")
         );
 
         var signingClientMock = new Mock<ISignClient>();

--- a/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
@@ -550,7 +550,7 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
                 }
             );
         FileStream fileStream = File.OpenRead(
-            Path.Combine(PathUtils.GetCoreTestsPath(), "Features", "Action", "TestData", signatureFileToRead)
+            Path.Join(PathUtils.GetCoreTestsPath(), "Features", "Action", "TestData", signatureFileToRead)
         );
         _dataClientMock
             .Setup(d =>

--- a/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
@@ -18,7 +18,7 @@ namespace Altinn.App.Core.Tests.Implementation;
 public class AppResourcesSITests
 {
     private readonly string _appBasePath =
-        Path.Combine(PathUtils.GetCoreTestsPath(), "Implementation", "TestData") + Path.DirectorySeparatorChar;
+        Path.Join(PathUtils.GetCoreTestsPath(), "Implementation", "TestData") + Path.DirectorySeparatorChar;
     private readonly TelemetrySink _telemetry = new();
 
     [Fact]

--- a/test/Altinn.App.Core.Tests/Internal/App/AppMetadataTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/App/AppMetadataTest.cs
@@ -23,7 +23,7 @@ public class AppMetadataTest
     };
 
     private readonly string _appBasePath =
-        Path.Combine(PathUtils.GetCoreTestsPath(), "Internal", "App", "TestData") + Path.DirectorySeparatorChar;
+        Path.Join(PathUtils.GetCoreTestsPath(), "Internal", "App", "TestData") + Path.DirectorySeparatorChar;
 
     [Fact]
     public async Task GetApplicationMetadata_desrializes_file_from_disk()

--- a/test/Altinn.App.Core.Tests/Internal/Process/TestUtils/ProcessTestUtils.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/TestUtils/ProcessTestUtils.cs
@@ -6,7 +6,7 @@ namespace Altinn.App.Core.Tests.Internal.Process.TestUtils;
 
 internal static class ProcessTestUtils
 {
-    private static readonly string TestDataPath = Path.Combine("Internal", "Process", "TestData");
+    private static readonly string TestDataPath = Path.Join("Internal", "Process", "TestData");
 
     internal static ProcessReader SetupProcessReader(
         string bpmnfile,
@@ -21,7 +21,7 @@ internal static class ProcessTestUtils
 
         Mock<IProcessClient> processServiceMock = new Mock<IProcessClient>();
         var s = new FileStream(
-            Path.Combine(PathUtils.GetCoreTestsPath(), testDataPath, bpmnfile),
+            Path.Join(PathUtils.GetCoreTestsPath(), testDataPath, bpmnfile),
             FileMode.Open,
             FileAccess.Read
         );

--- a/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
@@ -902,7 +902,7 @@ public sealed partial class AppFixture : IAsyncDisposable
         foreach (var file in Directory.GetFiles(packagesDirectory))
         {
             var fileName = Path.GetFileName(file);
-            var destFile = Path.Combine(appPackagesDirectory, fileName);
+            var destFile = Path.Join(appPackagesDirectory, fileName);
             await using var source = File.OpenRead(file);
             await using var destination = File.Create(destFile);
             await source.CopyToAsync(destination);
@@ -920,7 +920,7 @@ public sealed partial class AppFixture : IAsyncDisposable
         foreach (var file in Directory.GetFiles(sharedDirectory))
         {
             var fileName = Path.GetFileName(file);
-            var destFile = Path.Combine(appSharedDirectory, fileName);
+            var destFile = Path.Join(appSharedDirectory, fileName);
             await using var source = File.OpenRead(file);
             await using var destination = File.Create(destFile);
             await source.CopyToAsync(destination);

--- a/test/Altinn.App.Integration.Tests/_fixture/NuGetPackaging.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/NuGetPackaging.cs
@@ -79,9 +79,9 @@ internal static class NuGetPackaging
 
     private static void RepackNugetPackage(string path, DateTime dateTime)
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        var libDir = Path.Combine(tempDir, "lib");
-        var relsFile = Path.Combine(tempDir, "_rels", ".rels");
+        var tempDir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        var libDir = Path.Join(tempDir, "lib");
+        var relsFile = Path.Join(tempDir, "_rels", ".rels");
 
         try
         {
@@ -136,7 +136,7 @@ internal static class NuGetPackaging
     private static string RenamePsmdcp(string packageDir, string name)
     {
         string fileName = Directory.EnumerateFiles(packageDir, "*.psmdcp", SearchOption.AllDirectories).Single();
-        string newFileName = Path.Combine(Path.GetDirectoryName(fileName)!, name + ".psmdcp");
+        string newFileName = Path.Join(Path.GetDirectoryName(fileName)!, name + ".psmdcp");
 
         if (fileName != newFileName)
             Directory.Move(fileName, newFileName);
@@ -175,7 +175,7 @@ internal static class NuGetPackaging
         {
             var entry = s.CreateEntry(filePath);
             entry.LastWriteTime = dateTime;
-            using var fs = File.OpenRead(Path.Combine(directory, filePath));
+            using var fs = File.OpenRead(Path.Join(directory, filePath));
             using var entryS = entry.Open();
             fs.CopyTo(entryS);
         }

--- a/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
@@ -10,9 +10,9 @@ public class FixtureTests
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
 
-        var output1 = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var output1 = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
         Assert.False(Directory.Exists(output1), $"Output directory already exists: {output1}");
-        var output2 = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var output2 = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
         Assert.False(Directory.Exists(output2), $"Output directory already exists: {output2}");
 
         await NuGetPackaging.PackLibraries(output1, null, cts.Token);

--- a/test/Altinn.App.Integration.Tests/_testapps/_shared/FixtureConfigurationService.cs
+++ b/test/Altinn.App.Integration.Tests/_testapps/_shared/FixtureConfigurationService.cs
@@ -90,7 +90,7 @@ public sealed class FixtureConfigurationService : IDisposable
         var scenario = config.AppScenario ?? "default";
         if (scenario != "default")
         {
-            var scenarioOverridePath = Path.Combine(env.ContentRootPath, "scenario-overrides", "services");
+            var scenarioOverridePath = Path.Join(env.ContentRootPath, "scenario-overrides", "services");
             if (Directory.Exists(scenarioOverridePath))
             {
                 try
@@ -220,7 +220,7 @@ public sealed class FixtureConfigurationService : IDisposable
         foreach (var file in Directory.GetFiles(scenarioConfigPath, "*", SearchOption.AllDirectories))
         {
             var relativePath = Path.GetRelativePath(scenarioConfigPath, file);
-            var targetFile = Path.Combine(targetConfigPath, relativePath);
+            var targetFile = Path.Join(targetConfigPath, relativePath);
             var targetDir = Path.GetDirectoryName(targetFile);
 
             if (!string.IsNullOrEmpty(targetDir) && !Directory.Exists(targetDir))

--- a/test/Altinn.App.Tests.Common/Auth/JwtTokenMock.cs
+++ b/test/Altinn.App.Tests.Common/Auth/JwtTokenMock.cs
@@ -96,7 +96,7 @@ public static class JwtTokenMock
     {
         string unitTestFolder = Path.GetDirectoryName(GetCallerPath())!;
 
-        string certPath = Path.Combine(unitTestFolder, "TestResources", "jwtselfsignedcert.pfx");
+        string certPath = Path.Join(unitTestFolder, "TestResources", "jwtselfsignedcert.pfx");
         X509Certificate2 cert = new X509Certificate2(certPath, "qwer1234");
         return new X509SigningCredentials(cert, SecurityAlgorithms.RsaSha256);
     }


### PR DESCRIPTION
CodeQL complains about Path.Combine, and as far as I can tell we never use the "feature" where the last argument can pick a new root.

https://github.com/Altinn/app-lib-dotnet/security/code-scanning?query=branch%3Amain+is%3Aopen+rule%3Acs%2Fpath-combine