### PR TITLE
ModelSerialzationService: Add JSON de/serialization based on DataElement.ContentType

### DIFF
--- a/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
+++ b/src/Altinn.App.Core/Helpers/Serialization/ModelSerializationService.cs
@@ -81,7 +81,7 @@ public class ModelSerializationService
             );
         }
 
-        var contentType = dataType.AllowedContentTypes.FirstOrDefault() ?? "application/xml";
+        var contentType = dataType.AllowedContentTypes?.FirstOrDefault() ?? "application/xml";
 
         return contentType switch
         {

--- a/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -103,7 +103,8 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
 
                 return _modelSerializationService.DeserializeFromStorage(
                     binaryData.Span,
-                    this.GetDataType(dataElementIdentifier)
+                    this.GetDataType(dataElementIdentifier),
+                    GetDataElement(dataElementIdentifier).ContentType
                 );
             }
         );
@@ -359,7 +360,8 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
                         // and deserializing twice is not a big deal
                         PreviousFormData = _modelSerializationService.DeserializeFromStorage(
                             cachedBinary.Span,
-                            dataType
+                            dataType,
+                            dataElement.ContentType
                         ),
                         CurrentBinaryData = currentBinary,
                         PreviousBinaryData = cachedBinary,

--- a/test/Altinn.App.Api.Tests/Mocks/DataClientMock.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/DataClientMock.cs
@@ -204,7 +204,7 @@ public class DataClientMock : IDataClient
         string dataPath = TestData.GetDataBlobPath(org, app, instanceOwnerPartyId, instanceGuid, dataId);
         var dataBytes = await File.ReadAllBytesAsync(dataPath, cancellationToken);
 
-        var formData = _modelSerialization.DeserializeFromStorage(dataBytes, dataType);
+        var formData = _modelSerialization.DeserializeFromStorage(dataBytes, dataType, dataElement?.ContentType);
 
         return formData ?? throw new Exception("Unable to deserialize form data");
     }

--- a/test/Altinn.App.Core.Tests/Models/ModelSerializationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/ModelSerializationServiceTests.cs
@@ -1,0 +1,213 @@
+using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Internal.AppModel;
+using Altinn.Platform.Storage.Interface.Models;
+using FluentAssertions;
+using Moq;
+
+namespace Altinn.App.Core.Tests.Models;
+
+public class ModelSerializationServiceTests
+{
+    private static readonly string _testClassRef = typeof(TestDataModel).AssemblyQualifiedName!;
+    private static readonly string _otherClassRef = typeof(SomeOtherType).AssemblyQualifiedName!;
+
+    private readonly ModelSerializationService _sut;
+
+    private readonly Mock<IAppModel> _appModelMock = new Mock<IAppModel>();
+
+    public ModelSerializationServiceTests()
+    {
+        _appModelMock.Setup(x => x.GetModelType(It.Is<string>(s => s == _testClassRef))).Returns(typeof(TestDataModel));
+        _appModelMock
+            .Setup(x => x.GetModelType(It.Is<string>(s => s == _otherClassRef)))
+            .Returns(typeof(SomeOtherType));
+
+        _sut = new ModelSerializationService(_appModelMock.Object);
+    }
+
+    [Theory]
+    [InlineData("application/json", "application/json")]
+    [InlineData("application/xml", "application/xml")]
+    [InlineData(null, "application/xml")]
+    public void SerializeToStorage_ReturnsExpectedContentType(string? contentType, string expectedOutputType)
+    {
+        List<string> allowedContentTypes = contentType != null ? [contentType] : [];
+
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+
+        var dataType = CreateDataType(allowedContentTypes);
+
+        // Act
+        var (_, outputContentType) = _sut.SerializeToStorage(testObject, dataType);
+
+        // Assert
+        outputContentType.Should().Be(expectedOutputType);
+    }
+
+    [Fact]
+    public void SerializeToStorage_SerializesJson()
+    {
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+
+        var dataType = CreateDataType(["application/json"]);
+
+        // Act
+        var (data, _) = _sut.SerializeToStorage(testObject, dataType);
+
+        // Assert
+        var json = System.Text.Encoding.UTF8.GetString(data.Span);
+
+        json.Should().Be("{\"name\":\"Test\",\"value\":42}");
+    }
+
+    [Fact]
+    public void SerializeToStorage_SerializesXml()
+    {
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+
+        var dataType = CreateDataType(["application/xml"]);
+
+        // Act
+        var (data, _) = _sut.SerializeToStorage(testObject, dataType);
+
+        // Assert
+        var xml = System.Text.Encoding.UTF8.GetString(data.Span);
+
+        xml.Should()
+            .Be(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?><TestDataModel xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><Name>Test</Name><Value>42</Value></TestDataModel>"
+            );
+    }
+
+    [Fact]
+    public void SerializeToStorage_ThrowsOnUnsupportedContentType()
+    {
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+
+        var dataType = CreateDataType(["application/unsupported"]);
+
+        // Act
+        var act = () => _sut.SerializeToStorage(testObject, dataType);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void SerializeToStorage_ThrowsOnMismatchingModelType()
+    {
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+
+        var mismatchingDataType = new DataType()
+        {
+            Id = "mismatching",
+            AppLogic = new ApplicationLogic() { ClassRef = _otherClassRef },
+            AllowedContentTypes = ["application/json"],
+        };
+
+        // Act
+        var act = () => _sut.SerializeToStorage(testObject, mismatchingDataType);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void DeserializeFromStorage_ThrowsOnMismatchingModelType()
+    {
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+        var data = _sut.SerializeToJson(testObject);
+
+        var mismatchingDataType = new DataType()
+        {
+            Id = "mismatching",
+            AppLogic = new ApplicationLogic() { ClassRef = _otherClassRef },
+        };
+
+        // Act
+        var act = () => _sut.DeserializeFromStorage(data.Span, mismatchingDataType);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void DeserializeFromStorage_DeserializesJson()
+    {
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+        var data = _sut.SerializeToJson(testObject);
+
+        var dataType = CreateDataType(["application/json"]);
+
+        // Act
+        var result = _sut.DeserializeFromStorage(data.Span, dataType, "application/json");
+
+        // Assert
+        result.Should().BeOfType<TestDataModel>();
+        var model = (TestDataModel)result;
+        model.Name.Should().Be("Test");
+        model.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void DeserializeFromStorage_DeserializesXml()
+    {
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+        var data = _sut.SerializeToXml(testObject);
+
+        var dataType = CreateDataType(["application/xml"]);
+
+        // Act
+        var result = _sut.DeserializeFromStorage(data.Span, dataType, "application/xml");
+
+        // Assert
+        result.Should().BeOfType<TestDataModel>();
+        var model = (TestDataModel)result;
+        model.Name.Should().Be("Test");
+        model.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void DeserializeFromStorage_WithDefaultContentType_DeserializesXml()
+    {
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+        var data = _sut.SerializeToXml(testObject);
+
+        var dataType = CreateDataType(["application/xml"]);
+
+        // Act
+        var result = _sut.DeserializeFromStorage(data.Span, dataType);
+
+        // Assert
+        result.Should().BeOfType<TestDataModel>();
+        var model = (TestDataModel)result;
+        model.Name.Should().Be("Test");
+        model.Value.Should().Be(42);
+    }
+
+    private static DataType CreateDataType(List<string> allowedContentTypes)
+    {
+        return new DataType()
+        {
+            AppLogic = new ApplicationLogic() { ClassRef = _testClassRef },
+            AllowedContentTypes = allowedContentTypes,
+        };
+    }
+
+    public record SomeOtherType { }
+
+    public record TestDataModel
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Value { get; set; }
+    }
+}

--- a/test/Altinn.App.Core.Tests/Models/ModelSerializationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/ModelSerializationServiceTests.cs
@@ -118,6 +118,21 @@ public class ModelSerializationServiceTests
     }
 
     [Fact]
+    public void SerializeToStorage_MultipleAllowedContentTypes_PicksTheFirstOne()
+    {
+        // Arrange
+        var testObject = new TestDataModel { Name = "Test", Value = 42 };
+
+        var dataType = CreateDataType(["application/json", "application/xml"]);
+
+        // Act
+        var (_, outputContentType) = _sut.SerializeToStorage(testObject, dataType);
+
+        // Assert
+        outputContentType.Should().Be("application/json");
+    }
+
+    [Fact]
     public void DeserializeFromStorage_ThrowsOnMismatchingModelType()
     {
         // Arrange

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2229,7 +2229,7 @@ namespace Altinn.App.Core.Helpers.Serialization
     public class ModelSerializationService
     {
         public ModelSerializationService(Altinn.App.Core.Internal.AppModel.IAppModel appModel, Altinn.App.Core.Features.Telemetry? telemetry = null) { }
-        public object DeserializeFromStorage(System.ReadOnlySpan<byte> data, Altinn.Platform.Storage.Interface.Models.DataType dataType) { }
+        public object DeserializeFromStorage(System.ReadOnlySpan<byte> data, Altinn.Platform.Storage.Interface.Models.DataType dataType, string? contentType = "application/xml") { }
         public object DeserializeJson(System.ReadOnlySpan<byte> data, System.Type modelType) { }
         public System.Threading.Tasks.Task<Altinn.App.Core.Models.Result.ServiceResult<object, Microsoft.AspNetCore.Mvc.ProblemDetails>> DeserializeSingleFromStream(System.IO.Stream body, string? contentType, Altinn.Platform.Storage.Interface.Models.DataType dataType) { }
         public object DeserializeXml(System.ReadOnlySpan<byte> data, System.Type modelType) { }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for JSON content type in ModelSerializationService when de/serializing from/to storage.


## Related Issue(s)
- fixes https://github.com/Altinn/app-lib-dotnet/issues/892

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
