### PR TITLE
Set correct media type on customOpenapi.json

### DIFF
--- a/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
+++ b/src/Altinn.App.Api/Controllers/CustomOpenApiController.cs
@@ -130,7 +130,7 @@ public class CustomOpenApiController : Controller
         var walker = new OpenApiWalker(new SchemaPostVisitor());
         walker.Walk(document);
 
-        return Ok(document.Serialize(SpecVersion, SpecFormat));
+        return Content(document.Serialize(SpecVersion, SpecFormat), "application/json");
     }
 
     private string GetIntroDoc(ApplicationMetadata appMetadata)

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.cs
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Altinn.App.Api.Controllers;
 using Argon;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -35,7 +36,9 @@ public class OpenApiSpecChangeDetection : ApiTestBase, IClassFixture<WebApplicat
 
     private static async Task Snapshot(HttpResponseMessage response)
     {
-        response.EnsureSuccessStatusCode();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
         await using var stream = await response.Content.ReadAsStreamAsync();
         var reader = new OpenApiStreamReader();
         OpenApiDocument document = reader.Read(stream, out OpenApiDiagnostic diagnostic);


### PR DESCRIPTION
Previous implementation set the content type to `"text/plain"`, and it caused problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI endpoint now returns JSON with the correct application/json content type while maintaining a 200 status and unchanged response body.

* **Tests**
  * Strengthened tests to explicitly assert 200 OK status and application/json media type for the OpenAPI endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->