### PR TITLE
Updated CorrespondenceClient authentication

### DIFF
--- a/src/Altinn.App.Core/Features/AuthenticationMethod.cs
+++ b/src/Altinn.App.Core/Features/AuthenticationMethod.cs
@@ -70,6 +70,10 @@ internal abstract record AuthenticationMethod
 
     public static implicit operator AuthenticationMethod(StorageAuthenticationMethod storageAuthenticationMethod) =>
         storageAuthenticationMethod.Request;
+
+    public static implicit operator AuthenticationMethod(
+        CorrespondenceAuthenticationMethod storageAuthenticationMethod
+    ) => storageAuthenticationMethod.Request;
 }
 
 /// <summary>
@@ -94,6 +98,34 @@ public sealed record StorageAuthenticationMethod
     internal AuthenticationMethod Request { get; }
 
     private StorageAuthenticationMethod(AuthenticationMethod request)
+    {
+        Request = request;
+    }
+}
+
+/// <summary>
+/// Represents the method of authentication to be used for Correspondence requests.
+/// </summary>
+public sealed record CorrespondenceAuthenticationMethod
+{
+    private const string CorrespondenceWriteScope = "altinn:correspondence.write";
+
+    /// <summary>
+    /// Authenticates the request using a service owner token that includes the <c>altinn:correspondence.write</c> scope.
+    /// </summary>
+    public static CorrespondenceAuthenticationMethod Default() =>
+        new(AuthenticationMethod.ServiceOwner(CorrespondenceWriteScope));
+
+    /// <summary>
+    /// Authenticates the request using a custom token delegate. The delegate must return an Altinn-exchanged service owner
+    /// token that includes the <c>altinn:correspondence.write</c> scope.
+    /// </summary>
+    public static CorrespondenceAuthenticationMethod Custom(Func<Task<JwtToken>> tokenProvider) =>
+        new(AuthenticationMethod.Custom(tokenProvider));
+
+    internal AuthenticationMethod Request { get; }
+
+    private CorrespondenceAuthenticationMethod(AuthenticationMethod request)
     {
         Request = request;
     }

--- a/src/Altinn.App.Core/Features/Correspondence/CorrespondenceAuthorisationFactory.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/CorrespondenceAuthorisationFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Altinn.App.Core.Features.Correspondence;
 
+[Obsolete("Replaced by CorrespondenceAuthenticationMethod")]
 internal sealed class CorrespondenceAuthorisationFactory
 {
     private IMaskinportenClient? _maskinportenClient;

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceApiScopes.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceApiScopes.cs
@@ -3,6 +3,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models;
 /// <summary>
 /// Known scopes for the correspondence API.
 /// </summary>
+[Obsolete("Replaced by CorrespondenceAuthenticationMethod")]
 internal static class CorrespondenceApiScopes
 {
     public const string ServiceOwner = "altinn:serviceowner";

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondencePayload.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondencePayload.cs
@@ -8,11 +8,16 @@ namespace Altinn.App.Core.Features.Correspondence.Models;
 /// </summary>
 public abstract record CorrespondencePayloadBase
 {
+    internal CorrespondenceAuthenticationMethod? AuthenticationMethod { get; init; }
+
+    [Obsolete("Replaced by AuthenticationMethod")]
     internal Func<Task<JwtToken>>? AccessTokenFactory { get; init; }
 
+    [Obsolete("Replaced by AuthenticationMethod")]
     internal CorrespondenceAuthorisation? AuthorisationMethod { get; init; }
 
-    internal abstract string RequiredScope { get; }
+    [Obsolete("Replaced by AuthenticationMethod")]
+    internal string RequiredScope => CorrespondenceApiScopes.Write;
 }
 
 /// <summary>
@@ -21,13 +26,27 @@ public abstract record CorrespondencePayloadBase
 public sealed record SendCorrespondencePayload : CorrespondencePayloadBase
 {
     internal CorrespondenceRequest CorrespondenceRequest { get; init; }
-    internal override string RequiredScope => CorrespondenceApiScopes.Write;
+
+    /// <summary>
+    /// Instantiates a new payload for <see cref="SendCorrespondencePayload"/>.
+    /// </summary>
+    /// <param name="request">The correspondence request to send</param>
+    /// <param name="authenticationMethod">The authentication method to use</param>
+    public SendCorrespondencePayload(
+        CorrespondenceRequest request,
+        CorrespondenceAuthenticationMethod authenticationMethod
+    )
+    {
+        CorrespondenceRequest = request;
+        AuthenticationMethod = authenticationMethod;
+    }
 
     /// <summary>
     /// Instantiates a new payload for <see cref="SendCorrespondencePayload"/>.
     /// </summary>
     /// <param name="request">The correspondence request to send</param>
     /// <param name="accessTokenFactory">Access token factory delegate (e.g. <see cref="MaskinportenClient.GetAltinnExchangedToken"/>) to use for authorisation</param>
+    [Obsolete("Use SendCorrespondencePayload(CorrespondenceRequest, CorrespondenceAuthenticationMethod) instead")]
     public SendCorrespondencePayload(CorrespondenceRequest request, Func<Task<JwtToken>> accessTokenFactory)
     {
         CorrespondenceRequest = request;
@@ -39,6 +58,7 @@ public sealed record SendCorrespondencePayload : CorrespondencePayloadBase
     /// </summary>
     /// <param name="request">The correspondence request to send</param>
     /// <param name="authorisation">The built-in authorisation method to use</param>
+    [Obsolete("Use SendCorrespondencePayload(CorrespondenceRequest, CorrespondenceAuthenticationMethod) instead")]
     public SendCorrespondencePayload(CorrespondenceRequest request, CorrespondenceAuthorisation authorisation)
     {
         CorrespondenceRequest = request;
@@ -52,13 +72,27 @@ public sealed record SendCorrespondencePayload : CorrespondencePayloadBase
 public sealed record GetCorrespondenceStatusPayload : CorrespondencePayloadBase
 {
     internal Guid CorrespondenceId { get; init; }
-    internal override string RequiredScope => CorrespondenceApiScopes.Write;
+
+    /// <summary>
+    /// Instantiates a new payload for <see cref="SendCorrespondencePayload"/>.
+    /// </summary>
+    /// <param name="correspondenceId">The correspondence identifier to retrieve information about</param>
+    /// <param name="authenticationMethod">The authentication method to use</param>
+    public GetCorrespondenceStatusPayload(
+        Guid correspondenceId,
+        CorrespondenceAuthenticationMethod authenticationMethod
+    )
+    {
+        CorrespondenceId = correspondenceId;
+        AuthenticationMethod = authenticationMethod;
+    }
 
     /// <summary>
     /// Instantiates a new payload for <see cref="CorrespondenceClient.GetStatus"/>.
     /// </summary>
     /// <param name="correspondenceId">The correspondence identifier to retrieve information about</param>
     /// <param name="accessTokenFactory">Access token factory delegate (e.g. <see cref="MaskinportenClient.GetAltinnExchangedToken"/>) to use for authorisation</param>
+    [Obsolete("Use GetCorrespondenceStatusPayload(Guid, CorrespondenceAuthenticationMethod) instead")]
     public GetCorrespondenceStatusPayload(Guid correspondenceId, Func<Task<JwtToken>> accessTokenFactory)
     {
         CorrespondenceId = correspondenceId;
@@ -70,6 +104,7 @@ public sealed record GetCorrespondenceStatusPayload : CorrespondencePayloadBase
     /// </summary>
     /// <param name="correspondenceId">The correspondence identifier to retrieve information about</param>
     /// <param name="authorisation">The built-in authorisation method to use</param>
+    [Obsolete("Use GetCorrespondenceStatusPayload(Guid, CorrespondenceAuthenticationMethod) instead")]
     public GetCorrespondenceStatusPayload(Guid correspondenceId, CorrespondenceAuthorisation authorisation)
     {
         CorrespondenceId = correspondenceId;

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondencePayload.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondencePayload.cs
@@ -88,7 +88,7 @@ public sealed record GetCorrespondenceStatusPayload : CorrespondencePayloadBase
     }
 
     /// <summary>
-    /// Instantiates a new payload for <see cref="Correspond`enceClient.GetStatus"/>.
+    /// Instantiates a new payload for <see cref="CorrespondenceClient.GetStatus"/>.
     /// </summary>
     /// <param name="correspondenceId">The correspondence identifier to retrieve information about</param>
     /// <param name="accessTokenFactory">Access token factory delegate (e.g. <see cref="MaskinportenClient.GetAltinnExchangedToken"/>) to use for authorisation</param>

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondencePayload.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondencePayload.cs
@@ -28,7 +28,7 @@ public sealed record SendCorrespondencePayload : CorrespondencePayloadBase
     internal CorrespondenceRequest CorrespondenceRequest { get; init; }
 
     /// <summary>
-    /// Instantiates a new payload for <see cref="SendCorrespondencePayload"/>.
+    /// Instantiates a new payload for <see cref="CorrespondenceClient.Send"/>.
     /// </summary>
     /// <param name="request">The correspondence request to send</param>
     /// <param name="authenticationMethod">The authentication method to use</param>
@@ -42,7 +42,7 @@ public sealed record SendCorrespondencePayload : CorrespondencePayloadBase
     }
 
     /// <summary>
-    /// Instantiates a new payload for <see cref="SendCorrespondencePayload"/>.
+    /// Instantiates a new payload for <see cref="CorrespondenceClient.Send"/>.
     /// </summary>
     /// <param name="request">The correspondence request to send</param>
     /// <param name="accessTokenFactory">Access token factory delegate (e.g. <see cref="MaskinportenClient.GetAltinnExchangedToken"/>) to use for authorisation</param>
@@ -54,7 +54,7 @@ public sealed record SendCorrespondencePayload : CorrespondencePayloadBase
     }
 
     /// <summary>
-    /// Instantiates a new payload for <see cref="SendCorrespondencePayload"/>.
+    /// Instantiates a new payload for <see cref="CorrespondenceClient.Send"/>.
     /// </summary>
     /// <param name="request">The correspondence request to send</param>
     /// <param name="authorisation">The built-in authorisation method to use</param>
@@ -74,7 +74,7 @@ public sealed record GetCorrespondenceStatusPayload : CorrespondencePayloadBase
     internal Guid CorrespondenceId { get; init; }
 
     /// <summary>
-    /// Instantiates a new payload for <see cref="SendCorrespondencePayload"/>.
+    /// Instantiates a new payload for <see cref="CorrespondenceClient.Send"/>.
     /// </summary>
     /// <param name="correspondenceId">The correspondence identifier to retrieve information about</param>
     /// <param name="authenticationMethod">The authentication method to use</param>
@@ -88,7 +88,7 @@ public sealed record GetCorrespondenceStatusPayload : CorrespondencePayloadBase
     }
 
     /// <summary>
-    /// Instantiates a new payload for <see cref="CorrespondenceClient.GetStatus"/>.
+    /// Instantiates a new payload for <see cref="Correspond`enceClient.GetStatus"/>.
     /// </summary>
     /// <param name="correspondenceId">The correspondence identifier to retrieve information about</param>
     /// <param name="accessTokenFactory">Access token factory delegate (e.g. <see cref="MaskinportenClient.GetAltinnExchangedToken"/>) to use for authorisation</param>

--- a/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/MaskinportenClient.cs
@@ -381,7 +381,7 @@ internal sealed class MaskinportenClient : IMaskinportenClient
     /// </summary>
     /// <param name="scopes">A collection of scopes.</param>
     /// <returns>A single string containing the supplied scopes.</returns>
-    internal static string GetFormattedScopes(IEnumerable<string> scopes) => string.Join(" ", scopes);
+    internal static string GetFormattedScopes(IEnumerable<string> scopes) => string.Join(" ", scopes.Distinct());
 
     private TimeSpan GetTokenExpiryWithMargin(JwtToken token) =>
         token.ExpiresAt - _timeProvider.GetUtcNow() - TokenExpirationMargin;

--- a/src/Altinn.App.Core/Features/Signing/Services/ISigningCallToActionService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/ISigningCallToActionService.cs
@@ -14,7 +14,7 @@ internal interface ISigningCallToActionService
     /// Sends correspondence to a signee to notify them of a signing call to action.
     /// </summary>
     Task<SendCorrespondenceResponse?> SendSignCallToAction(
-        CommunicationConfig? CommunicationConfig,
+        CommunicationConfig? communicationConfig,
         AppIdentifier appIdentifier,
         InstanceIdentifier instanceIdentifier,
         Party signingParty,

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningCallToActionService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningCallToActionService.cs
@@ -108,7 +108,7 @@ internal sealed class SigningCallToActionService(
                 .WithContent(correspondenceContent)
                 .WithNotificationIfConfigured(SigningNotificationHelper.CreateNotification(contentWrapper))
                 .Build(),
-            CorrespondenceAuthorisation.Maskinporten
+            CorrespondenceAuthenticationMethod.Default()
         );
 
         SendCorrespondenceResponse response = await _correspondenceClient.Send(request, ct);

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
@@ -78,7 +78,7 @@ internal sealed class SigningReceiptService(
                     .WithContent(content)
                     .WithAttachments(attachments)
                     .Build(),
-                CorrespondenceAuthorisation.Maskinporten
+                CorrespondenceAuthenticationMethod.Default()
             ),
             ct
         );

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/TestHelpers.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/TestHelpers.cs
@@ -1,5 +1,8 @@
 using System.Net;
 using System.Text.Json;
+using Altinn.App.Core.Features.Auth;
+using Altinn.App.Core.Features.Correspondence.Models;
+using Altinn.App.Core.Features.Maskinporten;
 using Altinn.App.Core.Models;
 
 namespace Altinn.App.Core.Tests.Features.Correspondence;
@@ -26,4 +29,42 @@ public static class TestHelpers
 
         return new HttpResponseMessage(statusCode) { Content = new StringContent(test) };
     }
+
+    public static Task<JwtToken> OrgTokenFactory(IEnumerable<string> scopes)
+    {
+        var _scopes = new Scopes(MaskinportenClient.GetFormattedScopes(scopes));
+        var token = _scopes.HasScopeWithPrefix("altinn:serviceowner/")
+            ? TestAuthentication.GetServiceOwnerToken(scope: _scopes.ToString())
+            : TestAuthentication.GetOrgToken(scope: _scopes.ToString());
+
+        return Task.FromResult(JwtToken.Parse(token));
+    }
+
+    public static SendCorrespondenceResponse DummySendCorrespondenceResponse =>
+        new()
+        {
+            Correspondences = new List<CorrespondenceDetailsResponse>
+            {
+                new()
+                {
+                    CorrespondenceId = Guid.Empty,
+                    Status = CorrespondenceStatus.Initialized,
+                    Recipient = OrganisationOrPersonIdentifier.Create(GetOrganisationNumber(0)),
+                },
+            },
+        };
+
+    public static GetCorrespondenceStatusResponse DummyGetCorrespondenceStatusResponse =>
+        new()
+        {
+            CorrespondenceId = Guid.Empty,
+            Created = DateTimeOffset.MinValue,
+            StatusChanged = DateTimeOffset.MinValue,
+            Recipient = GetOrganisationNumber(0),
+            Sender = GetOrganisationNumber(1),
+            Status = CorrespondenceStatus.Published,
+            StatusHistory = [],
+            ResourceId = string.Empty,
+            SendersReference = string.Empty,
+        };
 }

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/TestHelpers.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/TestHelpers.cs
@@ -32,10 +32,17 @@ public static class TestHelpers
 
     public static Task<JwtToken> OrgTokenFactory(IEnumerable<string> scopes)
     {
-        var _scopes = new Scopes(MaskinportenClient.GetFormattedScopes(scopes));
-        var token = _scopes.HasScopeWithPrefix("altinn:serviceowner/")
-            ? TestAuthentication.GetServiceOwnerToken(scope: _scopes.ToString())
-            : TestAuthentication.GetOrgToken(scope: _scopes.ToString());
+        var formattedScopes = MaskinportenClient.GetFormattedScopes(scopes);
+        string token;
+
+        try
+        {
+            token = TestAuthentication.GetServiceOwnerToken(scope: formattedScopes);
+        }
+        catch (InvalidOperationException)
+        {
+            token = TestAuthentication.GetOrgToken(scope: formattedScopes);
+        }
 
         return Task.FromResult(JwtToken.Parse(token));
     }

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/MaskinportenClientTest.cs
@@ -6,14 +6,11 @@ using Altinn.App.Core.Features.Maskinporten.Constants;
 using Altinn.App.Core.Features.Maskinporten.Exceptions;
 using Altinn.App.Core.Features.Maskinporten.Models;
 using Altinn.App.Core.Internal.Maskinporten;
-using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Time.Testing;
-using Microsoft.Identity.Client;
 using Moq;
 
 namespace Altinn.App.Core.Tests.Features.Maskinporten;
@@ -121,6 +118,7 @@ public class MaskinportenClientTests
     [InlineData(new[] { "a", "b", "c" }, "a b c")]
     [InlineData(new[] { "a b", "c" }, "a b c")]
     [InlineData(new[] { "a b c" }, "a b c")]
+    [InlineData(new[] { "a", "a", "b", "b", "c", "c" }, "a b c")]
     public void FormattedScopes_FormatsCorrectly(IEnumerable<string> input, string expectedOutput)
     {
         var formattedScopes = MaskinportenClient.GetFormattedScopes(input);

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -1044,7 +1044,12 @@ namespace Altinn.App.Core.Features.Correspondence.Models
     }
     public sealed class GetCorrespondenceStatusPayload : Altinn.App.Core.Features.Correspondence.Models.CorrespondencePayloadBase, System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.GetCorrespondenceStatusPayload>
     {
+        [System.Obsolete("Use GetCorrespondenceStatusPayload(Guid, CorrespondenceAuthenticationMethod) inst" +
+            "ead")]
         public GetCorrespondenceStatusPayload(System.Guid correspondenceId, Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAuthorisation authorisation) { }
+        public GetCorrespondenceStatusPayload(System.Guid correspondenceId, Altinn.App.Core.Features.CorrespondenceAuthenticationMethod authenticationMethod) { }
+        [System.Obsolete("Use GetCorrespondenceStatusPayload(Guid, CorrespondenceAuthenticationMethod) inst" +
+            "ead")]
         public GetCorrespondenceStatusPayload(System.Guid correspondenceId, System.Func<System.Threading.Tasks.Task<Altinn.App.Core.Models.JwtToken>> accessTokenFactory) { }
     }
     public sealed class GetCorrespondenceStatusResponse : System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.GetCorrespondenceStatusResponse>
@@ -1107,7 +1112,12 @@ namespace Altinn.App.Core.Features.Correspondence.Models
     }
     public sealed class SendCorrespondencePayload : Altinn.App.Core.Features.Correspondence.Models.CorrespondencePayloadBase, System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.SendCorrespondencePayload>
     {
+        [System.Obsolete("Use SendCorrespondencePayload(CorrespondenceRequest, CorrespondenceAuthentication" +
+            "Method) instead")]
         public SendCorrespondencePayload(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceRequest request, Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAuthorisation authorisation) { }
+        public SendCorrespondencePayload(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceRequest request, Altinn.App.Core.Features.CorrespondenceAuthenticationMethod authenticationMethod) { }
+        [System.Obsolete("Use SendCorrespondencePayload(CorrespondenceRequest, CorrespondenceAuthentication" +
+            "Method) instead")]
         public SendCorrespondencePayload(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceRequest request, System.Func<System.Threading.Tasks.Task<Altinn.App.Core.Models.JwtToken>> accessTokenFactory) { }
     }
     public sealed class SendCorrespondenceResponse : System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.SendCorrespondenceResponse>
@@ -1119,84 +1129,13 @@ namespace Altinn.App.Core.Features.Correspondence.Models
         public required System.Collections.Generic.IReadOnlyList<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceDetailsResponse> Correspondences { get; init; }
     }
 }
-namespace Altinn.App.Core.Features.DataLists
-{
-    public class DataListsFactory
-    {
-        public DataListsFactory(System.IServiceProvider serviceProvider) { }
-        public Altinn.App.Core.Features.IDataListProvider GetDataListProvider(string listId) { }
-    }
-    public class DataListsService : Altinn.App.Core.Features.DataLists.IDataListsService
-    {
-        public DataListsService(Altinn.App.Core.Features.DataLists.DataListsFactory dataListsFactory, Altinn.App.Core.Features.DataLists.InstanceDataListsFactory instanceDataListsFactory, Altinn.App.Core.Features.Telemetry? telemetry = null) { }
-        public System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(string dataListId, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs) { }
-        public System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, string dataListId, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs) { }
-    }
-    public interface IDataListsService
-    {
-        System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(string dataListId, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs);
-        System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, string dataListId, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs);
-    }
-    public class InstanceDataListsFactory
-    {
-        public InstanceDataListsFactory(System.IServiceProvider serviceProvider) { }
-        public Altinn.App.Core.Features.IInstanceDataListProvider GetDataListProvider(string listId) { }
-    }
-    public class NullDataListProvider : Altinn.App.Core.Features.IDataListProvider
-    {
-        public NullDataListProvider() { }
-        public string Id { get; }
-        public System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs) { }
-    }
-    public class NullInstanceDataListProvider : Altinn.App.Core.Features.IInstanceDataListProvider
-    {
-        public NullInstanceDataListProvider() { }
-        public string Id { get; }
-        public System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetInstanceDataListAsync(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs) { }
-    }
-}
-namespace Altinn.App.Core.Features.DataProcessing
-{
-    public abstract class GenericDataProcessor<TModel> : Altinn.App.Core.Features.IDataProcessor
-        where TModel :  class
-    {
-        protected GenericDataProcessor() { }
-        public abstract System.Threading.Tasks.Task ProcessDataRead(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Guid? dataId, TModel model, string? langauge);
-        public System.Threading.Tasks.Task ProcessDataRead(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Guid? dataId, object data, string? language) { }
-        public abstract System.Threading.Tasks.Task ProcessDataWrite(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Guid? dataId, TModel model, TModel? previousModel, string? language);
-        public System.Threading.Tasks.Task ProcessDataWrite(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Guid? dataId, object data, object? previousData, string? language) { }
-    }
-    public class NullInstantiationProcessor : Altinn.App.Core.Features.IInstantiationProcessor
-    {
-        public NullInstantiationProcessor() { }
-        public System.Threading.Tasks.Task DataCreation(Altinn.Platform.Storage.Interface.Models.Instance instance, object data, System.Collections.Generic.Dictionary<string, string>? prefill) { }
-    }
-}
-namespace Altinn.App.Core.Features.ExternalApi
-{
-    public sealed class ExternalApiDataResult : System.IEquatable<Altinn.App.Core.Features.ExternalApi.ExternalApiDataResult>
-    {
-        public ExternalApiDataResult(object? Data, bool WasExternalApiFound) { }
-        public object? Data { get; init; }
-        public bool WasExternalApiFound { get; init; }
-    }
-    public class ExternalApiService : Altinn.App.Core.Features.ExternalApi.IExternalApiService
-    {
-        public ExternalApiService(Microsoft.Extensions.Logging.ILogger<Altinn.App.Core.Features.ExternalApi.ExternalApiService> logger, System.IServiceProvider serviceProvider) { }
-        public System.Threading.Tasks.Task<Altinn.App.Core.Features.ExternalApi.ExternalApiDataResult> GetExternalApiData(string externalApiId, Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Collections.Generic.Dictionary<string, string> queryParams) { }
-    }
-    public interface IExternalApiClient
-    {
-        string Id { get; }
-        System.Threading.Tasks.Task<object?> GetExternalApiDataAsync(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Collections.Generic.Dictionary<string, string> queryParams);
-    }
-    public interface IExternalApiService
-    {
-        System.Threading.Tasks.Task<Altinn.App.Core.Features.ExternalApi.ExternalApiDataResult> GetExternalApiData(string externalApiId, Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Collections.Generic.Dictionary<string, string> queryParams);
-    }
-}
 namespace Altinn.App.Core.Features
 {
+    public sealed class CorrespondenceAuthenticationMethod : System.IEquatable<Altinn.App.Core.Features.CorrespondenceAuthenticationMethod>
+    {
+        public static Altinn.App.Core.Features.CorrespondenceAuthenticationMethod Custom(System.Func<System.Threading.Tasks.Task<Altinn.App.Core.Models.JwtToken>> tokenProvider) { }
+        public static Altinn.App.Core.Features.CorrespondenceAuthenticationMethod Default() { }
+    }
     public static class FeatureFlags
     {
         public const string JsonObjectInDataResponse = "JsonObjectInDataResponse";
@@ -1438,6 +1377,82 @@ namespace Altinn.App.Core.Features
         public static System.Diagnostics.Activity SetUserId(this System.Diagnostics.Activity activity, int? userId) { }
         public static System.Diagnostics.Activity SetUserPartyId(this System.Diagnostics.Activity activity, int? userPartyId) { }
         public static System.Diagnostics.Activity SetUsername(this System.Diagnostics.Activity activity, string? username) { }
+    }
+}
+namespace Altinn.App.Core.Features.DataLists
+{
+    public class DataListsFactory
+    {
+        public DataListsFactory(System.IServiceProvider serviceProvider) { }
+        public Altinn.App.Core.Features.IDataListProvider GetDataListProvider(string listId) { }
+    }
+    public class DataListsService : Altinn.App.Core.Features.DataLists.IDataListsService
+    {
+        public DataListsService(Altinn.App.Core.Features.DataLists.DataListsFactory dataListsFactory, Altinn.App.Core.Features.DataLists.InstanceDataListsFactory instanceDataListsFactory, Altinn.App.Core.Features.Telemetry? telemetry = null) { }
+        public System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(string dataListId, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs) { }
+        public System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, string dataListId, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs) { }
+    }
+    public interface IDataListsService
+    {
+        System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(string dataListId, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs);
+        System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, string dataListId, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs);
+    }
+    public class InstanceDataListsFactory
+    {
+        public InstanceDataListsFactory(System.IServiceProvider serviceProvider) { }
+        public Altinn.App.Core.Features.IInstanceDataListProvider GetDataListProvider(string listId) { }
+    }
+    public class NullDataListProvider : Altinn.App.Core.Features.IDataListProvider
+    {
+        public NullDataListProvider() { }
+        public string Id { get; }
+        public System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetDataListAsync(string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs) { }
+    }
+    public class NullInstanceDataListProvider : Altinn.App.Core.Features.IInstanceDataListProvider
+    {
+        public NullInstanceDataListProvider() { }
+        public string Id { get; }
+        public System.Threading.Tasks.Task<Altinn.App.Core.Models.DataList> GetInstanceDataListAsync(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, string? language, System.Collections.Generic.Dictionary<string, string> keyValuePairs) { }
+    }
+}
+namespace Altinn.App.Core.Features.DataProcessing
+{
+    public abstract class GenericDataProcessor<TModel> : Altinn.App.Core.Features.IDataProcessor
+        where TModel :  class
+    {
+        protected GenericDataProcessor() { }
+        public abstract System.Threading.Tasks.Task ProcessDataRead(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Guid? dataId, TModel model, string? langauge);
+        public System.Threading.Tasks.Task ProcessDataRead(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Guid? dataId, object data, string? language) { }
+        public abstract System.Threading.Tasks.Task ProcessDataWrite(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Guid? dataId, TModel model, TModel? previousModel, string? language);
+        public System.Threading.Tasks.Task ProcessDataWrite(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Guid? dataId, object data, object? previousData, string? language) { }
+    }
+    public class NullInstantiationProcessor : Altinn.App.Core.Features.IInstantiationProcessor
+    {
+        public NullInstantiationProcessor() { }
+        public System.Threading.Tasks.Task DataCreation(Altinn.Platform.Storage.Interface.Models.Instance instance, object data, System.Collections.Generic.Dictionary<string, string>? prefill) { }
+    }
+}
+namespace Altinn.App.Core.Features.ExternalApi
+{
+    public sealed class ExternalApiDataResult : System.IEquatable<Altinn.App.Core.Features.ExternalApi.ExternalApiDataResult>
+    {
+        public ExternalApiDataResult(object? Data, bool WasExternalApiFound) { }
+        public object? Data { get; init; }
+        public bool WasExternalApiFound { get; init; }
+    }
+    public class ExternalApiService : Altinn.App.Core.Features.ExternalApi.IExternalApiService
+    {
+        public ExternalApiService(Microsoft.Extensions.Logging.ILogger<Altinn.App.Core.Features.ExternalApi.ExternalApiService> logger, System.IServiceProvider serviceProvider) { }
+        public System.Threading.Tasks.Task<Altinn.App.Core.Features.ExternalApi.ExternalApiDataResult> GetExternalApiData(string externalApiId, Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Collections.Generic.Dictionary<string, string> queryParams) { }
+    }
+    public interface IExternalApiClient
+    {
+        string Id { get; }
+        System.Threading.Tasks.Task<object?> GetExternalApiDataAsync(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Collections.Generic.Dictionary<string, string> queryParams);
+    }
+    public interface IExternalApiService
+    {
+        System.Threading.Tasks.Task<Altinn.App.Core.Features.ExternalApi.ExternalApiDataResult> GetExternalApiData(string externalApiId, Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Collections.Generic.Dictionary<string, string> queryParams);
     }
 }
 namespace Altinn.App.Core.Features.FileAnalysis


### PR DESCRIPTION
## Description
Adds support for the recently implemented [AuthenticationMethod](https://github.com/Altinn/app-lib-dotnet/pull/1425/files#diff-cf98aa3e214601941f200b87c7b252b78cdbc9ecfe8082ed17e762cd025f1145) concept. Deprecates old custom implementation of the same-ish concept.

Previous implementation had scaffolded support for different scope requirements between the `send` and `get status` methods, but the Correspondence team has confirmed that this predicted change will no longer take place.

## RFC
Comments and suggestions on naming are very welcome! Especially the `CorrespondenceAuthentiationMethod.Default` method name.

Currently this makes sense, but if the client is extended to support other endpoints, requiring other scopes than `altinn:correspondence.write`, this may perhaps become a bit iffy.

## Related issues
- closes https://github.com/Altinn/app-lib-dotnet/issues/1429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified correspondence authentication with Default and Custom token options; new data-list and data-processing helpers.
* **Bug Fixes**
  * Scope formatting now deduplicates scopes, improving token cache stability.
* **Refactor**
  * Correspondence payloads and client updated to use the new authentication flow; minor public API shape adjustments.
* **Chores**
  * Legacy correspondence auth types/constructors marked obsolete; migrate to the new method.
* **Tests**
  * Expanded tests covering multiple correspondence authentication scenarios and scope handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->