### PR TITLE
Fix ExpressionExclusiveGateway when no default data element is found

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -221,7 +221,7 @@ public static class ExpressionEvaluator
 
     private static async Task<ExpressionValue> DataModel(
         ModelBinding key,
-        DataElementIdentifier defaultDataElementIdentifier,
+        DataElementIdentifier? defaultDataElementIdentifier,
         int[]? indexes,
         LayoutEvaluatorState state
     )

--- a/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
+++ b/src/Altinn.App.Core/Internal/Process/ExpressionsExclusiveGateway.cs
@@ -88,8 +88,7 @@ public class ExpressionsExclusiveGateway : IProcessExclusiveGateway
                 dataTypeId = layoutSet?.DataType;
             }
             var expression = GetExpressionFromCondition(sequenceFlow.ConditionExpression);
-            DataElementIdentifier dataElement =
-                instance.Data.Find(d => d.DataType == dataTypeId) ?? new DataElementIdentifier();
+            DataElementIdentifier? dataElement = instance.Data.Find(d => d.DataType == dataTypeId);
 
             var componentContext = new ComponentContext(
                 state,

--- a/src/Altinn.App.Core/Models/Expressions/ComponentContext.cs
+++ b/src/Altinn.App.Core/Models/Expressions/ComponentContext.cs
@@ -19,7 +19,7 @@ public sealed class ComponentContext
         LayoutEvaluatorState state,
         BaseComponent? component,
         int[]? rowIndices,
-        DataElementIdentifier dataElementIdentifier,
+        DataElementIdentifier? dataElementIdentifier,
         List<ComponentContext>? childContexts = null
     )
     {
@@ -160,7 +160,7 @@ public sealed class ComponentContext
     /// <summary>
     /// The Id of the default data element in this context
     /// </summary>
-    public DataElementIdentifier DataElementIdentifier { get; }
+    public DataElementIdentifier? DataElementIdentifier { get; }
 
     /// <summary>
     /// Get all children and children of children of this componentContext (not including this)
@@ -199,7 +199,7 @@ public sealed class ComponentContext
         public BaseComponent? Component => _context.Component;
         public ComponentContext? Parent => _context.Parent;
         public bool? IsHidden => _context._isHidden;
-        public Guid DataElementId => _context.DataElementIdentifier.Guid;
+        public Guid? DataElementId => _context.DataElementIdentifier?.Guid;
         public int[]? RowIndices => _context.RowIndices;
 
         public DebuggerEvaluatedExpression HiddenExpression =>

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -4417,10 +4417,10 @@ namespace Altinn.App.Core.Models.Expressions
     [System.Diagnostics.DebuggerTypeProxy(typeof(Altinn.App.Core.Models.Expressions.ComponentContext.DebuggerProxy))]
     public sealed class ComponentContext
     {
-        public ComponentContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent? component, int[]? rowIndices, Altinn.App.Core.Models.DataElementIdentifier dataElementIdentifier, System.Collections.Generic.List<Altinn.App.Core.Models.Expressions.ComponentContext>? childContexts = null) { }
+        public ComponentContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent? component, int[]? rowIndices, Altinn.App.Core.Models.DataElementIdentifier? dataElementIdentifier, System.Collections.Generic.List<Altinn.App.Core.Models.Expressions.ComponentContext>? childContexts = null) { }
         public System.Collections.Generic.List<Altinn.App.Core.Models.Expressions.ComponentContext> ChildContexts { get; }
         public Altinn.App.Core.Models.Layout.Components.Base.BaseComponent? Component { get; }
-        public Altinn.App.Core.Models.DataElementIdentifier DataElementIdentifier { get; }
+        public Altinn.App.Core.Models.DataElementIdentifier? DataElementIdentifier { get; }
         public System.Collections.Generic.IEnumerable<Altinn.App.Core.Models.Expressions.ComponentContext> Descendants { get; }
         public bool HasChildContexts { get; }
         public Altinn.App.Core.Models.Expressions.ComponentContext? Parent { get; }


### PR DESCRIPTION
This also requires ComponentContext.DataElementIdentifier to be nullable

## Related Issue(s)
- Replaces #1562


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced data element identifier handling to support optional scenarios where identifiers may not be available, improving system flexibility and robustness.

* **Tests**
  * Updated API verification tests to reflect updated parameter and property nullability changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->