### PR TITLE
fix: flaky fiks arkiv disposal test

### DIFF
--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivHostTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivHostTest.cs
@@ -49,6 +49,8 @@ public class FiksArkivHostTest
             await cts.CancelAsync();
         }
 
+        await Task.Delay(50); // TODO: hopes and prayers that scheduled continuations have now run
+
         // Assert
         Assert.Single(createdClients);
         createdClients[0].Verify(x => x.DisposeAsync(), Times.Once);

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivHostTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivHostTest.cs
@@ -1,11 +1,9 @@
-using System.Linq.Expressions;
 using Altinn.App.Clients.Fiks.Constants;
 using Altinn.App.Clients.Fiks.Extensions;
 using Altinn.App.Clients.Fiks.FiksArkiv;
 using Altinn.App.Clients.Fiks.FiksArkiv.Models;
 using Altinn.App.Clients.Fiks.FiksIO;
 using Altinn.App.Clients.Fiks.FiksIO.Models;
-using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using KS.Fiks.Arkiv.Models.V1.Meldingstyper;
@@ -14,10 +12,8 @@ using KS.Fiks.IO.Client.Models;
 using KS.Fiks.IO.Client.Send;
 using KS.Fiks.IO.Crypto.Models;
 using KS.Fiks.IO.Send.Client.Models;
-using Ks.Fiks.Maskinporten.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using MessageReceivedCallback = System.Func<
@@ -37,19 +33,21 @@ public class FiksArkivHostTest
         var (clientFactoryMock, createdClients) = GetFixIOClientFactoryMock();
         using var cts = new CancellationTokenSource();
 
-        await using var fixture = TestFixture.Create(
-            services =>
-            {
-                services.AddFiksArkiv();
-                services.AddSingleton(loggerMock.Object);
-                services.AddSingleton(clientFactoryMock.Object);
-            },
-            mockFiksIOClientFactory: false
-        );
+        {
+            await using var fixture = TestFixture.Create(
+                services =>
+                {
+                    services.AddFiksArkiv();
+                    services.AddSingleton(loggerMock.Object);
+                    services.AddSingleton(clientFactoryMock.Object);
+                },
+                mockFiksIOClientFactory: false
+            );
 
-        // Act
-        await fixture.FiksArkivHost.StartAsync(cts.Token);
-        await cts.CancelAsync();
+            // Act
+            await fixture.FiksArkivHost.StartAsync(cts.Token);
+            await cts.CancelAsync();
+        }
 
         // Assert
         Assert.Single(createdClients);

--- a/test/Altinn.App.Clients.Fiks.Tests/TestFixture.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/TestFixture.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -30,7 +29,6 @@ using Altinn.App.Core.Models;
 using Altinn.Common.AccessTokenClient.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
## Description

`ExecuteAsync_StopsWhenCancellationRequested` is failing from time to time, see https://github.com/Altinn/app-lib-dotnet/actions/runs/19359210515/job/55386878626

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Optimized test fixture setup with tighter scoping and added a short post-action delay to ensure scheduled continuations complete.

* **Chores**
  * Removed unused using directives and pruned unnecessary test-file imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->