### PR TITLE
Fix gateway expression evaluation crash with invalid data element identifiers

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -285,10 +285,13 @@ public class LayoutEvaluatorState
             return defaultDataElementIdentifier;
         }
         // If the data element has the same type as default, return it
-        var defaultDataType = _dataAccessor.GetDataType(defaultDataElementIdentifier);
-        if (defaultDataType.Id == key.DataType)
+        if (defaultDataElementIdentifier.Guid != Guid.Empty)
         {
-            return defaultDataElementIdentifier;
+            var defaultDataType = _dataAccessor.GetDataType(defaultDataElementIdentifier);
+            if (defaultDataType.Id == key.DataType)
+            {
+                return defaultDataElementIdentifier;
+            }
         }
 
         // Return the correct element if the data type has a single element on the instance and MaxCount == 1


### PR DESCRIPTION
## Summary
Fixes a crash when evaluating gateway expressions in tasks without a layout-set (e.g., feedback tasks). The error manifested as:
```
System.InvalidOperationException: Data element of id  not found on instance with id <instance-id>
```

## The Bug
This issue was introduced in **v8.6.1** via PR #1310 (commit acbc651) which added support for explicit `dataType` references in subform expressions. The new code added a check that called `GetDataType(defaultDataElementIdentifier)` without first validating that the identifier was valid.

### Reproduction Scenario
1. App is in a task with **no layout-set** (e.g., `Task_3`, a feedback task in `ttd/stateless-app`), meaning no default data type.
2. Gateway has a conditional expression that references data from another task:
   ```xml
   <bpmn:conditionExpression>
       ["equals", ["dataModel", "gatewayShouldFail", "data-model-from-task2"], true]
   </bpmn:conditionExpression>
   ```
3. When calling `process/next`, the gateway evaluation crashes

### Root Cause
**In `ExpressionsExclusiveGateway.cs:91-92`:**
```csharp
DataElementIdentifier dataElement = 
    instance.Data.Find(d => d.DataType == dataTypeId) ?? new DataElementIdentifier();
```
When the current task has no data type, this creates an **invalid** `DataElementIdentifier` with:
- `Guid = Guid.Empty`
- `Id = null` (displays as empty string)
- `DataTypeId = null`

**In `LayoutEvaluatorState.cs:288` (before fix):**
```csharp
var defaultDataType = _dataAccessor.GetDataType(defaultDataElementIdentifier);
```
This line unconditionally tried to use the invalid identifier, calling `GetDataElement(dataElementIdentifier)` which threw the exception.

## The Fix
Added a validation check in `LayoutEvaluatorState.ResolveDataElementIdentifier()` to ensure the `defaultDataElementIdentifier` is valid before attempting to use it:

```csharp
if (defaultDataElementIdentifier.Guid != Guid.Empty)
{
    var defaultDataType = _dataAccessor.GetDataType(defaultDataElementIdentifier);
    if (defaultDataType.Id == key.DataType)
    {
        return defaultDataElementIdentifier;
    }
}
```

This allows the code to gracefully skip invalid default identifiers and continue resolving the explicitly requested data type from the expression.

## Testing
- Verified that gateway expressions with explicit data type references now work in tasks without layout-sets (by running frontend Cypress e2e tests against latest app-lib)
- Existing tests continue to pass

## Related
- Fixes regression from v8.6.1
- Fixes regression from PR #1310 (commit acbc651)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected selection of the default data element to apply only when a valid identifier is present, preventing unintended matches.
  * Reduces unexpected errors when opening or continuing forms and improves reliability of initial/prefilled data.
  * Enhances stability in apps with multiple form data types, minimizing edge-case failures and confusing validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->