### PR TITLE
Rename file name config in PdfConfig for the pdf service task.

### DIFF
--- a/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnPdfConfiguration.cs
+++ b/src/Altinn.App.Core/Internal/Process/Elements/AltinnExtensionProperties/AltinnPdfConfiguration.cs
@@ -8,10 +8,10 @@ namespace Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
 public sealed class AltinnPdfConfiguration
 {
     /// <summary>
-    /// Set the filename of the PDF. Supports text resource keys for language support.
+    /// Set the filename of the PDF using a text resource key.
     /// </summary>
-    [XmlElement("filename", Namespace = "http://altinn.no/process")]
-    public string? Filename { get; set; }
+    [XmlElement("filenameTextResourceKey", Namespace = "http://altinn.no/process")]
+    public string? FilenameTextResourceKey { get; set; }
 
     /// <summary>
     /// Enable auto-pdf for a list of tasks. Will not respect pdfLayoutName on those tasks, but use the main layout-set of the given tasks and render the components in summary mode. This setting will be ignored if the PDF task has a pdf layout set defined.
@@ -22,10 +22,15 @@ public sealed class AltinnPdfConfiguration
 
     internal ValidAltinnPdfConfiguration Validate()
     {
-        string? normalizedFilename = string.IsNullOrWhiteSpace(Filename) ? null : Filename.Trim();
+        string? normalizedFilename = string.IsNullOrWhiteSpace(FilenameTextResourceKey)
+            ? null
+            : FilenameTextResourceKey.Trim();
 
         return new ValidAltinnPdfConfiguration(normalizedFilename, AutoPdfTaskIds);
     }
 }
 
-internal readonly record struct ValidAltinnPdfConfiguration(string? Filename, List<string>? AutoPdfTaskIds);
+internal readonly record struct ValidAltinnPdfConfiguration(
+    string? FilenameTextResourceKey,
+    List<string>? AutoPdfTaskIds
+);

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/ServiceTasks/PdfServiceTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/ServiceTasks/PdfServiceTask.cs
@@ -42,7 +42,7 @@ internal sealed class PdfServiceTask : IPdfServiceTask
         await _pdfService.GenerateAndStorePdf(
             instance,
             taskId,
-            config.Filename,
+            config.FilenameTextResourceKey,
             config.AutoPdfTaskIds,
             context.CancellationToken
         );

--- a/test/Altinn.App.Core.Tests/Internal/Process/ServiceTasks/PdfServiceTaskTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ServiceTasks/PdfServiceTaskTests.cs
@@ -16,7 +16,7 @@ public class PdfServiceTaskTests
     private readonly Mock<IProcessReader> _processReaderMock = new();
     private readonly PdfServiceTask _serviceTask;
 
-    private const string FileName = "My file name";
+    private const string FileName = "customFilenameTextResourceKey";
 
     public PdfServiceTaskTests()
     {
@@ -26,7 +26,7 @@ public class PdfServiceTaskTests
                 new AltinnTaskExtension
                 {
                     TaskType = "pdf",
-                    PdfConfiguration = new AltinnPdfConfiguration { Filename = FileName },
+                    PdfConfiguration = new AltinnPdfConfiguration { FilenameTextResourceKey = FileName },
                 }
             );
 
@@ -76,7 +76,11 @@ public class PdfServiceTaskTests
                 new AltinnTaskExtension
                 {
                     TaskType = "pdf",
-                    PdfConfiguration = new AltinnPdfConfiguration { Filename = "test.pdf", AutoPdfTaskIds = taskIds },
+                    PdfConfiguration = new AltinnPdfConfiguration
+                    {
+                        FilenameTextResourceKey = "customFilenameTextResourceKey",
+                        AutoPdfTaskIds = taskIds,
+                    },
                 }
             );
 
@@ -97,7 +101,14 @@ public class PdfServiceTaskTests
 
         // Assert
         _pdfServiceMock.Verify(
-            x => x.GenerateAndStorePdf(instance, "pdfTask", "test.pdf", taskIds, It.IsAny<CancellationToken>()),
+            x =>
+                x.GenerateAndStorePdf(
+                    instance,
+                    "pdfTask",
+                    "customFilenameTextResourceKey",
+                    taskIds,
+                    It.IsAny<CancellationToken>()
+                ),
             Times.Once
         );
     }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -3318,8 +3318,8 @@ namespace Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties
         [System.Xml.Serialization.XmlArray(ElementName="autoPdfTaskIds", IsNullable=true, Namespace="http://altinn.no/process")]
         [System.Xml.Serialization.XmlArrayItem(ElementName="taskId", Namespace="http://altinn.no/process")]
         public System.Collections.Generic.List<string>? AutoPdfTaskIds { get; set; }
-        [System.Xml.Serialization.XmlElement("filename", Namespace="http://altinn.no/process")]
-        public string? Filename { get; set; }
+        [System.Xml.Serialization.XmlElement("filenameTextResourceKey", Namespace="http://altinn.no/process")]
+        public string? FilenameTextResourceKey { get; set; }
     }
     public class AltinnSignatureConfiguration
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * PDF configuration property renamed from "Filename" to "FilenameTextResourceKey" with corresponding XML serialization updates.

* **Tests**
  * Updated test fixtures to reflect PDF configuration API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->