### PR TITLE
Make ["component"] lookups work in expression validation (#1497)

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -244,12 +244,12 @@ public static class ExpressionEvaluator
             ),
         };
 
-        if (context?.Component is null)
+        if (context is null)
         {
             throw new ArgumentException("The component expression requires a component context");
         }
 
-        var targetContext = await state.GetComponentContext(context.Component.PageId, componentId, context.RowIndices);
+        var targetContext = await state.GetComponentContext(context.Component?.PageId, componentId, context.RowIndices);
 
         if (targetContext is null)
         {

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -100,7 +100,7 @@ public class LayoutEvaluatorState
     /// Get a specific component context based on
     /// </summary>
     public async Task<ComponentContext?> GetComponentContext(
-        string pageName,
+        string? pageName,
         string componentId,
         int[]? rowIndexes = null
     )
@@ -125,7 +125,8 @@ public class LayoutEvaluatorState
         {
             return filteredContexts[0];
         }
-        if (filteredContexts.Count(c => c.Component?.PageId == pageName) == 1)
+
+        if (pageName is not null && filteredContexts.Count(c => c.Component?.PageId == pageName) == 1)
         {
             // look first at the current page in case of duplicate ids (for backwards compatibility).
             return filteredContexts.First(c => c.Component?.PageId == pageName);

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -179,8 +179,5 @@ public record ExpressionValidationTestModel
 
         [JsonPropertyName("field")]
         public required string Field { get; set; }
-
-        [JsonPropertyName("componentId")]
-        public required string ComponentId { get; set; }
     }
 }

--- a/test/Altinn.App.Core.Tests/Features/Validators/expression-validation-tests/shared/component-lookup-hidden.json
+++ b/test/Altinn.App.Core.Tests/Features/Validators/expression-validation-tests/shared/component-lookup-hidden.json
@@ -1,0 +1,81 @@
+{
+  "name": "Should return null when looking up hidden component",
+  "expects": [
+    {
+      "message": "Navnet ditt kan ikke være feil.",
+      "severity": "error",
+      "field": "personer[0].navn",
+      "componentId": "person-navn"
+    }
+  ],
+  "validationConfig": {
+    "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/validation/validation.schema.v1.json",
+    "validations": {
+      "personer.navn": [
+        {
+          "message": "Navnet ditt kan ikke være feil.",
+          "severity": "error",
+          "condition": ["equals", ["component", "person-navn"], "feil"]
+        }
+      ]
+    }
+  },
+  "formData": {
+    "personer": [
+      {
+        "altinnRowId": "person0",
+        "navn": "feil",
+        "utenNavn": false
+      },
+      {
+        "altinnRowId": "person1",
+        "navn": "feil",
+        "utenNavn": true
+      },
+      {
+        "altinnRowId": "person2",
+        "navn": "riktig",
+        "utenNavn": false
+      }
+    ]
+  },
+  "layouts": {
+    "Page": {
+      "$schema": "https://altinncdn.no/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "personer",
+            "type": "RepeatingGroup",
+            "dataModelBindings": {
+              "group": "personer"
+            },
+            "children": [
+              "person-navn",
+              "uten-navn"
+            ]
+          },
+          {
+            "id": "person-navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "personer.navn"
+            },
+            "hidden": ["equals", ["component", "uten-navn"], true]
+          },
+          {
+            "id": "uten-navn",
+            "type": "Checkboxes",
+            "dataModelBindings": {
+              "simpleBinding": "personer.utenNavn"
+            },
+            "options": [
+              { "label": "Ja", "value": true },
+              { "label": "Nei", "value": false }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -3030,7 +3030,7 @@ namespace Altinn.App.Core.Internal.Expressions
         public System.Threading.Tasks.Task<Altinn.App.Core.Models.Layout.DataReference> AddInidicies(Altinn.App.Core.Models.Layout.ModelBinding binding, Altinn.App.Core.Models.DataElementIdentifier dataElementIdentifier, int[]? indexes) { }
         public int CountDataElements(string dataTypeId) { }
         public Altinn.App.Core.Models.Layout.Components.BaseComponent GetComponent(string pageName, string componentId) { }
-        public System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext?> GetComponentContext(string pageName, string componentId, int[]? rowIndexes = null) { }
+        public System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext?> GetComponentContext(string? pageName, string componentId, int[]? rowIndexes = null) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.List<Altinn.App.Core.Models.Expressions.ComponentContext>> GetComponentContexts() { }
         public string? GetFrontendSetting(string key) { }
         public string? GetGatewayAction() { }


### PR DESCRIPTION
## Related Issue(s)
- #1497 
