### PR TITLE
Mark obsolete endpoint (since 8.0) as obsolete

### DIFF
--- a/src/Altinn.App.Api/Controllers/ResourceController.cs
+++ b/src/Altinn.App.Api/Controllers/ResourceController.cs
@@ -39,15 +39,20 @@ public class ResourceController : ControllerBase
     /// Get the form layout
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <remarks> This endpoint assumes a single layout set and does not work for apps on version 8.0 and above.</remarks>
     /// <returns>A collection of FormLayout objects in JSON format.</returns>
     /// </summary>
     [ProducesResponseType(typeof(string), StatusCodes.Status200OK, "application/json")]
     [HttpGet]
     [Route("{org}/{app}/api/layouts")]
+    [Obsolete(
+        "This endpoint is no longer available. Use /{org}/{app}/api/layoutsets to get available layout sets and /{org}/{app}/api/layouts/{id} to get layouts for a specific layout set."
+    )]
     public ActionResult GetLayouts(string org, string app)
     {
-        string layouts = _appResourceService.GetLayouts();
-        return Ok(layouts);
+        return NotFound(
+            "This endpoint is no longer available. Use /{org}/{app}/api/layoutsets to get available layout sets and /{org}/{app}/api/layouts/{id} to get layouts for a specific layout set."
+        );
     }
 
     /// <summary>

--- a/src/Altinn.App.Api/Controllers/ResourceController.cs
+++ b/src/Altinn.App.Api/Controllers/ResourceController.cs
@@ -37,12 +37,12 @@ public class ResourceController : ControllerBase
 
     /// <summary>
     /// Get the form layout
+    /// </summary>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="app">Application identifier which is unique within an organisation.</param>
     /// <remarks> This endpoint assumes a single layout set and does not work for apps on version 8.0 and above.</remarks>
     /// <returns>A collection of FormLayout objects in JSON format.</returns>
-    /// </summary>
-    [ProducesResponseType(typeof(string), StatusCodes.Status200OK, "application/json")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound, "text/plain")]
     [HttpGet]
     [Route("{org}/{app}/api/layouts")]
     [Obsolete(

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -218,6 +218,7 @@ public class AppResourcesSI : IAppResources
     }
 
     /// <inheritdoc />
+    [Obsolete("Use GetLayoutsForSet or GetLayoutModelForTask instead")]
     public string GetLayouts()
     {
         using var activity = _telemetry?.StartGetLayoutsActivity();

--- a/src/Altinn.App.Core/Internal/App/IAppResources.cs
+++ b/src/Altinn.App.Core/Internal/App/IAppResources.cs
@@ -82,6 +82,7 @@ public interface IAppResources
     /// Gets the layouts for the app.
     /// </summary>
     /// <returns>A dictionary of FormLayout objects serialized to JSON</returns>
+    [Obsolete("Use GetLayoutsForSet or GetLayoutModelForTask instead")]
     string GetLayouts();
 
     /// <summary>

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -5090,11 +5090,13 @@
         "tags": [
           "Resource"
         ],
-        "summary": "Get the form layout\n<param name=\"org\">Unique identifier of the organisation responsible for the app.</param><param name=\"app\">Application identifier which is unique within an organisation.</param><remarks> This endpoint assumes a single layout set and does not work for apps on version 8.0 and above.</remarks><returns>A collection of FormLayout objects in JSON format.</returns>",
+        "summary": "Get the form layout",
+        "description": "This endpoint assumes a single layout set and does not work for apps on version 8.0 and above.",
         "parameters": [
           {
             "name": "org",
             "in": "path",
+            "description": "Unique identifier of the organisation responsible for the app.",
             "required": true,
             "schema": {
               "type": "string"
@@ -5103,6 +5105,7 @@
           {
             "name": "app",
             "in": "path",
+            "description": "Application identifier which is unique within an organisation.",
             "required": true,
             "schema": {
               "type": "string"
@@ -5110,10 +5113,10 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "OK",
+          "404": {
+            "description": "Not Found",
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
                   "type": "string"
                 }

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -5090,7 +5090,7 @@
         "tags": [
           "Resource"
         ],
-        "summary": "Get the form layout\n<param name=\"org\">Unique identifier of the organisation responsible for the app.</param><param name=\"app\">Application identifier which is unique within an organisation.</param><returns>A collection of FormLayout objects in JSON format.</returns>",
+        "summary": "Get the form layout\n<param name=\"org\">Unique identifier of the organisation responsible for the app.</param><param name=\"app\">Application identifier which is unique within an organisation.</param><remarks> This endpoint assumes a single layout set and does not work for apps on version 8.0 and above.</remarks><returns>A collection of FormLayout objects in JSON format.</returns>",
         "parameters": [
           {
             "name": "org",
@@ -5120,7 +5120,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/{org}/{app}/api/layouts/{id}": {

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -535,7 +535,7 @@ namespace Altinn.App.Api.Controllers
         [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/api/layoutsettings/{id}")]
         public Microsoft.AspNetCore.Mvc.ActionResult GetLayoutSettings(string org, string app, string id) { }
         [Microsoft.AspNetCore.Mvc.HttpGet]
-        [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(string), 200, "application/json", new string[0])]
+        [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(string), 404, "text/plain", new string[0])]
         [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/api/layouts")]
         [System.Obsolete("This endpoint is no longer available. Use /{org}/{app}/api/layoutsets to get avai" +
             "lable layout sets and /{org}/{app}/api/layouts/{id} to get layouts for a specifi" +

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -537,6 +537,9 @@ namespace Altinn.App.Api.Controllers
         [Microsoft.AspNetCore.Mvc.HttpGet]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(string), 200, "application/json", new string[0])]
         [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/api/layouts")]
+        [System.Obsolete("This endpoint is no longer available. Use /{org}/{app}/api/layoutsets to get avai" +
+            "lable layout sets and /{org}/{app}/api/layouts/{id} to get layouts for a specifi" +
+            "c layout set.")]
         public Microsoft.AspNetCore.Mvc.ActionResult GetLayouts(string org, string app) { }
         [Microsoft.AspNetCore.Mvc.HttpGet]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(string), 200, "application/json", new string[0])]

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2279,6 +2279,7 @@ namespace Altinn.App.Core.Implementation
         public Altinn.App.Core.Models.LayoutSettings? GetLayoutSettingsForSet(string? layoutSetId) { }
         public string? GetLayoutSettingsString() { }
         public string? GetLayoutSettingsStringForSet(string layoutSetId) { }
+        [System.Obsolete("Use GetLayoutsForSet or GetLayoutModelForTask instead")]
         public string GetLayouts() { }
         public string GetLayoutsForSet(string layoutSetId) { }
         public string GetModelJsonSchema(string modelId) { }
@@ -2845,6 +2846,7 @@ namespace Altinn.App.Core.Internal.App
         Altinn.App.Core.Models.LayoutSettings? GetLayoutSettingsForSet(string? layoutSetId);
         string? GetLayoutSettingsString();
         string? GetLayoutSettingsStringForSet(string layoutSetId);
+        [System.Obsolete("Use GetLayoutsForSet or GetLayoutModelForTask instead")]
         string GetLayouts();
         string GetLayoutsForSet(string layoutSetId);
         string GetModelJsonSchema(string modelId);


### PR DESCRIPTION
In v8 we removed support for the single layout set approach in backend and frontend. There was not added any compatibility for the `{org}/{app}/api/layouts` endpoint, and it did not work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Deprecated the GET /{org}/{app}/api/layouts endpoint; it now returns 404 Not Found with a guidance message directing callers to /{org}/{app}/api/layoutsets and /{org}/{app}/api/layouts/{id}.
  - Marked legacy layout retrieval API surface as deprecated so callers receive deprecation warnings.

- Documentation
  - OpenAPI updated to mark /{org}/{app}/api/layouts as deprecated and notes it assumes a single layout set and isn’t supported for apps v8.0+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->