### PR TITLE
Don't pin dotnet release hash in dockerfiles used for testing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,11 @@
         "Verify.AspNetCore"
       ],
       "allowedVersions": "<=4.0"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^mcr\\.microsoft\\.com/dotnet"],
+      "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
Apps runs with unpinned versions in production.

It's a hassle to get 3 PRs for 3 docker files, that don't really need updating.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified Docker image update settings in dependency management configuration. Microsoft .NET Docker images will no longer use pinned digests, enabling more flexible version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->