### PR TITLE
imports before namespace

### DIFF
--- a/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
+++ b/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
@@ -1,14 +1,8 @@
-using Altinn.App.Core.Constants;
-
-namespace Altinn.App.Api.Controllers;
-
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 using Altinn.App.Api.Models;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Process;
@@ -22,6 +16,8 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using DataType = Altinn.Platform.Storage.Interface.Models.DataType;
+
+namespace Altinn.App.Api.Controllers;
 
 /// <summary>
 /// Generate custom OpenAPI documentation for the app that includes all the data types and operations

--- a/src/Altinn.App.Core/Features/Payment/IOrderDetailsCalculator.cs
+++ b/src/Altinn.App.Core/Features/Payment/IOrderDetailsCalculator.cs
@@ -1,7 +1,7 @@
-namespace Altinn.App.Core.Features.Payment;
-
+using Altinn.App.Core.Features.Payment.Models;
 using Altinn.Platform.Storage.Interface.Models;
-using Models;
+
+namespace Altinn.App.Core.Features.Payment;
 
 /// <summary>
 /// Interface that app developers need to implement in order to use the payment feature

--- a/src/Altinn.App.Core/Features/Validation/Wrappers/FormDataValidatorWrapper.cs
+++ b/src/Altinn.App.Core/Features/Validation/Wrappers/FormDataValidatorWrapper.cs
@@ -1,10 +1,9 @@
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Models;
-
-namespace Altinn.App.Core.Features.Validation.Wrappers;
-
 using Altinn.App.Core.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.Core.Features.Validation.Wrappers;
 
 /// <summary>
 /// Wrap the old <see cref="IFormDataValidator"/> interface to the new <see cref="IValidator"/> interface.

--- a/src/Altinn.App.Core/Helpers/LogSanitizer.cs
+++ b/src/Altinn.App.Core/Helpers/LogSanitizer.cs
@@ -1,6 +1,6 @@
-﻿namespace Altinn.App.Core.Helpers;
+﻿using System.Text.RegularExpressions;
 
-using System.Text.RegularExpressions;
+namespace Altinn.App.Core.Helpers;
 
 /// <summary>
 /// Provides methods to sanitize user-controlled input before logging.

--- a/test/Altinn.App.Api.Tests/Utils/JsonUtils.cs
+++ b/test/Altinn.App.Api.Tests/Utils/JsonUtils.cs
@@ -1,7 +1,7 @@
-namespace Altinn.App.Api.Tests.Utils;
-
 using System.Text;
 using System.Text.Json;
+
+namespace Altinn.App.Api.Tests.Utils;
 
 public static class JsonUtils
 {

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
@@ -1,5 +1,3 @@
-namespace Altinn.App.Core.Tests.Features.Auth;
-
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO.Hashing;
@@ -12,6 +10,8 @@ using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 using AltinnCore.Authentication.Constants;
 using static Altinn.App.Core.Features.Auth.Authenticated;
+
+namespace Altinn.App.Core.Tests.Features.Auth;
 
 public class AuthenticatedTests
 {

--- a/test/Altinn.App.Core.Tests/Features/Auth/ScopesTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Auth/ScopesTests.cs
@@ -1,6 +1,6 @@
-namespace Altinn.App.Core.Tests.Features.Auth;
-
 using Altinn.App.Core.Features.Auth;
+
+namespace Altinn.App.Core.Tests.Features.Auth;
 
 public class ScopesTests
 {

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Email/EmailNotificationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Email/EmailNotificationClientTests.cs
@@ -1,7 +1,4 @@
-namespace Altinn.App.Core.Tests.Features.Notifications.Email;
-
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
@@ -18,7 +15,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
-using Xunit;
+
+namespace Altinn.App.Core.Tests.Features.Notifications.Email;
 
 public class EmailNotificationClientTests
 {
@@ -253,7 +251,9 @@ public class EmailNotificationClientTests
 
         services.AddSingleton<IAppMetadata>(new Mock<IAppMetadata>().Object);
         services.AddSingleton<IAccessTokenGenerator>(new Mock<IAccessTokenGenerator>().Object);
-        services.AddSingleton<IOptions<PlatformSettings>>(Options.Create(new PlatformSettings()));
+        services.AddSingleton<IOptions<PlatformSettings>>(
+            Microsoft.Extensions.Options.Options.Create(new PlatformSettings())
+        );
         services.AddLogging(logging =>
         {
             logging.ClearProviders();

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Sms/SmsNotificationClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Sms/SmsNotificationClientTests.cs
@@ -1,7 +1,4 @@
-namespace Altinn.App.Core.Tests.Features.Notifications.Sms;
-
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
@@ -18,7 +15,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
-using Xunit;
+
+namespace Altinn.App.Core.Tests.Features.Notifications.Sms;
 
 public class SmsNotificationClientTests
 {
@@ -255,7 +253,9 @@ public class SmsNotificationClientTests
 
         services.AddSingleton<IAppMetadata>(new Mock<IAppMetadata>().Object);
         services.AddSingleton<IAccessTokenGenerator>(new Mock<IAccessTokenGenerator>().Object);
-        services.AddSingleton<IOptions<PlatformSettings>>(Options.Create(new PlatformSettings()));
+        services.AddSingleton<IOptions<PlatformSettings>>(
+            Microsoft.Extensions.Options.Options.Create(new PlatformSettings())
+        );
         services.AddLogging(logging =>
         {
             logging.ClearProviders();

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/KeyVault/SecretsLocalClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/KeyVault/SecretsLocalClientTests.cs
@@ -1,12 +1,11 @@
 #nullable disable
-namespace Altinn.App.Core.Tests.Infrastructure.Clients.KeyVault;
-
 using System.Text.Json;
 using Altinn.App.Core.Infrastructure.Clients.KeyVault;
 using FluentAssertions;
 using Microsoft.Azure.KeyVault.WebKey;
 using Microsoft.Extensions.Configuration;
-using Xunit;
+
+namespace Altinn.App.Core.Tests.Infrastructure.Clients.KeyVault;
 
 public class SecretsLocalClientTests
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Imports before namespace

Why:
consistency
analyzer gets better - get warnings when using unnecessary imports
full path imports
default behaviour in all popular IDEs when getting import assistance ( e.g. `ctrl + .`)

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized namespace placement and using directive ordering across multiple files.
  - Adopted consistent file-scoped namespace style.
  - No changes to behavior, APIs, or routing.

- Tests
  - Updated options creation to use explicit type resolution.
  - Reorganized namespaces/usings for consistency.
  - Test behavior and coverage remain unchanged.

- Style
  - Applied minor formatting cleanups for readability and consistency.

- Chores
  - General codebase housekeeping to align with formatting and organizational conventions.

No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->