### PR TITLE
Improve reliability of integration tests

### DIFF
--- a/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
@@ -508,10 +508,11 @@ public sealed partial class AppFixture : IAsyncDisposable
             if (_logFromTestContainers)
                 localtestBuilder = localtestBuilder.WithLogger(testContainersLogger);
 
-            _localtestContainerImage = localtestBuilder.Build();
+            var localtestContainerImage = localtestBuilder.Build();
 
-            await _localtestContainerImage.CreateAsync(cancellationToken);
+            await localtestContainerImage.CreateAsync(cancellationToken);
             logger.LogInformation("Built localtest container image..");
+            _localtestContainerImage = localtestContainerImage;
             return _localtestContainerImage;
         }
         finally
@@ -596,9 +597,10 @@ public sealed partial class AppFixture : IAsyncDisposable
             if (_logFromTestContainers)
                 pdfServiceContainerBuilder = pdfServiceContainerBuilder.WithLogger(testContainersLogger);
 
-            _pdfServiceContainer = pdfServiceContainerBuilder.Build();
-            await _pdfServiceContainer.StartAsync(cancellationToken);
+            var pdfServiceContainer = pdfServiceContainerBuilder.Build();
+            await pdfServiceContainer.StartAsync(cancellationToken);
             logger.LogInformation("Started PDF service container");
+            _pdfServiceContainer = pdfServiceContainer;
 
             return _pdfServiceContainer;
         }


### PR DESCRIPTION
## Description

This PR solves some flakyness issues with the integration test harness..

* `_pdfServiceContainer` was being assigned before the container was actually started. Fixed this and followed the same pattern for all containers and images
* `HttpListener` has a bug where it sometimes fails, seemingly if there are incoming requests during its' startup:  https://github.com/dotnet/runtime/issues/28658

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of container startup by updating state only after builds/starts complete, avoiding partial state exposure.

- Refactor
  - Replaced legacy HTTP listener with a Kestrel-based server and lightweight request bridge, improving request handling, shutdown behavior, and logging.
  - Standardized request validation, response writing, and error handling; made configuration updates thread-safe and signaled readiness reliably.

- Tests
  - Modernized test infrastructure; no changes to public APIs or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->