### PR TITLE
feat: order signing data elements

### DIFF
--- a/src/Altinn.App.Api/Controllers/SigningController.cs
+++ b/src/Altinn.App.Api/Controllers/SigningController.cs
@@ -266,7 +266,10 @@ public class SigningController : ControllerBase
 
         List<DataElement> dataElements =
         [
-            .. instance.Data.Where(x => signingConfiguration.DataTypesToSign.Contains(x.DataType)),
+            .. instance
+                .Data.Where(x => signingConfiguration.DataTypesToSign.Contains(x.DataType))
+                .OrderBy(x => signingConfiguration.DataTypesToSign.IndexOf(x.DataType))
+                .ThenBy(x => x.Created),
         ];
 
         foreach (DataElement dataElement in dataElements)

--- a/test/Altinn.App.Api.Tests/Controllers/SigningControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/SigningControllerTests.cs
@@ -44,7 +44,7 @@ public class SigningControllerTests
     {
         SignatureConfiguration = new AltinnSignatureConfiguration
         {
-            DataTypesToSign = ["dataTypeToSign"],
+            DataTypesToSign = ["dataTypeToSign1", "dataTypeToSign2"],
             SignatureDataType = "signatureDataType",
             SigneeProviderId = "signeeProviderId",
             SigneeStatesDataTypeId = "signeeStatesDataTypeId",
@@ -659,6 +659,8 @@ public class SigningControllerTests
 
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
 
+        var now = DateTime.UtcNow;
+
         // Create test instance with data elements
         var instance = new Instance
         {
@@ -672,10 +674,11 @@ public class SigningControllerTests
                 new DataElement
                 {
                     Id = "dataElement1",
-                    DataType = "dataTypeToSign", // This matches the DataTypesToSign in _altinnTaskExtension
+                    DataType = "dataTypeToSign1", // This matches the DataTypesToSign in _altinnTaskExtension
                     ContentType = "application/json",
                     Size = 100,
                     Filename = "file1.json",
+                    Created = now,
                 },
                 new DataElement
                 {
@@ -684,14 +687,25 @@ public class SigningControllerTests
                     ContentType = "application/json",
                     Size = 200,
                     Filename = "file2.json",
+                    Created = now,
                 },
                 new DataElement
                 {
                     Id = "dataElement3",
-                    DataType = "dataTypeToSign", // This matches the DataTypesToSign in _altinnTaskExtension
+                    DataType = "dataTypeToSign2", // This matches the DataTypesToSign in _altinnTaskExtension
                     ContentType = "application/xml",
                     Size = 300,
                     Filename = "file3.xml",
+                    Created = now,
+                },
+                new DataElement
+                {
+                    Id = "dataElement4",
+                    DataType = "dataTypeToSign1", // This matches the DataTypesToSign in _altinnTaskExtension
+                    ContentType = "application/xml",
+                    Size = 400,
+                    Filename = "file4.xml",
+                    Created = now.AddMinutes(-1),
                 },
             ],
         };
@@ -711,10 +725,16 @@ public class SigningControllerTests
         Assert.NotNull(signingDataElementsResponse);
 
         // Should only include data elements with DataType that matches DataTypesToSign
-        Assert.Equal(2, signingDataElementsResponse.DataElements.Count);
+        Assert.Equal(3, signingDataElementsResponse.DataElements.Count);
         Assert.Contains(signingDataElementsResponse.DataElements, de => de.Id == "dataElement1");
         Assert.Contains(signingDataElementsResponse.DataElements, de => de.Id == "dataElement3");
         Assert.DoesNotContain(signingDataElementsResponse.DataElements, de => de.Id == "dataElement2");
+        Assert.Contains(signingDataElementsResponse.DataElements, de => de.Id == "dataElement4");
+
+        // The elements should be ordered according to the order in DataTypesToSign, then by Created
+        Assert.Equal("dataElement4", signingDataElementsResponse.DataElements[0].Id);
+        Assert.Equal("dataElement1", signingDataElementsResponse.DataElements[1].Id);
+        Assert.Equal("dataElement3", signingDataElementsResponse.DataElements[2].Id);
 
         // Verify all data elements have self links set
         foreach (var dataElement in signingDataElementsResponse.DataElements)


### PR DESCRIPTION
## Description
Order the elements returned from the /signing/data-elements endpoint according to the order of the data types in dataTypesToSign in process.bpmn. Subsequently order by creation date.

## Related Issue(s)
-  Altinn/app-frontend-react#3367

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
Altinn/altinn-studio-docs#2408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signing list ordering is now consistent: items follow the configured data-type sequence, then are sorted by creation time.
  * Improves predictability and readability of items presented for signing without changing which items are included.
  * Prevents previously arbitrary ordering that could confuse users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->