### PR TITLE
Handle the nullable hack we use for [XmlText] fields

### DIFF
--- a/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
+++ b/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
@@ -236,6 +236,19 @@ public static class FormDataWrapperUtils
             return true;
         }
 
+        // Skip properties with [JsonIgnore]
+        if (SourceReaderUtils.HasJsonIgnoreAttribute(property))
+        {
+            return true;
+        }
+
+        // Skip properties with [BindNever]
+        // TODO: Theese could be made "read-only", but skipping them for now as there has not been a use-case yet
+        if (SourceReaderUtils.HasBindNeverAttribute(property))
+        {
+            return true;
+        }
+
         return false;
     }
 }

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/Models/Skjema.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/Models/Skjema.cs
@@ -1,11 +1,21 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+#pragma warning disable IDE1006 // Naming Styles
 
 namespace Altinn.App.SourceGenerator.Integration.Tests.Models;
 
 public class Skjema
 {
+    // Extra properties to test that they get ignored by source generator
+    public const string FormDataType = "form";
+    public static readonly string FormDataTypeStatic = FormDataType;
+    public string FormDataTypeId => FormDataType;
+
     [JsonPropertyName("skjemanummer")]
     public string? Skjemanummer { get; set; }
 
@@ -39,6 +49,12 @@ public class SkjemaInnhold
 
     [JsonPropertyName("tidligere-adresse")]
     public List<Adresse>? TidligereAdresse { get; set; }
+
+    [JsonPropertyName("oldXmlValue")]
+    public OldXmlValue? OldXmlValue { get; set; }
+
+    [JsonPropertyName("withCollection")]
+    public ICollection<Adresse>? WithCollection { get; set; }
 }
 
 public class Adresse
@@ -58,7 +74,29 @@ public class Adresse
 
     // List of string is invalid in altinn datamodels, but might be used for backend purposes and must compile
     [JsonPropertyName("tags")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? Tags { get; set; }
+}
+
+public class OldXmlValue
+{
+    [Range(-999999999999999d, 999999999999999d)]
+    [Required]
+    [XmlIgnore]
+    [JsonPropertyName("value")]
+    public decimal? valueNullable { get; set; }
+
+    [XmlText]
+    [JsonIgnore]
+    public decimal value
+    {
+        get => valueNullable ?? default;
+        set { valueNullable = value; }
+    }
+
+    [XmlAttribute("orid")]
+    [BindNever]
+    public string orid { get; set; } = "7117";
 }
 
 public class Empty { }

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
@@ -102,6 +102,7 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             "deltar" when nextOffset is -1 && literalIndex is -1 => model.Deltar,
             "adresse" when literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
             "tidligere-adresse" => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
+            "oldXmlValue" when literalIndex is -1 => GetRecursive(model.OldXmlValue, path, nextOffset),
             // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
@@ -168,6 +169,25 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         }
 
         return GetRecursive(model[literalIndex], path, offset);
+    }
+
+    private static object? GetRecursive(
+        global::Altinn.App.SourceGenerator.Integration.Tests.Models.OldXmlValue? model,
+        global::System.ReadOnlySpan<char> path,
+        int offset
+    )
+    {
+        if (model is null || offset == -1)
+        {
+            return model;
+        }
+
+        return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
+        {
+            "value" when nextOffset is -1 && literalIndex is -1 => model.valueNullable,
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
+            _ => null,
+        };
     }
 
     #endregion Getters
@@ -389,6 +409,20 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                     );
                 }
                 return;
+            case "oldXmlValue":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 11;
+                if (pathOffset != -1)
+                {
+                    AddIndexToPathRecursive_Altinn_App_SourceGenerator_Integration_Tests_Models_OldXmlValue(
+                        path,
+                        pathOffset,
+                        rowIndexes,
+                        buffer,
+                        ref bufferOffset
+                    );
+                }
+                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -475,6 +509,31 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         }
     }
 
+    private void AddIndexToPathRecursive_Altinn_App_SourceGenerator_Integration_Tests_Models_OldXmlValue(
+        global::System.ReadOnlySpan<char> path,
+        int pathOffset,
+        global::System.ReadOnlySpan<int> rowIndexes,
+        global::System.Span<char> buffer,
+        ref int bufferOffset
+    )
+    {
+        if (bufferOffset > 0)
+        {
+            buffer[bufferOffset++] = '.';
+        }
+        var segment = ParseSegment(path, pathOffset, out pathOffset, out int literalIndex);
+        switch (segment)
+        {
+            case "value":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 5;
+                return;
+            default:
+                bufferOffset = 0;
+                return;
+        }
+    }
+
     #endregion AddIndexToPath
     #region Copy
 
@@ -540,6 +599,7 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             Deltar = data.Deltar,
             Adresse = CopyRecursive(data.Adresse),
             TidligereAdresse = CopyRecursive(data.TidligereAdresse),
+            OldXmlValue = CopyRecursive(data.OldXmlValue),
         };
     }
 
@@ -599,6 +659,22 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         }
 
         return result;
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("data")]
+    private static global::Altinn.App.SourceGenerator.Integration.Tests.Models.OldXmlValue? CopyRecursive(
+        global::Altinn.App.SourceGenerator.Integration.Tests.Models.OldXmlValue? data
+    )
+    {
+        if (data is null)
+        {
+            return null;
+        }
+
+        return new()
+        {
+            valueNullable = data.valueNullable,
+        };
     }
 
     #endregion Copy
@@ -720,6 +796,12 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             case "tidligere-adresse":
                 RemoveRecursive(model.TidligereAdresse, path, nextOffset, literalIndex, rowRemovalOption);
                 break;
+            case "oldXmlValue" when (nextOffset is -1) && (literalIndex is -1):
+                model.OldXmlValue = default;
+                break;
+            case "oldXmlValue":
+                RemoveRecursive(model.OldXmlValue, path, nextOffset, rowRemovalOption);
+                break;
             default:
                 // throw new ArgumentException("{path} is not a valid path.");
                 return;
@@ -821,6 +903,28 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         else
         {
             RemoveRecursive(model[index], path, offset, rowRemovalOption);
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::Altinn.App.SourceGenerator.Integration.Tests.Models.OldXmlValue? model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        switch (ParseSegment(path, offset, out int nextOffset, out int literalIndex))
+        {
+            case "value" when (nextOffset is -1) && (literalIndex is -1):
+                model.valueNullable = default;
+                break;
+            default:
+                // throw new ArgumentException("{path} is not a valid path.");
+                return;
         }
     }
 
@@ -1099,6 +1203,20 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
 //               "TypeName": "string",
 //               "IsJsonValueType": true,
 //               "ListType": "global::System.Collections.Generic.List<string>",
+//             }
+//           ]
+//         },
+//         {
+//           "JsonName": "oldXmlValue",
+//           "CSharpName": "OldXmlValue",
+//           "TypeName": "global::Altinn.App.SourceGenerator.Integration.Tests.Models.OldXmlValue",
+//           "IsJsonValueType": false,
+//           "Properties": [
+//             {
+//               "JsonName": "value",
+//               "CSharpName": "valueNullable",
+//               "TypeName": "decimal",
+//               "IsJsonValueType": true,
 //             }
 //           ]
 //         }

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
@@ -103,6 +103,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             "deltar" when nextOffset is -1 && literalIndex is -1 => model.Deltar,
             "adresse" when literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
             "tidligere-adresse" => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
+            "oldXmlValue" when literalIndex is -1 => GetRecursive(model.OldXmlValue, path, nextOffset),
             // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
@@ -169,6 +170,25 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         }
 
         return GetRecursive(model[literalIndex], path, offset);
+    }
+
+    private static object? GetRecursive(
+        global::Altinn.App.SourceGenerator.Tests.OldXmlValue? model,
+        global::System.ReadOnlySpan<char> path,
+        int offset
+    )
+    {
+        if (model is null || offset == -1)
+        {
+            return model;
+        }
+
+        return ParseSegment(path, offset, out int nextOffset, out int literalIndex) switch
+        {
+            "value" when nextOffset is -1 && literalIndex is -1 => model.valueNullable,
+            // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
+            _ => null,
+        };
     }
 
     #endregion Getters
@@ -390,6 +410,20 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     );
                 }
                 return;
+            case "oldXmlValue":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 11;
+                if (pathOffset != -1)
+                {
+                    AddIndexToPathRecursive_Altinn_App_SourceGenerator_Tests_OldXmlValue(
+                        path,
+                        pathOffset,
+                        rowIndexes,
+                        buffer,
+                        ref bufferOffset
+                    );
+                }
+                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -476,6 +510,31 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         }
     }
 
+    private void AddIndexToPathRecursive_Altinn_App_SourceGenerator_Tests_OldXmlValue(
+        global::System.ReadOnlySpan<char> path,
+        int pathOffset,
+        global::System.ReadOnlySpan<int> rowIndexes,
+        global::System.Span<char> buffer,
+        ref int bufferOffset
+    )
+    {
+        if (bufferOffset > 0)
+        {
+            buffer[bufferOffset++] = '.';
+        }
+        var segment = ParseSegment(path, pathOffset, out pathOffset, out int literalIndex);
+        switch (segment)
+        {
+            case "value":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 5;
+                return;
+            default:
+                bufferOffset = 0;
+                return;
+        }
+    }
+
     #endregion AddIndexToPath
     #region Copy
 
@@ -541,6 +600,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             Deltar = data.Deltar,
             Adresse = CopyRecursive(data.Adresse),
             TidligereAdresse = CopyRecursive(data.TidligereAdresse),
+            OldXmlValue = CopyRecursive(data.OldXmlValue),
         };
     }
 
@@ -600,6 +660,22 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         }
 
         return result;
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("data")]
+    private static global::Altinn.App.SourceGenerator.Tests.OldXmlValue? CopyRecursive(
+        global::Altinn.App.SourceGenerator.Tests.OldXmlValue? data
+    )
+    {
+        if (data is null)
+        {
+            return null;
+        }
+
+        return new()
+        {
+            valueNullable = data.valueNullable,
+        };
     }
 
     #endregion Copy
@@ -721,6 +797,12 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             case "tidligere-adresse":
                 RemoveRecursive(model.TidligereAdresse, path, nextOffset, literalIndex, rowRemovalOption);
                 break;
+            case "oldXmlValue" when (nextOffset is -1) && (literalIndex is -1):
+                model.OldXmlValue = default;
+                break;
+            case "oldXmlValue":
+                RemoveRecursive(model.OldXmlValue, path, nextOffset, rowRemovalOption);
+                break;
             default:
                 // throw new ArgumentException("{path} is not a valid path.");
                 return;
@@ -822,6 +904,28 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         else
         {
             RemoveRecursive(model[index], path, offset, rowRemovalOption);
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::Altinn.App.SourceGenerator.Tests.OldXmlValue? model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        switch (ParseSegment(path, offset, out int nextOffset, out int literalIndex))
+        {
+            case "value" when (nextOffset is -1) && (literalIndex is -1):
+                model.valueNullable = default;
+                break;
+            default:
+                // throw new ArgumentException("{path} is not a valid path.");
+                return;
         }
     }
 
@@ -1100,6 +1204,20 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //               "TypeName": "string",
 //               "IsJsonValueType": true,
 //               "ListType": "global::System.Collections.Generic.List<string>",
+//             }
+//           ]
+//         },
+//         {
+//           "JsonName": "oldXmlValue",
+//           "CSharpName": "OldXmlValue",
+//           "TypeName": "global::Altinn.App.SourceGenerator.Tests.OldXmlValue",
+//           "IsJsonValueType": false,
+//           "Properties": [
+//             {
+//               "JsonName": "value",
+//               "CSharpName": "valueNullable",
+//               "TypeName": "decimal",
+//               "IsJsonValueType": true,
 //             }
 //           ]
 //         }

--- a/test/Altinn.App.SourceGenerator.Tests/SourceReaderTests/JsonIgnoreAttributeTests.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceReaderTests/JsonIgnoreAttributeTests.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+using Altinn.App.Analyzers.SourceTextGenerator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Altinn.App.SourceGenerator.Tests.SourceReaderTests;
+
+public class JsonIgnoreAttributeTests
+{
+    [Theory]
+    [InlineData("[JsonIgnore]", true)]
+    [InlineData("[JsonIgnore()]", true)]
+    [InlineData("[JsonIgnore(Condition = JsonIgnoreCondition.Always)]", true)]
+    [InlineData("[JsonIgnore(Condition = JsonIgnoreCondition.Never)]", false)]
+    [InlineData("[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]", false)]
+    [InlineData("[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]", false)]
+    public void HasJsonIgnoreAttribute_ShouldBeIgnored(string attribute, bool ignored)
+    {
+        var source = $$"""
+            using System.Text.Json.Serialization;
+
+            public class TestClass
+            {
+                {{attribute}}
+                public string Property { get; set; }
+            }
+            """;
+        var property = GetPropertySymbol(source, "Property");
+        Assert.Equal(ignored, SourceReaderUtils.HasJsonIgnoreAttribute(property));
+    }
+
+    private static IPropertySymbol GetPropertySymbol(string source, string propertyName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = AppDomain
+            .CurrentDomain.GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))
+            .Select(assembly => MetadataReference.CreateFromFile(assembly.Location))
+            .Concat([MetadataReference.CreateFromFile(typeof(JsonIgnoreAttribute).Assembly.Location)]);
+
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        var root = syntaxTree.GetRoot();
+        var propertyDeclaration = root.DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.PropertyDeclarationSyntax>()
+            .Single(p => p.Identifier.Text == propertyName);
+
+        var propertySymbol = semanticModel.GetDeclaredSymbol(propertyDeclaration);
+        Assert.NotNull(propertySymbol);
+
+        return propertySymbol;
+    }
+}


### PR DESCRIPTION
`IFormDataWrapper` should operate as if the target is the json structure.

The `[XmlText]` attribute does not support nullable value types, so we used a hack on the form
```c#
public class OldXmlValue
{
    [Range(-999999999999999d, 999999999999999d)]
    [Required]
    [XmlIgnore]
    [JsonPropertyName("value")]
    public decimal? valueNullable { get; set; }

    [XmlText]
    [JsonIgnore]
    public decimal value
    {
        get => valueNullable ?? default;
        set { valueNullable = value; }
    }

    [XmlAttribute("orid")]
    [BindNever]
    public string orid { get; set; } = "7117";
}
```

The unfortunate consequence was that the SourceGenerator saw this and generated two properties with name `"value"` witch caused the compile to fail in service owners apps.

They fix was to properly respect `JsonIgnore` (including `Condition`) because only the json structure is relevant for source generated `IFormDataWrapper` implementations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for properties marked with `[JsonIgnore]` and `[BindNever]` attributes to be properly excluded from data wrapper processing.
  * Enhanced model property filtering to recognize these annotations alongside existing exclusion rules.

* **Tests**
  * Added test coverage for `[JsonIgnore]` attribute detection across different attribute syntax variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->