### PR TITLE
Backport: handle invalid `filename` in `Content-Disposition` header as 400 bad request instead of 500 internal server errors (#1450)

### DIFF
--- a/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
+++ b/test/Altinn.App.Api.Tests/Helpers/RequestHandling/DataRestrictionValidationTests.cs
@@ -62,7 +62,9 @@ public class DataRestrictionValidationTests
         errors
             .FirstOrDefault()!
             .Description.Should()
-            .BeEquivalentTo("Invalid data provided. Error: The Content-Disposition header must contain a filename");
+            .BeEquivalentTo(
+                "Invalid data provided. Error: The Content-Disposition header must contain a valid filename"
+            );
     }
 
     [Fact]

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -763,6 +763,7 @@ namespace Altinn.App.Api.Helpers.RequestHandling
                 "Errors"})]
         public static System.ValueTuple<bool, System.Collections.Generic.List<Altinn.App.Core.Models.Validation.ValidationIssue>> CompliesWithDataRestrictions(Microsoft.AspNetCore.Http.HttpRequest request, Altinn.Platform.Storage.Interface.Models.DataType? dataType) { }
         public static string? GetFileNameFromHeader(Microsoft.Extensions.Primitives.StringValues headerValues) { }
+        public static bool TryGetFileNameFromHeader(Microsoft.Extensions.Primitives.StringValues headerValues, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? filename) { }
     }
     public static class MultipartRequestReader
     {

--- a/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
+++ b/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
@@ -135,4 +135,48 @@ public class BasicAppTests(ITestOutputHelper _output, AppFixtureClassFixture _cl
             _ => throw new ArgumentOutOfRangeException(nameof(testCase)),
         };
     }
+
+    [Theory]
+    [InlineData("Test Doc 2025.pdf", false, false)]
+    [InlineData("Test Doc 2025.pdf", true, false)]
+    [InlineData("Test Doc 2025.pdf", false, true)]
+    [InlineData("Test Doc 2025.pdf", true, true)]
+    public async Task DataUpload(string filename, bool useNewEndpoint, bool filenameQuoted)
+    {
+        await using var fixtureScope = await _classFixture.Get(_output, TestApps.Basic);
+        var fixture = fixtureScope.Fixture;
+        var verifier = fixture.ScopedVerifier;
+        verifier.UseTestCase(new { useNewEndpoint, filenameQuoted });
+
+        var token = await fixture.Auth.GetUserToken(userId: 1337);
+
+        // Create instance
+        using var instantiationResponse = await fixture.Instances.PostSimplified(
+            token,
+            new InstansiationInstance { InstanceOwner = new InstanceOwner { PartyId = "501337" } }
+        );
+        using var readInstantiationResponse = await instantiationResponse.Read<Instance>();
+
+        // Create sample PDF data
+        var pdfData = System.Text.Encoding.UTF8.GetBytes("%PDF-1.4 fake pdf content");
+
+        // Test uploading attachment using the specified endpoint
+        using var uploadResponse = await fixture.Instances.PostData(
+            token,
+            readInstantiationResponse,
+            "attachment",
+            pdfData,
+            "application/pdf",
+            filenameQuoted ? $"\"{filename}\"" : filename,
+            useNewEndpoint
+        );
+        using var readUploadResponse = await uploadResponse.Read<DataPostResponse>();
+        using var updatedInstance = await fixture.Instances.Get(token, readInstantiationResponse);
+        using var readUpdatedInstance = await updatedInstance.Read<Instance>();
+
+        var scrubbers = new Scrubbers(StringScrubber: Scrubbers.InstanceStringScrubber(readUpdatedInstance));
+        if (!useNewEndpoint && readUploadResponse.Response.IsSuccessStatusCode)
+            readUploadResponse.IncludeBodyInSnapshot = false; // The old endpoint has different body, not `DataPostResponse`, so it messes with scrubbing
+        await verifier.Verify(readUploadResponse, scrubbers: scrubbers, snapshotName: "UploadResponse");
+    }
 }

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=False_useNewEndpoint=False_0_UploadResponse.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=False_useNewEndpoint=False_0_UploadResponse.verified.txt
@@ -1,0 +1,72 @@
+﻿{
+  HttpResponse: {
+    Version: 1.1,
+    Content: {
+      Headers: {
+        Content-Type: [
+          text/plain; charset=utf-8
+        ]
+      }
+    },
+    StatusCode: BadRequest,
+    ReasonPhrase: Bad Request,
+    Headers: {
+      Date: <date>,
+      Server: [
+        Kestrel
+      ],
+      Cache-Control: [
+        no-store, no-cache
+      ],
+      Transfer-Encoding: [
+        chunked
+      ],
+      Request-Context: [
+        appId=
+      ],
+      X-Frame-Options: [
+        deny
+      ],
+      X-Content-Type-Options: [
+        nosniff
+      ],
+      X-XSS-Protection: [
+        0
+      ],
+      Referer-Policy: [
+        no-referer
+      ]
+    },
+    TrailingHeaders: {},
+    RequestMessage: {
+      Version: 1.1,
+      Content: {
+        Headers: {
+          Content-Type: [
+            application/pdf
+          ],
+          Content-Disposition: [
+            attachment; filename=Test Doc 2025.pdf
+          ],
+          Content-Length: [
+            25
+          ]
+        }
+      },
+      Method: {
+        Method: POST
+      },
+      RequestUri: http://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data?dataType=attachment,
+      Headers: {
+        Authorization: [
+          Bearer <token>
+        ],
+        User-Agent: [
+          Altinn.App.Integration.Tests
+        ]
+      }
+    },
+    IsSuccessStatusCode: false
+  },
+  Response: Invalid data provided. Error: The Content-Disposition header must contain a valid filename
+}

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=False_useNewEndpoint=True_0_UploadResponse.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=False_useNewEndpoint=True_0_UploadResponse.verified.txt
@@ -1,0 +1,72 @@
+﻿{
+  HttpResponse: {
+    Version: 1.1,
+    Content: {
+      Headers: {
+        Content-Type: [
+          application/problem+json; charset=utf-8
+        ]
+      }
+    },
+    StatusCode: BadRequest,
+    ReasonPhrase: Bad Request,
+    Headers: {
+      Date: <date>,
+      Server: [
+        Kestrel
+      ],
+      Cache-Control: [
+        no-store, no-cache
+      ],
+      Transfer-Encoding: [
+        chunked
+      ],
+      Request-Context: [
+        appId=
+      ],
+      X-Frame-Options: [
+        deny
+      ],
+      X-Content-Type-Options: [
+        nosniff
+      ],
+      X-XSS-Protection: [
+        0
+      ],
+      Referer-Policy: [
+        no-referer
+      ]
+    },
+    TrailingHeaders: {},
+    RequestMessage: {
+      Version: 1.1,
+      Content: {
+        Headers: {
+          Content-Type: [
+            application/pdf
+          ],
+          Content-Disposition: [
+            attachment; filename=Test Doc 2025.pdf
+          ],
+          Content-Length: [
+            25
+          ]
+        }
+      },
+      Method: {
+        Method: POST
+      },
+      RequestUri: http://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/type/attachment,
+      Headers: {
+        Authorization: [
+          Bearer <token>
+        ],
+        User-Agent: [
+          Altinn.App.Integration.Tests
+        ]
+      }
+    },
+    IsSuccessStatusCode: false
+  },
+  Response: {"title":"File validation failed","status":400,"detail":"Common checks failed","uploadValidationIssues":[{"severity":1,"dataElementId":null,"field":null,"code":"MissingFileName","description":"Invalid data provided. Error: The Content-Disposition header must contain a valid filename","source":"DataRestrictionValidation"}]}
+}

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=False_0_UploadResponse.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=False_0_UploadResponse.verified.txt
@@ -1,0 +1,74 @@
+﻿{
+  HttpResponse: {
+    Version: 1.1,
+    Content: {
+      Headers: {
+        Content-Type: [
+          application/json; charset=utf-8
+        ]
+      }
+    },
+    StatusCode: Created,
+    ReasonPhrase: Created,
+    Headers: {
+      Date: <date>,
+      Server: [
+        Kestrel
+      ],
+      Cache-Control: [
+        no-store, no-cache
+      ],
+      Location: [
+        https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>
+      ],
+      Transfer-Encoding: [
+        chunked
+      ],
+      Request-Context: [
+        appId=
+      ],
+      X-Frame-Options: [
+        deny
+      ],
+      X-Content-Type-Options: [
+        nosniff
+      ],
+      X-XSS-Protection: [
+        0
+      ],
+      Referer-Policy: [
+        no-referer
+      ]
+    },
+    TrailingHeaders: {},
+    RequestMessage: {
+      Version: 1.1,
+      Content: {
+        Headers: {
+          Content-Type: [
+            application/pdf
+          ],
+          Content-Disposition: [
+            attachment; filename="Test Doc 2025.pdf"
+          ],
+          Content-Length: [
+            25
+          ]
+        }
+      },
+      Method: {
+        Method: POST
+      },
+      RequestUri: http://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data?dataType=attachment,
+      Headers: {
+        Authorization: [
+          Bearer <token>
+        ],
+        User-Agent: [
+          Altinn.App.Integration.Tests
+        ]
+      }
+    },
+    IsSuccessStatusCode: true
+  }
+}

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=True_0_UploadResponse.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.DataUpload_filenameQuoted=True_useNewEndpoint=True_0_UploadResponse.verified.txt
@@ -1,0 +1,149 @@
+﻿{
+  HttpResponse: {
+    Version: 1.1,
+    Content: {
+      Headers: {
+        Content-Type: [
+          application/json; charset=utf-8
+        ]
+      }
+    },
+    StatusCode: OK,
+    ReasonPhrase: OK,
+    Headers: {
+      Date: <date>,
+      Server: [
+        Kestrel
+      ],
+      Cache-Control: [
+        no-store, no-cache
+      ],
+      Transfer-Encoding: [
+        chunked
+      ],
+      Request-Context: [
+        appId=
+      ],
+      X-Frame-Options: [
+        deny
+      ],
+      X-Content-Type-Options: [
+        nosniff
+      ],
+      X-XSS-Protection: [
+        0
+      ],
+      Referer-Policy: [
+        no-referer
+      ]
+    },
+    TrailingHeaders: {},
+    RequestMessage: {
+      Version: 1.1,
+      Content: {
+        Headers: {
+          Content-Type: [
+            application/pdf
+          ],
+          Content-Disposition: [
+            attachment; filename="Test Doc 2025.pdf"
+          ],
+          Content-Length: [
+            25
+          ]
+        }
+      },
+      Method: {
+        Method: POST
+      },
+      RequestUri: http://local.altinn.cloud:<localtestPort>/ttd/basic/instances/501337/<instanceGuid>/data/type/attachment,
+      Headers: {
+        Authorization: [
+          Bearer <token>
+        ],
+        User-Agent: [
+          Altinn.App.Integration.Tests
+        ]
+      }
+    },
+    IsSuccessStatusCode: true
+  },
+  Response: {
+    NewDataElementId: Guid_1,
+    Instance: {
+      Id: 501337/<instanceGuid>,
+      InstanceOwner: {
+        PartyId: 501337,
+        PersonNumber: 01039012345
+      },
+      AppId: ttd/basic,
+      Org: ttd,
+      SelfLinks: {
+        Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>,
+        Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>
+      },
+      VisibleAfter: DateTime_1,
+      Process: {
+        Started: DateTime_2,
+        StartEvent: StartEvent_1,
+        CurrentTask: {
+          Flow: 2,
+          Started: DateTime_3,
+          ElementId: Task_1,
+          Name: Utfylling,
+          AltinnTaskType: data,
+          FlowType: CompleteCurrentMoveToNext
+        }
+      },
+      Status: {
+        IsArchived: false,
+        IsSoftDeleted: false,
+        IsHardDeleted: false,
+        ReadStatus: Read
+      },
+      Data: [
+        {
+          Id: <dataElementId[0]>,
+          InstanceGuid: <instanceGuid>,
+          DataType: model,
+          ContentType: application/xml,
+          BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[0]>,
+          SelfLinks: {
+            Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[0]>,
+            Platform: https://platform.local.altinn.cloud/storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[0]>
+          },
+          Size: 146,
+          Locked: false,
+          IsRead: true,
+          Created: DateTime_4,
+          CreatedBy: 1337,
+          LastChanged: DateTime_4,
+          LastChangedBy: 1337
+        },
+        {
+          Id: <dataElementId[1]>,
+          InstanceGuid: <instanceGuid>,
+          DataType: attachment,
+          Filename: Test Doc 2025.pdf,
+          ContentType: application/pdf,
+          BlobStoragePath: ttd/basic/<instanceGuid>/data/<dataElementId[1]>,
+          SelfLinks: {
+            Apps: https://app:5005/ttd/basic/instances/501337/<instanceGuid>/data/<dataElementId[1]>,
+            Platform: https://platform./storage/api/v1/instances/501337/<instanceGuid>/data/<dataElementId[1]>
+          },
+          Size: 25,
+          Locked: false,
+          IsRead: true,
+          Created: DateTime_5,
+          CreatedBy: 1337,
+          LastChanged: DateTime_5,
+          LastChangedBy: 1337
+        }
+      ],
+      Created: DateTime_1,
+      CreatedBy: 1337,
+      LastChanged: DateTime_6,
+      LastChangedBy: 1337
+    }
+  }
+}

--- a/test/Altinn.App.Integration.Tests/_testapps/basic/App/config/applicationmetadata.json
+++ b/test/Altinn.App.Integration.Tests/_testapps/basic/App/config/applicationmetadata.json
@@ -19,6 +19,23 @@
       "enabledFileValidators": []
     },
     {
+      "id": "attachment",
+      "allowedContentTypes": [
+        "application/pdf",
+        "image/jpeg",
+        "image/png",
+        "text/plain"
+      ],
+      "maxCount": 10,
+      "minCount": 0,
+      "taskId": "Task_1",
+      "enablePdfCreation": false,
+      "enableFileScan": false,
+      "validationErrorOnPendingFileScan": false,
+      "enabledFileAnalysers": [],
+      "enabledFileValidators": []
+    },
+    {
       "id": "model",
       "allowedContentTypes": [
         "application/xml"


### PR DESCRIPTION
## Description
Backport #1450 

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Structured error responses (problem+json) on the new data upload endpoint when the filename is missing/invalid, including a specific validation code.
  - Test app: added “attachment” data type with allowed content types (PDF, JPEG, PNG, TXT).

- Bug Fixes
  - More robust filename handling in file uploads; quoted and internationalized filenames are now accepted.
  - Missing/invalid filenames now yield a clear 400 Bad Request message instead of failing unpredictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->