### PR TITLE
Add rule to not update FluentAssertions due to lisence change in v8

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ that may break things downstream. Names and tags are in the `Telemetry` class.
 
 ### Testing
 
-We have automated tests in the `test/` folder using mainly xUnit, FluentAssertions, Moq and Verify.
+We have automated tests in the `test/` folder using mainly xUnit, Moq and Verify.
 Some tests invoke classes directly (while mocking dependencies as needed),
 while some construct adhoc DI containers or use ASP.NET Core `WebApplicationFactory<>`.
 The following resources are currently snapshot tested (some with Verify)

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,13 @@
   ],
   "packageRules": [
     {
+        // Limit FluentAssertions to version 7.x due to change of license in version 8.x
+        "matchPackageNames":[
+            "FluentAssertions"
+        ],
+        "allowedVersions":"<=7"
+    },
+    {
       "matchPackageNames": [
         "/dotnet(-|\\/)sdk/",
         "/^Microsoft\\.AspNetCore/",


### PR DESCRIPTION
Fluentassertions changed its licence in v8, and we need to keep using the free version until someone replaces all the old assertions with XUnit assertions (or other alternatives)

## Related Issue(s)
- Fixes https://github.com/Altinn/app-lib-dotnet/pull/1559

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance to list xUnit, Moq and Verify only and to remove FluentAssertions from recommended tools.

* **Chores**
  * Added a version constraint to limit FluentAssertions to 7.x due to licensing changes in later versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->