### PR TITLE
Also interpret 'altinn3local.no' as running in localtest

### DIFF
--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -194,6 +194,7 @@ public static class ServiceCollectionExtensions
         services.Configure<FrontEndSettings>(configuration.GetSection(nameof(FrontEndSettings)));
         services.Configure<PdfGeneratorSettings>(configuration.GetSection(nameof(PdfGeneratorSettings)));
 
+        services.AddLocaltestDiscovery();
         if (env.IsDevelopment())
             services.AddLocaltestValidation();
 

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -194,7 +194,7 @@ public static class ServiceCollectionExtensions
         services.Configure<FrontEndSettings>(configuration.GetSection(nameof(FrontEndSettings)));
         services.Configure<PdfGeneratorSettings>(configuration.GetSection(nameof(PdfGeneratorSettings)));
 
-        services.AddLocaltestDiscovery();
+        services.AddRuntimeEnvironment();
         if (env.IsDevelopment())
             services.AddLocaltestValidation();
 

--- a/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
+++ b/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
@@ -23,15 +23,15 @@ internal class AuthenticationTokenResolver : IAuthenticationTokenResolver
         IMaskinportenClient maskinportenClient,
         IAppMetadata appMetadata,
         IAuthenticationContext authenticationContext,
-        LocaltestDiscovery localtestDiscovery
+        RuntimeEnvironment runtimeEnvironment
     )
     {
         _maskinportenClient = maskinportenClient;
         _appMetadata = appMetadata;
         _httpClientFactory = httpClientFactory;
         _authenticationContext = authenticationContext;
-        _isDev = localtestDiscovery.IsRunning();
-        _localtestBaseUrl = localtestDiscovery.GetBaseUrl();
+        _isDev = runtimeEnvironment.IsLocaltestPlatform();
+        _localtestBaseUrl = runtimeEnvironment.GetPlatformBaseUrl();
     }
 
     /// <inheritdoc />

--- a/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
+++ b/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
@@ -25,16 +25,15 @@ internal class AuthenticationTokenResolver : IAuthenticationTokenResolver
         IMaskinportenClient maskinportenClient,
         IAppMetadata appMetadata,
         IAuthenticationContext authenticationContext,
-        IOptions<PlatformSettings> platformSettings,
-        IOptions<GeneralSettings> generalSettings
+        LocaltestDiscovery localtestDiscovery
     )
     {
         _maskinportenClient = maskinportenClient;
         _appMetadata = appMetadata;
         _httpClientFactory = httpClientFactory;
         _authenticationContext = authenticationContext;
-        _isDev = LocaltestValidation.IsLocaltest(generalSettings.Value);
-        _localtestBaseUrl = LocaltestValidation.GetLocaltestBaseUrl(platformSettings.Value);
+        _isDev = localtestDiscovery.IsRunning();
+        _localtestBaseUrl = localtestDiscovery.GetBaseUrl();
     }
 
     /// <inheritdoc />

--- a/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
+++ b/src/Altinn.App.Core/Internal/Auth/AuthenticationTokenResolver.cs
@@ -1,11 +1,9 @@
-using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Features.Maskinporten;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Models;
-using Microsoft.Extensions.Options;
 
 namespace Altinn.App.Core.Internal.Auth;
 

--- a/src/Altinn.App.Core/Internal/LocaltestDiscovery.cs
+++ b/src/Altinn.App.Core/Internal/LocaltestDiscovery.cs
@@ -1,0 +1,32 @@
+using System.Collections.Frozen;
+using Altinn.App.Core.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Altinn.App.Core.Internal;
+
+internal static class LocaltestDiscoveryDI
+{
+    public static IServiceCollection AddLocaltestDiscovery(this IServiceCollection services)
+    {
+        services.AddSingleton<LocaltestDiscovery>();
+        return services;
+    }
+}
+
+internal sealed class LocaltestDiscovery(
+    IOptionsMonitor<GeneralSettings> _generalSettings,
+    IOptionsMonitor<PlatformSettings> _platformSettings
+)
+{
+    private static readonly FrozenSet<string> _expectedHostnames = new[]
+    {
+        "local.altinn.cloud",
+        "altinn3local.no",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    public bool IsRunning() => _expectedHostnames.Contains(_generalSettings.CurrentValue.HostName);
+
+    public string GetBaseUrl() =>
+        new Uri(_platformSettings.CurrentValue.ApiStorageEndpoint).GetLeftPart(UriPartial.Authority);
+}

--- a/src/Altinn.App.Core/Internal/LocaltestValidation.cs
+++ b/src/Altinn.App.Core/Internal/LocaltestValidation.cs
@@ -20,29 +20,21 @@ internal static class LocaltestValidationDI
 
 internal sealed class LocaltestValidation : BackgroundService
 {
-    private const string ExpectedHostname = "local.altinn.cloud";
-
     private readonly ILogger<LocaltestValidation> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptionsMonitor<GeneralSettings> _generalSettings;
-    private readonly IOptionsMonitor<PlatformSettings> _platformSettings;
+    private readonly LocaltestDiscovery _localtestDiscovery;
     private readonly IHostApplicationLifetime _lifetime;
     private readonly TimeProvider _timeProvider;
     private readonly Channel<VersionResult> _resultChannel;
 
     internal IAsyncEnumerable<VersionResult> Results => _resultChannel.Reader.ReadAllAsync();
 
-    internal static string GetLocaltestBaseUrl(PlatformSettings platformSettings) =>
-        new Uri(platformSettings.ApiStorageEndpoint).GetLeftPart(UriPartial.Authority);
-
-    internal static bool IsLocaltest(GeneralSettings generalSettings) =>
-        generalSettings.HostName.Equals(ExpectedHostname, StringComparison.OrdinalIgnoreCase);
-
     public LocaltestValidation(
         ILogger<LocaltestValidation> logger,
         IHttpClientFactory httpClientFactory,
         IOptionsMonitor<GeneralSettings> generalSettings,
-        IOptionsMonitor<PlatformSettings> platformSettings,
+        LocaltestDiscovery localtestDiscovery,
         IHostApplicationLifetime lifetime,
         TimeProvider? timeProvider = null
     )
@@ -50,7 +42,7 @@ internal sealed class LocaltestValidation : BackgroundService
         _logger = logger;
         _httpClientFactory = httpClientFactory;
         _generalSettings = generalSettings;
-        _platformSettings = platformSettings;
+        _localtestDiscovery = localtestDiscovery;
         _lifetime = lifetime;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _resultChannel = Channel.CreateBounded<VersionResult>(
@@ -58,10 +50,7 @@ internal sealed class LocaltestValidation : BackgroundService
         );
     }
 
-    private void Exit()
-    {
-        _lifetime.StopApplication();
-    }
+    private void Exit() => _lifetime.StopApplication();
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -71,9 +60,10 @@ internal sealed class LocaltestValidation : BackgroundService
             if (settings.DisableLocaltestValidation)
                 return;
 
-            if (!IsLocaltest(settings))
+            if (!_localtestDiscovery.IsRunning())
                 return;
 
+            var baseUrl = _localtestDiscovery.GetBaseUrl();
             while (!stoppingToken.IsCancellationRequested)
             {
                 var result = await Version();
@@ -99,7 +89,7 @@ internal sealed class LocaltestValidation : BackgroundService
                             _logger.LogError(
                                 "Localtest version may be outdated, as we failed to probe {HostName} API for version information."
                                     + " Is localtest running? Do you have a recent copy of localtest? Shutting down..",
-                                ExpectedHostname
+                                baseUrl
                             );
                             Exit();
                             return;
@@ -176,7 +166,7 @@ internal sealed class LocaltestValidation : BackgroundService
         {
             using var client = _httpClientFactory.CreateClient();
 
-            var baseUrl = GetLocaltestBaseUrl(_platformSettings.CurrentValue);
+            var baseUrl = _localtestDiscovery.GetBaseUrl();
             var url = $"{baseUrl}/Home/Localtest/Version";
 
             using var response = await client.GetAsync(url, cancellationToken);

--- a/src/Altinn.App.Core/Internal/RuntimeEnvironment.cs
+++ b/src/Altinn.App.Core/Internal/RuntimeEnvironment.cs
@@ -25,7 +25,15 @@ internal sealed class RuntimeEnvironment(
         "altinn3local.no", // Old hostname for localtest
     }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
-    public bool IsLocaltestPlatform() => _expectedHostnames.Contains(_generalSettings.CurrentValue.HostName);
+    public bool IsLocaltestPlatform()
+    {
+        var hostName = _generalSettings.CurrentValue.HostName;
+        var colonIdx = hostName.IndexOf(':');
+        if (colonIdx >= 0)
+            hostName = hostName[..colonIdx];
+
+        return _expectedHostnames.Contains(hostName);
+    }
 
     public string GetPlatformBaseUrl() =>
         new Uri(_platformSettings.CurrentValue.ApiStorageEndpoint).GetLeftPart(UriPartial.Authority);

--- a/src/Altinn.App.Core/Internal/RuntimeEnvironment.cs
+++ b/src/Altinn.App.Core/Internal/RuntimeEnvironment.cs
@@ -5,28 +5,28 @@ using Microsoft.Extensions.Options;
 
 namespace Altinn.App.Core.Internal;
 
-internal static class LocaltestDiscoveryDI
+internal static class RuntimeEnvironmentDI
 {
-    public static IServiceCollection AddLocaltestDiscovery(this IServiceCollection services)
+    public static IServiceCollection AddRuntimeEnvironment(this IServiceCollection services)
     {
-        services.AddSingleton<LocaltestDiscovery>();
+        services.AddSingleton<RuntimeEnvironment>();
         return services;
     }
 }
 
-internal sealed class LocaltestDiscovery(
+internal sealed class RuntimeEnvironment(
     IOptionsMonitor<GeneralSettings> _generalSettings,
     IOptionsMonitor<PlatformSettings> _platformSettings
 )
 {
     private static readonly FrozenSet<string> _expectedHostnames = new[]
     {
-        "local.altinn.cloud",
-        "altinn3local.no",
+        "local.altinn.cloud", // Current hostname for localtest
+        "altinn3local.no", // Old hostname for localtest
     }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
-    public bool IsRunning() => _expectedHostnames.Contains(_generalSettings.CurrentValue.HostName);
+    public bool IsLocaltestPlatform() => _expectedHostnames.Contains(_generalSettings.CurrentValue.HostName);
 
-    public string GetBaseUrl() =>
+    public string GetPlatformBaseUrl() =>
         new Uri(_platformSettings.CurrentValue.ApiStorageEndpoint).GetLeftPart(UriPartial.Authority);
 }

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/CorrespondenceClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/CorrespondenceClientTests.cs
@@ -351,11 +351,12 @@ public class CorrespondenceClientTests
                 services.AddSingleton(mockHttpClientFactory.Object);
                 services.AddSingleton(mockMaskinportenClient.Object);
                 services.AddSingleton(authenticationContextMock.Object);
-                services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new PlatformSettings()));
-                services.AddSingleton(
+                services.Configure<PlatformSettings>(_ => { });
+                services.Configure<GeneralSettings>(options =>
+                {
                     // NOTE: This must be set to tt02/prod to avoid localhost token generation in AuthenticationTokenResolver
-                    Microsoft.Extensions.Options.Options.Create(new GeneralSettings { HostName = "tt02.altinn.no" })
-                );
+                    options.HostName = "tt02.altinn.no";
+                });
                 services.Configure<MaskinportenSettings>(options =>
                 {
                     options.Authority = "https://maskinporten.dev/";

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
@@ -10,6 +10,7 @@ using Altinn.App.Core.Features.Maskinporten;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Infrastructure.Clients.Storage;
+using Altinn.App.Core.Internal;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Auth;
@@ -22,7 +23,6 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
 using Xunit.Abstractions;
 
@@ -35,8 +35,6 @@ public class DataClientTests
 
     private const string ApiStorageEndpoint = "https://local.platform.altinn.no/api/storage/";
     private static readonly ApplicationMetadata _appMetadata = new("test-org/test-app");
-    private static readonly GeneralSettings _generalSettings = new() { HostName = "tt02.altinn.no" };
-    private static readonly PlatformSettings _platformSettings = new() { ApiStorageEndpoint = ApiStorageEndpoint };
     private static readonly Authenticated _defaultAuth = TestAuthentication.GetUserAuthentication();
 
     private static readonly TestTokens _testTokens = new(
@@ -1049,8 +1047,9 @@ public class DataClientTests
                 .ReturnsAsync(_testTokens.ServiceOwnerToken);
 
             var services = new ServiceCollection();
-            services.AddSingleton(Options.Create(_platformSettings));
-            services.AddSingleton(Options.Create(_generalSettings));
+            services.Configure<PlatformSettings>(options => options.ApiStorageEndpoint = ApiStorageEndpoint);
+            services.Configure<GeneralSettings>(options => options.HostName = "tt02.altinn.no");
+            services.AddLocaltestDiscovery();
             services.AddSingleton<IAuthenticationTokenResolver, AuthenticationTokenResolver>();
             services.AddSingleton<ModelSerializationService>();
             services.AddSingleton(mocks.AppModelMock.Object);

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
@@ -1049,7 +1049,7 @@ public class DataClientTests
             var services = new ServiceCollection();
             services.Configure<PlatformSettings>(options => options.ApiStorageEndpoint = ApiStorageEndpoint);
             services.Configure<GeneralSettings>(options => options.HostName = "tt02.altinn.no");
-            services.AddLocaltestDiscovery();
+            services.AddRuntimeEnvironment();
             services.AddSingleton<IAuthenticationTokenResolver, AuthenticationTokenResolver>();
             services.AddSingleton<ModelSerializationService>();
             services.AddSingleton(mocks.AppModelMock.Object);

--- a/test/Altinn.App.Core.Tests/Internal/Auth/AuthenticationTokenResolverTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Auth/AuthenticationTokenResolverTest.cs
@@ -4,6 +4,7 @@ using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Features.Maskinporten;
 using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Internal;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Auth;
@@ -12,7 +13,6 @@ using Altinn.App.PlatformServices.Tests.Mocks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
 using Xunit.Abstractions;
 
@@ -183,8 +183,13 @@ public class AuthenticationTokenResolverTest
                 });
 
             var services = new ServiceCollection();
-            services.AddSingleton(Options.Create(_platformSettings));
-            services.AddSingleton(Options.Create(generalSettings ?? _generalSettingsLocal));
+            services.AddLocaltestDiscovery();
+            services.Configure<PlatformSettings>(options =>
+                options.ApiStorageEndpoint = _platformSettings.ApiStorageEndpoint
+            );
+            services.Configure<GeneralSettings>(options =>
+                options.HostName = generalSettings?.HostName ?? _generalSettingsLocal.HostName
+            );
             services.AddSingleton<IAuthenticationTokenResolver, AuthenticationTokenResolver>();
             services.AddSingleton<ModelSerializationService>();
             services.AddSingleton(mocks.AppModelMock.Object);

--- a/test/Altinn.App.Core.Tests/Internal/Auth/AuthenticationTokenResolverTest.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Auth/AuthenticationTokenResolverTest.cs
@@ -183,7 +183,7 @@ public class AuthenticationTokenResolverTest
                 });
 
             var services = new ServiceCollection();
-            services.AddLocaltestDiscovery();
+            services.AddRuntimeEnvironment();
             services.Configure<PlatformSettings>(options =>
                 options.ApiStorageEndpoint = _platformSettings.ApiStorageEndpoint
             );


### PR DESCRIPTION
## Description

* Also interpret 'altinn3local.no' as running in localtest
* Slight refactoring to pull some of these functions into `LocaltestDiscovery` (naming?)
* Adding `Options.Create` directly during tests leaves `IOptionsMonitor<>` still injectable but referring to something else... Affected tests use `Configure` instead, and it a little brittle in other ways :sweat: we should remove all `Options.Create` manual registrations in a separate PR

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved detection of local test platform, making authentication and token retrieval more reliable in local environments.

- Refactor
  - Centralized environment logic into a runtime environment service used across authentication, token resolution, and startup.
  - Simplified platform base-URL resolution and related validation.

- Tests
  - Updated tests to obtain environment settings via DI and the new runtime environment service.

- Chores
  - Registered the runtime environment service during app startup for consistent environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->