### PR TITLE
Handle invalid `filename` in `Content-Disposition` header as 400 bad request instead of  500 internal server errors

### DIFF
--- a/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
@@ -62,7 +62,9 @@ public class DataRestrictionValidationTests
         errors
             .FirstOrDefault()!
             .Description.Should()
-            .BeEquivalentTo("Invalid data provided. Error: The Content-Disposition header must contain a filename");
+            .BeEquivalentTo(
+                "Invalid data provided. Error: The Content-Disposition header must contain a valid filename"
+            );
     }
 
     [Fact]

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -758,6 +758,7 @@ namespace Altinn.App.Api.Helpers.RequestHandling
                 "Errors"})]
         public static System.ValueTuple<bool, System.Collections.Generic.List<Altinn.App.Core.Models.Validation.ValidationIssue>> CompliesWithDataRestrictions(Microsoft.AspNetCore.Http.HttpRequest request, Altinn.Platform.Storage.Interface.Models.DataType? dataType) { }
         public static string? GetFileNameFromHeader(Microsoft.Extensions.Primitives.StringValues headerValues) { }
+        public static bool TryGetFileNameFromHeader(Microsoft.Extensions.Primitives.StringValues headerValues, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? filename) { }
     }
     public static class MultipartRequestReader
     {

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=False_useNewEndpoint=False_0_UploadResponse.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=False_useNewEndpoint=False_0_UploadResponse.verified.txt
@@ -1,0 +1,72 @@
+﻿{
+  HttpResponse: {
+    Version: 1.1,
+    Content: {
+      Headers: {
+        Content-Type: [
+          text/plain; charset=utf-8
+        ]
+      }
+    },
+    StatusCode: BadRequest,
+    ReasonPhrase: Bad Request,
+    Headers: {
+      Date: <date>,
+      Server: [
+        Kestrel
+      ],
+      Cache-Control: [
+        no-store, no-cache
+      ],
+      Transfer-Encoding: [
+        chunked
+      ],
+      Request-Context: [
+        appId=
+      ],
+      X-Frame-Options: [
+        deny
+      ],
+      X-Content-Type-Options: [
+        nosniff
+      ],
+      X-XSS-Protection: [
+        0
+      ],
+      Referrer-Policy: [
+        no-referrer
+      ]
+    },
+    TrailingHeaders: {},
+    RequestMessage: {
+      Version: 1.1,
+      Content: {
+        Headers: {
+          Content-Type: [
+            application/pdf
+          ],
+          Content-Disposition: [
+            attachment; filename=Test Doc 2025.pdf
+          ],
+          Content-Length: [
+            25
+          ]
+        }
+      },
+      Method: {
+        Method: POST
+      },
+      RequestUri: http://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data?dataType=attachment,
+      Headers: {
+        Authorization: [
+          Bearer <token>
+        ],
+        User-Agent: [
+          Altinn.App.Integration.Tests
+        ]
+      }
+    },
+    IsSuccessStatusCode: false
+  },
+  Response: Invalid data provided. Error: The Content-Disposition header must contain a valid filename
+}

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=False_useNewEndpoint=True_0_UploadResponse.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=False_useNewEndpoint=True_0_UploadResponse.verified.txt
@@ -1,0 +1,72 @@
+﻿{
+  HttpResponse: {
+    Version: 1.1,
+    Content: {
+      Headers: {
+        Content-Type: [
+          application/problem+json; charset=utf-8
+        ]
+      }
+    },
+    StatusCode: BadRequest,
+    ReasonPhrase: Bad Request,
+    Headers: {
+      Date: <date>,
+      Server: [
+        Kestrel
+      ],
+      Cache-Control: [
+        no-store, no-cache
+      ],
+      Transfer-Encoding: [
+        chunked
+      ],
+      Request-Context: [
+        appId=
+      ],
+      X-Frame-Options: [
+        deny
+      ],
+      X-Content-Type-Options: [
+        nosniff
+      ],
+      X-XSS-Protection: [
+        0
+      ],
+      Referrer-Policy: [
+        no-referrer
+      ]
+    },
+    TrailingHeaders: {},
+    RequestMessage: {
+      Version: 1.1,
+      Content: {
+        Headers: {
+          Content-Type: [
+            application/pdf
+          ],
+          Content-Disposition: [
+            attachment; filename=Test Doc 2025.pdf
+          ],
+          Content-Length: [
+            25
+          ]
+        }
+      },
+      Method: {
+        Method: POST
+      },
+      RequestUri: http://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/type/attachment,
+      Headers: {
+        Authorization: [
+          Bearer <token>
+        ],
+        User-Agent: [
+          Altinn.App.Integration.Tests
+        ]
+      }
+    },
+    IsSuccessStatusCode: false
+  },
+  Response: {"title":"File validation failed","status":400,"detail":"Common checks failed","uploadValidationIssues":[{"severity":1,"dataElementId":null,"field":null,"code":"MissingFileName","description":"Invalid data provided. Error: The Content-Disposition header must contain a valid filename","source":"DataRestrictionValidation"}]}
+}

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=False_0_UploadResponse.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=False_0_UploadResponse.verified.txt
@@ -1,0 +1,74 @@
+﻿{
+  HttpResponse: {
+    Version: 1.1,
+    Content: {
+      Headers: {
+        Content-Type: [
+          application/json; charset=utf-8
+        ]
+      }
+    },
+    StatusCode: Created,
+    ReasonPhrase: Created,
+    Headers: {
+      Date: <date>,
+      Server: [
+        Kestrel
+      ],
+      Cache-Control: [
+        no-store, no-cache
+      ],
+      Location: [
+        https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>
+      ],
+      Transfer-Encoding: [
+        chunked
+      ],
+      Request-Context: [
+        appId=
+      ],
+      X-Frame-Options: [
+        deny
+      ],
+      X-Content-Type-Options: [
+        nosniff
+      ],
+      X-XSS-Protection: [
+        0
+      ],
+      Referrer-Policy: [
+        no-referrer
+      ]
+    },
+    TrailingHeaders: {},
+    RequestMessage: {
+      Version: 1.1,
+      Content: {
+        Headers: {
+          Content-Type: [
+            application/pdf
+          ],
+          Content-Disposition: [
+            attachment; filename="Test Doc 2025.pdf"
+          ],
+          Content-Length: [
+            25
+          ]
+        }
+      },
+      Method: {
+        Method: POST
+      },
+      RequestUri: http://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data?dataType=attachment,
+      Headers: {
+        Authorization: [
+          Bearer <token>
+        ],
+        User-Agent: [
+          Altinn.App.Integration.Tests
+        ]
+      }
+    },
+    IsSuccessStatusCode: true
+  }
+}

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=True_0_UploadResponse.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=True_0_UploadResponse.verified.txt
@@ -1,0 +1,149 @@
+﻿{
+  HttpResponse: {
+    Version: 1.1,
+    Content: {
+      Headers: {
+        Content-Type: [
+          application/json; charset=utf-8
+        ]
+      }
+    },
+    StatusCode: OK,
+    ReasonPhrase: OK,
+    Headers: {
+      Date: <date>,
+      Server: [
+        Kestrel
+      ],
+      Cache-Control: [
+        no-store, no-cache
+      ],
+      Transfer-Encoding: [
+        chunked
+      ],
+      Request-Context: [
+        appId=
+      ],
+      X-Frame-Options: [
+        deny
+      ],
+      X-Content-Type-Options: [
+        nosniff
+      ],
+      X-XSS-Protection: [
+        0
+      ],
+      Referrer-Policy: [
+        no-referrer
+      ]
+    },
+    TrailingHeaders: {},
+    RequestMessage: {
+      Version: 1.1,
+      Content: {
+        Headers: {
+          Content-Type: [
+            application/pdf
+          ],
+          Content-Disposition: [
+            attachment; filename="Test Doc 2025.pdf"
+          ],
+          Content-Length: [
+            25
+          ]
+        }
+      },
+      Method: {
+        Method: POST
+      },
+      RequestUri: http://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/type/attachment,
+      Headers: {
+        Authorization: [
+          Bearer <token>
+        ],
+        User-Agent: [
+          Altinn.App.Integration.Tests
+        ]
+      }
+    },
+    IsSuccessStatusCode: true
+  },
+  Response: {
+    NewDataElementId: Guid_1,
+    Instance: {
+      Id: 501337/<instanceGuid>,
+      InstanceOwner: {
+        PartyId: 501337,
+        PersonNumber: 01039012345
+      },
+      AppId: ttd/basic,
+      Org: ttd,
+      SelfLinks: {
+        Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+        Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
+      },
+      VisibleAfter: DateTime_1,
+      Process: {
+        Started: DateTime_2,
+        StartEvent: StartEvent_1,
+        CurrentTask: {
+          Flow: 2,
+          Started: DateTime_3,
+          ElementId: Task_1,
+          Name: Utfylling,
+          AltinnTaskType: data,
+          FlowType: CompleteCurrentMoveToNext
+        }
+      },
+      Status: {
+        IsArchived: false,
+        IsSoftDeleted: false,
+        IsHardDeleted: false,
+        ReadStatus: Read
+      },
+      Data: [
+        {
+          Id: <dataElementId[0]>,
+          InstanceGuid: <instanceGuid>,
+          DataType: model,
+          ContentType: application/xml,
+          BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
+          SelfLinks: {
+            Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+            Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
+          },
+          Size: 146,
+          Locked: false,
+          IsRead: true,
+          Created: DateTime_4,
+          CreatedBy: 1337,
+          LastChanged: DateTime_4,
+          LastChangedBy: 1337
+        },
+        {
+          Id: <dataElementId[1]>,
+          InstanceGuid: <instanceGuid>,
+          DataType: attachment,
+          Filename: Test Doc 2025.pdf,
+          ContentType: application/pdf,
+          BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
+          SelfLinks: {
+            Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+            Platform: https://platform./storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
+          },
+          Size: 25,
+          Locked: false,
+          IsRead: true,
+          Created: DateTime_5,
+          CreatedBy: 1337,
+          LastChanged: DateTime_5,
+          LastChangedBy: 1337
+        }
+      ],
+      Created: DateTime_1,
+      CreatedBy: 1337,
+      LastChanged: DateTime_6,
+      LastChangedBy: 1337
+    }
+  }
+}

--- a/test/Altinn.App.Integration.Tests/_testapps/basic/App/config/applicationmetadata.json
+++ b/test/Altinn.App.Integration.Tests/_testapps/basic/App/config/applicationmetadata.json
@@ -19,6 +19,23 @@
       "enabledFileValidators": []
     },
     {
+      "id": "attachment",
+      "allowedContentTypes": [
+        "application/pdf",
+        "image/jpeg",
+        "image/png",
+        "text/plain"
+      ],
+      "maxCount": 10,
+      "minCount": 0,
+      "taskId": "Task_1",
+      "enablePdfCreation": false,
+      "enableFileScan": false,
+      "validationErrorOnPendingFileScan": false,
+      "enabledFileAnalysers": [],
+      "enabledFileValidators": []
+    },
+    {
       "id": "model",
       "allowedContentTypes": [
         "application/xml"


### PR DESCRIPTION
## Description
Got a report from a user that they got a 500 error when uploading attachment where the `Content-Disposition` `filename` value was unquoted. Added integration tests for this. Testcase diff:

<img width="1929" height="718" alt="image" src="https://github.com/user-attachments/assets/c39befd9-21ac-434c-9206-244e7683bbda" />


## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved validation for uploaded file headers and unified error text to require a “valid filename,” yielding clearer feedback on invalid/missing filenames.

- New Features
  - Added support for an "attachment" data type in the test app configuration to enable file upload scenarios.

- Tests
  - Added integration tests and snapshots covering uploads across legacy and new endpoints with quoted/unquoted filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->