### PR TITLE
Fix use of checked AltinnPartyClient in PrefillSI

### DIFF
--- a/test/Altinn.App.Core.Tests/Implementation/PrefillSITest.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/PrefillSITest.cs
@@ -2,6 +2,7 @@ using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Implementation;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Registers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -26,7 +27,7 @@ public class TestPrefillFields
 public class PrefillSITests
 {
     [Fact]
-    public void PrefillDataModel_AssignsValuesCorrectly()
+    public async Task PrefillDataModel_AssignsValuesCorrectly()
     {
         var externalPrefill = new Dictionary<string, string>
         {
@@ -43,14 +44,17 @@ public class PrefillSITests
 
         var loggerMock = new Mock<ILogger<PrefillSI>>();
         var appResourcesMock = new Mock<IAppResources>();
-        var altinnPartyClientMock = new Mock<IAltinnPartyClient>();
         var authenticationContextMock = new Mock<IAuthenticationContext>();
+        var services = new ServiceCollection();
+        var registryClientMock = new Mock<IRegisterClient>();
+        services.AddSingleton<IRegisterClient>(registryClientMock.Object);
+        await using var sp = services.BuildStrictServiceProvider();
 
         var prefillToTest = new PrefillSI(
             loggerMock.Object,
             appResourcesMock.Object,
-            altinnPartyClientMock.Object,
-            authenticationContextMock.Object
+            authenticationContextMock.Object,
+            sp
         );
 
         prefillToTest.PrefillDataModel(dataModel, externalPrefill, continueOnError: false);

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2297,7 +2297,7 @@ namespace Altinn.App.Core.Implementation
     }
     public class PrefillSI : Altinn.App.Core.Internal.Prefill.IPrefill
     {
-        public PrefillSI(Microsoft.Extensions.Logging.ILogger<Altinn.App.Core.Implementation.PrefillSI> logger, Altinn.App.Core.Internal.App.IAppResources appResourcesService, Altinn.App.Core.Internal.Registers.IAltinnPartyClient altinnPartyClient, Altinn.App.Core.Features.Auth.IAuthenticationContext authenticationContext, Altinn.App.Core.Features.Telemetry? telemetry = null) { }
+        public PrefillSI(Microsoft.Extensions.Logging.ILogger<Altinn.App.Core.Implementation.PrefillSI> logger, Altinn.App.Core.Internal.App.IAppResources appResourcesService, Altinn.App.Core.Features.Auth.IAuthenticationContext authenticationContext, System.IServiceProvider serviceProvider, Altinn.App.Core.Features.Telemetry? telemetry = null) { }
         public void PrefillDataModel(object dataModel, System.Collections.Generic.Dictionary<string, string> externalPrefill, bool continueOnError = false) { }
         public System.Threading.Tasks.Task PrefillDataModel(string partyId, string dataModelName, object dataModel, System.Collections.Generic.Dictionary<string, string>? externalPrefill = null) { }
     }


### PR DESCRIPTION
## Description
Found a trace related to the bug report: c3e48a1a59a09a417e2098b0b6a6ce9d

This is a `PostSimplified` instantiation trace. During process init we are prefilling.
The caller is a system user instantiating on behalf of someone else (meaning the system user org party ID is not the instance owner). When that happens the modified switch statement falls through to `GetParty` which doesn't work for system users.

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/1514

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Prefill service updated to use centralized dependency resolution for improved reliability and maintainability.
  - Streamlined party lookup path for more robust data retrieval.
- Tests
  - Converted a core test to async and aligned test setup with the new dependency approach.
- Documentation
  - Updated constructor parameter documentation to reflect the revised dependency model.
- Chores
  - Updated public API verification artifacts to match the adjusted constructor signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->