### PR TITLE
Fix gateway expression evaluation crash with invalid data element identifiers

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -288,8 +288,7 @@ public class LayoutEvaluatorState
                 );
         }
         // If the data element has the same type as default, return it
-
-        if (defaultDataElementIdentifier.HasValue)
+        if (defaultDataElementIdentifier.HasValue && defaultDataElementIdentifier.Value.Guid != Guid.Empty)
         {
             var defaultDataType = _dataAccessor.GetDataType(defaultDataElementIdentifier.Value);
             if (defaultDataType.Id == key.DataType)


### PR DESCRIPTION
## Description

My earlier fix in #1539 regressed when #1530 was merged. Applying a fix for this problem again so that the relevant cypress tests in `ttd/stateless-app` works again in the monorepo.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out) (in the monorepo!)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where invalid default data element identifiers could be processed in certain scenarios. The system now validates that default identifiers contain valid values before using them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->