### PR TITLE
Actually remove pined versions of microsoft C# images for testing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,9 +36,13 @@
       "allowedVersions": "<=4.0"
     },
     {
-      "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["^mcr\\.microsoft\\.com/dotnet"],
-      "pinDigests": false
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": false,
+      "matchPackageNames": [
+        "/^mcr\\.microsoft\\.com/dotnet/"
+      ]
     }
   ]
 }

--- a/test/Altinn.App.Analyzers.Tests/testapp/Dockerfile
+++ b/test/Altinn.App.Analyzers.Tests/testapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine@sha256:b2ad158bbc77970a5095e02db40079970227f2d5aee0af0f82e38668d5e43a09 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 WORKDIR /App
 
 COPY /App/App.csproj .
@@ -8,7 +8,7 @@ COPY /App .
 
 RUN dotnet publish App.csproj --configuration Release --output /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine@sha256:c41927c17f93a060a001bbedf977c0aa30be3b7d6559ecc5b656edbac639cc84 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS final
 EXPOSE 5005
 WORKDIR /App
 COPY --from=build /app_output .

--- a/test/Altinn.App.Integration.Tests/_testapps/basic/Dockerfile
+++ b/test/Altinn.App.Integration.Tests/_testapps/basic/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine@sha256:b2ad158bbc77970a5095e02db40079970227f2d5aee0af0f82e38668d5e43a09 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 
 COPY NuGet.config .
 COPY _packages _packages/
@@ -14,7 +14,7 @@ RUN dotnet publish App.csproj --configuration Release --output /app_output
 # Ensure that the config folder is copied to the output folder (policy.xml was missing)
 RUN cp -R config /app_output/
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine@sha256:c41927c17f93a060a001bbedf977c0aa30be3b7d6559ecc5b656edbac639cc84 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS final
 EXPOSE 5005
 EXPOSE 5006
 WORKDIR /App

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:ff8311847c54c04d1a14c488362807997d59b61372da5095a95f89cbcda7f9b7 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app-root-dir
 
 COPY AppLibDotnet.sln .


### PR DESCRIPTION
Should have done this in the previous PR

- #1527

Lets see if this makes Renovate close the PRs sugesting to update the pin
- #1522
- #1523
- #1524
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration for Docker image matching
  * Removed explicit image digest pinning from base Docker images in test configurations, allowing tag-based image resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->