### PR TITLE
Delay throwing exceptions for invalid expressions untill thy actually gets evalutated.

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -133,11 +133,9 @@ public static class ExpressionEvaluator
             ExpressionFunction.gatewayAction => state.GetGatewayAction(),
             ExpressionFunction.language => state.GetLanguage(),
             ExpressionFunction.INVALID => throw new ExpressionEvaluatorTypeErrorException(
-                $"Function {expr.Args.FirstOrDefault()} not implemented in backend" + expr.ToString()
+                $"Function {expr.Args.FirstOrDefault()} not implemented in backend {expr}"
             ),
-            _ => throw new UnreachableException(
-                $"Function {(int)expr.Function} not a valid enum value" + expr.ToString()
-            ),
+            _ => throw new UnreachableException($"Function {(int)expr.Function} not a valid enum value {expr}"),
         };
         return ret;
     }
@@ -777,7 +775,7 @@ public static class ExpressionEvaluator
         var all = true;
         foreach (var arg in args)
         {
-            // Ensure all args gets converted, because they might throw an Exception
+            // the LINQ All() method would short-circuit and not evaluate all args, so we do it manually to ensure exceptions are thrown correctly
             if (!PrepareBooleanArg(arg))
             {
                 all = false;
@@ -819,7 +817,7 @@ public static class ExpressionEvaluator
         bool any = false;
         foreach (var arg in args)
         {
-            // Ensure all args gets converted, because they might throw an Exception
+            // the LINQ Any() method would short-circuit and not evaluate all args, so we do it manually to ensure exceptions are thrown correctly
             if (PrepareBooleanArg(arg))
             {
                 any = true;

--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -80,12 +81,13 @@ public static class ExpressionEvaluator
         ExpressionValue[]? positionalArguments = null
     )
     {
-        if (!expr.IsFunctionExpression)
+        if (expr.IsLiteralValue)
         {
             return expr.ValueUnion;
         }
+
         ValidateExpressionArgs(expr);
-        var args = new ExpressionValue[expr.Args.Count];
+        var args = new ExpressionValue[expr.Args.Length];
         for (var i = 0; i < args.Length; i++)
         {
             args[i] = await EvaluateExpression_internal(state, expr.Args[i], context, positionalArguments);
@@ -93,6 +95,7 @@ public static class ExpressionEvaluator
 
         ExpressionValue ret = expr.Function switch
         {
+            //ExpressionFunction.LITERAL_VALUE => expr.ValueUnion, // Handled above
             ExpressionFunction.dataModel => await DataModel(args, context, state),
             ExpressionFunction.component => await Component(args, context, state),
             ExpressionFunction.countDataElements => CountDataElements(args, state),
@@ -129,27 +132,33 @@ public static class ExpressionEvaluator
             ExpressionFunction.argv => Argv(args, positionalArguments),
             ExpressionFunction.gatewayAction => state.GetGatewayAction(),
             ExpressionFunction.language => state.GetLanguage(),
-            _ => throw new ExpressionEvaluatorTypeErrorException("Function not implemented", expr.Function, args),
+            ExpressionFunction.INVALID => throw new ExpressionEvaluatorTypeErrorException(
+                $"Function {expr.Args.FirstOrDefault()} not implemented in backend" + expr.ToString()
+            ),
+            _ => throw new UnreachableException(
+                $"Function {(int)expr.Function} not a valid enum value" + expr.ToString()
+            ),
         };
         return ret;
     }
 
     private static void ValidateExpressionArgs(Expression expr)
     {
+        // Some functions have restrictions that arguments must be literal values and not subexpressions.
         switch (expr)
         {
-            case { Function: ExpressionFunction.dataModel, Args: [_, { IsFunctionExpression: true }] }:
+            case { Function: ExpressionFunction.dataModel, Args: [_, { IsLiteralValue: false }] }:
                 throw new ExpressionEvaluatorTypeErrorException(
                     "The data type must be a string (expressions cannot be used here)"
                 );
-            case { Function: ExpressionFunction.@if, Args: [_, _, { IsFunctionExpression: true }, _] }:
+            case { Function: ExpressionFunction.@if, Args: [_, _, { IsLiteralValue: false }, _] }:
                 throw new ExpressionEvaluatorTypeErrorException("Expected third argument to be \"else\"");
-            case { Function: ExpressionFunction.compare, Args: [_, { IsFunctionExpression: true }, _] }:
-            case { Function: ExpressionFunction.compare, Args: [_, _, { IsFunctionExpression: true }, _] }:
+            case { Function: ExpressionFunction.compare, Args: [_, { IsLiteralValue: false }, _] }:
+            case { Function: ExpressionFunction.compare, Args: [_, _, { IsLiteralValue: false }, _] }:
                 throw new ExpressionEvaluatorTypeErrorException(
                     "Invalid operator (it cannot be an expression or null)"
                 );
-            case { Function: ExpressionFunction.compare, Args: [_, { IsFunctionExpression: true }, _, _] }:
+            case { Function: ExpressionFunction.compare, Args: [_, { IsLiteralValue: false }, _, _] }:
                 throw new ExpressionEvaluatorTypeErrorException(
                     "Second argument must be \"not\" when providing 4 arguments in total"
                 );
@@ -333,7 +342,7 @@ public static class ExpressionEvaluator
             date = TimeZoneInfo.ConvertTime(date.Value, timezone);
         }
 
-        string? language = state.GetLanguage();
+        string language = state.GetLanguage();
         return UnicodeDateTimeTokenConverter.Format(
             date,
             args.Length == 2 ? args[1].ToStringForEquals() : null,
@@ -653,12 +662,7 @@ public static class ExpressionEvaluator
             );
         }
 
-        var number = PrepareNumericArg(args[0]);
-
-        if (number is null)
-        {
-            number = 0;
-        }
+        var number = PrepareNumericArg(args[0]) ?? 0;
 
         int precision = 0;
 
@@ -667,7 +671,7 @@ public static class ExpressionEvaluator
             precision = (int)(PrepareNumericArg(args[1]) ?? 0);
         }
 
-        return number.Value.ToString($"N{precision}", CultureInfo.InvariantCulture);
+        return number.ToString($"N{precision}", CultureInfo.InvariantCulture);
     }
 
     private static string? UpperCase(ExpressionValue[] args)
@@ -770,9 +774,17 @@ public static class ExpressionEvaluator
             throw new ExpressionEvaluatorTypeErrorException("Expected 1+ argument(s), got 0");
         }
 
-        var preparedArgs = args.Select(arg => PrepareBooleanArg(arg)).ToArray();
-        // Ensure all args gets converted, because they might throw an Exception
-        return preparedArgs.All(a => a);
+        var all = true;
+        foreach (var arg in args)
+        {
+            // Ensure all args gets converted, because they might throw an Exception
+            if (!PrepareBooleanArg(arg))
+            {
+                all = false;
+            }
+        }
+
+        return all;
     }
 
     private static async Task<string?> Text(
@@ -804,9 +816,17 @@ public static class ExpressionEvaluator
             throw new ExpressionEvaluatorTypeErrorException("Expected 1+ argument(s), got 0");
         }
 
-        var preparedArgs = args.Select(arg => PrepareBooleanArg(arg)).ToArray();
-        // Ensure all args gets converted, because they might throw an Exception
-        return preparedArgs.Any(a => a);
+        bool any = false;
+        foreach (var arg in args)
+        {
+            // Ensure all args gets converted, because they might throw an Exception
+            if (PrepareBooleanArg(arg))
+            {
+                any = true;
+            }
+        }
+
+        return any;
     }
 
     private static bool? Not(ExpressionValue[] args)

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -270,7 +270,7 @@ public class LayoutEvaluatorState
                 $"Failed to add indexes to path {binding.Field} with indexes "
                     + $"{(context.RowIndices is null ? "null" : string.Join(", ", context.RowIndices))} on {dataElementId}"
             );
-        ;
+
         return new DataReference() { Field = field, DataElementIdentifier = dataElementId };
     }
 

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -401,7 +401,7 @@ public class LayoutEvaluatorState
 
     // private void GetModelErrorsForExpression(Expression expr, BaseComponent component, List<string> errors)
     // {
-    //     if (!expr.IsFunctionExpression)
+    //     if (expr.IsLiteralValue)
     //     {
     //         return;
     //     }

--- a/src/Altinn.App.Core/Models/Expressions/ComponentContext.cs
+++ b/src/Altinn.App.Core/Models/Expressions/ComponentContext.cs
@@ -220,9 +220,9 @@ public sealed class ComponentContext
             public IEnumerable<DebuggerEvaluatedExpression>? Args =>
                 _expression.Args?.Select(e => new DebuggerEvaluatedExpression(e, _context));
             public Task<ExpressionValue> EvaluationResult =>
-                _expression.IsFunctionExpression
-                    ? ExpressionEvaluator.EvaluateExpression_internal(_context.State, _expression, _context, null)
-                    : Task.FromResult(_expression.ValueUnion);
+                _expression.IsLiteralValue
+                    ? Task.FromResult(_expression.ValueUnion)
+                    : ExpressionEvaluator.EvaluateExpression_internal(_context.State, _expression, _context, null);
 
             public override string ToString()
             {

--- a/src/Altinn.App.Core/Models/Expressions/Expression.cs
+++ b/src/Altinn.App.Core/Models/Expressions/Expression.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Altinn.App.Core/Models/Expressions/Expression.cs
+++ b/src/Altinn.App.Core/Models/Expressions/Expression.cs
@@ -130,7 +130,8 @@ public readonly struct Expression : IEquatable<Expression>
     public bool IsLiteralString => ValueUnion.ValueKind == JsonValueKind.String;
 
     /// <summary>
-    /// We have a custom JsonSerializer so this will return the json array representation of this expression
+    /// The custom <see cref="ExpressionConverter"/> is a <see cref="JsonConverter{T}"/>
+    /// that serializes the expression to JSON (array for function or literal value).
     /// </summary>
     public override string ToString()
     {

--- a/src/Altinn.App.Core/Models/Expressions/ExpressionFunction.cs
+++ b/src/Altinn.App.Core/Models/Expressions/ExpressionFunction.cs
@@ -13,6 +13,13 @@ namespace Altinn.App.Core.Models.Expressions;
 public enum ExpressionFunction
 {
     /// <summary>
+    /// Expressions that hold a literal value have this as function
+    /// </summary>
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+    LITERAL_VALUE = -1,
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+
+    /// <summary>
     /// Value for all unknown functions.
     /// </summary>
     INVALID,

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/TestInvalid.cs
@@ -55,7 +55,7 @@ public class TestInvalid
 
             await ExpressionEvaluator.EvaluateExpression(state, test.Expression, await test.GetContextOrNull(state));
         };
-        (await act.Should().ThrowAsync<Exception>()).WithMessage(testCase.ExpectsFailure);
+        (await act.Should().ThrowAsync<Exception>()).WithMessage(testCase.ExpectsFailure + "*");
     }
 
     private static async Task<InvalidTestCase> LoadData(string testName, string folder)

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/ExpressionEvaluatorTests/ExpressionTests.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/ExpressionEvaluatorTests/ExpressionTests.cs
@@ -61,14 +61,14 @@ public class ExpressionTests
     {
         var trueExpression = Expression.True;
         Assert.True(trueExpression.ValueUnion.Bool);
-        Assert.False(trueExpression.IsFunctionExpression);
+        Assert.True(trueExpression.IsLiteralValue);
 
         var falseExpression = Expression.False;
         Assert.False(falseExpression.ValueUnion.Bool);
-        Assert.False(falseExpression.IsFunctionExpression);
+        Assert.True(falseExpression.IsLiteralValue);
 
         var nullExpression = Expression.Null;
         Assert.Equal(JsonValueKind.Null, nullExpression.ValueUnion.ValueKind);
-        Assert.False(nullExpression.IsFunctionExpression);
+        Assert.True(nullExpression.IsLiteralValue);
     }
 }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -4428,22 +4428,20 @@ namespace Altinn.App.Core.Models.Expressions
         [System.Obsolete("Use the constructor with ExpressionValue instead")]
         public Expression(object? value) { }
         public Expression(Altinn.App.Core.Models.Expressions.ExpressionFunction function, Altinn.App.Core.Models.Expressions.Expression arg1) { }
-        public Expression(Altinn.App.Core.Models.Expressions.ExpressionFunction function, System.Collections.Generic.List<Altinn.App.Core.Models.Expressions.Expression>? args) { }
+        public Expression(Altinn.App.Core.Models.Expressions.ExpressionFunction function, Altinn.App.Core.Models.Expressions.Expression[] args) { }
+        [System.Obsolete("Use the constructor with Expression[] instead")]
+        public Expression(Altinn.App.Core.Models.Expressions.ExpressionFunction function, System.Collections.Generic.List<Altinn.App.Core.Models.Expressions.Expression> args) { }
         public Expression(Altinn.App.Core.Models.Expressions.ExpressionFunction function, Altinn.App.Core.Models.Expressions.Expression arg1, Altinn.App.Core.Models.Expressions.Expression arg2) { }
-        public System.Collections.Generic.List<Altinn.App.Core.Models.Expressions.Expression>? Args { get; }
+        public Altinn.App.Core.Models.Expressions.Expression[]? Args { get; }
         public Altinn.App.Core.Models.Expressions.ExpressionFunction Function { get; }
-        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "Value")]
-        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "ValueUnion")]
-        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, new string?[]?[] {
-                "Function",
-                "Args"})]
-        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "Value")]
-        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "ValueUnion")]
-        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, new string?[]?[] {
-                "Function",
-                "Args"})]
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Args")]
+        [System.Obsolete("Use IsLiteralExpression instead")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Args")]
         public bool IsFunctionExpression { get; }
         public bool IsLiteralString { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "Args")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "Args")]
+        public bool IsLiteralValue { get; }
         [System.Obsolete("Use ValueUnion instead")]
         public object? Value { get; }
         public Altinn.App.Core.Internal.Expressions.ExpressionValue ValueUnion { get; }
@@ -4468,6 +4466,7 @@ namespace Altinn.App.Core.Models.Expressions
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
     public enum ExpressionFunction
     {
+        LITERAL_VALUE = -1,
         INVALID = 0,
         dataModel = 1,
         component = 2,

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -4435,7 +4435,7 @@ namespace Altinn.App.Core.Models.Expressions
         public Altinn.App.Core.Models.Expressions.Expression[]? Args { get; }
         public Altinn.App.Core.Models.Expressions.ExpressionFunction Function { get; }
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Args")]
-        [System.Obsolete("Use IsLiteralExpression instead")]
+        [System.Obsolete("Use !IsLiteralValue instead")]
         [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Args")]
         public bool IsFunctionExpression { get; }
         public bool IsLiteralString { get; }


### PR DESCRIPTION
After https://github.com/Altinn/app-lib-dotnet/pull/1421 we parse `textResourceBindings` on components in backend, and that causes issues with expressions that are not implemented. We don't (yet) evaluate the bindings if they are expressions, so delaying the exceptions restores the previous behaviour

I also renamed (and inverted) `Expression.IsFunctionExpression` to `!Expression.IsLiteralValue`, because I for a second was confused what an expression would be if it was not a function expression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, more consistent error reporting for invalid or unimplemented expressions.
  * More robust parsing/handling of malformed expressions to reduce surprising failures.

* **Refactor**
  * Literal values are handled consistently across evaluation and parsing, improving stability and null-safety.
  * Validation, boolean/number handling, and evaluation order tightened for more predictable results.
  * Internal argument representation streamlined while preserving compatibility.

* **Tests**
  * Updated tests to allow more flexible error-message matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->