### PR TITLE
Fix referrer-policy security header spelling

### DIFF
--- a/src/Altinn.App.Api/Infrastructure/Middleware/SecurityHeadersMiddleware.cs
+++ b/src/Altinn.App.Api/Infrastructure/Middleware/SecurityHeadersMiddleware.cs
@@ -9,7 +9,7 @@ namespace Altinn.App.Api.Infrastructure.Middleware;
 /// X-Frame-Options
 /// X-Content-Type-Options
 /// X-XSS-Protection
-/// Referer-Policy
+/// Referrer-Policy
 /// </summary>
 public class SecurityHeadersMiddleware
 {
@@ -34,7 +34,7 @@ public class SecurityHeadersMiddleware
         context.Response.Headers.Append("X-Frame-Options", "deny");
         context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
         context.Response.Headers.Append("X-XSS-Protection", "0");
-        context.Response.Headers.Append("Referer-Policy", "no-referer");
+        context.Response.Headers.Append("Referrer-Policy", "no-referrer");
         context.Response.Headers.Append("Cache-Control", "no-store,no-cache");
 
         return _next(context);

--- a/test/Altinn.App.Api.Tests/Controllers/HomeControllerTest_SetQueryParams.ReturnsMappedModelWhenValidationSucceds.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/HomeControllerTest_SetQueryParams.ReturnsMappedModelWhenValidationSucceds.verified.txt
@@ -3,7 +3,7 @@
   X-Frame-Options: deny
   X-Content-Type-Options: nosniff
   X-XSS-Protection: 0
-  Referer-Policy: no-referer
+  Referrer-Policy: no-referrer
   Cache-Control: no-store,no-cache
   Content-Type: application/json; charset=utf-8
 }

--- a/test/Altinn.App.Api.Tests/Controllers/HomeControllerTest_SetQueryParams.SetQueryParms_ReturnBadRequestWhenValidationFails.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/HomeControllerTest_SetQueryParams.SetQueryParms_ReturnBadRequestWhenValidationFails.verified.txt
@@ -3,7 +3,7 @@
   X-Frame-Options: deny
   X-Content-Type-Options: nosniff
   X-XSS-Protection: 0
-  Referer-Policy: no-referer
+  Referrer-Policy: no-referrer
   Cache-Control: no-store,no-cache
   Content-Type: application/problem+json; charset=utf-8
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ProfileControllerTests.User.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProfileControllerTests.User.verified.txt
@@ -63,7 +63,7 @@
     Status: 200 OK,
     Headers: {
       Cache-Control: no-store, no-cache,
-      Referer-Policy: no-referer,
+      Referrer-Policy: no-referrer,
       X-Content-Type-Options: nosniff,
       X-Frame-Options: deny,
       X-XSS-Protection: 0

--- a/test/Altinn.App.Api.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
+++ b/test/Altinn.App.Api.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
@@ -31,6 +31,6 @@ public class SecurityHeadersMiddlewareTests
         Assert.Equal("deny", response.Headers.GetValues("X-Frame-Options").FirstOrDefault());
         Assert.Equal("nosniff", response.Headers.GetValues("X-Content-Type-Options").FirstOrDefault());
         Assert.Equal("0", response.Headers.GetValues("X-XSS-Protection").FirstOrDefault());
-        Assert.Equal("no-referer", response.Headers.GetValues("Referer-Policy").FirstOrDefault());
+        Assert.Equal("no-referrer", response.Headers.GetValues("Referrer-Policy").FirstOrDefault());
     }
 }

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartJsonPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartJsonPrefill_0_Instantiation.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
@@ -36,8 +36,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_1_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_1_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_2_PatchFormData.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_2_PatchFormData.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_3_ProcessNext.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_3_ProcessNext.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_5_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_5_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_6_Download-PDF.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartNoPrefill_6_Download-PDF.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
@@ -36,8 +36,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_1_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_1_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_2_PatchFormData.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_2_PatchFormData.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_3_ProcessNext.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_3_ProcessNext.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_5_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_5_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_6_Download-PDF.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=MultipartXmlPrefill_6_Download-PDF.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -36,8 +36,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_1_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_1_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_2_PatchFormData.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_2_PatchFormData.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_3_ProcessNext.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_3_ProcessNext.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_5_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_5_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_6_Download-PDF.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_6_Download-PDF.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -36,8 +36,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_1_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_1_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_2_PatchFormData.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_2_PatchFormData.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_3_ProcessNext.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_3_ProcessNext.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_5_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_5_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_6_Download-PDF.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_6_Download-PDF.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartJsonPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartJsonPrefill_0_Instantiation.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_0_Instantiation.verified.txt
@@ -36,8 +36,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_1_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_1_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_2_PatchFormData.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_2_PatchFormData.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_3_ProcessNext.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_3_ProcessNext.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_4_Download-Instance.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_5_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_5_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_6_Download-PDF.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartNoPrefill_6_Download-PDF.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_0_Instantiation.verified.txt
@@ -36,8 +36,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_1_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_1_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_2_PatchFormData.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_2_PatchFormData.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_3_ProcessNext.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_3_ProcessNext.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_4_Download-Instance.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_5_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_5_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_6_Download-PDF.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=MultipartXmlPrefill_6_Download-PDF.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -36,8 +36,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_1_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_1_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_2_PatchFormData.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_2_PatchFormData.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_3_ProcessNext.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_3_ProcessNext.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_4_Download-Instance.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_5_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_5_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_6_Download-PDF.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_6_Download-PDF.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -36,8 +36,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_1_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_1_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_2_PatchFormData.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_2_PatchFormData.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_3_ProcessNext.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_3_ProcessNext.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_4_Download-Instance.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_5_Download-Data[0].verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_5_Download-Data[0].verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_6_Download-PDF.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_6_Download-PDF.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.ApplicationMetadata_0.verified.txt
+++ b/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.ApplicationMetadata_0.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500000_0_Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500000_0_Instance.verified.txt
@@ -33,8 +33,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},

--- a/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500002_0_Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500002_0_Instance.verified.txt
@@ -36,8 +36,8 @@
       X-XSS-Protection: [
         0
       ],
-      Referer-Policy: [
-        no-referer
+      Referrer-Policy: [
+        no-referrer
       ]
     },
     TrailingHeaders: {},


### PR DESCRIPTION
## Description
As commented by coderabbit in a different PR

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrects HTTP security header to the standard Referrer-Policy with value no-referrer across responses.

- Tests
  - Updates unit and integration test expectations and snapshots to reflect the corrected header name and value.

- Documentation
  - Updates inline documentation to reference Referrer-Policy instead of the deprecated/incorrect spelling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->