### PR TITLE
Fix source generator to behave better with List<string> and List<int?>

### DIFF
--- a/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
+++ b/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
@@ -4,7 +4,7 @@ using NanoJsonReader;
 
 namespace Altinn.App.Analyzers;
 
-internal static class FormDataWrapperUtils
+public static class FormDataWrapperUtils
 {
     public static bool IsApplicationMetadataFile(AdditionalText text)
     {
@@ -114,25 +114,6 @@ internal static class FormDataWrapperUtils
         return rootClasses;
     }
 
-    public sealed record Result<T>(T? Value, List<Diagnostic> Diagnostics)
-        where T : class
-    {
-        public Result(Diagnostic diagnostics)
-            : this(null, [diagnostics]) { }
-
-        public Result(T value)
-            : this(value, []) { }
-    };
-
-    public sealed record ModelClassOrDiagnostic(string? ClassName, Location? Location, List<Diagnostic> Diagnostics)
-    {
-        public ModelClassOrDiagnostic(Diagnostic diagnostic)
-            : this(null, null, new([diagnostic])) { }
-
-        public ModelClassOrDiagnostic(string className, Location? location)
-            : this(className, location, []) { }
-    };
-
     public static ModelPathNode? CreateRootSymbolNode(
         string classFullName,
         Compilation compilation,
@@ -149,16 +130,23 @@ internal static class FormDataWrapperUtils
             "",
             "",
             SourceReaderUtils.TypeSymbolToString(rootSymbol),
-            isImmutableValue: false,
             GetNodeProperties(rootSymbol, diagnostics)
         );
     }
 
-    public static EquatableArray<ModelPathNode>? GetNodeProperties(
-        INamedTypeSymbol namedTypeSymbol,
-        List<Diagnostic> diagnostics
-    )
+    private static ModelPathNode[]? GetNodeProperties(ITypeSymbol typeSymbol, List<Diagnostic> diagnostics)
     {
+        if (typeSymbol is not INamedTypeSymbol namedTypeSymbol)
+        {
+            return null;
+        }
+
+        // If this is a JSON value type, we do not want to explore its properties
+        if (IsJsonValueType(namedTypeSymbol.ContainingNamespace?.ToDisplayString(), namedTypeSymbol.Name))
+        {
+            return null;
+        }
+
         var nodeProperties = new List<ModelPathNode>();
         foreach (var property in namedTypeSymbol.GetMembers().OfType<IPropertySymbol>())
         {
@@ -178,41 +166,70 @@ internal static class FormDataWrapperUtils
                 ? null
                 : SourceReaderUtils.TypeSymbolToString(propertyCollectionTypeSymbol);
 
-            // TODO: Find a better way to identify "value types" than to check for System namespace
-            // this works because the only value types we expect are numbers, datatimes, bools and strings,
-            // all defined in System namespace
-            //
-            if (
-                propertyTypeSymbol is INamedTypeSymbol propertyNamedTypeSymbol
-                && !propertyNamedTypeSymbol.ContainingNamespace.ToString().StartsWith("System")
-            )
+            var subProperties = GetNodeProperties(propertyTypeSymbol, diagnostics);
+
+            nodeProperties.Add(
+                new ModelPathNode(cSharpName, jsonName, typeString, subProperties, collectionTypeString)
+            );
+        }
+        return nodeProperties.ToArray();
+    }
+
+    // <summary>
+    // Determine if the given symbol represents something that System.Text.Json can serialize as a JSON value
+    // (primitive types, string, DateTime, Guid, Uri)
+    // </summary>
+    // <remarks>
+    // Based on https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/supported-types#supported-key-types
+    // </remarks>
+    public static bool IsJsonValueType(string? ns, string name)
+    {
+        if (ns == "System")
+        {
+            return name switch
             {
-                nodeProperties.Add(
-                    new ModelPathNode(
-                        cSharpName,
-                        jsonName,
-                        typeString,
-                        isImmutableValue: false,
-                        GetNodeProperties(propertyNamedTypeSymbol, diagnostics),
-                        collectionTypeString
-                    )
-                );
-            }
-            else
+                "Boolean"
+                or "Byte"
+                or "DateTime"
+                or "DateTimeOffset"
+                or "Decimal"
+                or "Double"
+                or "Enum"
+                or "Guid"
+                or "Int16"
+                or "Int32"
+                or "Int64"
+                or "SByte"
+                or "Single"
+                or "String"
+                or "TimeSpan"
+                or "UInt16"
+                or "UInt32"
+                or "UInt64"
+                or "Uri"
+                or "Version" => true,
+                _ => false,
+            };
+        }
+
+        if (ns == "System.Text.Json")
+        {
+            if (name is "JsonElement" or "JsonDocument")
             {
-                nodeProperties.Add(
-                    new ModelPathNode(
-                        cSharpName,
-                        jsonName,
-                        typeString,
-                        isImmutableValue: true,
-                        null,
-                        collectionTypeString
-                    )
-                );
+                return true;
             }
         }
-        return nodeProperties;
+
+        if (ns == "System.Text.Json.Nodes" && name == "JsonNode")
+        {
+            return true;
+        }
+
+        // TODO: Add support for other types that System.Text.Json can serialize as JSON values,
+        // In addition, the JsonConverter<T>.WriteAsPropertyName(Utf8JsonWriter, T, JsonSerializerOptions)
+        // and JsonConverter<T>.ReadAsPropertyName(Utf8JsonReader, Type, JsonSerializerOptions) methods let
+        // you add dictionary key support for any type of your choosing.
+        return false;
     }
 
     private static bool PropertyShouldBeSkipped(IPropertySymbol property)

--- a/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
+++ b/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
@@ -149,6 +149,7 @@ internal static class FormDataWrapperUtils
             "",
             "",
             SourceReaderUtils.TypeSymbolToString(rootSymbol),
+            isImmutableValue: false,
             GetNodeProperties(rootSymbol, diagnostics)
         );
     }
@@ -177,6 +178,10 @@ internal static class FormDataWrapperUtils
                 ? null
                 : SourceReaderUtils.TypeSymbolToString(propertyCollectionTypeSymbol);
 
+            // TODO: Find a better way to identify "value types" than to check for System namespace
+            // this works because the only value types we expect are numbers, datatimes, bools and strings,
+            // all defined in System namespace
+            //
             if (
                 propertyTypeSymbol is INamedTypeSymbol propertyNamedTypeSymbol
                 && !propertyNamedTypeSymbol.ContainingNamespace.ToString().StartsWith("System")
@@ -187,6 +192,7 @@ internal static class FormDataWrapperUtils
                         cSharpName,
                         jsonName,
                         typeString,
+                        isImmutableValue: false,
                         GetNodeProperties(propertyNamedTypeSymbol, diagnostics),
                         collectionTypeString
                     )
@@ -194,7 +200,16 @@ internal static class FormDataWrapperUtils
             }
             else
             {
-                nodeProperties.Add(new ModelPathNode(cSharpName, jsonName, typeString, null, collectionTypeString));
+                nodeProperties.Add(
+                    new ModelPathNode(
+                        cSharpName,
+                        jsonName,
+                        typeString,
+                        isImmutableValue: true,
+                        null,
+                        collectionTypeString
+                    )
+                );
             }
         }
         return nodeProperties;

--- a/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
+++ b/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
@@ -182,55 +182,35 @@ public static class FormDataWrapperUtils
     // <remarks>
     // Based on https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/supported-types#supported-key-types
     // </remarks>
-    public static bool IsJsonValueType(string? ns, string name)
-    {
-        if (ns == "System")
+    public static bool IsJsonValueType(string? ns, string name) =>
+        ns switch
         {
-            return name switch
-            {
-                "Boolean"
-                or "Byte"
-                or "DateTime"
-                or "DateTimeOffset"
-                or "Decimal"
-                or "Double"
-                or "Enum"
-                or "Guid"
-                or "Int16"
-                or "Int32"
-                or "Int64"
-                or "SByte"
-                or "Single"
-                or "String"
-                or "TimeSpan"
-                or "UInt16"
-                or "UInt32"
-                or "UInt64"
-                or "Uri"
-                or "Version" => true,
-                _ => false,
-            };
-        }
-
-        if (ns == "System.Text.Json")
-        {
-            if (name is "JsonElement" or "JsonDocument")
-            {
-                return true;
-            }
-        }
-
-        if (ns == "System.Text.Json.Nodes" && name == "JsonNode")
-        {
-            return true;
-        }
-
-        // TODO: Add support for other types that System.Text.Json can serialize as JSON values,
-        // In addition, the JsonConverter<T>.WriteAsPropertyName(Utf8JsonWriter, T, JsonSerializerOptions)
-        // and JsonConverter<T>.ReadAsPropertyName(Utf8JsonReader, Type, JsonSerializerOptions) methods let
-        // you add dictionary key support for any type of your choosing.
-        return false;
-    }
+            "System"
+                when name
+                    is "Boolean"
+                        or "Byte"
+                        or "DateTime"
+                        or "DateTimeOffset"
+                        or "Decimal"
+                        or "Double"
+                        or "Enum"
+                        or "Guid"
+                        or "Int16"
+                        or "Int32"
+                        or "Int64"
+                        or "SByte"
+                        or "Single"
+                        or "String"
+                        or "TimeSpan"
+                        or "UInt16"
+                        or "UInt32"
+                        or "UInt64"
+                        or "Uri"
+                        or "Version" => true,
+            // "System.Text.Json" when name is "JsonElement" or "JsonDocument" => true,
+            // "System.Text.Json.Nodes" when name is "JsonNode" => true,
+            _ => false,
+        };
 
     private static bool PropertyShouldBeSkipped(IPropertySymbol property)
     {

--- a/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
+++ b/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
@@ -175,13 +175,13 @@ public static class FormDataWrapperUtils
         return nodeProperties.ToArray();
     }
 
-    // <summary>
-    // Determine if the given symbol represents something that System.Text.Json can serialize as a JSON value
-    // (primitive types, string, DateTime, Guid, Uri)
-    // </summary>
-    // <remarks>
-    // Based on https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/supported-types#supported-key-types
-    // </remarks>
+    /// <summary>
+    /// Determine if the given symbol represents something that System.Text.Json can serialize as a JSON value
+    /// (primitive types, string, DateTime, Guid, Uri)
+    /// </summary>
+    /// <remarks>
+    /// Based on https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/supported-types#supported-key-types
+    /// </remarks>
     public static bool IsJsonValueType(string? ns, string name) =>
         ns switch
         {

--- a/src/Altinn.App.Analyzers/ModelPathNode.cs
+++ b/src/Altinn.App.Analyzers/ModelPathNode.cs
@@ -17,8 +17,7 @@ public record ModelPathNode
         string cSharpName,
         string jsonName,
         string typeName,
-        bool isImmutableValue,
-        EquatableArray<ModelPathNode>? properties = null,
+        ModelPathNode[]? properties = null,
         string? listType = null
     )
     {
@@ -26,8 +25,8 @@ public record ModelPathNode
         JsonName = jsonName;
         ListType = listType;
         TypeName = typeName;
-        IsImmutableValue = isImmutableValue;
-        Properties = properties ?? EquatableArray<ModelPathNode>.Empty;
+        IsJsonValueType = properties is null;
+        Properties = properties ?? [];
     }
 
     /// <summary>
@@ -73,7 +72,7 @@ public record ModelPathNode
     /// <summary>
     /// Indicates whether the type represented by this node is to be treated as primitive immutable value.
     /// </summary>
-    public bool IsImmutableValue { get; }
+    public bool IsJsonValueType { get; }
 
     /// <summary>
     /// The sub properties of this node.

--- a/src/Altinn.App.Analyzers/ModelPathNode.cs
+++ b/src/Altinn.App.Analyzers/ModelPathNode.cs
@@ -17,6 +17,7 @@ public record ModelPathNode
         string cSharpName,
         string jsonName,
         string typeName,
+        bool isImmutableValue,
         EquatableArray<ModelPathNode>? properties = null,
         string? listType = null
     )
@@ -25,6 +26,7 @@ public record ModelPathNode
         JsonName = jsonName;
         ListType = listType;
         TypeName = typeName;
+        IsImmutableValue = isImmutableValue;
         Properties = properties ?? EquatableArray<ModelPathNode>.Empty;
     }
 
@@ -67,6 +69,11 @@ public record ModelPathNode
     /// We assume this is a subtype of <see cref="ICollection{T}"/>
     /// </remarks>
     public string? ListType { get; }
+
+    /// <summary>
+    /// Indicates whether the type represented by this node is to be treated as primitive immutable value.
+    /// </summary>
+    public bool IsImmutableValue { get; }
 
     /// <summary>
     /// The sub properties of this node.

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/AddIndexToPathGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/AddIndexToPathGenerator.cs
@@ -90,7 +90,7 @@ internal static class AddIndexToPathGenerator
                                         buffer[bufferOffset++] = '[';
                                         if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
                                         {
-                                            throw new global::System.FormatException($"Invalid index in {path}.");
+                                            throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
                                         }
 
                                         bufferOffset += charsWritten;
@@ -101,7 +101,10 @@ internal static class AddIndexToPathGenerator
                                     {
                                         // Write index from rowIndexes to buffer
                                         buffer[bufferOffset++] = '[';
-                                        rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                                        if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                                        {
+                                            throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
+                                        }
                                         bufferOffset += charsWritten;
                                         buffer[bufferOffset++] = ']';
                                         rowIndexes = rowIndexes.Slice(1);

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/CopyGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/CopyGenerator.cs
@@ -32,6 +32,12 @@ internal static class CopyGenerator
             // Ignore repeated types
             return;
         }
+
+        if (node.IsImmutableValue)
+        {
+            // Copy of value types is an assignment and is handled in the list copy method
+            return;
+        }
         builder.Append(
             $$"""
 
@@ -50,6 +56,7 @@ internal static class CopyGenerator
         );
         if (node.Properties.Count == 0)
         {
+            // A class with no properties prints prettier without an empty initializer list
             builder.Append("        return new();\r\n    }\r\n");
         }
         else
@@ -58,16 +65,23 @@ internal static class CopyGenerator
             foreach (var property in node.Properties)
             {
                 builder.Append(
-                    property.Properties.Count == 0
-                        ? $"            {property.CSharpName} = data.{property.CSharpName},\r\n"
-                        : $"            {property.CSharpName} = CopyRecursive(data.{property.CSharpName}),\r\n"
+                    property switch
+                    {
+                        { ListType: not null } =>
+                            $"            {property.CSharpName} = CopyRecursive(data.{property.CSharpName}),\r\n",
+                        { Properties.Count: 0 } =>
+                            $"            {property.CSharpName} = data.{property.CSharpName},\r\n",
+                        _ => $"            {property.CSharpName} = CopyRecursive(data.{property.CSharpName}),\r\n",
+                    }
                 );
             }
 
             builder.Append("        };\r\n    }\r\n");
         }
 
-        foreach (var recursiveChild in node.Properties.Where(c => c.Properties.Count != 0))
+        foreach (
+            var recursiveChild in node.Properties.Where(c => c.ListType is not null || c.IsImmutableValue == false)
+        )
         {
             GenerateCopyRecursive(builder, recursiveChild, classNames);
         }
@@ -91,7 +105,7 @@ internal static class CopyGenerator
                     {{node.ListType}} result = new(list.Count);
                     foreach (var item in list)
                     {
-                        result.Add(CopyRecursive(item));
+                        result.Add({{(node.IsImmutableValue ? "item" : "CopyRecursive(item)")}});
                     }
 
                     return result;

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/CopyGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/CopyGenerator.cs
@@ -33,7 +33,7 @@ internal static class CopyGenerator
             return;
         }
 
-        if (node.IsImmutableValue)
+        if (node.IsJsonValueType)
         {
             // Copy of value types is an assignment and is handled in the list copy method
             return;
@@ -79,9 +79,7 @@ internal static class CopyGenerator
             builder.Append("        };\r\n    }\r\n");
         }
 
-        foreach (
-            var recursiveChild in node.Properties.Where(c => c.ListType is not null || c.IsImmutableValue == false)
-        )
+        foreach (var recursiveChild in node.Properties.Where(c => c.ListType is not null || !c.IsJsonValueType))
         {
             GenerateCopyRecursive(builder, recursiveChild, classNames);
         }
@@ -105,7 +103,7 @@ internal static class CopyGenerator
                     {{node.ListType}} result = new(list.Count);
                     foreach (var item in list)
                     {
-                        result.Add({{(node.IsImmutableValue ? "item" : "CopyRecursive(item)")}});
+                        result.Add({{(node.IsJsonValueType ? "item" : "CopyRecursive(item)")}});
                     }
 
                     return result;

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/GenerateJsonComment.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/GenerateJsonComment.cs
@@ -34,6 +34,10 @@ public static class GenerateJsonComment
         sb.Append("\"TypeName\": \"");
         sb.Append(node.TypeName);
         sb.Append("\",");
+        sb.Append(linePrefix);
+        sb.Append("\"IsImmutableValue\": \"");
+        sb.Append(node.IsImmutableValue ? "true" : "false");
+        sb.Append("\",");
         if (node.ListType != null)
         {
             sb.Append(linePrefix);

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/GenerateJsonComment.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/GenerateJsonComment.cs
@@ -35,9 +35,14 @@ public static class GenerateJsonComment
         sb.Append(node.TypeName);
         sb.Append("\",");
         sb.Append(linePrefix);
-        sb.Append("\"IsImmutableValue\": \"");
-        sb.Append(node.IsImmutableValue ? "true" : "false");
-        sb.Append("\",");
+        if (node.IsJsonValueType)
+        {
+            sb.Append("\"IsJsonValueType\": true,");
+        }
+        else
+        {
+            sb.Append("\"IsJsonValueType\": false,");
+        }
         if (node.ListType != null)
         {
             sb.Append(linePrefix);

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/GetterGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/GetterGenerator.cs
@@ -76,7 +76,7 @@ internal static class GetterGenerator
                 """
             );
         }
-        if (modelPathNode.Properties.Count == 0 || !generatedTypes.Add(modelPathNode.TypeName))
+        if (modelPathNode.IsJsonValueType || !generatedTypes.Add(modelPathNode.TypeName))
         {
             // Do not generate recursive getters for primitive types, or types already generated
             return;
@@ -117,7 +117,7 @@ internal static class GetterGenerator
         }
 
         // Return null for unknown paths
-        // Could be an exception when we have propper validation
+        // Could be an exception when we have proper validation
         builder.Append(
             """
                         // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/GetterGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/GetterGenerator.cs
@@ -44,12 +44,6 @@ internal static class GetterGenerator
         HashSet<string> generatedTypes
     )
     {
-        if (modelPathNode.Properties.Count == 0)
-        {
-            // Do not generate for primitive types
-            return;
-        }
-
         if (modelPathNode.ListType != null && generatedTypes.Add(modelPathNode.ListType))
         {
             builder.Append(
@@ -62,21 +56,29 @@ internal static class GetterGenerator
                         int offset
                     )
                     {
+                        if (literalIndex == -1)
+                        {
+                            return model;
+                        }
+
                         if (model is null || literalIndex < 0 || literalIndex >= model.Count)
                         {
                             return null;
                         }
 
-                        return GetRecursive(model[literalIndex], path, offset);
+                        {{(
+                    modelPathNode.Properties.Count == 0
+                        ? "return model[literalIndex];"
+                        : "return GetRecursive(model[literalIndex], path, offset);"
+                )}}
                     }
 
                 """
             );
         }
-
-        if (!generatedTypes.Add(modelPathNode.TypeName))
+        if (modelPathNode.Properties.Count == 0 || !generatedTypes.Add(modelPathNode.TypeName))
         {
-            // Do not generate the same type twice
+            // Do not generate recursive getters for primitive types, or types already generated
             return;
         }
 
@@ -89,9 +91,9 @@ internal static class GetterGenerator
                     int offset
                 )
                 {
-                    if(model is null)
+                    if (model is null || offset == -1)
                     {
-                        return null;
+                        return model;
                     }
 
                     return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
@@ -104,20 +106,21 @@ internal static class GetterGenerator
             builder.Append(
                 child switch
                 {
+                    { ListType: not null } =>
+                        $"            \"{child.JsonName}\" => GetRecursive(model.{child.CSharpName}, path, literalIndex, nextOffset),\r\n",
                     { Properties.Count: 0 } =>
                         $"            \"{child.JsonName}\" when nextOffset is -1 && literalIndex is -1 => model.{child.CSharpName},\r\n",
-                    { ListType: not null } =>
-                        $"            \"{child.JsonName}\" when nextOffset > -1 && literalIndex > -1 => GetRecursive(model.{child.CSharpName}, path, literalIndex, nextOffset),\r\n",
                     _ =>
-                        $"            \"{child.JsonName}\" when nextOffset > -1 && literalIndex is -1 => GetRecursive(model.{child.CSharpName}, path, nextOffset),\r\n",
+                        $"            \"{child.JsonName}\" when literalIndex is -1 => GetRecursive(model.{child.CSharpName}, path, nextOffset),\r\n",
                 }
             );
         }
 
+        // Return null for unknown paths
+        // Could be an exception when we have propper validation
         builder.Append(
             """
-                        "" => model,
-                        // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+                        // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
                         _ => null,
                     };
                 }

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/RemoveGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/RemoveGenerator.cs
@@ -44,12 +44,6 @@ internal static class RemoveGenerator
         HashSet<string> generatedTypes
     )
     {
-        if (modelPathNode.Properties.Count == 0)
-        {
-            // Do not generate for primitive types
-            return;
-        }
-
         if (modelPathNode.ListType != null && generatedTypes.Add(modelPathNode.ListType))
         {
             builder.Append(
@@ -83,14 +77,33 @@ internal static class RemoveGenerator
                                     break;
                             }
                         }
-                        else
-                        {
-                            RemoveRecursive(model[index], path, offset, rowRemovalOption);
-                        }
+                """
+            );
+            if (modelPathNode.Properties.Count > 0)
+            {
+                // Don't recurs into primitives (classes with no properties)
+                builder.Append(
+                    """
+
+                            else
+                            {
+                                RemoveRecursive(model[index], path, offset, rowRemovalOption);
+                            }
+                    """
+                );
+            }
+            builder.Append(
+                """
+
                     }
 
                 """
             );
+        }
+        if (modelPathNode.Properties.Count == 0)
+        {
+            // Do not generate for primitive types
+            return;
         }
 
         if (!generatedTypes.Add(modelPathNode.TypeName))

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/SourceTextGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/SourceTextGenerator.cs
@@ -70,7 +70,7 @@ public static class SourceTextGenerator
             $$"""
                 public static global::System.ReadOnlySpan<char> ParseSegment(global::System.ReadOnlySpan<char> path, int offset, out int nextOffset, out int literalIndex)
                 {
-                    if (offset < 0 || offset >= path.Length)
+                    if (offset < 0 || offset > path.Length)
                     {
                         throw new global::System.ArgumentOutOfRangeException(nameof(offset));
                     }
@@ -114,11 +114,19 @@ public static class SourceTextGenerator
                         throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid negative index in {path}.");
                     }
 
-                    nextOffset = offset + bracketOffset + 2;
-                    if (nextOffset >= path.Length)
+                    if (offset + bracketOffset + 1 == path.Length)
                     {
+                        // End of path
                         nextOffset = -1;
+                        return index;
                     }
+
+                    if (path[offset + bracketOffset + 1] != '.')
+                    {
+                        throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid character after closing bracket ']' in {path}. Expected '.' or end of path.");
+                    }
+
+                    nextOffset = offset + bracketOffset + 2;
 
                     return index;
                 }

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/SourceTextGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/SourceTextGenerator.cs
@@ -104,7 +104,11 @@ public static class SourceTextGenerator
                         throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Missing closing bracket ']' in {path}.");
                     }
 
-                    if (!int.TryParse(segment[..bracketOffset], out var index))
+                    if (!int.TryParse(
+                        segment[..bracketOffset],
+                        global::System.Globalization.NumberStyles.None,
+                        global::System.Globalization.CultureInfo.InvariantCulture,
+                        out var index))
                     {
                         throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid index in {path}.");
                     }

--- a/src/Altinn.App.Core/Features/Signing/Services/SigneeContextsManager.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigneeContextsManager.cs
@@ -36,7 +36,7 @@ internal sealed class SigneeContextsManager(
         }
     );
 
-    // <inheritdoc />
+    /// <inheritdoc />
     public async Task<List<SigneeContext>> GenerateSigneeContexts(
         IInstanceDataMutator instanceDataMutator,
         AltinnSignatureConfiguration signatureConfiguration,
@@ -78,7 +78,7 @@ internal sealed class SigneeContextsManager(
         return signeeContexts;
     }
 
-    // <inheritdoc />
+    /// <inheritdoc />
     public async Task<List<SigneeContext>> GetSigneeContexts(
         IInstanceDataAccessor instanceDataAccessor,
         AltinnSignatureConfiguration signatureConfiguration,

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
@@ -53,7 +53,7 @@ internal sealed class SigningService(
     private readonly ISigningCallToActionService _signingCallToActionService = signingCallToActionService;
     private const string ApplicationJsonContentType = "application/json";
 
-    // <inheritdoc />
+    /// <inheritdoc />
     public async Task<List<SigneeContext>> InitializeSignees(
         IInstanceDataMutator instanceDataMutator,
         List<SigneeContext> signeeContexts,
@@ -157,7 +157,7 @@ internal sealed class SigningService(
         return signeeContexts;
     }
 
-    // <inheritdoc />
+    /// <inheritdoc />
     public async Task<List<SigneeContext>> GetSigneeContexts(
         IInstanceDataAccessor instanceDataAccessor,
         AltinnSignatureConfiguration signatureConfiguration,
@@ -189,7 +189,7 @@ internal sealed class SigningService(
         return signeeContexts;
     }
 
-    // <inheritdoc />
+    /// <inheritdoc />
     public async Task<List<OrganizationSignee>> GetAuthorizedOrganizationSignees(
         IInstanceDataAccessor instanceDataAccessor,
         AltinnSignatureConfiguration signatureConfiguration,
@@ -217,7 +217,7 @@ internal sealed class SigningService(
         return authorizedOrganizations;
     }
 
-    // <inheritdoc />
+    /// <inheritdoc />
     public async Task AbortRuntimeDelegatedSigning(
         IInstanceDataMutator instanceDataMutator,
         AltinnSignatureConfiguration signatureConfiguration,

--- a/src/Altinn.App.Core/Internal/Pdf/IPdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/IPdfService.cs
@@ -24,7 +24,7 @@ public interface IPdfService
     /// <param name="ct">Cancellation token for when a request should be stopped before it's completed.</param>
     Task<Stream> GeneratePdf(Instance instance, string taskId, CancellationToken ct);
 
-    // <inheritdoc cref="GeneratePdf(Instance, string, CancellationToken)" select="summary"/>
+    /// <inheritdoc cref="GeneratePdf(Instance, string, CancellationToken)" select="summary"/>
     /// <param name="instance">
     ///   <inheritdoc cref="GeneratePdf(Instance, string, CancellationToken)" path="/param[@name='instance']"/>
     /// </param>

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/Models/Skjema.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/Models/Skjema.cs
@@ -55,6 +55,10 @@ public class Adresse
 
     [JsonPropertyName("poststed")]
     public string? Poststed { get; set; }
+
+    // List of string is invalid in altinn datamodels, but might be used for backend purposes and must compile
+    [JsonPropertyName("tags")]
+    public List<string>? Tags { get; set; }
 }
 
 public class Empty { }

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestFormDataWrapperFactory.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestFormDataWrapperFactory.cs
@@ -26,6 +26,10 @@ public class TestFormDataWrapperFactory(ITestOutputHelper testOutputHelper)
         Assert.NotNull(result);
         Assert.Equal(model, result);
 
+        // Try to force garbage collection to get a better measurement of second execution
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
         // Measure second execution time
         stopwatch.Restart();
         var wrapper2 = FormDataWrapperFactory.Create(model);
@@ -37,6 +41,6 @@ public class TestFormDataWrapperFactory(ITestOutputHelper testOutputHelper)
 
         // Assert that the second execution is very fast (due to caching)
         // Would like to assert lower, but lets be conservative to avoid flaky tests
-        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromMilliseconds(2));
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromMilliseconds(1));
     }
 }

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGeneratedCopy.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGeneratedCopy.cs
@@ -58,6 +58,7 @@ public class TestGeneratedCopy
                             Gate = "TidligereGata2",
                             Postnummer = 1235,
                             Poststed = "TidligereSted2",
+                            Tags = ["Tag1", "Tag2"],
                         },
                     ],
                 },
@@ -86,13 +87,20 @@ public class TestGeneratedCopy
 
         // Modifications to the copy should not affect the original
 
+        Assert.Equal("1", data.Skjemaversjon);
         copy.Skjemaversjon = "Changed";
         Assert.Equal("1", data.Skjemaversjon);
 
+        Assert.Null(data.Skjemainnhold![1]!.Adresse!.Postnummer);
         copy.Skjemainnhold![1]!.Adresse!.Postnummer = 9999;
         Assert.Null(data.Skjemainnhold![1]!.Adresse!.Postnummer);
 
+        Assert.Equal("TidligereGata", data.Skjemainnhold![1]!.TidligereAdresse![0]!.Gate);
         copy.Skjemainnhold![1]!.TidligereAdresse![0]!.Gate = "CHANGED";
         Assert.Equal("TidligereGata", data.Skjemainnhold![1]!.TidligereAdresse![0]!.Gate);
+
+        Assert.Equal("Tag1", data.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags![0]);
+        copy.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags![0] = "CHANGED";
+        Assert.Equal("Tag1", data.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags![0]);
     }
 }

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGeneratedCopy.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGeneratedCopy.cs
@@ -84,6 +84,13 @@ public class TestGeneratedCopy
         Assert.Equal("TidligereGata", copy.Skjemainnhold?[1]?.TidligereAdresse?[0]?.Gate);
         Assert.Equal("TidligereGata", copyWrapper.Get("skjemainnhold[1].tidligere-adresse[0].gate"));
         Assert.Equal("TidligereGata2", copy.Skjemainnhold?[1]?.TidligereAdresse?[1]?.Gate);
+        // Ensure the Tags list itself is a different instance (not shared)
+        Assert.NotNull(data.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags);
+        Assert.NotNull(copy.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags);
+        Assert.NotSame(
+            data.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags,
+            copy.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags
+        );
 
         // Modifications to the copy should not affect the original
 
@@ -102,5 +109,8 @@ public class TestGeneratedCopy
         Assert.Equal("Tag1", data.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags![0]);
         copy.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags![0] = "CHANGED";
         Assert.Equal("Tag1", data.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags![0]);
+        // Adding to the copy's list must not affect the original list length
+        copy.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags!.Add("NEW");
+        Assert.Equal(2, data.Skjemainnhold![1]!.TidligereAdresse![1]!.Tags!.Count);
     }
 }

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGeneratedGetter.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGeneratedGetter.cs
@@ -92,7 +92,8 @@ public class TestGeneratedGetter(ITestOutputHelper testOutputHelper)
     [InlineData("skjemainnhold[1].adresse.postnummer", 1234)]
     [InlineData("skjemainnhold[1].tidligere-adresse[1].postnummer", 1236)]
     [InlineData("skjemainnhold[1].tidligere-adresse[1].tags[0]", "tag1")]
-    public void TestGetRaw(string path, object expected)
+    [InlineData("skjemainnhold[1].tidligere-adresse[1].tags[99000]", null)]
+    public void TestGetRaw(string path, object? expected)
     {
         IFormDataWrapper dataWrapper = new Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFormDataWrapper(
             _skjema

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGeneratedGetter.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGeneratedGetter.cs
@@ -1,12 +1,14 @@
 using System;
+using System.Collections.Generic;
 using Altinn.App.Core.Helpers.DataModel;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.SourceGenerator.Integration.Tests.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Altinn.App.SourceGenerator.Integration.Tests.UnitTest;
 
-public class TestGeneratedGetter
+public class TestGeneratedGetter(ITestOutputHelper testOutputHelper)
 {
     /// <summary>
     /// Create a shared instance of Skjema for testing.
@@ -32,7 +34,12 @@ public class TestGeneratedGetter
                 TidligereAdresse =
                 [
                     new() { Gate = "gate1", Postnummer = 1235 },
-                    new() { Gate = "gate2", Postnummer = 1236 },
+                    new()
+                    {
+                        Gate = "gate2",
+                        Postnummer = 1236,
+                        Tags = ["tag1", "tag2"],
+                    },
                 ],
             },
         ],
@@ -84,6 +91,7 @@ public class TestGeneratedGetter
     [InlineData("skjemainnhold[1].adresse.gate", "gate")]
     [InlineData("skjemainnhold[1].adresse.postnummer", 1234)]
     [InlineData("skjemainnhold[1].tidligere-adresse[1].postnummer", 1236)]
+    [InlineData("skjemainnhold[1].tidligere-adresse[1].tags[0]", "tag1")]
     public void TestGetRaw(string path, object expected)
     {
         IFormDataWrapper dataWrapper = new Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFormDataWrapper(
@@ -124,6 +132,7 @@ public class TestGeneratedGetter
     [InlineData("skjemainnhold[0].navn.not-exists")]
     [InlineData("skjemainnhold[1].tidligere-adresse[99].postnummer")]
     [InlineData("skjemainnhold[0].adresse.gate")]
+    [InlineData("skjemainnhold[1].adresse.")]
     [InlineData("skjemainnhold[1].adresse[0]")]
     [InlineData("skjemainnhold[1].")]
     public void TestGetRawErrorReturnNull(string? path)
@@ -142,16 +151,47 @@ public class TestGeneratedGetter
     [InlineData("skjemainnhold[-1]")]
     [InlineData("skjemainnhold[a]")]
     [InlineData("skjemainnhold[1].tidligere-adresse[-1]")]
+    [InlineData("skjemainnhold[1]tidligere-adresse[-1]")]
     public void TestGetRawErrorReturnException(string? path)
     {
         // These might all throw exceptions when we have better validation of data model bindings at startup
         IFormDataWrapper dataWrapper = new Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFormDataWrapper(
             _skjema
         );
-        Assert.Throws<DataModelException>(() => dataWrapper.Get(path));
+        testOutputHelper.WriteLine(Assert.Throws<DataModelException>(() => dataWrapper.Get(path)).ToString());
 
         var reflector = new ReflectionFormDataWrapper(_skjema);
-        Assert.Throws<DataModelException>(() => reflector.Get(path));
+        testOutputHelper.WriteLine(Assert.Throws<DataModelException>(() => reflector.Get(path)).ToString());
+    }
+
+    [Fact]
+    public void TestGetListRaw()
+    {
+        var path = "skjemainnhold[1].tidligere-adresse[1].tags";
+        var expected = _skjema.Skjemainnhold?[1]?.TidligereAdresse?[1]?.Tags;
+        Assert.NotNull(expected);
+        IFormDataWrapper dataWrapper = new Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFormDataWrapper(
+            _skjema
+        );
+        Assert.Equivalent(expected, dataWrapper.Get(path));
+
+        var reflector = new ReflectionFormDataWrapper(_skjema);
+        Assert.Equivalent(expected, reflector.Get(path));
+    }
+
+    [Fact]
+    public void GetObjectRaw()
+    {
+        var path = "skjemainnhold[1].adresse";
+        var expected = _skjema.Skjemainnhold?[1]?.Adresse;
+        Assert.NotNull(expected);
+        IFormDataWrapper dataWrapper = new Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFormDataWrapper(
+            _skjema
+        );
+        Assert.Equal(expected, dataWrapper.Get(path));
+
+        var reflector = new ReflectionFormDataWrapper(_skjema);
+        Assert.Equal(expected, reflector.Get(path));
     }
 
     [Fact]
@@ -176,13 +216,17 @@ public class TestGeneratedGetter
         Assert.Equal("navn", segment);
         Assert.Equal(-1, nextOffset);
         Assert.Equal(-1, literalIndex);
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
-            Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFormDataWrapper.ParseSegment(
-                path,
-                nextOffset,
-                out nextOffset,
-                out literalIndex
-            )
+        testOutputHelper.WriteLine(
+            Assert
+                .Throws<ArgumentOutOfRangeException>(() =>
+                    Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFormDataWrapper.ParseSegment(
+                        path,
+                        nextOffset,
+                        out nextOffset,
+                        out literalIndex
+                    )
+                )
+                .ToString()
         );
     }
 

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
@@ -228,7 +228,7 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                     buffer[bufferOffset++] = '[';
                     if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
                     {
-                        throw new global::System.FormatException($"Invalid index in {path}.");
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
                     }
 
                     bufferOffset += charsWritten;
@@ -239,7 +239,10 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                 {
                     // Write index from rowIndexes to buffer
                     buffer[bufferOffset++] = '[';
-                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
+                    }
                     bufferOffset += charsWritten;
                     buffer[bufferOffset++] = ']';
                     rowIndexes = rowIndexes.Slice(1);
@@ -343,7 +346,7 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                     buffer[bufferOffset++] = '[';
                     if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
                     {
-                        throw new global::System.FormatException($"Invalid index in {path}.");
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
                     }
 
                     bufferOffset += charsWritten;
@@ -354,7 +357,10 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                 {
                     // Write index from rowIndexes to buffer
                     buffer[bufferOffset++] = '[';
-                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
+                    }
                     bufferOffset += charsWritten;
                     buffer[bufferOffset++] = ']';
                     rowIndexes = rowIndexes.Slice(1);
@@ -430,7 +436,7 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                     buffer[bufferOffset++] = '[';
                     if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
                     {
-                        throw new global::System.FormatException($"Invalid index in {path}.");
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
                     }
 
                     bufferOffset += charsWritten;
@@ -441,7 +447,10 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                 {
                     // Write index from rowIndexes to buffer
                     buffer[bufferOffset++] = '[';
-                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
+                    }
                     bufferOffset += charsWritten;
                     buffer[bufferOffset++] = ']';
                     rowIndexes = rowIndexes.Slice(1);

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
@@ -47,19 +47,18 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         int offset
     )
     {
-        if(model is null)
+        if (model is null || offset == -1)
         {
-            return null;
+            return model;
         }
 
         return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
         {
             "skjemanummer" when nextOffset is -1 && literalIndex is -1 => model.Skjemanummer,
             "skjemaversjon" when nextOffset is -1 && literalIndex is -1 => model.Skjemaversjon,
-            "skjemainnhold" when nextOffset > -1 && literalIndex > -1 => GetRecursive(model.Skjemainnhold, path, literalIndex, nextOffset),
-            "eierAdresse" when nextOffset > -1 && literalIndex is -1 => GetRecursive(model.EierAdresse, path, nextOffset),
-            "" => model,
-            // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+            "skjemainnhold" => GetRecursive(model.Skjemainnhold, path, literalIndex, nextOffset),
+            "eierAdresse" when literalIndex is -1 => GetRecursive(model.EierAdresse, path, nextOffset),
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
     }
@@ -71,6 +70,11 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         int offset
     )
     {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
         if (model is null || literalIndex < 0 || literalIndex >= model.Count)
         {
             return null;
@@ -85,9 +89,9 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         int offset
     )
     {
-        if(model is null)
+        if (model is null || offset == -1)
         {
-            return null;
+            return model;
         }
 
         return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
@@ -96,10 +100,9 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             "navn" when nextOffset is -1 && literalIndex is -1 => model.Navn,
             "alder" when nextOffset is -1 && literalIndex is -1 => model.Alder,
             "deltar" when nextOffset is -1 && literalIndex is -1 => model.Deltar,
-            "adresse" when nextOffset > -1 && literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
-            "tidligere-adresse" when nextOffset > -1 && literalIndex > -1 => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
-            "" => model,
-            // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+            "adresse" when literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
+            "tidligere-adresse" => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
     }
@@ -110,9 +113,9 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         int offset
     )
     {
-        if(model is null)
+        if (model is null || offset == -1)
         {
-            return null;
+            return model;
         }
 
         return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
@@ -121,10 +124,30 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             "gate" when nextOffset is -1 && literalIndex is -1 => model.Gate,
             "postnummer" when nextOffset is -1 && literalIndex is -1 => model.Postnummer,
             "poststed" when nextOffset is -1 && literalIndex is -1 => model.Poststed,
-            "" => model,
-            // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+            "tags" => GetRecursive(model.Tags, path, literalIndex, nextOffset),
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
+    }
+
+    private static object? GetRecursive(
+        global::System.Collections.Generic.List<string>? model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset
+    )
+    {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
+        if (model is null || literalIndex < 0 || literalIndex >= model.Count)
+        {
+            return null;
+        }
+
+        return model[literalIndex];
     }
 
     private static object? GetRecursive(
@@ -134,6 +157,11 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         int offset
     )
     {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
         if (model is null || literalIndex < 0 || literalIndex >= model.Count)
         {
             return null;
@@ -392,6 +420,10 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 8;
                 return;
+            case "tags":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 4;
+                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -482,7 +514,27 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             Gate = data.Gate,
             Postnummer = data.Postnummer,
             Poststed = data.Poststed,
+            Tags = CopyRecursive(data.Tags),
         };
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
+    private static global::System.Collections.Generic.List<string>? CopyRecursive(
+        global::System.Collections.Generic.List<string>? list
+    )
+    {
+        if (list is null)
+        {
+            return null;
+        }
+
+        global::System.Collections.Generic.List<string> result = new(list.Count);
+        foreach (var item in list)
+        {
+            result.Add(item);
+        }
+
+        return result;
     }
 
     [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
@@ -651,9 +703,45 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             case "poststed" when (nextOffset is -1) && (literalIndex is -1):
                 model.Poststed = default;
                 break;
+            case "tags" when (nextOffset is -1) && (literalIndex is -1):
+                model.Tags = default;
+                break;
+            case "tags":
+                RemoveRecursive(model.Tags, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
             default:
                 // throw new ArgumentException("{path} is not a valid path.");
                 return;
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::System.Collections.Generic.List<string>? model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        int index,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        if (index < 0 || index >= model.Count)
+        {
+            return;
+        }
+        if (offset == -1)
+        {
+            switch (rowRemovalOption)
+            {
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.DeleteRow:
+                    model.RemoveAt(index);
+                    break;
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.SetToNull:
+                    model[index] = default!;
+                    break;
+            }
         }
     }
 
@@ -765,7 +853,7 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
     #endregion AltinnRowIds
     public static global::System.ReadOnlySpan<char> ParseSegment(global::System.ReadOnlySpan<char> path, int offset, out int nextOffset, out int literalIndex)
     {
-        if (offset < 0 || offset >= path.Length)
+        if (offset < 0 || offset > path.Length)
         {
             throw new global::System.ArgumentOutOfRangeException(nameof(offset));
         }
@@ -809,11 +897,19 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid negative index in {path}.");
         }
 
-        nextOffset = offset + bracketOffset + 2;
-        if (nextOffset >= path.Length)
+        if (offset + bracketOffset + 1 == path.Length)
         {
+            // End of path
             nextOffset = -1;
+            return index;
         }
+
+        if (path[offset + bracketOffset + 1] != '.')
+        {
+            throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid character after closing bracket ']' in {path}. Expected '.' or end of path.");
+        }
+
+        nextOffset = offset + bracketOffset + 2;
 
         return index;
     }
@@ -833,67 +929,87 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
 //   "JsonName": "",
 //   "CSharpName": "",
 //   "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.Skjema",
+//   "IsImmutableValue": "false",
 //   "Properties": [
 //     {
 //       "JsonName": "skjemanummer",
 //       "CSharpName": "Skjemanummer",
 //       "TypeName": "string",
+//       "IsImmutableValue": "true",
 //     },
 //     {
 //       "JsonName": "skjemaversjon",
 //       "CSharpName": "Skjemaversjon",
 //       "TypeName": "string",
+//       "IsImmutableValue": "true",
 //     },
 //     {
 //       "JsonName": "skjemainnhold",
 //       "CSharpName": "Skjemainnhold",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.SkjemaInnhold",
+//       "IsImmutableValue": "false",
 //       "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Integration.Tests.Models.SkjemaInnhold?>",
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "navn",
 //           "CSharpName": "Navn",
 //           "TypeName": "string",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "alder",
 //           "CSharpName": "Alder",
 //           "TypeName": "int",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "deltar",
 //           "CSharpName": "Deltar",
 //           "TypeName": "bool",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "adresse",
 //           "CSharpName": "Adresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.Adresse",
+//           "IsImmutableValue": "false",
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "string",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "int",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "string",
+//               "IsImmutableValue": "true",
+//             },
+//             {
+//               "JsonName": "tags",
+//               "CSharpName": "Tags",
+//               "TypeName": "string",
+//               "IsImmutableValue": "true",
+//               "ListType": "global::System.Collections.Generic.List<string>",
 //             }
 //           ]
 //         },
@@ -901,27 +1017,39 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
 //           "JsonName": "tidligere-adresse",
 //           "CSharpName": "TidligereAdresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.Adresse",
+//           "IsImmutableValue": "false",
 //           "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Integration.Tests.Models.Adresse>",
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "string",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "int",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "string",
+//               "IsImmutableValue": "true",
+//             },
+//             {
+//               "JsonName": "tags",
+//               "CSharpName": "Tags",
+//               "TypeName": "string",
+//               "IsImmutableValue": "true",
+//               "ListType": "global::System.Collections.Generic.List<string>",
 //             }
 //           ]
 //         }
@@ -931,26 +1059,38 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
 //       "JsonName": "eierAdresse",
 //       "CSharpName": "EierAdresse",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.Adresse",
+//       "IsImmutableValue": "false",
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "gate",
 //           "CSharpName": "Gate",
 //           "TypeName": "string",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "postnummer",
 //           "CSharpName": "Postnummer",
 //           "TypeName": "int",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "poststed",
 //           "CSharpName": "Poststed",
 //           "TypeName": "string",
+//           "IsImmutableValue": "true",
+//         },
+//         {
+//           "JsonName": "tags",
+//           "CSharpName": "Tags",
+//           "TypeName": "string",
+//           "IsImmutableValue": "true",
+//           "ListType": "global::System.Collections.Generic.List<string>",
 //         }
 //       ]
 //     }

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
@@ -210,6 +210,14 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         var segment = ParseSegment(path, pathOffset, out pathOffset, out int literalIndex);
         switch (segment)
         {
+            case "skjemanummer":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 12;
+                return;
+            case "skjemaversjon":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 13;
+                return;
             case "skjemainnhold":
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 13;
@@ -274,14 +282,6 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                     );
                 }
                 return;
-            case "skjemanummer":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 12;
-                return;
-            case "skjemaversjon":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 13;
-                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -303,6 +303,22 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         var segment = ParseSegment(path, pathOffset, out pathOffset, out int literalIndex);
         switch (segment)
         {
+            case "altinnRowId":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 11;
+                return;
+            case "navn":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 4;
+                return;
+            case "alder":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 5;
+                return;
+            case "deltar":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 6;
+                return;
             case "adresse":
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 7;
@@ -367,22 +383,6 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                     );
                 }
                 return;
-            case "altinnRowId":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 11;
-                return;
-            case "navn":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 4;
-                return;
-            case "alder":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 5;
-                return;
-            case "deltar":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 6;
-                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -423,6 +423,42 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             case "tags":
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 4;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.FormatException($"Invalid index in {path}.");
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
                 return;
             default:
                 bufferOffset = 0;

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
@@ -887,7 +887,11 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Missing closing bracket ']' in {path}.");
         }
 
-        if (!int.TryParse(segment[..bracketOffset], out var index))
+        if (!int.TryParse(
+            segment[..bracketOffset],
+            global::System.Globalization.NumberStyles.None,
+            global::System.Globalization.CultureInfo.InvariantCulture,
+            out var index))
         {
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid index in {path}.");
         }
@@ -929,86 +933,86 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
 //   "JsonName": "",
 //   "CSharpName": "",
 //   "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.Skjema",
-//   "IsImmutableValue": "false",
+//   "IsJsonValueType": false,
 //   "Properties": [
 //     {
 //       "JsonName": "skjemanummer",
 //       "CSharpName": "Skjemanummer",
 //       "TypeName": "string",
-//       "IsImmutableValue": "true",
+//       "IsJsonValueType": true,
 //     },
 //     {
 //       "JsonName": "skjemaversjon",
 //       "CSharpName": "Skjemaversjon",
 //       "TypeName": "string",
-//       "IsImmutableValue": "true",
+//       "IsJsonValueType": true,
 //     },
 //     {
 //       "JsonName": "skjemainnhold",
 //       "CSharpName": "Skjemainnhold",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.SkjemaInnhold",
-//       "IsImmutableValue": "false",
+//       "IsJsonValueType": false,
 //       "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Integration.Tests.Models.SkjemaInnhold?>",
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "navn",
 //           "CSharpName": "Navn",
 //           "TypeName": "string",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "alder",
 //           "CSharpName": "Alder",
 //           "TypeName": "int",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "deltar",
 //           "CSharpName": "Deltar",
 //           "TypeName": "bool",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "adresse",
 //           "CSharpName": "Adresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.Adresse",
-//           "IsImmutableValue": "false",
+//           "IsJsonValueType": false,
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "int",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "tags",
 //               "CSharpName": "Tags",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //               "ListType": "global::System.Collections.Generic.List<string>",
 //             }
 //           ]
@@ -1017,38 +1021,38 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
 //           "JsonName": "tidligere-adresse",
 //           "CSharpName": "TidligereAdresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.Adresse",
-//           "IsImmutableValue": "false",
+//           "IsJsonValueType": false,
 //           "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Integration.Tests.Models.Adresse>",
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "int",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "tags",
 //               "CSharpName": "Tags",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //               "ListType": "global::System.Collections.Generic.List<string>",
 //             }
 //           ]
@@ -1059,37 +1063,37 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
 //       "JsonName": "eierAdresse",
 //       "CSharpName": "EierAdresse",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.Adresse",
-//       "IsImmutableValue": "false",
+//       "IsJsonValueType": false,
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "gate",
 //           "CSharpName": "Gate",
 //           "TypeName": "string",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "postnummer",
 //           "CSharpName": "Postnummer",
 //           "TypeName": "int",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "poststed",
 //           "CSharpName": "Poststed",
 //           "TypeName": "string",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "tags",
 //           "CSharpName": "Tags",
 //           "TypeName": "string",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //           "ListType": "global::System.Collections.Generic.List<string>",
 //         }
 //       ]

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
@@ -211,6 +211,14 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         var segment = ParseSegment(path, pathOffset, out pathOffset, out int literalIndex);
         switch (segment)
         {
+            case "skjemanummer":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 12;
+                return;
+            case "skjemaversjon":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 13;
+                return;
             case "skjemainnhold":
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 13;
@@ -275,14 +283,6 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     );
                 }
                 return;
-            case "skjemanummer":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 12;
-                return;
-            case "skjemaversjon":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 13;
-                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -304,6 +304,22 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         var segment = ParseSegment(path, pathOffset, out pathOffset, out int literalIndex);
         switch (segment)
         {
+            case "altinnRowId":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 11;
+                return;
+            case "navn":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 4;
+                return;
+            case "alder":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 5;
+                return;
+            case "deltar":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 6;
+                return;
             case "adresse":
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 7;
@@ -368,22 +384,6 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     );
                 }
                 return;
-            case "altinnRowId":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 11;
-                return;
-            case "navn":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 4;
-                return;
-            case "alder":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 5;
-                return;
-            case "deltar":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 6;
-                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -424,6 +424,42 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             case "tags":
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 4;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.FormatException($"Invalid index in {path}.");
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
                 return;
             default:
                 bufferOffset = 0;

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
@@ -48,19 +48,18 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
-        if(model is null)
+        if (model is null || offset == -1)
         {
-            return null;
+            return model;
         }
 
         return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
         {
             "skjemanummer" when nextOffset is -1 && literalIndex is -1 => model.Skjemanummer,
             "skjemaversjon" when nextOffset is -1 && literalIndex is -1 => model.Skjemaversjon,
-            "skjemainnhold" when nextOffset > -1 && literalIndex > -1 => GetRecursive(model.Skjemainnhold, path, literalIndex, nextOffset),
-            "eierAdresse" when nextOffset > -1 && literalIndex is -1 => GetRecursive(model.EierAdresse, path, nextOffset),
-            "" => model,
-            // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+            "skjemainnhold" => GetRecursive(model.Skjemainnhold, path, literalIndex, nextOffset),
+            "eierAdresse" when literalIndex is -1 => GetRecursive(model.EierAdresse, path, nextOffset),
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
     }
@@ -72,6 +71,11 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
         if (model is null || literalIndex < 0 || literalIndex >= model.Count)
         {
             return null;
@@ -86,9 +90,9 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
-        if(model is null)
+        if (model is null || offset == -1)
         {
-            return null;
+            return model;
         }
 
         return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
@@ -97,10 +101,9 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             "navn" when nextOffset is -1 && literalIndex is -1 => model.Navn,
             "alder" when nextOffset is -1 && literalIndex is -1 => model.Alder,
             "deltar" when nextOffset is -1 && literalIndex is -1 => model.Deltar,
-            "adresse" when nextOffset > -1 && literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
-            "tidligere-adresse" when nextOffset > -1 && literalIndex > -1 => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
-            "" => model,
-            // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+            "adresse" when literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
+            "tidligere-adresse" => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
     }
@@ -111,9 +114,9 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
-        if(model is null)
+        if (model is null || offset == -1)
         {
-            return null;
+            return model;
         }
 
         return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
@@ -122,10 +125,30 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             "gate" when nextOffset is -1 && literalIndex is -1 => model.Gate,
             "postnummer" when nextOffset is -1 && literalIndex is -1 => model.Postnummer,
             "poststed" when nextOffset is -1 && literalIndex is -1 => model.Poststed,
-            "" => model,
-            // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+            "tags" => GetRecursive(model.Tags, path, literalIndex, nextOffset),
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
+    }
+
+    private static object? GetRecursive(
+        global::System.Collections.Generic.List<string>? model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset
+    )
+    {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
+        if (model is null || literalIndex < 0 || literalIndex >= model.Count)
+        {
+            return null;
+        }
+
+        return model[literalIndex];
     }
 
     private static object? GetRecursive(
@@ -135,6 +158,11 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
         if (model is null || literalIndex < 0 || literalIndex >= model.Count)
         {
             return null;
@@ -393,6 +421,10 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 8;
                 return;
+            case "tags":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 4;
+                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -483,7 +515,27 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             Gate = data.Gate,
             Postnummer = data.Postnummer,
             Poststed = data.Poststed,
+            Tags = CopyRecursive(data.Tags),
         };
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
+    private static global::System.Collections.Generic.List<string>? CopyRecursive(
+        global::System.Collections.Generic.List<string>? list
+    )
+    {
+        if (list is null)
+        {
+            return null;
+        }
+
+        global::System.Collections.Generic.List<string> result = new(list.Count);
+        foreach (var item in list)
+        {
+            result.Add(item);
+        }
+
+        return result;
     }
 
     [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
@@ -652,9 +704,45 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             case "poststed" when (nextOffset is -1) && (literalIndex is -1):
                 model.Poststed = default;
                 break;
+            case "tags" when (nextOffset is -1) && (literalIndex is -1):
+                model.Tags = default;
+                break;
+            case "tags":
+                RemoveRecursive(model.Tags, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
             default:
                 // throw new ArgumentException("{path} is not a valid path.");
                 return;
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::System.Collections.Generic.List<string>? model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        int index,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        if (index < 0 || index >= model.Count)
+        {
+            return;
+        }
+        if (offset == -1)
+        {
+            switch (rowRemovalOption)
+            {
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.DeleteRow:
+                    model.RemoveAt(index);
+                    break;
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.SetToNull:
+                    model[index] = default!;
+                    break;
+            }
         }
     }
 
@@ -766,7 +854,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
     #endregion AltinnRowIds
     public static global::System.ReadOnlySpan<char> ParseSegment(global::System.ReadOnlySpan<char> path, int offset, out int nextOffset, out int literalIndex)
     {
-        if (offset < 0 || offset >= path.Length)
+        if (offset < 0 || offset > path.Length)
         {
             throw new global::System.ArgumentOutOfRangeException(nameof(offset));
         }
@@ -810,11 +898,19 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid negative index in {path}.");
         }
 
-        nextOffset = offset + bracketOffset + 2;
-        if (nextOffset >= path.Length)
+        if (offset + bracketOffset + 1 == path.Length)
         {
+            // End of path
             nextOffset = -1;
+            return index;
         }
+
+        if (path[offset + bracketOffset + 1] != '.')
+        {
+            throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid character after closing bracket ']' in {path}. Expected '.' or end of path.");
+        }
+
+        nextOffset = offset + bracketOffset + 2;
 
         return index;
     }
@@ -834,67 +930,87 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //   "JsonName": "",
 //   "CSharpName": "",
 //   "TypeName": "global::Altinn.App.SourceGenerator.Tests.Skjema",
+//   "IsImmutableValue": "false",
 //   "Properties": [
 //     {
 //       "JsonName": "skjemanummer",
 //       "CSharpName": "Skjemanummer",
 //       "TypeName": "string",
+//       "IsImmutableValue": "true",
 //     },
 //     {
 //       "JsonName": "skjemaversjon",
 //       "CSharpName": "Skjemaversjon",
 //       "TypeName": "string",
+//       "IsImmutableValue": "true",
 //     },
 //     {
 //       "JsonName": "skjemainnhold",
 //       "CSharpName": "Skjemainnhold",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold",
+//       "IsImmutableValue": "false",
 //       "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold?>",
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "navn",
 //           "CSharpName": "Navn",
 //           "TypeName": "string",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "alder",
 //           "CSharpName": "Alder",
 //           "TypeName": "int",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "deltar",
 //           "CSharpName": "Deltar",
 //           "TypeName": "bool",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "adresse",
 //           "CSharpName": "Adresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
+//           "IsImmutableValue": "false",
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "string",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "int",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "string",
+//               "IsImmutableValue": "true",
+//             },
+//             {
+//               "JsonName": "tags",
+//               "CSharpName": "Tags",
+//               "TypeName": "string",
+//               "IsImmutableValue": "true",
+//               "ListType": "global::System.Collections.Generic.List<string>",
 //             }
 //           ]
 //         },
@@ -902,27 +1018,39 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //           "JsonName": "tidligere-adresse",
 //           "CSharpName": "TidligereAdresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
+//           "IsImmutableValue": "false",
 //           "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.Adresse>",
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "string",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "int",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "string",
+//               "IsImmutableValue": "true",
+//             },
+//             {
+//               "JsonName": "tags",
+//               "CSharpName": "Tags",
+//               "TypeName": "string",
+//               "IsImmutableValue": "true",
+//               "ListType": "global::System.Collections.Generic.List<string>",
 //             }
 //           ]
 //         }
@@ -932,26 +1060,38 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //       "JsonName": "eierAdresse",
 //       "CSharpName": "EierAdresse",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
+//       "IsImmutableValue": "false",
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "gate",
 //           "CSharpName": "Gate",
 //           "TypeName": "string",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "postnummer",
 //           "CSharpName": "Postnummer",
 //           "TypeName": "int",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "poststed",
 //           "CSharpName": "Poststed",
 //           "TypeName": "string",
+//           "IsImmutableValue": "true",
+//         },
+//         {
+//           "JsonName": "tags",
+//           "CSharpName": "Tags",
+//           "TypeName": "string",
+//           "IsImmutableValue": "true",
+//           "ListType": "global::System.Collections.Generic.List<string>",
 //         }
 //       ]
 //     }

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
@@ -229,7 +229,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     buffer[bufferOffset++] = '[';
                     if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
                     {
-                        throw new global::System.FormatException($"Invalid index in {path}.");
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
                     }
 
                     bufferOffset += charsWritten;
@@ -240,7 +240,10 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 {
                     // Write index from rowIndexes to buffer
                     buffer[bufferOffset++] = '[';
-                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
+                    }
                     bufferOffset += charsWritten;
                     buffer[bufferOffset++] = ']';
                     rowIndexes = rowIndexes.Slice(1);
@@ -344,7 +347,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     buffer[bufferOffset++] = '[';
                     if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
                     {
-                        throw new global::System.FormatException($"Invalid index in {path}.");
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
                     }
 
                     bufferOffset += charsWritten;
@@ -355,7 +358,10 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 {
                     // Write index from rowIndexes to buffer
                     buffer[bufferOffset++] = '[';
-                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
+                    }
                     bufferOffset += charsWritten;
                     buffer[bufferOffset++] = ']';
                     rowIndexes = rowIndexes.Slice(1);
@@ -431,7 +437,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     buffer[bufferOffset++] = '[';
                     if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
                     {
-                        throw new global::System.FormatException($"Invalid index in {path}.");
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
                     }
 
                     bufferOffset += charsWritten;
@@ -442,7 +448,10 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 {
                     // Write index from rowIndexes to buffer
                     buffer[bufferOffset++] = '[';
-                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
+                    }
                     bufferOffset += charsWritten;
                     buffer[bufferOffset++] = ']';
                     rowIndexes = rowIndexes.Slice(1);

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
@@ -888,7 +888,11 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Missing closing bracket ']' in {path}.");
         }
 
-        if (!int.TryParse(segment[..bracketOffset], out var index))
+        if (!int.TryParse(
+            segment[..bracketOffset],
+            global::System.Globalization.NumberStyles.None,
+            global::System.Globalization.CultureInfo.InvariantCulture,
+            out var index))
         {
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid index in {path}.");
         }
@@ -930,86 +934,86 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //   "JsonName": "",
 //   "CSharpName": "",
 //   "TypeName": "global::Altinn.App.SourceGenerator.Tests.Skjema",
-//   "IsImmutableValue": "false",
+//   "IsJsonValueType": false,
 //   "Properties": [
 //     {
 //       "JsonName": "skjemanummer",
 //       "CSharpName": "Skjemanummer",
 //       "TypeName": "string",
-//       "IsImmutableValue": "true",
+//       "IsJsonValueType": true,
 //     },
 //     {
 //       "JsonName": "skjemaversjon",
 //       "CSharpName": "Skjemaversjon",
 //       "TypeName": "string",
-//       "IsImmutableValue": "true",
+//       "IsJsonValueType": true,
 //     },
 //     {
 //       "JsonName": "skjemainnhold",
 //       "CSharpName": "Skjemainnhold",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold",
-//       "IsImmutableValue": "false",
+//       "IsJsonValueType": false,
 //       "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold?>",
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "navn",
 //           "CSharpName": "Navn",
 //           "TypeName": "string",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "alder",
 //           "CSharpName": "Alder",
 //           "TypeName": "int",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "deltar",
 //           "CSharpName": "Deltar",
 //           "TypeName": "bool",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "adresse",
 //           "CSharpName": "Adresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
-//           "IsImmutableValue": "false",
+//           "IsJsonValueType": false,
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "int",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "tags",
 //               "CSharpName": "Tags",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //               "ListType": "global::System.Collections.Generic.List<string>",
 //             }
 //           ]
@@ -1018,38 +1022,38 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //           "JsonName": "tidligere-adresse",
 //           "CSharpName": "TidligereAdresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
-//           "IsImmutableValue": "false",
+//           "IsJsonValueType": false,
 //           "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.Adresse>",
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "int",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "tags",
 //               "CSharpName": "Tags",
 //               "TypeName": "string",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //               "ListType": "global::System.Collections.Generic.List<string>",
 //             }
 //           ]
@@ -1060,37 +1064,37 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //       "JsonName": "eierAdresse",
 //       "CSharpName": "EierAdresse",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
-//       "IsImmutableValue": "false",
+//       "IsJsonValueType": false,
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "gate",
 //           "CSharpName": "Gate",
 //           "TypeName": "string",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "postnummer",
 //           "CSharpName": "Postnummer",
 //           "TypeName": "int",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "poststed",
 //           "CSharpName": "Poststed",
 //           "TypeName": "string",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "tags",
 //           "CSharpName": "Tags",
 //           "TypeName": "string",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //           "ListType": "global::System.Collections.Generic.List<string>",
 //         }
 //       ]

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.cs
@@ -79,6 +79,11 @@ public class FullTests
 
                 [JsonPropertyName("poststed")]
                 public string? Poststed { get; set; }
+
+
+                // List of string is invalid in altinn datamodels, but might be used for backend purposes and must compile
+                [JsonPropertyName("tags")]
+                public List<string>? Tags { get; set; }
             }
             """;
         var syntax = CSharpSyntaxTree.ParseText(source, path: "models/Models.cs");

--- a/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
@@ -189,6 +189,14 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         var segment = ParseSegment(path, pathOffset, out pathOffset, out int literalIndex);
         switch (segment)
         {
+            case "skjemanummer":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 12;
+                return;
+            case "skjemaversjon":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 13;
+                return;
             case "skjemainnhold":
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 13;
@@ -253,14 +261,6 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     );
                 }
                 return;
-            case "skjemanummer":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 12;
-                return;
-            case "skjemaversjon":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 13;
-                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -282,6 +282,22 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         var segment = ParseSegment(path, pathOffset, out pathOffset, out int literalIndex);
         switch (segment)
         {
+            case "altinnRowId":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 11;
+                return;
+            case "navn":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 4;
+                return;
+            case "alder":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 5;
+                return;
+            case "deltar":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 6;
+                return;
             case "adresse":
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 7;
@@ -345,22 +361,6 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                         ref bufferOffset
                     );
                 }
-                return;
-            case "altinnRowId":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 11;
-                return;
-            case "navn":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 4;
-                return;
-            case "alder":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 5;
-                return;
-            case "deltar":
-                segment.CopyTo(buffer.Slice(bufferOffset));
-                bufferOffset += 6;
                 return;
             default:
                 bufferOffset = 0;

--- a/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
@@ -207,7 +207,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     buffer[bufferOffset++] = '[';
                     if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
                     {
-                        throw new global::System.FormatException($"Invalid index in {path}.");
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
                     }
 
                     bufferOffset += charsWritten;
@@ -218,7 +218,10 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 {
                     // Write index from rowIndexes to buffer
                     buffer[bufferOffset++] = '[';
-                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
+                    }
                     bufferOffset += charsWritten;
                     buffer[bufferOffset++] = ']';
                     rowIndexes = rowIndexes.Slice(1);
@@ -322,7 +325,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     buffer[bufferOffset++] = '[';
                     if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
                     {
-                        throw new global::System.FormatException($"Invalid index in {path}.");
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
                     }
 
                     bufferOffset += charsWritten;
@@ -333,7 +336,10 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 {
                     // Write index from rowIndexes to buffer
                     buffer[bufferOffset++] = '[';
-                    rowIndexes[0].TryFormat(buffer.Slice(bufferOffset), out int charsWritten);
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException($"Buffer too small to write index for {path}.");
+                    }
                     bufferOffset += charsWritten;
                     buffer[bufferOffset++] = ']';
                     rowIndexes = rowIndexes.Slice(1);

--- a/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
@@ -47,19 +47,18 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
-        if(model is null)
+        if (model is null || offset == -1)
         {
-            return null;
+            return model;
         }
 
         return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
         {
             "skjemanummer" when nextOffset is -1 && literalIndex is -1 => model.Skjemanummer,
             "skjemaversjon" when nextOffset is -1 && literalIndex is -1 => model.Skjemaversjon,
-            "skjemainnhold" when nextOffset > -1 && literalIndex > -1 => GetRecursive(model.Skjemainnhold, path, literalIndex, nextOffset),
-            "eierAdresse" when nextOffset > -1 && literalIndex is -1 => GetRecursive(model.EierAdresse, path, nextOffset),
-            "" => model,
-            // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+            "skjemainnhold" => GetRecursive(model.Skjemainnhold, path, literalIndex, nextOffset),
+            "eierAdresse" when literalIndex is -1 => GetRecursive(model.EierAdresse, path, nextOffset),
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
     }
@@ -71,6 +70,11 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
         if (model is null || literalIndex < 0 || literalIndex >= model.Count)
         {
             return null;
@@ -85,9 +89,9 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
-        if(model is null)
+        if (model is null || offset == -1)
         {
-            return null;
+            return model;
         }
 
         return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
@@ -96,10 +100,9 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             "navn" when nextOffset is -1 && literalIndex is -1 => model.Navn,
             "alder" when nextOffset is -1 && literalIndex is -1 => model.Alder,
             "deltar" when nextOffset is -1 && literalIndex is -1 => model.Deltar,
-            "adresse" when nextOffset > -1 && literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
-            "tidligere-adresse" when nextOffset > -1 && literalIndex > -1 => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
-            "" => model,
-            // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+            "adresse" when literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
+            "tidligere-adresse" => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
     }
@@ -110,9 +113,9 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
-        if(model is null)
+        if (model is null || offset == -1)
         {
-            return null;
+            return model;
         }
 
         return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
@@ -121,8 +124,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             "gate" when nextOffset is -1 && literalIndex is -1 => model.Gate,
             "postnummer" when nextOffset is -1 && literalIndex is -1 => model.Postnummer,
             "poststed" when nextOffset is -1 && literalIndex is -1 => model.Poststed,
-            "" => model,
-            // _ => throw new global::System.ArgumentException("{path} is not a valid path."),
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
     }
@@ -134,6 +136,11 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         int offset
     )
     {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
         if (model is null || literalIndex < 0 || literalIndex >= model.Count)
         {
             return null;
@@ -765,7 +772,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
     #endregion AltinnRowIds
     public static global::System.ReadOnlySpan<char> ParseSegment(global::System.ReadOnlySpan<char> path, int offset, out int nextOffset, out int literalIndex)
     {
-        if (offset < 0 || offset >= path.Length)
+        if (offset < 0 || offset > path.Length)
         {
             throw new global::System.ArgumentOutOfRangeException(nameof(offset));
         }
@@ -809,11 +816,19 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid negative index in {path}.");
         }
 
-        nextOffset = offset + bracketOffset + 2;
-        if (nextOffset >= path.Length)
+        if (offset + bracketOffset + 1 == path.Length)
         {
+            // End of path
             nextOffset = -1;
+            return index;
         }
+
+        if (path[offset + bracketOffset + 1] != '.')
+        {
+            throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid character after closing bracket ']' in {path}. Expected '.' or end of path.");
+        }
+
+        nextOffset = offset + bracketOffset + 2;
 
         return index;
     }
@@ -833,67 +848,80 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //   "JsonName": "",
 //   "CSharpName": "",
 //   "TypeName": "global::Altinn.App.SourceGenerator.Tests.Skjema",
+//   "IsImmutableValue": "false",
 //   "Properties": [
 //     {
 //       "JsonName": "skjemanummer",
 //       "CSharpName": "Skjemanummer",
 //       "TypeName": "global::System.String",
+//       "IsImmutableValue": "true",
 //     },
 //     {
 //       "JsonName": "skjemaversjon",
 //       "CSharpName": "Skjemaversjon",
 //       "TypeName": "global::System.String",
+//       "IsImmutableValue": "true",
 //     },
 //     {
 //       "JsonName": "skjemainnhold",
 //       "CSharpName": "Skjemainnhold",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold",
+//       "IsImmutableValue": "false",
 //       "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold>",
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "navn",
 //           "CSharpName": "Navn",
 //           "TypeName": "global::System.String",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "alder",
 //           "CSharpName": "Alder",
 //           "TypeName": "global::System.Int32",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "deltar",
 //           "CSharpName": "Deltar",
 //           "TypeName": "global::System.Boolean",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "adresse",
 //           "CSharpName": "Adresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
+//           "IsImmutableValue": "false",
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "global::System.String",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "global::System.Int32",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "global::System.String",
+//               "IsImmutableValue": "true",
 //             }
 //           ]
 //         },
@@ -901,27 +929,32 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //           "JsonName": "tidligere-adresse",
 //           "CSharpName": "TidligereAdresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
+//           "IsImmutableValue": "false",
 //           "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.Adresse>",
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "global::System.String",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "global::System.Int32",
+//               "IsImmutableValue": "true",
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "global::System.String",
+//               "IsImmutableValue": "true",
 //             }
 //           ]
 //         }
@@ -931,26 +964,31 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //       "JsonName": "eierAdresse",
 //       "CSharpName": "EierAdresse",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
+//       "IsImmutableValue": "false",
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "gate",
 //           "CSharpName": "Gate",
 //           "TypeName": "global::System.String",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "postnummer",
 //           "CSharpName": "Postnummer",
 //           "TypeName": "global::System.Int32",
+//           "IsImmutableValue": "true",
 //         },
 //         {
 //           "JsonName": "poststed",
 //           "CSharpName": "Poststed",
 //           "TypeName": "global::System.String",
+//           "IsImmutableValue": "true",
 //         }
 //       ]
 //     }

--- a/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
@@ -806,7 +806,11 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Missing closing bracket ']' in {path}.");
         }
 
-        if (!int.TryParse(segment[..bracketOffset], out var index))
+        if (!int.TryParse(
+            segment[..bracketOffset],
+            global::System.Globalization.NumberStyles.None,
+            global::System.Globalization.CultureInfo.InvariantCulture,
+            out var index))
         {
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid index in {path}.");
         }
@@ -848,80 +852,80 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //   "JsonName": "",
 //   "CSharpName": "",
 //   "TypeName": "global::Altinn.App.SourceGenerator.Tests.Skjema",
-//   "IsImmutableValue": "false",
+//   "IsJsonValueType": false,
 //   "Properties": [
 //     {
 //       "JsonName": "skjemanummer",
 //       "CSharpName": "Skjemanummer",
 //       "TypeName": "global::System.String",
-//       "IsImmutableValue": "true",
+//       "IsJsonValueType": true,
 //     },
 //     {
 //       "JsonName": "skjemaversjon",
 //       "CSharpName": "Skjemaversjon",
 //       "TypeName": "global::System.String",
-//       "IsImmutableValue": "true",
+//       "IsJsonValueType": true,
 //     },
 //     {
 //       "JsonName": "skjemainnhold",
 //       "CSharpName": "Skjemainnhold",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold",
-//       "IsImmutableValue": "false",
+//       "IsJsonValueType": false,
 //       "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold>",
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "navn",
 //           "CSharpName": "Navn",
 //           "TypeName": "global::System.String",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "alder",
 //           "CSharpName": "Alder",
 //           "TypeName": "global::System.Int32",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "deltar",
 //           "CSharpName": "Deltar",
 //           "TypeName": "global::System.Boolean",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "adresse",
 //           "CSharpName": "Adresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
-//           "IsImmutableValue": "false",
+//           "IsJsonValueType": false,
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "global::System.String",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "global::System.Int32",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "global::System.String",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             }
 //           ]
 //         },
@@ -929,32 +933,32 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //           "JsonName": "tidligere-adresse",
 //           "CSharpName": "TidligereAdresse",
 //           "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
-//           "IsImmutableValue": "false",
+//           "IsJsonValueType": false,
 //           "ListType": "global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.Adresse>",
 //           "Properties": [
 //             {
 //               "JsonName": "altinnRowId",
 //               "CSharpName": "AltinnRowId",
 //               "TypeName": "global::System.Guid",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "gate",
 //               "CSharpName": "Gate",
 //               "TypeName": "global::System.String",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "postnummer",
 //               "CSharpName": "Postnummer",
 //               "TypeName": "global::System.Int32",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             },
 //             {
 //               "JsonName": "poststed",
 //               "CSharpName": "Poststed",
 //               "TypeName": "global::System.String",
-//               "IsImmutableValue": "true",
+//               "IsJsonValueType": true,
 //             }
 //           ]
 //         }
@@ -964,31 +968,31 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //       "JsonName": "eierAdresse",
 //       "CSharpName": "EierAdresse",
 //       "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
-//       "IsImmutableValue": "false",
+//       "IsJsonValueType": false,
 //       "Properties": [
 //         {
 //           "JsonName": "altinnRowId",
 //           "CSharpName": "AltinnRowId",
 //           "TypeName": "global::System.Guid",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "gate",
 //           "CSharpName": "Gate",
 //           "TypeName": "global::System.String",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "postnummer",
 //           "CSharpName": "Postnummer",
 //           "TypeName": "global::System.Int32",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         },
 //         {
 //           "JsonName": "poststed",
 //           "CSharpName": "Poststed",
 //           "TypeName": "global::System.String",
-//           "IsImmutableValue": "true",
+//           "IsJsonValueType": true,
 //         }
 //       ]
 //     }

--- a/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.GenerateEmpty.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.GenerateEmpty.verified.cs
@@ -119,7 +119,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_EmptyFormDataWrapper
     #endregion AltinnRowIds
     public static global::System.ReadOnlySpan<char> ParseSegment(global::System.ReadOnlySpan<char> path, int offset, out int nextOffset, out int literalIndex)
     {
-        if (offset < 0 || offset >= path.Length)
+        if (offset < 0 || offset > path.Length)
         {
             throw new global::System.ArgumentOutOfRangeException(nameof(offset));
         }
@@ -163,11 +163,19 @@ public sealed class Altinn_App_SourceGenerator_Tests_EmptyFormDataWrapper
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid negative index in {path}.");
         }
 
-        nextOffset = offset + bracketOffset + 2;
-        if (nextOffset >= path.Length)
+        if (offset + bracketOffset + 1 == path.Length)
         {
+            // End of path
             nextOffset = -1;
+            return index;
         }
+
+        if (path[offset + bracketOffset + 1] != '.')
+        {
+            throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid character after closing bracket ']' in {path}. Expected '.' or end of path.");
+        }
+
+        nextOffset = offset + bracketOffset + 2;
 
         return index;
     }
@@ -187,4 +195,5 @@ public sealed class Altinn_App_SourceGenerator_Tests_EmptyFormDataWrapper
 //   "JsonName": "",
 //   "CSharpName": "",
 //   "TypeName": "global::Altinn.App.SourceGenerator.Tests.Empty",
+//   "IsImmutableValue": "false",
 // }

--- a/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.GenerateEmpty.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.GenerateEmpty.verified.cs
@@ -153,7 +153,11 @@ public sealed class Altinn_App_SourceGenerator_Tests_EmptyFormDataWrapper
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Missing closing bracket ']' in {path}.");
         }
 
-        if (!int.TryParse(segment[..bracketOffset], out var index))
+        if (!int.TryParse(
+            segment[..bracketOffset],
+            global::System.Globalization.NumberStyles.None,
+            global::System.Globalization.CultureInfo.InvariantCulture,
+            out var index))
         {
             throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"Invalid index in {path}.");
         }
@@ -195,5 +199,5 @@ public sealed class Altinn_App_SourceGenerator_Tests_EmptyFormDataWrapper
 //   "JsonName": "",
 //   "CSharpName": "",
 //   "TypeName": "global::Altinn.App.SourceGenerator.Tests.Empty",
-//   "IsImmutableValue": "false",
+//   "IsJsonValueType": false,
 // }


### PR DESCRIPTION
Altinn does not use Lists of primitive types in its data models, but it seems like some service owners have used them for internal fields, and this caused the source generator to generate code that would not compile.

Reviewing the code for this kind of issues also discovered
* that the Getter did not work properly for partial paths (it should return non-leaf nodes also)
* An issue with Copy, not taking a copy of list of primitive types
* The compilation error with Remove that called a method that was not generated.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for string-list properties ("Tags") in data models with full get/copy/remove support.

* **Bug Fixes**
  * More precise path parsing with stricter end-of-path validation and culture-invariant index parsing.
  * JSON value types treated as terminals to avoid unnecessary traversal and fix copy/remove/get behavior.
  * Improved handling of list element copying to preserve isolation between source and copy.

* **Tests**
  * Expanded tests for list access, deep traversal, copy isolation, and updated test output/assertions.

* **Documentation**
  * Updated XML documentation comments for several public methods and interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->