### PR TITLE
Make integration tests more reliable on different container runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -390,3 +390,5 @@ BenchmarkDotNet.Artifacts/
 test/Altinn.App.Integration.Tests/_localtest/
 test/Altinn.App.Integration.Tests/_testapps/*/_packages/
 test/Altinn.App.Integration.Tests/_testapps/*/_shared/
+
+**/_snapshots/_local/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,14 @@ The libraries integrate with:
 - We want to minimize external dependencies
 - For HTTP APIs we should have `...Request` and `...Response` DTOs (see `LookupPersonRequest.cs` and the corresponding response as an example)
 - Types meant to be implemented by apps should be marked with the `ImplementableByApps` attribute
+- _Don't_ use `.GetAwaiter().GetResult()`, `.Result()`, `.Wait()` or other blocking APIs on `Task`
+- _Don't_ use `Async` suffix for async methods
+- Write efficient code
+  - _Don't_ allocate unnecessarily. Examples:
+    - Instead of calling `ToString` twice in a row, store it in a variable
+    - Sometimes a for loop is just as good as LINQ
+  - _Don't_ invoke the same async operation multiple times in the same codepath unless necessary
+  - _Don't_ await async operations in a loop (prefer batching, but have an upper bound on parallelism that makes sense) 
 
 ### Feature Implementation
 New features should follow the established pattern in `/src/Altinn.App.Core/Features/`:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,11 +18,12 @@
     <PackageVersion Include="Buildalyzer.Workspaces" Version="7.1.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="CSharpier.MsBuild" Version="1.0.3" />
+    <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
     <PackageVersion Include="FluentAssertions" Version="7.2.0" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="JWTCookieAuthentication" Version="3.0.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.29"/>
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.29" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ ta: test-all
 
 ti: test-integration
 tir: test-integration-repeatedly
+tid: test-integration-debug
 
 # Main projects (more lightweight)
 .PHONY: clean
@@ -60,6 +61,10 @@ else
 	dotnet test test/Altinn.App.Integration.Tests/ --logger "console;verbosity=detailed"
 endif
 
-.PHONY: test-integration
+.PHONY: test-integration-repeatedly
 test-integration-repeatedly:
 	@bash run-repeatedly.sh
+
+.PHONY: test-integration-debug
+test-integration-debug:
+	TEST_KEEP_CONTAINERS=1 make ti filter="FullyQualifiedName~BasicAppTests.Full&DisplayName~SimplifiedNoPrefill&DisplayName~OldUser"

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,11 @@ endif
 
 .PHONY: test-integration-repeatedly
 test-integration-repeatedly:
+ifdef filter
+	@TEST_FILTER="$(filter)" bash run-repeatedly.sh
+else
 	@bash run-repeatedly.sh
+endif
 
 .PHONY: test-integration-debug
 test-integration-debug:

--- a/run-repeatedly.sh
+++ b/run-repeatedly.sh
@@ -88,12 +88,12 @@ for i in $(seq 1 $MAX_RUNS); do
     echo "========================================"
 
     # Run the integration tests
-    DOTNET_TEST_ARGS="--no-restore --no-build test/Altinn.App.Integration.Tests/ --logger \"console;verbosity=detailed\""
+    DOTNET_TEST_ARGS_ARRAY=("--no-restore" "--no-build" "test/Altinn.App.Integration.Tests/" "--logger" "console;verbosity=detailed")
     if [ -n "$TEST_FILTER" ]; then
-        DOTNET_TEST_ARGS="$DOTNET_TEST_ARGS --filter \"$TEST_FILTER\""
+        DOTNET_TEST_ARGS_ARRAY+=("--filter" "$TEST_FILTER")
     fi
     
-    if TEST_LOCALTEST_BRANCH="$TEST_LOCALTEST_BRANCH" TEST_KEEP_CONTAINERS="$TEST_KEEP_CONTAINERS" eval "dotnet test $DOTNET_TEST_ARGS"; then
+    if env TEST_LOCALTEST_BRANCH="$TEST_LOCALTEST_BRANCH" TEST_KEEP_CONTAINERS="$TEST_KEEP_CONTAINERS" dotnet test "${DOTNET_TEST_ARGS_ARRAY[@]}"; then
         echo "✓ Test run $i completed successfully"
 
         # Check for snapshot differences

--- a/run-repeatedly.sh
+++ b/run-repeatedly.sh
@@ -6,6 +6,7 @@ IFS=$'\n\t'
 # Configuration
 TEST_LOCALTEST_BRANCH="${TEST_LOCALTEST_BRANCH:-main}"
 TEST_KEEP_CONTAINERS="${TEST_KEEP_CONTAINERS:-true}"
+TEST_FILTER="${TEST_FILTER:-}"
 MAX_RUNS="${MAX_RUNS:-10}"
 
 # Detect container runtime (docker or podman)
@@ -21,6 +22,7 @@ fi
 echo "Running integration tests repeatedly with:"
 echo "  TEST_LOCALTEST_BRANCH=$TEST_LOCALTEST_BRANCH"
 echo "  TEST_KEEP_CONTAINERS=$TEST_KEEP_CONTAINERS"
+echo "  TEST_FILTER=$TEST_FILTER"
 echo "  MAX_RUNS=$MAX_RUNS"
 echo "  CONTAINER_RUNTIME=$CONTAINER_RUNTIME"
 echo
@@ -86,7 +88,12 @@ for i in $(seq 1 $MAX_RUNS); do
     echo "========================================"
 
     # Run the integration tests
-    if TEST_LOCALTEST_BRANCH="$TEST_LOCALTEST_BRANCH" TEST_KEEP_CONTAINERS="$TEST_KEEP_CONTAINERS" dotnet test --no-restore --no-build test/Altinn.App.Integration.Tests/ --logger "console;verbosity=detailed"; then
+    DOTNET_TEST_ARGS="--no-restore --no-build test/Altinn.App.Integration.Tests/ --logger \"console;verbosity=detailed\""
+    if [ -n "$TEST_FILTER" ]; then
+        DOTNET_TEST_ARGS="$DOTNET_TEST_ARGS --filter \"$TEST_FILTER\""
+    fi
+    
+    if TEST_LOCALTEST_BRANCH="$TEST_LOCALTEST_BRANCH" TEST_KEEP_CONTAINERS="$TEST_KEEP_CONTAINERS" eval "dotnet test $DOTNET_TEST_ARGS"; then
         echo "✓ Test run $i completed successfully"
 
         # Check for snapshot differences

--- a/run-repeatedly.sh
+++ b/run-repeatedly.sh
@@ -7,10 +7,21 @@ TEST_LOCALTEST_BRANCH="${TEST_LOCALTEST_BRANCH:-main}"
 TEST_KEEP_CONTAINERS="${TEST_KEEP_CONTAINERS:-true}"
 MAX_RUNS="${MAX_RUNS:-10}"
 
+# Detect container runtime (docker or podman)
+if command -v docker >/dev/null 2>&1; then
+    CONTAINER_RUNTIME="docker"
+elif command -v podman >/dev/null 2>&1; then
+    CONTAINER_RUNTIME="podman"
+else
+    echo "❌ ERROR: Neither docker nor podman was found, something is wrong"
+    exit 1
+fi
+
 echo "Running integration tests repeatedly with:"
 echo "  TEST_LOCALTEST_BRANCH=$TEST_LOCALTEST_BRANCH"
 echo "  TEST_KEEP_CONTAINERS=$TEST_KEEP_CONTAINERS"
 echo "  MAX_RUNS=$MAX_RUNS"
+echo "  CONTAINER_RUNTIME=$CONTAINER_RUNTIME"
 echo
 
 # Function to check for snapshot diffs
@@ -41,14 +52,14 @@ cleanup_containers() {
     echo "Cleaning up containers after successful run $run_number..."
 
     # Stop and remove all containers
-    if [ "$(docker ps -q | wc -l)" -gt 0 ]; then
+    if [ "$($CONTAINER_RUNTIME ps -q | wc -l)" -gt 0 ]; then
         echo "Stopping running containers..."
-        docker stop $(docker ps -q) || true
+        $CONTAINER_RUNTIME stop $($CONTAINER_RUNTIME ps -q) || true
     fi
 
-    if [ "$(docker ps -a -q | wc -l)" -gt 0 ]; then
+    if [ "$($CONTAINER_RUNTIME ps -a -q | wc -l)" -gt 0 ]; then
         echo "Removing stopped containers..."
-        docker rm $(docker ps -a -q) || true
+        $CONTAINER_RUNTIME rm $($CONTAINER_RUNTIME ps -a -q) || true
     fi
 
     echo "✓ Container cleanup completed"

--- a/test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj
+++ b/test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Docker.DotNet" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Testcontainers" />
     <PackageReference Include="xunit" />

--- a/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
+++ b/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json.Nodes;
 using Altinn.App.Api.Models;
 using Altinn.Platform.Storage.Interface.Models;

--- a/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
+++ b/test/Altinn.App.Integration.Tests/Basic/BasicAppTests.cs
@@ -106,7 +106,7 @@ public class BasicAppTests(ITestOutputHelper _output, AppFixtureClassFixture _cl
         using var download2 = await fixture.Instances.Download(token, readInstantiationResponse);
         await download2.Verify(verifier);
 
-        await verifier.Verify(await fixture.GetSnapshotAppLogs(), snapshotName: "Logs");
+        await verifier.Verify(fixture.GetSnapshotAppLogs(), snapshotName: "Logs");
     }
 
     [Theory]

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.ContainerConnectivity_Pdf.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.ContainerConnectivity_Pdf.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   Success: true,
   StatusCode: 200,
-  Url: http://host.docker.internal:<pdfPort>/config,
+  Url: http://host.containers.internal:<pdfPort>/config,
   ResponseContent: {"allowFileProtocol":false,"chromeRefreshTime":1800000,"connectionTimeout":60000,"disabledFeatures":[],"enableAPIGet":false,"enableCors":false,"enableHeapdump":false,"errorAlertURL":null,"exitOnHealthFailure":false,"functionBuiltIns":["url"],"functionEnvVars":[],"functionEnableIncognitoMode":false,"functionExternals":["lighthouse","node-pdftk","sharp"],"healthFailureURL":null,"sessionCheckFailURL":null,"host":"0.0.0.0","keepAlive":false,"maxCPU":99,"maxConcurrentSessions":10,"maxMemory":99,"maxQueueLength":20,"metricsJSONPath":null,"port":3000,"prebootChrome":false,"prebootQuantity":0,"queuedAlertURL":null,"rejectAlertURL":null,"singleRun":false,"timeoutAlertURL":null,"token":null,"workspaceDir":"/usr/src/app/workspace","socketBehavior":"http"},
   Message: PDF service connectivity verified
 }

--- a/test/Altinn.App.Integration.Tests/PartyTypesAllowed/SubunitOnlyAppTests.cs
+++ b/test/Altinn.App.Integration.Tests/PartyTypesAllowed/SubunitOnlyAppTests.cs
@@ -33,7 +33,7 @@ public class SubunitOnlyAppTests(ITestOutputHelper _output, AppFixtureClassFixtu
             scrubbers: new Scrubbers(StringScrubber: Scrubbers.InstanceStringScrubber(data))
         );
 
-        await verifier.Verify(await fixture.GetSnapshotAppLogs(), snapshotName: "Logs");
+        await verifier.Verify(fixture.GetSnapshotAppLogs(), snapshotName: "Logs");
     }
 
     [Fact]
@@ -49,6 +49,6 @@ public class SubunitOnlyAppTests(ITestOutputHelper _output, AppFixtureClassFixtu
         using var applicationMetadata = await response.Read<ApplicationMetadata>();
         await verifier.Verify<ApplicationMetadata>(applicationMetadata);
 
-        await verifier.Verify(await fixture.GetSnapshotAppLogs(), snapshotName: "Logs");
+        await verifier.Verify(fixture.GetSnapshotAppLogs(), snapshotName: "Logs");
     }
 }

--- a/test/Altinn.App.Integration.Tests/README.md
+++ b/test/Altinn.App.Integration.Tests/README.md
@@ -12,7 +12,7 @@ The test harness creates isolated environments with a **localtest container** (s
 - Docker install
 - May need a `127.0.0.1  local.altinn.cloud` record in `/etc/hosts`
 - May need firewall changes
-  - linux ufw firewall blocked container -> host traffic via `host.docker.internal` in one case
+  - linux ufw firewall blocked container -> host traffic via `host.containers.internal` in one case
     - Verify root cause temporarily by: `sudo ufw disable`
     - Run `BasicAppTests.ContainerConnectivity` test, it needs to succeed for the harness container setup to work
 

--- a/test/Altinn.App.Integration.Tests/README.md
+++ b/test/Altinn.App.Integration.Tests/README.md
@@ -14,7 +14,9 @@ The test harness creates isolated environments with a **localtest container** (s
 - May need firewall changes
   - linux ufw firewall blocked container -> host traffic via `host.containers.internal` in one case
     - Verify root cause temporarily by: `sudo ufw disable`
-    - Run `BasicAppTests.ContainerConnectivity` test, it needs to succeed for the harness container setup to work
+    - Run diagnostics tests
+      - `make ti filter=ContainerConnectivity` - needs to succeed for the harness container setup to work
+      - `make ti filter=DebugNetworking` - outputs diagnostics into `_fixture/_snapshots/_local/FixtureTests.DebugNetworking.verified.txt`
 
 ## Architecture Overview
 
@@ -35,7 +37,7 @@ public class MyIntegrationTests(ITestOutputHelper output) : IAsyncLifetime
 {
     private readonly ITestOutputHelper _output = output;
     private AppFixture? _fixture;
-    
+
     public AppFixture Fixture
     {
         get

--- a/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
@@ -230,7 +230,7 @@ public sealed partial class AppFixture : IAsyncDisposable
         // - Log messages from `SnapshotLogger` in the app
         // - Error logs (`fail:` prefix in the default M.E.L log format)
 
-        var expectedPrefix = $"[{_currentFixtureInstance:00}/{_app}/{_scenario}]";
+        var expectedPrefix = $"[{_currentFixtureInstance:00}/{_app}/{_scenario}";
         var allLines = _appLogsConsumer.GetLines();
 
         var data = new List<string>(allLines.Count);
@@ -244,12 +244,13 @@ public sealed partial class AppFixture : IAsyncDisposable
         {
             start = line;
             isSnapshotMessage = start.StartsWith(prefix);
-            isError = start.StartsWith("fail:");
+            isError = start.StartsWith("fail:") || start.StartsWith("crit:");
             return isSnapshotMessage
                 || isError
                 || start.StartsWith("info:")
                 || start.StartsWith("warn:")
-                || start.StartsWith("dbug:");
+                || start.StartsWith("dbug:")
+                || start.StartsWith("trce:");
         }
 
         static void AddLines(IReadOnlyList<string> source, List<string> target, string prefix)
@@ -264,8 +265,8 @@ public sealed partial class AppFixture : IAsyncDisposable
 
                 if (isSnapshotMessage)
                 {
-                    start = $"[{start.Slice(4)}"; // Remove the fixture index as tests run with parallelism
-                    target.Add(start.ToString());
+                    // Remove the fixture index as tests run with parallelism - use efficient slicing
+                    target.Add($"[{start[4..]}");
                 }
                 else if (isErrorMessage)
                 {

--- a/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
@@ -271,7 +271,8 @@ public sealed partial class AppFixture : IAsyncDisposable
                 {
                     var fullMessage = new StringBuilder();
                     fullMessage.Append(start);
-                    for (int j = i + 1; j < source.Count; j++)
+                    var j = i + 1;
+                    for (; j < source.Count; j++)
                     {
                         if (IsStartOfLogMessage(source[j], prefix, out start, out _, out _))
                             break;
@@ -282,6 +283,7 @@ public sealed partial class AppFixture : IAsyncDisposable
                         fullMessage.Append(start);
                     }
                     target.Add(fullMessage.ToString());
+                    i = j - 1; // skip lines we just consumed
                 }
             }
         }

--- a/test/Altinn.App.Integration.Tests/_fixture/AppFixtureClassFixture.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/AppFixtureClassFixture.cs
@@ -4,7 +4,7 @@ namespace Altinn.App.Integration.Tests;
 
 public sealed record AppFixtureScope(AppFixture Fixture) : IAsyncDisposable
 {
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         if (Fixture.TestErrored)
         {
@@ -13,8 +13,9 @@ public sealed record AppFixtureScope(AppFixture Fixture) : IAsyncDisposable
             // we snapshot app logs. So we have additional code here
             // to output container logs at the end so that test failures in CI for example
             // is easier to debug.
-            await Fixture.LogContainerLogs();
+            Fixture.LogContainerLogs();
         }
+        return default;
     }
 }
 

--- a/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
@@ -29,8 +29,8 @@ public static partial class ContainerRuntimeService
             var probeScript = """
                 set -e
                 try_host() {
-                    # use ping to avoid depending on getent; parse 'PING name (A.B.C.D)'
-                    ip=$(ping -c1 -W1 "$1" 2>/dev/null | sed -n 's/^PING [^(]*(\([0-9.]*\)).*/\1/p')
+                    # use ping -4 to force IPv4; parse 'PING name (A.B.C.D)'
+                    ip=$(ping -4 -c1 -W1 "$1" 2>/dev/null | sed -n 's/^PING [^(]*(\([0-9.]*\)).*/\1/p')
                     if [ -n "$ip" ]; then echo "$ip"; return 0; fi
                     return 1
                 }

--- a/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
@@ -1,0 +1,269 @@
+// Requires NuGet: Docker.DotNet (>= 3.125.15) or similar
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+
+namespace Altinn.App.Integration.Tests;
+
+public static class ContainerRuntimeService
+{
+    private static DockerClient? _client;
+    private static string? _cachedHostIp; // process-lifetime cache
+    private static readonly SemaphoreSlim _lock = new(1, 1);
+
+    // You can change this to "alpine:3" if you prefer; busybox is tiny & multi-arch.
+    private const string ProbeImage = "busybox:1.36";
+
+    /// <summary>
+    /// Returns an IPv4 address that containers can use to reach the host.
+    /// </summary>
+    public static async Task<string> GetHostIP(CancellationToken cancellationToken = default)
+    {
+        if (!string.IsNullOrEmpty(_cachedHostIp))
+            return _cachedHostIp;
+
+        await _lock.WaitAsync(cancellationToken);
+        try
+        {
+            _client ??= await CreateDockerClient(cancellationToken);
+            await EnsureImage(ProbeImage, cancellationToken);
+
+            // One-shot probe container that prints a single IPv4 and exits.
+            // Strategy:
+            // 1) Try common internal hostnames (Docker Desktop, Podman, Rancher Desktop).
+            // 2) Fallback: parse default gateway from /proc/net/route (works on Linux engines).
+            var probeScript = """
+                set -e
+                try_host() {
+                    # use ping to avoid depending on getent; parse 'PING name (A.B.C.D)'
+                    ip=$(ping -c1 -W1 "$1" 2>/dev/null | sed -n 's/^PING [^(]*(\([0-9.]*\)).*/\1/p')
+                    if [ -n "$ip" ]; then echo "$ip"; return 0; fi
+                    return 1
+                }
+                for n in host.docker.internal host.containers.internal host.rancher-desktop.internal; do
+                    try_host "$n" && exit 0
+                done
+                # default route (Gateway hex in column 3 of /proc/net/route on the 0.0.0.0 row)
+                g=$(awk '$2=="00000000" {print $3}' /proc/net/route | head -n1)
+                if [ -n "$g" ]; then
+                    printf "%d.%d.%d.%d\n" 0x${g:6:2} 0x${g:4:2} 0x${g:2:2} 0x${g:0:2}
+                fi
+                """.ReplaceLineEndings("\n");
+
+            // Create container
+            var create = await _client.Containers.CreateContainerAsync(
+                new CreateContainerParameters
+                {
+                    Image = ProbeImage,
+                    Tty = false, // disable TTY to allow proper multiplexed log reading
+                    Cmd = ["sh", "-lc", probeScript],
+                    // default network is fine for a simple, portable probe
+                    HostConfig = new HostConfig
+                    {
+                        AutoRemove = false, // we'll remove explicitly after reading logs
+                    },
+                },
+                cancellationToken
+            );
+
+            string id = create.ID;
+            try
+            {
+                await _client.Containers.StartContainerAsync(id, null, cancellationToken);
+                // Wait for it to finish
+                await _client.Containers.WaitContainerAsync(id, cancellationToken);
+
+                // Grab logs (stdout)
+                using var logs = await _client.Containers.GetContainerLogsAsync(
+                    id,
+                    false,
+                    new ContainerLogsParameters
+                    {
+                        ShowStdout = true,
+                        ShowStderr = true,
+                        Timestamps = false,
+                    },
+                    cancellationToken
+                );
+
+                var (stdout, stderr) = await logs.ReadOutputToEndAsync(cancellationToken);
+                var output = stdout + stderr;
+
+                var ip = ExtractFirstIPv4(output);
+                if (ip is null)
+                    throw new InvalidOperationException($"Unable to determine host IPv4 from probe: {output}");
+
+                _cachedHostIp = ip;
+                return ip;
+            }
+            finally
+            {
+                try
+                {
+                    await _client.Containers.RemoveContainerAsync(
+                        id,
+                        new ContainerRemoveParameters { Force = true },
+                        cancellationToken
+                    );
+                }
+                catch
+                { /* ignore */
+                }
+            }
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private static string? ExtractFirstIPv4(string text)
+    {
+        var m = Regex.Match(text, @"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)(?:\.|$)){4}\b");
+        return m.Success ? m.Value : null;
+    }
+
+    private static async Task EnsureImage(string image, CancellationToken cancellationToken)
+    {
+        Assert.NotNull(_client);
+        try
+        {
+            await _client.Images.InspectImageAsync(image, cancellationToken); // present → return
+            return;
+        }
+        catch (DockerApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // not present → pull
+        }
+
+        var parts = image.Split(':', 2);
+        var fromImage = parts[0];
+        var tag = parts.Length > 1 ? parts[1] : "latest";
+
+        await _client.Images.CreateImageAsync(
+            new ImagesCreateParameters { FromImage = fromImage, Tag = tag },
+            authConfig: null,
+            progress: new Progress<JSONMessage>(_ => { }),
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private static async Task<DockerClient> CreateDockerClient(CancellationToken cancellationToken)
+    {
+        var endpoints = CandidateDockerApiEndpoints(cancellationToken);
+        List<Exception> errors = new();
+
+        await foreach (var uri in endpoints)
+        {
+            try
+            {
+                var cfg = new DockerClientConfiguration(uri);
+                var client = cfg.CreateClient();
+                // quick ping to validate
+                await client.System.PingAsync();
+                return client;
+            }
+            catch (Exception ex)
+            {
+                errors.Add(new InvalidOperationException($"Failed connecting to {uri}", ex));
+            }
+        }
+
+        throw new AggregateException(
+            "No Docker-compatible API socket found. Ensure Docker or Podman (Docker API) is running.",
+            errors
+        );
+    }
+
+    private static async IAsyncEnumerable<Uri> CandidateDockerApiEndpoints(
+        [EnumeratorCancellation] CancellationToken cancellationToken
+    )
+    {
+        // 1) Respect DOCKER_HOST if set
+        var env = Environment.GetEnvironmentVariable("DOCKER_HOST");
+        if (!string.IsNullOrWhiteSpace(env) && Uri.TryCreate(env, UriKind.Absolute, out var fromEnv))
+            yield return fromEnv;
+
+        // 2) Platform-specific defaults
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            yield return new Uri("npipe://./pipe/docker_engine");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            // podman-mac-helper: forwards Docker API at /var/run/docker.sock
+            var ddCompat = "/var/run/docker.sock"; // /private/var/run/docker.sock also works
+            if (File.Exists(ddCompat))
+                yield return new Uri($"unix://{ddCompat}");
+
+            // Docker Desktop’s user socket (sometimes present)
+            var userSock = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".docker",
+                "run",
+                "docker.sock"
+            );
+            if (File.Exists(userSock))
+                yield return new Uri($"unix://{userSock}");
+
+            // Ask podman for the exact host-side socket path
+            var fromCli = await TryReadPodmanSocketPath(cancellationToken);
+            if (!string.IsNullOrWhiteSpace(fromCli) && File.Exists(fromCli))
+                yield return new Uri($"unix://{fromCli}");
+
+            yield break;
+        }
+        else
+        {
+            // Docker Engine / Docker Desktop on Linux
+            yield return new Uri("unix:///var/run/docker.sock");
+
+            // Podman (rootless, socket-activated)
+            var uid = await GetUnixUid(cancellationToken);
+            if (uid != null)
+                yield return new Uri($"unix:///run/user/{uid}/podman/podman.sock");
+
+            // Podman (rootful)
+            yield return new Uri("unix:///run/podman/podman.sock");
+        }
+    }
+
+    private static async Task<uint?> GetUnixUid(CancellationToken cancellationToken)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return null;
+
+        await foreach (var line in File.ReadLinesAsync("/proc/self/status", cancellationToken))
+        {
+            // Format: "Uid:\t<real>\t<effective>\t<saved>\t<fs>"
+            if (line.StartsWith("Uid:"))
+            {
+                var parts = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+                // parts[1] = real UID
+                if (parts.Length >= 2 && uint.TryParse(parts[1], out var real))
+                    return real;
+            }
+        }
+
+        throw new InvalidOperationException("Could not determine UID");
+    }
+
+    private static async Task<string?> TryReadPodmanSocketPath(CancellationToken cancellationToken)
+    {
+        var result = await new Command(
+            "podman",
+            "machine inspect --format {{.ConnectionInfo.PodmanSocket.Path}}",
+            WorkingDirectory: ModuleInitializer.GetSolutionDirectory(),
+            ThrowOnNonZero: false,
+            CancellationToken: cancellationToken
+        );
+        if (!result.IsSuccess)
+            return null;
+        var stdout = result.StdOut.Trim();
+        return string.IsNullOrWhiteSpace(stdout) ? null : stdout;
+    }
+}

--- a/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
@@ -3,7 +3,7 @@ using DotNet.Testcontainers.Builders;
 
 namespace Altinn.App.Integration.Tests;
 
-public static partial class ContainerRuntimeService
+internal static partial class ContainerRuntimeService
 {
     private static string? _cachedHostIp; // process-lifetime cache
     private static readonly SemaphoreSlim _lock = new(1, 1);

--- a/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
@@ -34,7 +34,7 @@ public static partial class ContainerRuntimeService
                     if [ -n "$ip" ]; then echo "$ip"; return 0; fi
                     return 1
                 }
-                for n in host.docker.internal host.containers.internal host.rancher-desktop.internal; do
+                for n in host.docker.internal host.containers.internal host.rancher-desktop.internal host.lima.internal; do
                     try_host "$n" && exit 0
                 done
                 # default route (Gateway hex in column 3 of /proc/net/route on the 0.0.0.0 row)

--- a/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
@@ -56,12 +56,12 @@ public static partial class ContainerRuntimeService
 
                 // Get the logs from the container
                 var (stdout, stderr) = await container.GetLogsAsync(timestampsEnabled: false, ct: cancellationToken);
-                if (!string.IsNullOrWhiteSpace(stderr))
-                    throw new InvalidOperationException($"Error while probing host IP: {stderr}");
 
                 var ip = ExtractFirstIPv4(stdout);
                 if (ip is null)
-                    throw new InvalidOperationException($"Unable to determine host IPv4 from probe: {stdout}");
+                    throw new InvalidOperationException(
+                        $"Unable to determine host IPv4 from probe. stdout: {stdout}, stderr: {stderr}"
+                    );
 
                 _cachedHostIp = ip;
                 return ip;

--- a/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/ContainerRuntimeService.cs
@@ -1,20 +1,12 @@
-// Requires NuGet: Docker.DotNet (>= 3.125.15) or similar
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using Docker.DotNet;
-using Docker.DotNet.Models;
+using DotNet.Testcontainers.Builders;
 
 namespace Altinn.App.Integration.Tests;
 
-public static class ContainerRuntimeService
+public static partial class ContainerRuntimeService
 {
-    private static DockerClient? _client;
     private static string? _cachedHostIp; // process-lifetime cache
     private static readonly SemaphoreSlim _lock = new(1, 1);
-
-    // You can change this to "alpine:3" if you prefer; busybox is tiny & multi-arch.
-    private const string ProbeImage = "busybox:1.36";
 
     /// <summary>
     /// Returns an IPv4 address that containers can use to reach the host.
@@ -27,8 +19,8 @@ public static class ContainerRuntimeService
         await _lock.WaitAsync(cancellationToken);
         try
         {
-            _client ??= await CreateDockerClient(cancellationToken);
-            await EnsureImage(ProbeImage, cancellationToken);
+            if (!string.IsNullOrEmpty(_cachedHostIp))
+                return _cachedHostIp;
 
             // One-shot probe container that prints a single IPv4 and exits.
             // Strategy:
@@ -52,65 +44,31 @@ public static class ContainerRuntimeService
                 fi
                 """.ReplaceLineEndings("\n");
 
-            // Create container
-            var create = await _client.Containers.CreateContainerAsync(
-                new CreateContainerParameters
-                {
-                    Image = ProbeImage,
-                    Tty = false, // disable TTY to allow proper multiplexed log reading
-                    Cmd = ["sh", "-lc", probeScript],
-                    // default network is fine for a simple, portable probe
-                    HostConfig = new HostConfig
-                    {
-                        AutoRemove = false, // we'll remove explicitly after reading logs
-                    },
-                },
-                cancellationToken
-            );
+            var container = new ContainerBuilder()
+                .WithImage("busybox:1.37")
+                .WithCommand("sh", "-lc", probeScript)
+                .Build();
 
-            string id = create.ID;
             try
             {
-                await _client.Containers.StartContainerAsync(id, null, cancellationToken);
-                // Wait for it to finish
-                await _client.Containers.WaitContainerAsync(id, cancellationToken);
+                await container.StartAsync(cancellationToken);
+                await container.GetExitCodeAsync(cancellationToken);
 
-                // Grab logs (stdout)
-                using var logs = await _client.Containers.GetContainerLogsAsync(
-                    id,
-                    false,
-                    new ContainerLogsParameters
-                    {
-                        ShowStdout = true,
-                        ShowStderr = true,
-                        Timestamps = false,
-                    },
-                    cancellationToken
-                );
+                // Get the logs from the container
+                var (stdout, stderr) = await container.GetLogsAsync(timestampsEnabled: false, ct: cancellationToken);
+                if (!string.IsNullOrWhiteSpace(stderr))
+                    throw new InvalidOperationException($"Error while probing host IP: {stderr}");
 
-                var (stdout, stderr) = await logs.ReadOutputToEndAsync(cancellationToken);
-                var output = stdout + stderr;
-
-                var ip = ExtractFirstIPv4(output);
+                var ip = ExtractFirstIPv4(stdout);
                 if (ip is null)
-                    throw new InvalidOperationException($"Unable to determine host IPv4 from probe: {output}");
+                    throw new InvalidOperationException($"Unable to determine host IPv4 from probe: {stdout}");
 
                 _cachedHostIp = ip;
                 return ip;
             }
             finally
             {
-                try
-                {
-                    await _client.Containers.RemoveContainerAsync(
-                        id,
-                        new ContainerRemoveParameters { Force = true },
-                        cancellationToken
-                    );
-                }
-                catch
-                { /* ignore */
-                }
+                await container.DisposeAsync();
             }
         }
         finally
@@ -119,151 +77,12 @@ public static class ContainerRuntimeService
         }
     }
 
-    // --- helpers -------------------------------------------------------------
+    [GeneratedRegex(@"(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}")]
+    private static partial Regex IPv4Regex();
 
     private static string? ExtractFirstIPv4(string text)
     {
-        var m = Regex.Match(text, @"\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)(?:\.|$)){4}\b");
+        var m = IPv4Regex().Match(text);
         return m.Success ? m.Value : null;
-    }
-
-    private static async Task EnsureImage(string image, CancellationToken cancellationToken)
-    {
-        Assert.NotNull(_client);
-        try
-        {
-            await _client.Images.InspectImageAsync(image, cancellationToken); // present → return
-            return;
-        }
-        catch (DockerApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            // not present → pull
-        }
-
-        var parts = image.Split(':', 2);
-        var fromImage = parts[0];
-        var tag = parts.Length > 1 ? parts[1] : "latest";
-
-        await _client.Images.CreateImageAsync(
-            new ImagesCreateParameters { FromImage = fromImage, Tag = tag },
-            authConfig: null,
-            progress: new Progress<JSONMessage>(_ => { }),
-            cancellationToken: cancellationToken
-        );
-    }
-
-    private static async Task<DockerClient> CreateDockerClient(CancellationToken cancellationToken)
-    {
-        var endpoints = CandidateDockerApiEndpoints(cancellationToken);
-        List<Exception> errors = new();
-
-        await foreach (var uri in endpoints)
-        {
-            try
-            {
-                var cfg = new DockerClientConfiguration(uri);
-                var client = cfg.CreateClient();
-                // quick ping to validate
-                await client.System.PingAsync();
-                return client;
-            }
-            catch (Exception ex)
-            {
-                errors.Add(new InvalidOperationException($"Failed connecting to {uri}", ex));
-            }
-        }
-
-        throw new AggregateException(
-            "No Docker-compatible API socket found. Ensure Docker or Podman (Docker API) is running.",
-            errors
-        );
-    }
-
-    private static async IAsyncEnumerable<Uri> CandidateDockerApiEndpoints(
-        [EnumeratorCancellation] CancellationToken cancellationToken
-    )
-    {
-        // 1) Respect DOCKER_HOST if set
-        var env = Environment.GetEnvironmentVariable("DOCKER_HOST");
-        if (!string.IsNullOrWhiteSpace(env) && Uri.TryCreate(env, UriKind.Absolute, out var fromEnv))
-            yield return fromEnv;
-
-        // 2) Platform-specific defaults
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            yield return new Uri("npipe://./pipe/docker_engine");
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            // podman-mac-helper: forwards Docker API at /var/run/docker.sock
-            var ddCompat = "/var/run/docker.sock"; // /private/var/run/docker.sock also works
-            if (File.Exists(ddCompat))
-                yield return new Uri($"unix://{ddCompat}");
-
-            // Docker Desktop’s user socket (sometimes present)
-            var userSock = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                ".docker",
-                "run",
-                "docker.sock"
-            );
-            if (File.Exists(userSock))
-                yield return new Uri($"unix://{userSock}");
-
-            // Ask podman for the exact host-side socket path
-            var fromCli = await TryReadPodmanSocketPath(cancellationToken);
-            if (!string.IsNullOrWhiteSpace(fromCli) && File.Exists(fromCli))
-                yield return new Uri($"unix://{fromCli}");
-
-            yield break;
-        }
-        else
-        {
-            // Docker Engine / Docker Desktop on Linux
-            yield return new Uri("unix:///var/run/docker.sock");
-
-            // Podman (rootless, socket-activated)
-            var uid = await GetUnixUid(cancellationToken);
-            if (uid != null)
-                yield return new Uri($"unix:///run/user/{uid}/podman/podman.sock");
-
-            // Podman (rootful)
-            yield return new Uri("unix:///run/podman/podman.sock");
-        }
-    }
-
-    private static async Task<uint?> GetUnixUid(CancellationToken cancellationToken)
-    {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            return null;
-
-        await foreach (var line in File.ReadLinesAsync("/proc/self/status", cancellationToken))
-        {
-            // Format: "Uid:\t<real>\t<effective>\t<saved>\t<fs>"
-            if (line.StartsWith("Uid:"))
-            {
-                var parts = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
-                // parts[1] = real UID
-                if (parts.Length >= 2 && uint.TryParse(parts[1], out var real))
-                    return real;
-            }
-        }
-
-        throw new InvalidOperationException("Could not determine UID");
-    }
-
-    private static async Task<string?> TryReadPodmanSocketPath(CancellationToken cancellationToken)
-    {
-        var result = await new Command(
-            "podman",
-            "machine inspect --format {{.ConnectionInfo.PodmanSocket.Path}}",
-            WorkingDirectory: ModuleInitializer.GetSolutionDirectory(),
-            ThrowOnNonZero: false,
-            CancellationToken: cancellationToken
-        );
-        if (!result.IsSuccess)
-            return null;
-        var stdout = result.StdOut.Trim();
-        return string.IsNullOrWhiteSpace(stdout) ? null : stdout;
     }
 }

--- a/test/Altinn.App.Integration.Tests/_fixture/Operations/AppFixture.Connectivity.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/Operations/AppFixture.Connectivity.cs
@@ -24,7 +24,7 @@ public partial class AppFixture : IAsyncDisposable
 
         /// <summary>
         /// Tests container-to-container connectivity by calling the app's PDF diagnostic endpoint.
-        /// This verifies that the app container can reach the PDF service container via host.docker.internal.
+        /// This verifies that the app container can reach the PDF service container via host.containers.internal.
         /// </summary>
         public async Task<ConnectivityResult> Pdf()
         {
@@ -37,7 +37,7 @@ public partial class AppFixture : IAsyncDisposable
 
         /// <summary>
         /// Tests container-to-container connectivity by calling the app's localtest diagnostic endpoint.
-        /// This verifies that the app container can reach the localtest health endpoint via host.docker.internal.
+        /// This verifies that the app container can reach the localtest health endpoint via host.containers.internal.
         /// </summary>
         public async Task<ConnectivityResult> Localtest()
         {

--- a/test/Altinn.App.Integration.Tests/_fixture/SynchronizedWriteStream.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/SynchronizedWriteStream.cs
@@ -1,0 +1,228 @@
+namespace Altinn.App.Integration.Tests;
+
+internal sealed class SynchronizedWriteStream(Stream _inner) : Stream
+{
+    private readonly SemaphoreSlim _lock = new(1, 1);
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override bool CanTimeout => _inner.CanTimeout;
+    public override long Length => _inner.Length;
+    public override long Position
+    {
+        get => _inner.Position;
+        set => throw new NotSupportedException();
+    }
+
+    public override int WriteTimeout
+    {
+        get => _inner.WriteTimeout;
+        set => _inner.WriteTimeout = value;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _lock.Wait();
+        try
+        {
+            _inner.Write(buffer, offset, count);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        await _lock.WaitAsync(cancellationToken);
+        try
+        {
+            await _inner.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        _lock.Wait();
+        try
+        {
+            _inner.Write(buffer);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public override async ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await _lock.WaitAsync(cancellationToken);
+        try
+        {
+            await _inner.WriteAsync(buffer, cancellationToken);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public override void WriteByte(byte value)
+    {
+        _lock.Wait();
+        try
+        {
+            _inner.WriteByte(value);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public override void Flush()
+    {
+        _lock.Wait();
+        try
+        {
+            _inner.Flush();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public override async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        await _lock.WaitAsync(cancellationToken);
+        try
+        {
+            await _inner.FlushAsync(cancellationToken);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public override void Close()
+    {
+        _lock.Wait();
+        try
+        {
+            _inner.Close();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private bool _disposed;
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (_disposed)
+                return;
+            _lock.Wait();
+            try
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+                _inner.Dispose();
+            }
+            finally
+            {
+                _lock.Release();
+            }
+            _lock.Dispose();
+        }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+        await _lock.WaitAsync();
+        try
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            await _inner.DisposeAsync();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+        _lock.Dispose();
+    }
+
+    public override bool Equals(object? obj) => _inner.Equals(obj);
+
+    public override int GetHashCode() => _inner.GetHashCode();
+
+    public override string? ToString() => _inner.ToString();
+
+    // Not supported operations below
+
+    public override int Read(Span<byte> buffer) => throw new NotSupportedException();
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override int ReadByte() => throw new NotSupportedException();
+
+    public override int ReadTimeout
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override IAsyncResult BeginRead(
+        byte[] buffer,
+        int offset,
+        int count,
+        AsyncCallback? callback,
+        object? state
+    ) => throw new NotSupportedException();
+
+    public override int EndRead(IAsyncResult asyncResult) => throw new NotSupportedException();
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override IAsyncResult BeginWrite(
+        byte[] buffer,
+        int offset,
+        int count,
+        AsyncCallback? callback,
+        object? state
+    ) => throw new NotSupportedException();
+
+    public override void EndWrite(IAsyncResult asyncResult) => throw new NotSupportedException();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void CopyTo(Stream destination, int bufferSize) => throw new NotSupportedException();
+
+    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+}

--- a/test/Altinn.App.Integration.Tests/_fixture/SynchronizedWriteStream.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/SynchronizedWriteStream.cs
@@ -115,19 +115,6 @@ internal sealed class SynchronizedWriteStream(Stream _inner) : Stream
         }
     }
 
-    public override void Close()
-    {
-        _lock.Wait();
-        try
-        {
-            _inner.Close();
-        }
-        finally
-        {
-            _lock.Release();
-        }
-    }
-
     private bool _disposed;
 
     protected override void Dispose(bool disposing)

--- a/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
@@ -69,12 +69,16 @@ public class FixtureTests
             .WithCommand(
                 "/bin/sh",
                 "-c",
+                // We separate stdout and stderr here because
+                // the current LogsConsumer gets stdout and stderr as separate
+                // streams due to Testcontainers. So we can't really rely on the ordering much
                 """
                 printf 'stdout line 1\n'
-                printf 'stderr line 1\n' >&2
                 printf 'stdout line 2\n'
-                printf 'stderr line 2\n' >&2
                 printf 'stdout line 3\n'
+                sleep 1
+                printf 'stderr line 1\n' >&2
+                printf 'stderr line 2\n' >&2
                 printf 'stderr line 3\n' >&2
                 exit 0
                 """.ReplaceLineEndings("\n")

--- a/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
@@ -130,6 +130,7 @@ public class FixtureTests
 
         await using var container = new ContainerBuilder()
             .WithImage("busybox:1.37")
+            .WithName("applib-diagnostics")
             .WithCommand("/bin/sh", "-c", pingScript)
             .WithExtraHost("host.containers.internal", hostIp)
             .Build();

--- a/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
@@ -93,4 +93,54 @@ public class FixtureTests
 
         await Verify(string.Join("\n", lines));
     }
+
+    [Fact]
+    public async Task DebugNetworking()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        var cancellationToken = cts.Token;
+
+        var hostIp = await ContainerRuntimeService.GetHostIP(cancellationToken);
+
+        var pingScript = $"""
+            echo "--/etc/hosts---------------------"
+            echo ""
+            cat /etc/hosts
+            echo ""
+            echo "---------------------------------"
+
+            echo "--ip routes---------------------"
+            echo ""
+            ip route show
+            echo ""
+            echo "---------------------------------"
+
+            echo "--Ping host IP-------------------"
+            echo ""
+            ping -4 -c1 -W1 {hostIp}
+            echo ""
+            echo "---------------------------------"
+
+            echo "--Ping host.containers.internal--"
+            echo ""
+            ping -4 -c1 -W1 host.containers.internal
+            echo ""
+            echo "---------------------------------"
+            """.ReplaceLineEndings("\n");
+
+        await using var container = new ContainerBuilder()
+            .WithImage("busybox:1.37")
+            .WithCommand("/bin/sh", "-c", pingScript)
+            .WithExtraHost("host.containers.internal", hostIp)
+            .Build();
+
+        await container.StartAsync(cancellationToken);
+        await container.GetExitCodeAsync(cancellationToken);
+
+        var (stdout, stderr) = await container.GetLogsAsync(timestampsEnabled: false, ct: cancellationToken);
+
+        var output = $"stdout:\n{stdout}\n\nstderr:\n{stderr}";
+
+        await Verify(output).UseDirectory("_snapshots/_local").AutoVerify(includeBuildServer: true);
+    }
 }

--- a/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/Tests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 
 namespace Altinn.App.Integration.Tests;
 
+[Trait("Category", "Integration")]
 public class FixtureTests
 {
     private readonly ITestOutputHelper _output;

--- a/test/Altinn.App.Integration.Tests/_fixture/_snapshots/FixtureTests.LogsConsumer.verified.txt
+++ b/test/Altinn.App.Integration.Tests/_fixture/_snapshots/FixtureTests.LogsConsumer.verified.txt
@@ -1,0 +1,6 @@
+﻿stdout line 1
+stdout line 2
+stdout line 3
+stderr line 1
+stderr line 2
+stderr line 3

--- a/test/Altinn.App.Integration.Tests/_testapps/_shared/ConnectivityDiagnostics.cs
+++ b/test/Altinn.App.Integration.Tests/_testapps/_shared/ConnectivityDiagnostics.cs
@@ -11,7 +11,7 @@ namespace TestApp.Shared;
 
 /// <summary>
 /// Provides connectivity diagnostic endpoints to verify container-to-container communication.
-/// This is useful for testing network connectivity and diagnosing host.docker.internal issues.
+/// This is useful for testing network connectivity and diagnosing host.containers.internal issues.
 /// </summary>
 public static class ConnectivityDiagnostics
 {


### PR DESCRIPTION
## Description
Suprising amount of work to get both podman and docker to work
* Podman (+ rancher desktop + others?) does not support `host-gateway`. It seems to be a feature of moby and buildx so I opted for figuring out the host IP through code
* `--timestamps` logging is different from podman to docker, so the logging stuff has been refatored (it was ugly anyway)
* Only refer to `host.containers.internal`, not the docker specific one

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New debug integration-test target (tid) and a repeat-runner; test runner now auto-detects container runtime and supports test filtering.

* **Tests**
  * Improved cross-container networking and per-fixture streamed log capture; added diagnostics tests, updated snapshots, and minor test adjustments.
  * Added Docker.DotNet to test dependencies.

* **Documentation**
  * Added development guidelines on async patterns, performance, and feature structure.

* **Chores**
  * Centralized package version for Docker.DotNet and updated .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->