### PR TITLE
Feat/translation service improvements

### DIFF
--- a/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -68,6 +69,13 @@ public interface IInstanceDataAccessor
     /// </summary>
     /// <exception cref="InvalidOperationException">If the data element is not found on the instance</exception>
     DataElement GetDataElement(DataElementIdentifier dataElementIdentifier);
+
+    /// <summary>
+    /// Currently marked internal, as we might want to deprecate <see cref="LayoutEvaluatorState"/> and use
+    /// <see cref="IInstanceDataAccessor"/> directly in the expression evaluator.
+    /// </summary>
+    /// <returns></returns>
+    internal LayoutEvaluatorState? GetLayoutEvaluatorState();
 
     /// <summary>
     /// <para>Set the authentication method used when reading and writing data of the given data type.</para>

--- a/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Features/IInstanceDataAccessor.cs
@@ -16,6 +16,16 @@ public interface IInstanceDataAccessor
     Instance Instance { get; }
 
     /// <summary>
+    /// If available, the language currently preferred for the user.
+    /// </summary>
+    string? Language { get; }
+
+    /// <summary>
+    /// If available, the taskId context for which data is being accessed.
+    /// </summary>
+    string? TaskId { get; }
+
+    /// <summary>
     /// Get the data types from application metadata.
     /// </summary>
     IReadOnlyCollection<DataType> DataTypes { get; }

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningCallToActionService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningCallToActionService.cs
@@ -192,7 +192,7 @@ internal sealed class SigningCallToActionService(
                 communicationConfig?.ReminderNotification?.Sms?.BodyTextResourceKey,
                 language
             );
-            appName = await translationService.TranslateFirstMatchingTextKey(language, "appName", "ServiceName");
+            appName = await translationService.TranslateTextKey("appName", language);
         }
         catch (Exception e)
         {

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
@@ -158,7 +158,7 @@ internal sealed class SigningReceiptService(
             title = await translationService.TranslateTextKey("signing.correspondence_receipt_title", language);
             summary = await translationService.TranslateTextKey("signing.correspondence_receipt_summary", language);
             body = await translationService.TranslateTextKey("signing.correspondence_receipt_body", language);
-            appName = await translationService.TranslateFirstMatchingTextKey(language, "appName", "ServiceName");
+            appName = await translationService.TranslateTextKey("appName", language);
         }
         catch (Exception e)
         {

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
@@ -153,8 +153,6 @@ internal sealed class SigningReceiptService(
 
         try
         {
-            AppIdentifier appIdentifier = new(context.Instance);
-
             title = await translationService.TranslateTextKey("signing.correspondence_receipt_title", language);
             summary = await translationService.TranslateTextKey("signing.correspondence_receipt_summary", language);
             body = await translationService.TranslateTextKey("signing.correspondence_receipt_body", language);

--- a/src/Altinn.App.Core/Internal/Data/CleanInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Internal/Data/CleanInstanceDataAccessor.cs
@@ -13,35 +13,31 @@ namespace Altinn.App.Core.Internal.Data;
 internal class CleanInstanceDataAccessor : IInstanceDataAccessor
 {
     private readonly IInstanceDataAccessor _dataAccessor;
-    private readonly string? _taskId;
     private readonly IAppResources _appResources;
     private readonly FrontEndSettings _frontEndSettings;
     private readonly RowRemovalOption _rowRemovalOption;
-    private readonly string? _language;
     private readonly ITranslationService _translationService;
     private readonly Telemetry? _telemetry;
 
     public CleanInstanceDataAccessor(
         IInstanceDataAccessor dataAccessor,
-        string? taskId,
         IAppResources appResources,
         ITranslationService translationService,
         FrontEndSettings frontEndSettings,
         RowRemovalOption rowRemovalOption,
-        string? language,
         Telemetry? telemetry
     )
     {
         _dataAccessor = dataAccessor;
-        _taskId = taskId;
         _appResources = appResources;
         _frontEndSettings = frontEndSettings;
         _rowRemovalOption = rowRemovalOption;
-        _language = language;
         _telemetry = telemetry;
         _translationService = translationService;
 
-        LayoutModel? layouts = taskId is not null ? appResources.GetLayoutModelForTask(taskId) : null;
+        LayoutModel? layouts = dataAccessor.TaskId is not null
+            ? appResources.GetLayoutModelForTask(dataAccessor.TaskId)
+            : null;
         if (layouts is null)
         {
             _hiddenFieldsTask = new(() => Task.FromResult(new List<DataReference>()));
@@ -53,8 +49,7 @@ internal class CleanInstanceDataAccessor : IInstanceDataAccessor
                 layouts,
                 translationService,
                 frontEndSettings,
-                gatewayAction: null,
-                language
+                gatewayAction: null
             );
             _hiddenFieldsTask = new(() =>
             {
@@ -72,6 +67,8 @@ internal class CleanInstanceDataAccessor : IInstanceDataAccessor
 
     public IReadOnlyCollection<DataType> DataTypes => _dataAccessor.DataTypes;
 
+    public string? TaskId => _dataAccessor.TaskId;
+    public string? Language => _dataAccessor.Language;
     public IReadOnlyDictionary<DataType, StorageAuthenticationMethod> AuthenticationMethodOverrides =>
         _dataAccessor.AuthenticationMethodOverrides;
 
@@ -124,12 +121,10 @@ internal class CleanInstanceDataAccessor : IInstanceDataAccessor
         }
         return new CleanInstanceDataAccessor(
             _dataAccessor,
-            _taskId,
             _appResources,
             _translationService,
             _frontEndSettings,
             rowRemovalOption,
-            _language,
             _telemetry
         );
     }

--- a/src/Altinn.App.Core/Internal/Data/CleanInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Internal/Data/CleanInstanceDataAccessor.cs
@@ -144,6 +144,13 @@ internal class CleanInstanceDataAccessor : IInstanceDataAccessor
         return _dataAccessor.GetDataElement(dataElementIdentifier);
     }
 
+    public LayoutEvaluatorState? GetLayoutEvaluatorState()
+    {
+        throw new NotImplementedException(
+            "GetLayoutEvaluatorState is not implemented in CleanInstanceDataAccessor, because LayoutEvaluatorState will be deprecated."
+        );
+    }
+
     public void OverrideAuthenticationMethod(DataType dataType, StorageAuthenticationMethod method)
     {
         _dataAccessor.OverrideAuthenticationMethod(dataType, method);

--- a/src/Altinn.App.Core/Internal/Data/CleanInstanceDataAccessor.cs
+++ b/src/Altinn.App.Core/Internal/Data/CleanInstanceDataAccessor.cs
@@ -10,7 +10,7 @@ using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Data;
 
-internal class CleanInstanceDataAccessor : IInstanceDataAccessor
+internal sealed class CleanInstanceDataAccessor : IInstanceDataAccessor
 {
     private readonly IInstanceDataAccessor _dataAccessor;
     private readonly IAppResources _appResources;
@@ -53,7 +53,7 @@ internal class CleanInstanceDataAccessor : IInstanceDataAccessor
             );
             _hiddenFieldsTask = new(() =>
             {
-                using var activity = telemetry?.StartRemoveHiddenDataForValidation();
+                using var activity = _telemetry?.StartRemoveHiddenDataForValidation();
                 return LayoutEvaluator.GetHiddenFieldsForRemoval(state, evaluateRemoveWhenHidden: false);
             });
         }

--- a/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -39,8 +39,6 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
 
     private readonly IAppResources _appResources;
     private readonly IOptions<FrontEndSettings> _frontEndSettings;
-    private readonly string? _taskId;
-    private readonly string? _language;
     private readonly ITranslationService _translationService;
     private readonly Telemetry? _telemetry;
 
@@ -89,8 +87,8 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
         _appMetadata = appMetadata;
         _translationService = translationService;
         _modelSerializationService = modelSerializationService;
-        _taskId = taskId;
-        _language = language;
+        TaskId = taskId;
+        Language = language;
         _frontEndSettings = frontEndSettings;
         _appResources = appResources;
         _instanceClient = instanceClient;
@@ -100,6 +98,10 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
     public Instance Instance { get; }
 
     public IReadOnlyCollection<DataType> DataTypes { get; }
+
+    public string? TaskId { get; }
+
+    public string? Language { get; }
 
     /// <inheritdoc />
     public void OverrideAuthenticationMethod(DataType dataType, StorageAuthenticationMethod method)
@@ -141,12 +143,10 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
     {
         return new CleanInstanceDataAccessor(
             this,
-            _taskId,
             _appResources,
             _translationService,
             _frontEndSettings.Value,
             rowRemovalOption,
-            _language,
             _telemetry
         );
     }
@@ -163,12 +163,10 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
 
         _previousDataAccessorCache = new PreviousDataAccessor(
             this,
-            _taskId,
             _appResources,
             _translationService,
             _modelSerializationService,
             _frontEndSettings.Value,
-            _language,
             _telemetry
         );
         return _previousDataAccessorCache;

--- a/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -7,6 +7,7 @@ using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Texts;
 using Altinn.App.Core.Models;
@@ -170,6 +171,29 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             _telemetry
         );
         return _previousDataAccessorCache;
+    }
+
+    public LayoutEvaluatorState? GetLayoutEvaluatorState()
+    {
+        if (TaskId is null)
+        {
+            return null;
+        }
+        var layouts = _appResources.GetLayoutModelForTask(TaskId);
+        if (layouts is null)
+        {
+            return null;
+        }
+
+        var state = new LayoutEvaluatorState(
+            this,
+            layouts,
+            _translationService,
+            _frontEndSettings.Value,
+            gatewayAction: null,
+            Language
+        );
+        return state;
     }
 
     /// <inheritdoc />

--- a/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -173,11 +173,17 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
         return _previousDataAccessorCache;
     }
 
+    private LayoutEvaluatorState? _layoutEvaluatorStateCache;
+
     public LayoutEvaluatorState? GetLayoutEvaluatorState()
     {
         if (TaskId is null)
         {
             return null;
+        }
+        if (_layoutEvaluatorStateCache is not null)
+        {
+            return _layoutEvaluatorStateCache;
         }
         var layouts = _appResources.GetLayoutModelForTask(TaskId);
         if (layouts is null)
@@ -185,7 +191,7 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             return null;
         }
 
-        var state = new LayoutEvaluatorState(
+        _layoutEvaluatorStateCache = new LayoutEvaluatorState(
             this,
             layouts,
             _translationService,
@@ -193,7 +199,7 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             gatewayAction: null,
             Language
         );
-        return state;
+        return _layoutEvaluatorStateCache;
     }
 
     /// <inheritdoc />

--- a/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -185,6 +185,8 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
         {
             return _layoutEvaluatorStateCache;
         }
+
+        // Could use a double lock here, but a deadlock is more problematic than creating the state twice
         var layouts = _appResources.GetLayoutModelForTask(TaskId);
         if (layouts is null)
         {

--- a/src/Altinn.App.Core/Internal/Data/PreviousDataAccessor.cs
+++ b/src/Altinn.App.Core/Internal/Data/PreviousDataAccessor.cs
@@ -13,11 +13,9 @@ namespace Altinn.App.Core.Internal.Data;
 internal class PreviousDataAccessor : IInstanceDataAccessor
 {
     private readonly IInstanceDataAccessor _dataAccessor;
-    private readonly string? _taskId;
     private readonly IAppResources _appResources;
     private readonly ModelSerializationService _modelSerializationService;
     private readonly FrontEndSettings _frontEndSettings;
-    private readonly string? _language;
     private readonly ITranslationService _translationService;
     private readonly Telemetry? _telemetry;
 
@@ -25,28 +23,27 @@ internal class PreviousDataAccessor : IInstanceDataAccessor
 
     public PreviousDataAccessor(
         IInstanceDataAccessor dataAccessor,
-        string? taskId,
         IAppResources appResources,
         ITranslationService translationService,
         ModelSerializationService modelSerializationService,
         FrontEndSettings frontEndSettings,
-        string? language,
         Telemetry? telemetry
     )
     {
         _dataAccessor = dataAccessor;
-        _taskId = taskId;
         _appResources = appResources;
         _translationService = translationService;
         _modelSerializationService = modelSerializationService;
         _frontEndSettings = frontEndSettings;
-        _language = language;
         _telemetry = telemetry;
     }
 
     public Instance Instance => _dataAccessor.Instance;
 
     public IReadOnlyCollection<DataType> DataTypes => _dataAccessor.DataTypes;
+
+    public string? TaskId => _dataAccessor.TaskId;
+    public string? Language => _dataAccessor.Language;
 
     public IReadOnlyDictionary<DataType, StorageAuthenticationMethod> AuthenticationMethodOverrides =>
         throw new NotImplementedException();
@@ -86,12 +83,10 @@ internal class PreviousDataAccessor : IInstanceDataAccessor
     {
         return new CleanInstanceDataAccessor(
             this,
-            _taskId,
             _appResources,
             _translationService,
             _frontEndSettings,
             rowRemovalOption,
-            _language,
             _telemetry
         );
     }

--- a/src/Altinn.App.Core/Internal/Data/PreviousDataAccessor.cs
+++ b/src/Altinn.App.Core/Internal/Data/PreviousDataAccessor.cs
@@ -4,6 +4,7 @@ using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.Serialization;
 using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Internal.Texts;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -94,6 +95,13 @@ internal class PreviousDataAccessor : IInstanceDataAccessor
     public IInstanceDataAccessor GetPreviousDataAccessor()
     {
         return this;
+    }
+
+    public LayoutEvaluatorState? GetLayoutEvaluatorState()
+    {
+        throw new NotImplementedException(
+            "GetLayoutEvaluatorState is not implemented in PreviousDataAccessor, because LayoutEvaluatorState will be deprecated."
+        );
     }
 
     public async Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier)

--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionValue.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionValue.cs
@@ -273,6 +273,28 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
         };
 
     /// <summary>
+    /// Converts the current instance of <see cref="ExpressionValue"/> to its string representation
+    /// suitable for text-based contexts.
+    /// </summary>
+    /// <returns>
+    /// A string representation of the value. Returns "true" for boolean true, "false" for boolean false,
+    /// the string content for string values, the numeric value as a string for number values, or an empty string for null.
+    /// Throws <see cref="InvalidOperationException"/> for invalid or unsupported value kinds.
+    /// </returns>
+    public string? ToStringForText() =>
+        _valueKind switch
+        {
+            JsonValueKind.Null => null,
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.String => String,
+            JsonValueKind.Number => Number.ToString(CultureInfo.InvariantCulture),
+            // JsonValueKind.Object => JsonSerializer.Serialize(Object),
+            // JsonValueKind.Array => JsonSerializer.Serialize(Array),
+            _ => throw new InvalidOperationException($"Invalid value kind {ValueKind}"),
+        };
+
+    /// <summary>
     /// Get the value as a string that can be used for equality comparisons in ["equals"] expressions.
     ///
     /// Has special handeling for strings that are "true", "false", or "null" to make them equal to the primitive types

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -185,7 +185,7 @@ public class LayoutEvaluatorState
     /// </summary>
     public async Task<object?> GetModelData(
         ModelBinding key,
-        DataElementIdentifier defaultDataElementIdentifier,
+        DataElementIdentifier? defaultDataElementIdentifier,
         int[]? indexes
     )
     {
@@ -276,21 +276,25 @@ public class LayoutEvaluatorState
 
     private DataElementIdentifier ResolveDataElementIdentifier(
         ModelBinding key,
-        DataElementIdentifier defaultDataElementIdentifier
+        DataElementIdentifier? defaultDataElementIdentifier
     )
     {
         // If the binding don't have a specific data type, use the default
-        if (key.DataType == null)
+        if (key.DataType is null)
         {
-            return defaultDataElementIdentifier;
+            return defaultDataElementIdentifier
+                ?? throw new InvalidOperationException(
+                    "Cannot resolve data element identifier without a default or specific data type"
+                );
         }
         // If the data element has the same type as default, return it
-        if (defaultDataElementIdentifier.Guid != Guid.Empty)
+
+        if (defaultDataElementIdentifier.HasValue)
         {
-            var defaultDataType = _dataAccessor.GetDataType(defaultDataElementIdentifier);
+            var defaultDataType = _dataAccessor.GetDataType(defaultDataElementIdentifier.Value);
             if (defaultDataType.Id == key.DataType)
             {
-                return defaultDataElementIdentifier;
+                return defaultDataElementIdentifier.Value;
             }
         }
 
@@ -423,4 +427,12 @@ public class LayoutEvaluatorState
     //         GetModelErrorsForExpression(arg, component, errors);
     //     }
     // }
+
+    /// <summary>
+    /// Get the default data type from the current layoutset
+    /// </summary>
+    public DataType? GetDefaultDataType()
+    {
+        return _componentModel?.DefaultDataType;
+    }
 }

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -61,7 +61,7 @@ public class LayoutEvaluatorState
         _frontEndSettings = frontEndSettings;
         Instance = dataAccessor.Instance;
         _gatewayAction = gatewayAction;
-        _language = language;
+        _language = language ?? dataAccessor.Language;
         _timeZone = timeZone;
     }
 

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -88,7 +88,7 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
             return Task.FromResult(_data);
         }
 
-        public IInstanceDataAccessor GetCleanAccessor(RowRemovalOption rowRemovalOption)
+        public IInstanceDataAccessor GetCleanAccessor(RowRemovalOption rowRemovalOption = RowRemovalOption.SetToNull)
         {
             throw new NotSupportedException("Legacy single data accessor does not implement GetCleanAccessor");
         }

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -100,9 +100,7 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
 
         public LayoutEvaluatorState? GetLayoutEvaluatorState()
         {
-            throw new NotImplementedException(
-                "GetLayoutEvaluatorState is not implemented in CleanInstanceDataAccessor, because LayoutEvaluatorState will be deprecated."
-            );
+            throw new NotImplementedException("Legacy single data accessor does not implement GetLayoutEvaluatorState");
         }
 
         public Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier)

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -65,6 +65,9 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
 
         public Instance Instance { get; }
 
+        public string? TaskId => null;
+        public string? Language => null;
+
         public IReadOnlyCollection<DataType> DataTypes => _applicationMetadata.DataTypes;
 
         public async Task<object> GetFormData(DataElementIdentifier dataElementIdentifier)

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorStateInitializer.cs
@@ -98,6 +98,13 @@ public class LayoutEvaluatorStateInitializer : ILayoutEvaluatorStateInitializer
             throw new NotSupportedException("Legacy single data accessor does not implement GetPreviousDataAccessor");
         }
 
+        public LayoutEvaluatorState? GetLayoutEvaluatorState()
+        {
+            throw new NotImplementedException(
+                "GetLayoutEvaluatorState is not implemented in CleanInstanceDataAccessor, because LayoutEvaluatorState will be deprecated."
+            );
+        }
+
         public Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier)
         {
             return Task.FromException<ReadOnlyMemory<byte>>(

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -171,7 +171,7 @@ public class PdfService : IPdfService
 
     private async Task<string> GetFileName(string? language)
     {
-        string? titleText = await _translationService.TranslateTextKey("appName", language);
+        string? titleText = await _translationService.TranslateTextKey("backend.pdf_default_file_name", language);
 
         if (string.IsNullOrEmpty(titleText))
         {
@@ -179,7 +179,7 @@ public class PdfService : IPdfService
             titleText = "Altinn PDF";
         }
 
-        return GetValidFileName(titleText + ".pdf");
+        return GetValidFileName(titleText);
     }
 
     private static string GetValidFileName(string fileName)

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -139,13 +139,14 @@ public class PdfService : IPdfService
         // Uses string manipulation instead of UriBuilder, since UriBuilder messes up
         // query parameters in combination with hash fragments in the url.
         string url = baseUrl + pagePath;
+        string lang = Uri.EscapeDataString(language);
         if (url.Contains('?'))
         {
-            url += $"&lang={language}";
+            url += $"&lang={lang}";
         }
         else
         {
-            url += $"?lang={language}";
+            url += $"?lang={lang}";
         }
 
         return new Uri(url);
@@ -176,10 +177,11 @@ public class PdfService : IPdfService
         if (string.IsNullOrEmpty(titleText))
         {
             // translation for appName should always be present, but in case it is not, we fall back to a generic title
-            titleText = "Altinn PDF";
+            titleText = "Altinn PDF.pdf";
         }
 
-        return GetValidFileName(titleText);
+        var file = GetValidFileName(titleText);
+        return file.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase) ? file : $"{file}.pdf";
     }
 
     private static string GetValidFileName(string fileName)

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -176,7 +176,8 @@ public class PdfService : IPdfService
 
         if (string.IsNullOrEmpty(titleText))
         {
-            // translation for appName should always be present, but in case it is not, we fall back to a generic title
+            // translation for backend.pdf_default_file_name should always be present (it has a falback in the translation service),
+            // but just in case, we default to a hardcoded string.
             titleText = "Altinn PDF.pdf";
         }
 

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -3,9 +3,8 @@ using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Helpers.Extensions;
-using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
-using Altinn.App.Core.Internal.Language;
+using Altinn.App.Core.Internal.Texts;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Http;
@@ -20,13 +19,13 @@ namespace Altinn.App.Core.Internal.Pdf;
 /// </summary>
 public class PdfService : IPdfService
 {
-    private readonly IAppResources _resourceService;
     private readonly IDataClient _dataClient;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IPdfGeneratorClient _pdfGeneratorClient;
     private readonly PdfGeneratorSettings _pdfGeneratorSettings;
     private readonly ILogger<PdfService> _logger;
     private readonly IAuthenticationContext _authenticationContext;
+    private readonly ITranslationService _translationService;
     private readonly GeneralSettings _generalSettings;
     private readonly Telemetry? _telemetry;
     private const string PdfElementType = "ref-data-as-pdf";
@@ -35,17 +34,7 @@ public class PdfService : IPdfService
     /// <summary>
     /// Initializes a new instance of the <see cref="PdfService"/> class.
     /// </summary>
-    /// <param name="appResources">The service giving access to local resources.</param>
-    /// <param name="dataClient">The data client.</param>
-    /// <param name="httpContextAccessor">The httpContextAccessor</param>
-    /// <param name="pdfGeneratorClient">PDF generator client for the experimental PDF generator service</param>
-    /// <param name="pdfGeneratorSettings">PDF generator related settings.</param>
-    /// <param name="generalSettings">The app general settings.</param>
-    /// <param name="logger">The logger.</param>
-    /// <param name="authenticationContext">The auth context.</param>
-    /// <param name="telemetry">Telemetry for metrics and traces.</param>
     public PdfService(
-        IAppResources appResources,
         IDataClient dataClient,
         IHttpContextAccessor httpContextAccessor,
         IPdfGeneratorClient pdfGeneratorClient,
@@ -53,10 +42,10 @@ public class PdfService : IPdfService
         IOptions<GeneralSettings> generalSettings,
         ILogger<PdfService> logger,
         IAuthenticationContext authenticationContext,
+        ITranslationService translationService,
         Telemetry? telemetry = null
     )
     {
-        _resourceService = appResources;
         _dataClient = dataClient;
         _httpContextAccessor = httpContextAccessor;
         _pdfGeneratorClient = pdfGeneratorClient;
@@ -64,6 +53,7 @@ public class PdfService : IPdfService
         _generalSettings = generalSettings.Value;
         _logger = logger;
         _authenticationContext = authenticationContext;
+        _translationService = translationService;
         _telemetry = telemetry;
     }
 
@@ -78,11 +68,9 @@ public class PdfService : IPdfService
 
         var language = GetOverriddenLanguage(queries) ?? await auth.GetLanguage();
 
-        TextResource? textResource = await GetTextResource(instance, language);
+        var pdfContent = await GeneratePdfContent(instance, language, isPreview: false, ct);
 
-        var pdfContent = await GeneratePdfContent(instance, language, false, textResource, ct);
-
-        string fileName = GetFileName(instance, textResource);
+        string fileName = await GetFileName(language);
         await _dataClient.InsertBinaryData(
             instance.Id,
             PdfElementType,
@@ -105,9 +93,7 @@ public class PdfService : IPdfService
 
         var language = GetOverriddenLanguage(queries) ?? await auth.GetLanguage();
 
-        TextResource? textResource = await GetTextResource(instance, language);
-
-        return await GeneratePdfContent(instance, language, isPreview, textResource, ct);
+        return await GeneratePdfContent(instance, language, isPreview, ct);
     }
 
     /// <inheritdoc/>
@@ -120,7 +106,6 @@ public class PdfService : IPdfService
         Instance instance,
         string language,
         bool isPreview,
-        TextResource? textResource,
         CancellationToken ct
     )
     {
@@ -137,11 +122,11 @@ public class PdfService : IPdfService
 
         if (isPreview)
         {
-            footerContent = GetPreviewFooter(textResource);
+            footerContent = await GetPreviewFooter(language);
         }
         else if (displayFooter)
         {
-            footerContent = GetFooterContent(instance, textResource);
+            footerContent = await GetFooterContent(instance, language);
         }
 
         Stream pdfContent = await _pdfGeneratorClient.GeneratePdf(uri, footerContent, ct);
@@ -184,78 +169,17 @@ public class PdfService : IPdfService
         return null;
     }
 
-    private async Task<TextResource?> GetTextResource(Instance instance, string language)
+    private async Task<string> GetFileName(string? language)
     {
-        var appIdentifier = new AppIdentifier(instance);
-        string org = appIdentifier.Org;
-        string app = appIdentifier.App;
-        TextResource? textResource = await _resourceService.GetTexts(org, app, language);
+        string? titleText = await _translationService.TranslateTextKey("appName", language);
 
-        if (textResource == null && language != LanguageConst.Nb)
+        if (string.IsNullOrEmpty(titleText))
         {
-            // fallback to norwegian if texts does not exist
-            textResource = await _resourceService.GetTexts(org, app, LanguageConst.Nb);
+            // translation for appName should always be present, but in case it is not, we fall back to a generic title
+            titleText = "Altinn PDF";
         }
 
-        return textResource;
-    }
-
-    private static string GetFileName(Instance instance, TextResource? textResource)
-    {
-        string app = instance.AppId.Split("/")[1];
-        string fileName = $"{app}.pdf";
-
-        if (textResource is null)
-        {
-            return GetValidFileName(fileName);
-        }
-
-        string? titleText = GetTitleText(textResource);
-
-        if (!string.IsNullOrEmpty(titleText))
-        {
-            fileName = titleText + ".pdf";
-        }
-
-        return GetValidFileName(fileName);
-    }
-
-    private static string? GetTitleText(TextResource? textResource)
-    {
-        if (textResource is not null)
-        {
-            TextResourceElement? titleText =
-                textResource.Resources.Find(textResourceElement =>
-                    textResourceElement.Id.Equals("appName", StringComparison.Ordinal)
-                )
-                ?? textResource.Resources.Find(textResourceElement =>
-                    textResourceElement.Id.Equals("ServiceName", StringComparison.Ordinal)
-                );
-
-            if (titleText is not null)
-            {
-                return titleText.Value;
-            }
-        }
-
-        return null;
-    }
-
-    private static string GetPdfPreviewText(TextResource? textResource)
-    {
-        if (textResource is not null)
-        {
-            TextResourceElement? titleText = textResource.Resources.Find(textResourceElement =>
-                textResourceElement.Id.Equals("pdfPreviewText", StringComparison.Ordinal)
-            );
-
-            if (titleText is not null)
-            {
-                return titleText.Value;
-            }
-        }
-
-        return "Dokumentet er en forhåndsvisning";
+        return GetValidFileName(titleText + ".pdf");
     }
 
     private static string GetValidFileName(string fileName)
@@ -264,9 +188,9 @@ public class PdfService : IPdfService
         return fileName;
     }
 
-    private static string GetPreviewFooter(TextResource? textResource)
+    private async Task<string> GetPreviewFooter(string language)
     {
-        string previewText = GetPdfPreviewText(textResource);
+        var previewText = await _translationService.TranslateTextKey("pdfPreviewText", language);
         return $@"<div style='font-family: Inter; font-size: 12px; width: 100%; display: flex; flex-direction: row; align-items: center; gap: 12px; padding: 0 70px 0 70px;'>
                 <div style='display: flex; flex-direction: row; width: 100%; align-items: center; font-style: italic; color: #e02e49;'>
                     <span>{previewText}</span>
@@ -274,7 +198,7 @@ public class PdfService : IPdfService
             </div>";
     }
 
-    private string GetFooterContent(Instance instance, TextResource? textResource)
+    private async Task<string> GetFooterContent(Instance instance, string? language)
     {
         TimeZoneInfo timeZone = TimeZoneInfo.Utc;
         try
@@ -289,7 +213,7 @@ public class PdfService : IPdfService
 
         DateTimeOffset now = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, timeZone);
 
-        string title = GetTitleText(textResource) ?? "Altinn";
+        string title = await _translationService.TranslateTextKey("appName", language) ?? "Altinn";
 
         string dateGenerated = now.ToString("dd.MM.yyyy HH:mm", new CultureInfo("nb-NO"));
         string altinnReferenceId = instance.Id.Split("/")[1].Split("-")[4];

--- a/src/Altinn.App.Core/Internal/Texts/ITranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/ITranslationService.cs
@@ -70,5 +70,6 @@ public interface ITranslationService
     /// <param name="language">Language for the text. If omitted, 'nb' will be used</param>
     /// <param name="keys">Array of keys to search for</param>
     /// <returns>The value of the first matching text resource in the specified language or null</returns>
+    [Obsolete("Multiple keys should be implemented by a default fallback that references the other key")]
     Task<string?> TranslateFirstMatchingTextKey(string? language, params string[] keys);
 }

--- a/src/Altinn.App.Core/Internal/Texts/ITranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/ITranslationService.cs
@@ -1,3 +1,4 @@
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Models.Expressions;
 using Altinn.App.Core.Models.Validation;
@@ -29,13 +30,28 @@ public interface ITranslationService
     /// </summary>
     /// <param name="key">The identifier of the text resource to be translated.</param>
     /// <param name="state">The layout evaluator state containing shared data required for translation.</param>
-    /// <param name="context">The component context in which the translation is being performed.</param>
+    /// <param name="context">The component context used for relative path resolution.</param>
     /// <param name="customTextParameters">Dictionary of extra parameters for rendering this text <see cref="ValidationIssue.CustomTextParameters"/></param>
     /// <returns>The translated text value, or null if the key cannot be translated.</returns>
     Task<string?> TranslateTextKey(
         string key,
         LayoutEvaluatorState state,
         ComponentContext? context,
+        Dictionary<string, string>? customTextParameters = null
+    );
+
+    /// <summary>
+    /// Translates the specified text key using the provided instance data accessor and component context to support dynamic variable replacement.
+    /// </summary>
+    /// <param name="key">The resource key</param>
+    /// <param name="instanceDataAccessor">The instance data accessor providing access to instance data</param>
+    /// <param name="context">The component context used for relative path resolution</param>
+    /// <param name="customTextParameters">Dictionary of extra parameters for rendering this text <see cref="ValidationIssue.CustomTextParameters"/></param>
+    /// <returns>The translated text value, or null if the key cannot be translated</returns>
+    Task<string?> TranslateTextKey(
+        string key,
+        IInstanceDataAccessor instanceDataAccessor,
+        ComponentContext? context = null,
         Dictionary<string, string>? customTextParameters = null
     );
 

--- a/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
@@ -243,7 +243,7 @@ internal sealed class TranslationService : ITranslationService
             if (_appMetadata is not null)
             {
                 var appMetadata = await _appMetadata.GetApplicationMetadata();
-                if (appMetadata.Title.TryGetValue(language, out var title) == true)
+                if (appMetadata.Title.TryGetValue(language, out var title))
                 {
                     return new TextResourceElement() { Id = "appName", Value = title };
                 }

--- a/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
@@ -257,6 +257,30 @@ internal class TranslationService : ITranslationService
                         _ => "Field is required",
                     },
                 };
+            case "backend.pdf_default_file_name":
+                return new TextResourceElement()
+                {
+                    Id = "backend.pdf_default_file_name",
+                    Value = language switch
+                    {
+                        _ => "{0}.pdf",
+                    },
+                    Variables = new List<TextResourceVariable>()
+                    {
+                        new TextResourceVariable() { Key = "appName", DataSource = "static" },
+                    },
+                };
+            case "pdfPreviewText":
+                return new TextResourceElement()
+                {
+                    Id = "pdfPreviewText",
+                    Value = language switch
+                    {
+                        LanguageConst.En => "The document is a preview",
+                        LanguageConst.Nn => "Dokumentet er ein førehandsvisning",
+                        _ => "Dokumentet er en forhåndsvisning",
+                    },
+                };
         }
 
         return null;

--- a/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Internal.Language;
@@ -61,6 +62,24 @@ internal class TranslationService : ITranslationService
         string language = state.GetLanguage();
         var resourceElement = await GetTextResourceElement(key, language);
         var value = await ReplaceVariables(resourceElement, state, context, customTextParameters, language);
+        return value;
+    }
+
+    public async Task<string?> TranslateTextKey(
+        string key,
+        IInstanceDataAccessor instanceDataAccessor,
+        ComponentContext? context = null,
+        Dictionary<string, string>? customTextParameters = null
+    )
+    {
+        var resourceElement = await GetTextResourceElement(key, instanceDataAccessor.Language);
+        var value = await ReplaceVariables(
+            resourceElement,
+            instanceDataAccessor.GetLayoutEvaluatorState(),
+            context,
+            customTextParameters,
+            instanceDataAccessor.Language
+        );
         return value;
     }
 

--- a/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
@@ -139,7 +139,7 @@ public class PdfControllerTests
                     ItExpr.IsAny<CancellationToken>()
                 )
                 .Callback<HttpRequestMessage, CancellationToken>(
-                    (m, c) => requestBody = m.Content!.ReadAsStringAsync().Result
+                    async (m, c) => requestBody = await m.Content!.ReadAsStringAsync()
                 )
                 .ReturnsAsync(mockResponse);
 
@@ -209,7 +209,7 @@ public class PdfControllerTests
                     ItExpr.IsAny<CancellationToken>()
                 )
                 .Callback<HttpRequestMessage, CancellationToken>(
-                    (m, c) => requestBody = m.Content!.ReadAsStringAsync().Result
+                    async (m, c) => requestBody = await m.Content!.ReadAsStringAsync()
                 )
                 .ReturnsAsync(mockResponse);
 
@@ -281,7 +281,7 @@ public class PdfControllerTests
                     ItExpr.IsAny<CancellationToken>()
                 )
                 .Callback<HttpRequestMessage, CancellationToken>(
-                    (m, c) => requestBody = m.Content!.ReadAsStringAsync().Result
+                    async (m, c) => requestBody = await m.Content!.ReadAsStringAsync()
                 )
                 .ReturnsAsync(mockResponse);
 

--- a/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
@@ -9,6 +9,7 @@ using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Instances;
 using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Internal.Pdf;
+using Altinn.App.Core.Internal.Texts;
 using Altinn.Platform.Storage.Interface.Models;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -44,6 +45,7 @@ public class PdfControllerTests
     private readonly Mock<IAuthenticationContext> _authenticationContext = new();
 
     private readonly Mock<ILogger<PdfService>> _logger = new();
+    private readonly Mock<ITranslationService> _translationService = new();
 
     public PdfControllerTests()
     {
@@ -71,14 +73,14 @@ public class PdfControllerTests
     )
     {
         var pdfService = new PdfService(
-            _appResources.Object,
             _dataClient.Object,
             httpContextAccessor.Object,
             pdfGeneratorClient,
             _pdfGeneratorSettingsOptions,
             generalSettingsOptions,
             _logger.Object,
-            _authenticationContext.Object
+            _authenticationContext.Object,
+            _translationService.Object
         );
         return pdfService;
     }

--- a/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/PdfControllerTests.cs
@@ -138,10 +138,13 @@ public class PdfControllerTests
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>()
                 )
-                .Callback<HttpRequestMessage, CancellationToken>(
-                    async (m, c) => requestBody = await m.Content!.ReadAsStringAsync()
-                )
-                .ReturnsAsync(mockResponse);
+                .Returns<HttpRequestMessage, CancellationToken>(
+                    async (m, c) =>
+                    {
+                        requestBody = await m.Content!.ReadAsStringAsync();
+                        return mockResponse;
+                    }
+                );
 
             var result = await pdfController.GetPdfPreview(_org, _app, _partyId, _instanceId);
             result.Should().BeOfType(typeof(FileStreamResult));
@@ -208,10 +211,13 @@ public class PdfControllerTests
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>()
                 )
-                .Callback<HttpRequestMessage, CancellationToken>(
-                    async (m, c) => requestBody = await m.Content!.ReadAsStringAsync()
-                )
-                .ReturnsAsync(mockResponse);
+                .Returns<HttpRequestMessage, CancellationToken>(
+                    async (m, c) =>
+                    {
+                        requestBody = await m.Content!.ReadAsStringAsync();
+                        return mockResponse;
+                    }
+                );
 
             var result = await pdfController.GetPdfPreview(_org, _app, _partyId, _instanceId);
             result.Should().BeOfType(typeof(FileStreamResult));
@@ -280,10 +286,13 @@ public class PdfControllerTests
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>()
                 )
-                .Callback<HttpRequestMessage, CancellationToken>(
-                    async (m, c) => requestBody = await m.Content!.ReadAsStringAsync()
-                )
-                .ReturnsAsync(mockResponse);
+                .Returns<HttpRequestMessage, CancellationToken>(
+                    async (m, c) =>
+                    {
+                        requestBody = await m.Content!.ReadAsStringAsync();
+                        return mockResponse;
+                    }
+                );
 
             var result = await pdfController.GetPdfPreview(_org, _app, _partyId, _instanceId);
             result.Should().BeOfType(typeof(FileStreamResult));

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -81,16 +81,6 @@
       HasParent: true
     },
     {
-      Name: ApplicationMetadata.Service.GetTexts,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetTexts,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
       Name: ApplicationMetadata.Service.GetValidationConfiguration,
       IdFormat: W3C,
       HasParent: true

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningCallToActionServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningCallToActionServiceTests.cs
@@ -103,7 +103,8 @@ public class SigningCallToActionServiceTests(ITestOutputHelper output)
         TranslationService translationService = new(
             appIdentifier,
             appResourcesMock.Object,
-            FakeLoggerXunit.Get<TranslationService>(output)
+            FakeLoggerXunit.Get<TranslationService>(output),
+            appMetadataMock.Object
         );
 
         SigningCallToActionService service = SetupService(
@@ -192,7 +193,8 @@ public class SigningCallToActionServiceTests(ITestOutputHelper output)
         TranslationService translationService = new(
             appIdentifier,
             appResourcesMock.Object,
-            FakeLoggerXunit.Get<TranslationService>(output)
+            FakeLoggerXunit.Get<TranslationService>(output),
+            appMetadataMock.Object
         );
 
         SigningCallToActionService service = SetupService(
@@ -293,7 +295,8 @@ public class SigningCallToActionServiceTests(ITestOutputHelper output)
         TranslationService translationService = new(
             appIdentifier,
             appResourcesMock.Object,
-            FakeLoggerXunit.Get<TranslationService>(output)
+            FakeLoggerXunit.Get<TranslationService>(output),
+            appMetadataMock.Object
         );
 
         SigningCallToActionService service = SetupService(
@@ -394,7 +397,8 @@ public class SigningCallToActionServiceTests(ITestOutputHelper output)
         TranslationService translationService = new(
             appIdentifier,
             appResourcesMock.Object,
-            FakeLoggerXunit.Get<TranslationService>(output)
+            FakeLoggerXunit.Get<TranslationService>(output),
+            appMetadataMock.Object
         );
 
         SigningCallToActionService service = SetupService(
@@ -482,7 +486,8 @@ public class SigningCallToActionServiceTests(ITestOutputHelper output)
         TranslationService translationService = new(
             appIdentifier,
             appResourcesMock.Object,
-            FakeLoggerXunit.Get<TranslationService>(output)
+            FakeLoggerXunit.Get<TranslationService>(output),
+            appMetadataMock.Object
         );
 
         SigningCallToActionService service = SetupService(
@@ -538,7 +543,8 @@ public class SigningCallToActionServiceTests(ITestOutputHelper output)
         TranslationService translationService = new(
             appIdentifier,
             mock.Object,
-            FakeLoggerXunit.Get<TranslationService>(output)
+            FakeLoggerXunit.Get<TranslationService>(output),
+            appMetadata: null
         );
         SigningCallToActionService service = SetupService(translationServiceOverride: translationService);
 

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningReceiptServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningReceiptServiceTests.cs
@@ -292,7 +292,7 @@ public class SigningReceiptServiceTests(ITestOutputHelper output)
 
         var service = SetupService(translationServiceOverride: translationService);
 
-        Instance instance = new() { Id = "org/app" };
+        Instance instance = new() { AppId = "org/app" };
 
         Mock<IInstanceDataMutator> instanceDataMutatorMock = new();
         instanceDataMutatorMock.Setup(x => x.Instance).Returns(instance);
@@ -318,12 +318,9 @@ public class SigningReceiptServiceTests(ITestOutputHelper output)
         CorrespondenceContent result = await service.GetContent(context, appMetadata, senderDetails);
 
         // Assert
-        Assert.Equal("Fallback App Name: Signeringen er bekreftet", result.Title);
-        Assert.Equal("Du har signert for Fallback App Name.", result.Summary);
-        Assert.Equal(
-            "Dokumentene du har signert er vedlagt. Disse kan lastes ned om ønskelig. <br /><br />Hvis du lurer på noe, kan du kontakte Sender NB.",
-            result.Body
-        );
+        Assert.Equal("Custom receipt title", result.Title);
+        Assert.Equal("Custom receipt summary", result.Summary);
+        Assert.Equal("Custom receipt body", result.Body);
         Assert.Equal(LanguageCode<Iso6391>.Parse(LanguageConst.Nb), result.Language);
     }
 

--- a/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Pdf/PdfServiceTests.cs
@@ -9,6 +9,8 @@ using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Internal.Pdf;
 using Altinn.App.Core.Internal.Profile;
+using Altinn.App.Core.Internal.Texts;
+using Altinn.App.Core.Models;
 using Altinn.App.Core.Tests.TestUtils;
 using Altinn.App.PlatformServices.Tests.Mocks;
 using Altinn.Platform.Storage.Interface.Models;
@@ -18,11 +20,13 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
+using Xunit.Abstractions;
 
 namespace Altinn.App.PlatformServices.Tests.Internal.Pdf;
 
 public class PdfServiceTests
 {
+    private readonly ITestOutputHelper _outputHelper;
     private const string HostName = "at22.altinn.cloud";
 
     private readonly Mock<IAppResources> _appResources = new();
@@ -43,10 +47,9 @@ public class PdfServiceTests
 
     private readonly Mock<IAuthenticationContext> _authenticationContext = new();
 
-    private readonly Mock<ILogger<PdfService>> _logger = new();
-
-    public PdfServiceTests()
+    public PdfServiceTests(ITestOutputHelper outputHelper)
     {
+        _outputHelper = outputHelper;
         var resource = new TextResource()
         {
             Id = "digdir-not-really-an-app-nb",
@@ -312,14 +315,18 @@ public class PdfServiceTests
     )
     {
         return new PdfService(
-            appResources?.Object ?? _appResources.Object,
             dataClient?.Object ?? _dataClient.Object,
             httpContentAccessor?.Object ?? _httpContextAccessor.Object,
             pdfGeneratorClient?.Object ?? _pdfGeneratorClient.Object,
             pdfGeneratorSettingsOptions ?? _pdfGeneratorSettingsOptions,
             generalSettingsOptions ?? _generalSettingsOptions,
-            _logger.Object,
+            FakeLoggerXunit.Get<PdfService>(_outputHelper),
             authenticationContext?.Object ?? _authenticationContext.Object,
+            new TranslationService(
+                new AppIdentifier("digdir", "not-really-an-app"),
+                appResources?.Object ?? _appResources.Object,
+                FakeLoggerXunit.Get<TranslationService>(_outputHelper)
+            ),
             telemetrySink?.Object
         );
     }

--- a/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceInstanceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceInstanceTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Immutable;
+using Altinn.App.Core.Internal.Texts;
+using Altinn.App.Core.Models.Expressions;
+using Altinn.App.Core.Models.Layout;
+using Altinn.App.Core.Models.Layout.Components;
+using Altinn.App.Tests.Common.Fixtures;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Altinn.App.Core.Tests.Internal.Texts;
+
+public class TranslationServiceInstanceTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public TranslationServiceInstanceTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public class SkjemaModel
+    {
+        public string? Input1 { get; set; }
+    }
+
+    [Fact]
+    public async Task TranslateTextKey_WithDataSources()
+    {
+        var fixture = new MockedServiceCollection();
+        fixture.AddXunitLogging(_output);
+        var language = "esperanto";
+        fixture.AddTextResource(
+            language,
+            new TextResourceElement()
+            {
+                Id = "resourceKey",
+                Value = "AppName: {0}, Value: {1}",
+                Variables =
+                [
+                    new TextResourceVariable() { DataSource = "text", Key = "appName" },
+                    new TextResourceVariable() { DataSource = "dataModel.default", Key = "Input1" },
+                ],
+            }
+        );
+        fixture.TryAddCommonServices();
+
+        await using var provider = fixture.BuildServiceProvider();
+        var dataAccessor = await provider.CreateInstanceDataMutatorWithDataAndLayout(
+            new SkjemaModel() { Input1 = "123Test" },
+            [
+                new UnknownComponent
+                {
+                    Id = "input1",
+                    PageId = "page1",
+                    LayoutId = "layoutSet1",
+                    Type = "Input",
+                    Hidden = default,
+                    RemoveWhenHidden = default,
+                    Required = default,
+                    ReadOnly = default,
+                    DataModelBindings = new Dictionary<string, ModelBinding>()
+                    {
+                        {
+                            "simpleBinding",
+                            new ModelBinding { Field = nameof(SkjemaModel.Input1) }
+                        },
+                    },
+                    TextResourceBindings = ImmutableDictionary<string, Expression>.Empty,
+                },
+            ],
+            language
+        );
+        var translationService = provider.GetRequiredService<ITranslationService>();
+
+        var translation = await translationService.TranslateTextKey("resourceKey", dataAccessor);
+
+        Assert.Equal("AppName: Testapplikasjon, Value: 123Test", translation);
+    }
+}

--- a/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceTests.cs
@@ -79,7 +79,7 @@ public class TranslationServiceTests
     {
         await using var provider = _services.BuildServiceProvider();
         var translationService = provider.GetRequiredService<ITranslationService>();
-        var result = await translationService.TranslateTextKey("text", null);
+        var result = await translationService.TranslateTextKey("text", language: null);
         Assert.Equal("bokmål", result);
     }
 

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestFunctions.cs
@@ -418,19 +418,20 @@ public class TestFunctions
         switch (test.Expects.ValueKind)
         {
             case JsonValueKind.String:
-                result.Should().Be(test.Expects.GetString());
+                Assert.Equal(test.Expects.GetString(), result);
                 break;
             case JsonValueKind.True:
+                Assert.True(result as bool?);
                 result.Should().Be(true);
                 break;
             case JsonValueKind.False:
-                result.Should().Be(false);
+                Assert.False(result as bool?);
                 break;
             case JsonValueKind.Null:
-                result.Should().Be(null);
+                Assert.Null(result);
                 break;
             case JsonValueKind.Number:
-                result.Should().Be(test.Expects.GetDouble());
+                Assert.Equal(test.Expects.GetDouble(), result);
                 break;
             case JsonValueKind.Undefined:
 

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/CleanDataAccessor/TestValidateCleanData.CleanFull.verified.txt
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/CleanDataAccessor/TestValidateCleanData.CleanFull.verified.txt
@@ -91,7 +91,9 @@
               EnableFileScan: false,
               ValidationErrorOnPendingFileScan: false
             }
-          ]
+          ],
+          TaskId: Task_1-access,
+          Language: test-language
         },
         language: test-language,
         taskId: Task_1-access

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/CleanDataAccessor/TestValidateCleanData.CleanIncremental.verified.txt
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/CleanDataAccessor/TestValidateCleanData.CleanIncremental.verified.txt
@@ -307,7 +307,9 @@
               EnableFileScan: false,
               ValidationErrorOnPendingFileScan: false
             }
-          ]
+          ],
+          TaskId: Task_1-access,
+          Language: test-language
         },
         taskId: Task_1-access
       }
@@ -380,7 +382,9 @@
               EnableFileScan: false,
               ValidationErrorOnPendingFileScan: false
             }
-          ]
+          ],
+          TaskId: Task_1-access,
+          Language: test-language
         },
         language: test-language,
         taskId: Task_1-access

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/CleanDataAccessor/TestValidateCleanData.DirtyFull.verified.txt
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/CleanDataAccessor/TestValidateCleanData.DirtyFull.verified.txt
@@ -92,6 +92,8 @@
               ValidationErrorOnPendingFileScan: false
             }
           ],
+          TaskId: Task_1-access,
+          Language: test-language,
           HasAbandonIssues: false
         },
         language: test-language,

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/CleanDataAccessor/TestValidateCleanData.DirtyIncremental.verified.txt
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/FullTests/CleanDataAccessor/TestValidateCleanData.DirtyIncremental.verified.txt
@@ -331,6 +331,8 @@
               ValidationErrorOnPendingFileScan: false
             }
           ],
+          TaskId: Task_1-access,
+          Language: test-language,
           HasAbandonIssues: false
         },
         taskId: Task_1-access
@@ -405,6 +407,8 @@
               ValidationErrorOnPendingFileScan: false
             }
           ],
+          TaskId: Task_1-access,
+          Language: test-language,
           HasAbandonIssues: false
         },
         language: test-language,

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -93,6 +94,11 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
         throw new NotImplementedException(
             "GetPreviousDataAccessor is not yet implemented for InstanceDataAccessorFake"
         );
+    }
+
+    public LayoutEvaluatorState? GetLayoutEvaluatorState()
+    {
+        throw new NotImplementedException();
     }
 
     public Task<ReadOnlyMemory<byte>> GetBinaryData(DataElementIdentifier dataElementIdentifier)

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/TestUtilities/InstanceDataAccessorFake.cs
@@ -10,7 +10,6 @@ namespace Altinn.App.Core.Tests.LayoutExpressions.TestUtilities;
 public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyValuePair<DataElement?, object>>
 {
     private readonly ApplicationMetadata _applicationMetadata;
-    private readonly string? _defaultTaskId;
     private readonly string _defaultDataType;
 
     public InstanceDataAccessorFake(
@@ -21,7 +20,7 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
     )
     {
         _applicationMetadata = applicationMetadata ?? new ApplicationMetadata("app/org") { DataTypes = [] };
-        _defaultTaskId = defaultTaskId;
+        TaskId = defaultTaskId;
         _defaultDataType = defaultDataType;
         Instance = instance;
         Instance.Data ??= new();
@@ -48,7 +47,7 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
             dataType = new DataType()
             {
                 Id = dataElement.DataType,
-                TaskId = _defaultTaskId,
+                TaskId = TaskId,
                 AppLogic = new() { ClassRef = data.GetType().FullName },
                 MaxCount = maxCount,
             };
@@ -67,6 +66,10 @@ public class InstanceDataAccessorFake : IInstanceDataAccessor, IEnumerable<KeyVa
     }
 
     public Instance Instance { get; }
+
+    public string? TaskId { get; }
+
+    public string? Language => null;
 
     public IReadOnlyCollection<DataType> DataTypes => _applicationMetadata.DataTypes;
 

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -3188,7 +3188,7 @@ namespace Altinn.App.Core.Internal.Pdf
     }
     public class PdfService : Altinn.App.Core.Internal.Pdf.IPdfService
     {
-        public PdfService(Altinn.App.Core.Internal.App.IAppResources appResources, Altinn.App.Core.Internal.Data.IDataClient dataClient, Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor, Altinn.App.Core.Internal.Pdf.IPdfGeneratorClient pdfGeneratorClient, Microsoft.Extensions.Options.IOptions<Altinn.App.Core.Internal.Pdf.PdfGeneratorSettings> pdfGeneratorSettings, Microsoft.Extensions.Options.IOptions<Altinn.App.Core.Configuration.GeneralSettings> generalSettings, Microsoft.Extensions.Logging.ILogger<Altinn.App.Core.Internal.Pdf.PdfService> logger, Altinn.App.Core.Features.Auth.IAuthenticationContext authenticationContext, Altinn.App.Core.Features.Telemetry? telemetry = null) { }
+        public PdfService(Altinn.App.Core.Internal.Data.IDataClient dataClient, Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor, Altinn.App.Core.Internal.Pdf.IPdfGeneratorClient pdfGeneratorClient, Microsoft.Extensions.Options.IOptions<Altinn.App.Core.Internal.Pdf.PdfGeneratorSettings> pdfGeneratorSettings, Microsoft.Extensions.Options.IOptions<Altinn.App.Core.Configuration.GeneralSettings> generalSettings, Microsoft.Extensions.Logging.ILogger<Altinn.App.Core.Internal.Pdf.PdfService> logger, Altinn.App.Core.Features.Auth.IAuthenticationContext authenticationContext, Altinn.App.Core.Internal.Texts.ITranslationService translationService, Altinn.App.Core.Features.Telemetry? telemetry = null) { }
         public System.Threading.Tasks.Task GenerateAndStorePdf(Altinn.Platform.Storage.Interface.Models.Instance instance, string taskId, System.Threading.CancellationToken ct) { }
         public System.Threading.Tasks.Task<System.IO.Stream> GeneratePdf(Altinn.Platform.Storage.Interface.Models.Instance instance, string taskId, System.Threading.CancellationToken ct) { }
         public System.Threading.Tasks.Task<System.IO.Stream> GeneratePdf(Altinn.Platform.Storage.Interface.Models.Instance instance, string taskId, bool isPreview, System.Threading.CancellationToken ct) { }
@@ -3775,6 +3775,7 @@ namespace Altinn.App.Core.Internal.Texts
     {
         System.Threading.Tasks.Task<string?> TranslateFirstMatchingTextKey(string? language, params string[] keys);
         System.Threading.Tasks.Task<string?> TranslateTextKey(string key, string? language, System.Collections.Generic.Dictionary<string, string>? customTextParameters = null);
+        System.Threading.Tasks.Task<string?> TranslateTextKey(string key, Altinn.App.Core.Features.IInstanceDataAccessor instanceDataAccessor, Altinn.App.Core.Models.Expressions.ComponentContext? context = null, System.Collections.Generic.Dictionary<string, string>? customTextParameters = null);
         System.Threading.Tasks.Task<string?> TranslateTextKey(string key, Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.Expressions.ComponentContext? context, System.Collections.Generic.Dictionary<string, string>? customTextParameters = null);
         System.Threading.Tasks.Task<string?> TranslateTextKeyLenient(string? key, string? language);
     }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -3046,6 +3046,7 @@ namespace Altinn.App.Core.Internal.Expressions
         public object? ToObject() { }
         public override string ToString() { }
         public string? ToStringForEquals() { }
+        public string? ToStringForText() { }
         public static Altinn.App.Core.Internal.Expressions.ExpressionValue FromObject(object? value) { }
         public static Altinn.App.Core.Internal.Expressions.ExpressionValue op_Implicit(bool? value) { }
         public static Altinn.App.Core.Internal.Expressions.ExpressionValue op_Implicit(double? value) { }
@@ -3081,11 +3082,12 @@ namespace Altinn.App.Core.Internal.Expressions
         public void GetComponent(string pageName, string componentId) { }
         public System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext?> GetComponentContext(string? pageName, string componentId, int[]? rowIndexes = null) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.List<Altinn.App.Core.Models.Expressions.ComponentContext>> GetComponentContexts() { }
+        public Altinn.Platform.Storage.Interface.Models.DataType? GetDefaultDataType() { }
         public string? GetFrontendSetting(string key) { }
         public string? GetGatewayAction() { }
         public string GetInstanceContext(string key) { }
         public string GetLanguage() { }
-        public System.Threading.Tasks.Task<object?> GetModelData(Altinn.App.Core.Models.Layout.ModelBinding key, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? indexes) { }
+        public System.Threading.Tasks.Task<object?> GetModelData(Altinn.App.Core.Models.Layout.ModelBinding key, Altinn.App.Core.Models.DataElementIdentifier? defaultDataElementIdentifier, int[]? indexes) { }
         public System.Threading.Tasks.Task<Altinn.App.Core.Models.Layout.DataReference[]> GetResolvedKeys(Altinn.App.Core.Models.Layout.DataReference reference) { }
         public System.TimeZoneInfo? GetTimeZone() { }
         public System.Threading.Tasks.Task RemoveDataField(Altinn.App.Core.Models.Layout.DataReference key, Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption) { }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -3773,6 +3773,8 @@ namespace Altinn.App.Core.Internal.Texts
     }
     public interface ITranslationService
     {
+        [System.Obsolete("Multiple keys should be implemented by a default fallback that references the oth" +
+            "er key")]
         System.Threading.Tasks.Task<string?> TranslateFirstMatchingTextKey(string? language, params string[] keys);
         System.Threading.Tasks.Task<string?> TranslateTextKey(string key, string? language, System.Collections.Generic.Dictionary<string, string>? customTextParameters = null);
         System.Threading.Tasks.Task<string?> TranslateTextKey(string key, Altinn.App.Core.Features.IInstanceDataAccessor instanceDataAccessor, Altinn.App.Core.Models.Expressions.ComponentContext? context = null, System.Collections.Generic.Dictionary<string, string>? customTextParameters = null);

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -1195,6 +1195,8 @@ namespace Altinn.App.Core.Features
         System.Collections.Generic.IReadOnlyDictionary<Altinn.Platform.Storage.Interface.Models.DataType, Altinn.App.Core.Features.StorageAuthenticationMethod> AuthenticationMethodOverrides { get; }
         System.Collections.Generic.IReadOnlyCollection<Altinn.Platform.Storage.Interface.Models.DataType> DataTypes { get; }
         Altinn.Platform.Storage.Interface.Models.Instance Instance { get; }
+        string? Language { get; }
+        string? TaskId { get; }
         System.Threading.Tasks.Task<System.ReadOnlyMemory<byte>> GetBinaryData(Altinn.App.Core.Models.DataElementIdentifier dataElementIdentifier);
         Altinn.App.Core.Features.IInstanceDataAccessor GetCleanAccessor(Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption = 1);
         Altinn.Platform.Storage.Interface.Models.DataElement GetDataElement(Altinn.App.Core.Models.DataElementIdentifier dataElementIdentifier);

--- a/test/Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj
+++ b/test/Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing"/>
+    <PackageReference Include="Moq" />
     <PackageReference Include="Verify.Xunit"/>
     <PackageReference Include="Verify.Http"/>
     <PackageReference Include="xunit.assert"/>

--- a/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
+++ b/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
@@ -1,0 +1,286 @@
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using System.Xml;
+using System.Xml.Serialization;
+using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Internal.AppModel;
+using Altinn.App.Core.Internal.Auth;
+using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Language;
+using Altinn.App.Core.Internal.Texts;
+using Altinn.App.Core.Internal.Validation;
+using Altinn.App.Core.Models;
+using Altinn.App.Core.Models.Expressions;
+using Altinn.App.Core.Models.Layout;
+using Altinn.App.Core.Models.Layout.Components;
+using Altinn.App.Core.Models.Layout.Components.Base;
+using Altinn.App.Tests.Common.Mocks;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit.Abstractions;
+
+namespace Altinn.App.Tests.Common.Fixtures;
+
+public class MockedServiceCollection
+{
+    public const string Org = "ttd";
+    public const string App = "test";
+
+    public PlatformSettings PlatformSettings { get; } = new PlatformSettings();
+    public AppSettings AppSettings { get; } = new AppSettings();
+    public GeneralSettings GeneralSettings { get; } = new GeneralSettings();
+
+    public ApplicationMetadata AppMetadata { get; } =
+        new($"{Org}/{App}")
+        {
+            Title = new() { [LanguageConst.Nb] = "Testapplikasjon", [LanguageConst.En] = "Test Application" },
+            DataTypes = [],
+        };
+
+    public StorageClientInterceptor Storage { get; } = new();
+
+    public Mock<IAppResources> AppResourcesMock { get; } = new(MockBehavior.Strict);
+    public Mock<IAppMetadata> AppMetadataMock { get; } = new(MockBehavior.Strict);
+    public Mock<IAppModel> AppModelMock { get; } = new(MockBehavior.Strict);
+
+    internal Mock<IAuthenticationTokenResolver> AuthenticationTokenResolverMock { get; } = new(MockBehavior.Strict);
+
+    public Mock<IUserTokenProvider> UserTokenProviderMock { get; } = new(MockBehavior.Strict);
+
+    private readonly IServiceCollection _services = new ServiceCollection();
+
+    public MockedServiceCollection()
+    {
+        _services.AddSingleton(this);
+    }
+
+    public void AddXunitLogging(ITestOutputHelper outputHelper)
+    {
+        FakeLoggerXunit.AddFakeLoggingWithXunit(_services, outputHelper);
+    }
+
+    public void TryAddCommonServices()
+    {
+        AppImplementationFactoryExtensions.AddAppImplementationFactory(_services);
+
+        // Adding options
+        ServiceCollectionDescriptorExtensions.TryAddSingleton(_services, Options.Create(PlatformSettings));
+        ServiceCollectionDescriptorExtensions.TryAddSingleton(_services, Options.Create(AppSettings));
+        ServiceCollectionDescriptorExtensions.TryAddSingleton(_services, Options.Create(GeneralSettings));
+
+        ServiceCollectionDescriptorExtensions.TryAddSingleton(_services, new AppIdentifier(Org, App));
+
+        // Adding Validation infrastructure
+        ServiceCollectionDescriptorExtensions.TryAddSingleton<IValidationService, ValidationService>(_services);
+        ServiceCollectionDescriptorExtensions.TryAddSingleton<IValidatorFactory, ValidatorFactory>(_services);
+
+        // Adding Translation infrastructure
+        ServiceCollectionDescriptorExtensions.TryAddSingleton<ITranslationService, TranslationService>(_services);
+
+        // InstanceDataUnitOfWork
+        ServiceCollectionDescriptorExtensions.TryAddSingleton<InstanceDataUnitOfWorkInitializer>(_services);
+        ServiceCollectionDescriptorExtensions.TryAddSingleton<ModelSerializationService>(_services);
+
+        // Just add the httpClients without a branch
+        Storage.AddStorageClients(_services);
+
+        // Ensure logging is present
+        var hasLogger = Enumerable.Any<ServiceDescriptor>(_services, s => s.ServiceType == typeof(ILoggerFactory));
+        if (!hasLogger)
+        {
+            ServiceCollectionServiceExtensions.AddSingleton<ILoggerFactory>(_services, NullLoggerFactory.Instance);
+        }
+
+        // Add standard mocks
+        ServiceCollectionDescriptorExtensions.TryAddSingleton(_services, AppResourcesMock.Object);
+        ServiceCollectionDescriptorExtensions.TryAddSingleton(_services, AppMetadataMock.Object);
+        ServiceCollectionDescriptorExtensions.TryAddSingleton(_services, AppModelMock.Object);
+        ServiceCollectionDescriptorExtensions.TryAddSingleton(_services, AuthenticationTokenResolverMock.Object);
+        ServiceCollectionDescriptorExtensions.TryAddSingleton(_services, UserTokenProviderMock.Object);
+
+        // Setup default mock behaviours
+        AppMetadataMock.Setup(a => a.GetApplicationMetadata()).ReturnsAsync(AppMetadata);
+        AuthenticationTokenResolverMock
+            .Setup(a => a.GetAccessToken(It.IsAny<AuthenticationMethod>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new JwtToken());
+        UserTokenProviderMock.Setup(utp => utp.GetUserToken()).Returns("[userToken]");
+        AppResourcesMock
+            .Setup(a => a.GetTexts(Org, App, It.IsAny<String>()))
+            .ReturnsAsync(
+                (string _, string _, string language) =>
+                {
+                    lock (_textResources)
+                    {
+                        return _textResources.GetValueOrDefault(language);
+                    }
+                }
+            );
+    }
+
+    private static byte[] SerializeXml<T>(T model)
+        where T : class, new()
+    {
+        XmlWriterSettings xmlWriterSettings = new XmlWriterSettings()
+        {
+            Encoding = new UTF8Encoding(false),
+            NewLineHandling = NewLineHandling.None,
+        };
+        using var memoryStream = new MemoryStream();
+        using XmlWriter xmlWriter = XmlWriter.Create(memoryStream, xmlWriterSettings);
+
+        XmlSerializer serializer = new XmlSerializer(model.GetType());
+        serializer.Serialize(xmlWriter, model);
+        return memoryStream.ToArray();
+    }
+
+    public void AddDataType(DataType dataType)
+    {
+        lock (AppMetadata.DataTypes)
+        {
+            AppMetadata.DataTypes.Add(dataType);
+        }
+    }
+
+    public void AddDataType<T>(DataType dataType)
+        where T : class, new()
+    {
+        var classRef =
+            typeof(T).FullName
+            ?? throw new InvalidOperationException("DataType for formData does not have a ClassRef defined.");
+
+        dataType.AppLogic ??= new();
+        dataType.AppLogic.ClassRef = classRef;
+
+        AppModelMock.Setup(a => a.GetModelType(classRef)).Returns(typeof(T));
+        AppModelMock.Setup(a => a.Create(classRef)).Returns(new T());
+
+        AddDataType(dataType);
+    }
+
+    private readonly Dictionary<string, TextResource> _textResources = new();
+
+    public void AddTextResource(string language, TextResourceElement textResource)
+    {
+        lock (_textResources)
+        {
+            _textResources.TryAdd(
+                language,
+                new()
+                {
+                    Id = $"{Org}-{App}-{language}",
+                    Org = Org,
+                    Language = language,
+                    Resources = [],
+                }
+            );
+            _textResources[language].Resources.Add(textResource);
+        }
+    }
+
+    public ServiceProvider BuildServiceProvider() =>
+        ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(_services);
+}
+
+public static class MockedServiceProviderExtensions
+{
+    internal static async Task<InstanceDataUnitOfWork> CreateInstanceDataMutatorWithDataAndLayout<T>(
+        this ServiceProvider serviceProvider,
+        T model,
+        List<BaseComponent> components,
+        string? language
+    )
+        where T : class, new()
+    {
+        var appServices = serviceProvider.GetRequiredService<MockedServiceCollection>();
+        var instanceGuid = Guid.NewGuid();
+        var dataGuid = Guid.NewGuid();
+        var partyId = 123456;
+        var dataTypeId = typeof(T).Name.ToLowerInvariant();
+        var layoutSetName = "layoutSet1";
+        var taskId = "Task_1";
+        var pages = components
+            .GroupBy(c => c.PageId)
+            .Select(group => new PageComponent
+            {
+                Id = group.Key,
+                PageId = group.Key,
+                LayoutId = layoutSetName,
+                Type = "page",
+                Components = group.ToList(),
+                Hidden = default,
+                RemoveWhenHidden = default,
+                Required = default,
+                ReadOnly = default,
+                DataModelBindings = ImmutableDictionary<string, ModelBinding>.Empty,
+                TextResourceBindings = ImmutableDictionary<string, Expression>.Empty,
+            });
+
+        DataType defaultDataType = new()
+        {
+            Id = dataTypeId,
+            MaxCount = 1,
+            AllowedContentTypes = ["application/xml"],
+        };
+
+        appServices.AddDataType<T>(defaultDataType);
+
+        var layoutModel = new LayoutModel(
+            [new LayoutSetComponent(pages.ToList(), layoutSetName, defaultDataType)],
+            new LayoutSet()
+            {
+                DataType = defaultDataType.Id,
+                Id = layoutSetName,
+                Tasks = [taskId],
+            }
+        );
+        appServices.AppResourcesMock.Setup(a => a.GetLayoutModelForTask(taskId)).Returns(layoutModel);
+
+        var data = new DataElement()
+        {
+            Id = dataGuid.ToString(),
+            InstanceGuid = instanceGuid.ToString(),
+            DataType = defaultDataType.Id,
+        };
+        var instance = new Instance()
+        {
+            Id = $"{partyId}/{instanceGuid}",
+            AppId = $"{MockedServiceCollection.Org}/{MockedServiceCollection.App}",
+            InstanceOwner = new InstanceOwner() { PartyId = partyId.ToString() },
+            Data = [data],
+            Process = new() { CurrentTask = new() { ElementId = taskId } },
+        };
+
+        appServices.Storage.AddInstance(instance);
+        appServices.Storage.AddData(dataGuid, SerializeXml(model));
+
+        var instanceCopy = JsonSerializer.Deserialize<Instance>(JsonSerializer.SerializeToUtf8Bytes(instance))!;
+
+        var initializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
+        return await initializer.Init(instanceCopy, taskId, language);
+    }
+
+    private static byte[] SerializeXml<T>(T model)
+        where T : class, new()
+    {
+        XmlWriterSettings xmlWriterSettings = new XmlWriterSettings()
+        {
+            Encoding = new UTF8Encoding(false),
+            NewLineHandling = NewLineHandling.None,
+        };
+        using var memoryStream = new MemoryStream();
+        using XmlWriter xmlWriter = XmlWriter.Create(memoryStream, xmlWriterSettings);
+
+        XmlSerializer serializer = new XmlSerializer(model.GetType());
+        serializer.Serialize(xmlWriter, model);
+        return memoryStream.ToArray();
+    }
+}

--- a/test/Altinn.App.Tests.Common/Fixtures/StorageClientInterceptor.cs
+++ b/test/Altinn.App.Tests.Common/Fixtures/StorageClientInterceptor.cs
@@ -1,0 +1,136 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using Altinn.App.Core.Infrastructure.Clients.Storage;
+using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Internal.Instances;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Altinn.App.Tests.Common.Mocks;
+
+public class StorageClientInterceptor : HttpMessageHandler
+{
+    public void AddStorageClients(IServiceCollection services)
+    {
+        services.AddHttpClient<IDataClient, DataClient>().ConfigurePrimaryHttpMessageHandler(() => this);
+        services.AddHttpClient<IInstanceClient, InstanceClient>().ConfigurePrimaryHttpMessageHandler(() => this);
+    }
+
+    private ConcurrentDictionary<string, Instance> _instances = new();
+    private ConcurrentDictionary<Guid, byte[]> _data = new();
+
+    public void AddInstance(Instance instance)
+    {
+        _instances[instance.Id] = instance;
+    }
+
+    public void AddData(Guid dataId, byte[] data)
+    {
+        _data[dataId] = data;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        var requestBody = request.Content is not null
+            ? await request.Content.ReadAsByteArrayAsync(cancellationToken)
+            : null;
+
+        return (request.Method.Method, request.RequestUri?.AbsolutePath.Trim('/').Split('/')) switch
+        {
+            ("GET", { } path) when TryParseInstanceUrl(path, out int partyId, out Guid instanceGuid) => GetInstance(
+                partyId,
+                instanceGuid
+            ),
+            ("GET", { } path) when TryParseDataUrl(path, out int partyId, out Guid instanceGuid, out Guid dataId) =>
+                GetData(partyId, instanceGuid, dataId),
+            var (method, _) => throw new Exception(
+                $"Unhandled request to {request.RequestUri?.AbsolutePath} with method {method} and body\n\n{(requestBody is not null ? System.Text.Encoding.UTF8.GetString(requestBody) : "[no body]")}"
+            ),
+        };
+    }
+
+    private HttpResponseMessage GetData(int partyId, Guid instanceGuid, Guid dataId)
+    {
+        if (!_instances.TryGetValue($"{partyId}/{instanceGuid}", out Instance? instance))
+        {
+            return new HttpResponseMessage(System.Net.HttpStatusCode.NotFound)
+            {
+                Content = new StringContent($"Instance with id {instanceGuid} not found"),
+            };
+        }
+        var dataElement = instance.Data.FirstOrDefault(de => de.Id == dataId.ToString());
+        if (dataElement == null)
+        {
+            return new HttpResponseMessage(System.Net.HttpStatusCode.NotFound)
+            {
+                Content = new StringContent($"Data element with id {dataId} not found in instance {instanceGuid}"),
+            };
+        }
+
+        if (!_data.TryGetValue(dataId, out var storedData))
+        {
+            return new HttpResponseMessage(System.Net.HttpStatusCode.NotFound)
+            {
+                Content = new StringContent($"Data with id {dataId} not found"),
+            };
+        }
+        return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(storedData)
+            {
+                Headers =
+                {
+                    ContentType = new MediaTypeHeaderValue(dataElement.ContentType ?? "application/octet-stream"),
+                },
+            },
+        };
+    }
+
+    private HttpResponseMessage GetInstance(int partyId, Guid instanceGuid)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool TryParseInstanceUrl(string[] pathSegments, out int instanceOwnerPartyId, out Guid instanceGuid)
+    {
+        if (
+            pathSegments is ["storage", "api", "v1", "instances", var partyIdStr, var instanceGuidStr]
+            && int.TryParse(partyIdStr, out instanceOwnerPartyId)
+            && Guid.TryParse(instanceGuidStr, out instanceGuid)
+        )
+        {
+            return true;
+        }
+
+        instanceOwnerPartyId = 0;
+        instanceGuid = Guid.Empty;
+        return false;
+    }
+
+    public bool TryParseDataUrl(
+        string[] pathSegments,
+        out int instanceOwnerPartyId,
+        out Guid instanceGuid,
+        out Guid dataId
+    )
+    {
+        if (
+            pathSegments
+                is ["storage", "api", "v1", "instances", var partyIdStr, var instanceGuidStr, "data", var dataIdStr]
+            && int.TryParse(partyIdStr, out instanceOwnerPartyId)
+            && Guid.TryParse(instanceGuidStr, out instanceGuid)
+            && Guid.TryParse(dataIdStr, out dataId)
+        )
+        {
+            return true;
+        }
+
+        instanceOwnerPartyId = 0;
+        instanceGuid = Guid.Empty;
+        dataId = Guid.Empty;
+        return false;
+    }
+}


### PR DESCRIPTION
A few minor improvements to `ITranslationService` divided into a few separate commits

* Add Language and TaskId as public properties on IInstanceDataAccessor
   These should probably have been public before, and this is a good time as ever to do it.
* Add custom handling of "appName" with fallback to "ServiceName" and AppId
   Every time you read "appName" you need to ensure the fallback, so add this in translation service
* Add internal GetLayoutEvaluatorState on IInstanceDataAccessor so that dataAccessor can substitute for state
   In the long term I expect `LayoutEvaluatorState` to be deprecated in favour of `IInstanceDataAccessor`, but currently that is too much work. This makes it possible to pretend the accessor is enough.
* Use ITranslationService in PdfService
   The fallback for appName and default text resources made this pretty simple


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instance data accessors now expose TaskId and Language for context-aware rendering.
  * Translation API gained an overload accepting instance context for richer variable substitution.
  * Expressions can render values specifically for text output (text-friendly conversion).

* **Improvements**
  * PDF generation and previews use the translation service for filenames, footers and content for better localization.
  * Translation rendering is more language-aware and supports cross-language variable resolution and defaults.

* **Tests**
  * Tests and fixtures updated to cover translation-driven PDF behavior and instance-aware translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->