### PR TITLE
[Tests] Improve MocedServiceColletcition with Otel traces, logs and metrics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,6 +44,7 @@
     <PackageVersion Include="Nullable.Extended.Analyzer" Version="1.15.6581" />
     <PackageVersion Include="OpenTelemetry" Version="1.13.1" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.13.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.13.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTestsXmlJson.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTestsXmlJson.cs
@@ -22,7 +22,7 @@ public class DataClientTestsXmlJson
 
     public DataClientTestsXmlJson(ITestOutputHelper outputHelper)
     {
-        _mockedServiceCollection.AddXunitLogging(outputHelper);
+        _mockedServiceCollection.OutputHelper = outputHelper;
         _mockedServiceCollection.TryAddCommonServices();
 
         _mockedServiceCollection.AddDataType<TestDataJson>(

--- a/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceInstanceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceInstanceTests.cs
@@ -28,7 +28,7 @@ public class TranslationServiceInstanceTests
     public async Task TranslateTextKey_WithDataSources()
     {
         var fixture = new MockedServiceCollection();
-        fixture.AddXunitLogging(_output);
+        fixture.OutputHelper = _output;
         var language = "esperanto";
         fixture.AddTextResource(
             language,

--- a/test/Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj
+++ b/test/Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Verify.Http"/>
     <PackageReference Include="xunit.assert"/>
     <PackageReference Include="OpenTelemetry"/>
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="System.Linq.Async"/>
   </ItemGroup>
 

--- a/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
+++ b/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
@@ -306,7 +306,8 @@ public class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsync
         outputHelper.WriteLine($"Meters collected: {Metrics.Count}");
         foreach (var metric in Metrics)
         {
-            outputHelper.WriteLine($"{metric.Name}");
+            // Figure out a better way to dump metric data later
+            outputHelper.WriteLine($"{metric.Name} - {metric.Temporality} - {metric.Unit}");
         }
     }
 
@@ -396,10 +397,16 @@ public class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsync
         return _serviceProvider.GetRequiredKeyedService(serviceType, serviceKey);
     }
 
+    private bool _dumpedTracesAndMetrics;
+
 #pragma warning disable CA1816
     public void Dispose()
     {
-        DumpTracesAndMetrics();
+        if (!_dumpedTracesAndMetrics)
+        {
+            _dumpedTracesAndMetrics = true;
+            DumpTracesAndMetrics();
+        }
         _serviceProvider.Dispose();
         _tracerProvider.Dispose();
         _meterProvider.Dispose();
@@ -407,7 +414,11 @@ public class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsync
 
     public async ValueTask DisposeAsync()
     {
-        DumpTracesAndMetrics();
+        if (!_dumpedTracesAndMetrics)
+        {
+            _dumpedTracesAndMetrics = true;
+            DumpTracesAndMetrics();
+        }
         await _serviceProvider.DisposeAsync();
         _tracerProvider.Dispose();
         _meterProvider.Dispose();

--- a/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
+++ b/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
@@ -1,4 +1,7 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
@@ -17,13 +20,17 @@ using Altinn.App.Core.Models.Layout;
 using Altinn.App.Core.Models.Layout.Components;
 using Altinn.App.Core.Models.Layout.Components.Base;
 using Altinn.App.Tests.Common.Mocks;
+using Altinn.App.Tests.Common.Utils;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 using Xunit.Abstractions;
 
 namespace Altinn.App.Tests.Common.Fixtures;
@@ -31,7 +38,7 @@ namespace Altinn.App.Tests.Common.Fixtures;
 public class MockedServiceCollection
 {
     public const string Org = "ttd";
-    public const string App = "test";
+    public const string App = "mocked-app";
 
     public PlatformSettings PlatformSettings { get; } = new PlatformSettings();
     public AppSettings AppSettings { get; } = new AppSettings();
@@ -40,6 +47,14 @@ public class MockedServiceCollection
     public ApplicationMetadata AppMetadata => Storage.AppMetadata;
 
     public StorageClientInterceptor Storage { get; }
+
+    public List<Activity> Traces { get; } = new();
+
+    public List<Metric> Metrics { get; } = new();
+
+    public List<LogRecord> Logs { get; } = new();
+
+    public ITestOutputHelper? OutputHelper { get; set; }
 
     public Mock<IAppResources> AppResourcesMock { get; } = new(MockBehavior.Strict);
     public Mock<IAppMetadata> AppMetadataMock { get; } = new(MockBehavior.Strict);
@@ -55,11 +70,6 @@ public class MockedServiceCollection
     {
         Storage = new StorageClientInterceptor();
         _services.AddSingleton(this);
-    }
-
-    public void AddXunitLogging(ITestOutputHelper outputHelper)
-    {
-        FakeLoggerXunit.AddFakeLoggingWithXunit(_services, outputHelper);
     }
 
     public void TryAddCommonServices()
@@ -88,12 +98,16 @@ public class MockedServiceCollection
         _services.AddHttpClient<IDataClient, DataClient>().ConfigurePrimaryHttpMessageHandler(() => Storage);
         _services.AddHttpClient<IInstanceClient, InstanceClient>().ConfigurePrimaryHttpMessageHandler(() => Storage);
 
-        // Ensure logging is present
-        var hasLogger = _services.Any(s => s.ServiceType == typeof(ILoggerFactory));
-        if (!hasLogger)
+        _services.TryAddSingleton<Telemetry>();
+        _services.AddLogging(builder =>
         {
-            _services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
-        }
+            builder.AddOpenTelemetry(options =>
+            {
+                options.AddInMemoryExporter(Logs);
+                options.IncludeFormattedMessage = true;
+                options.IncludeScopes = true;
+            });
+        });
 
         // Add standard mocks
         _services.TryAddSingleton(AppResourcesMock.Object);
@@ -108,8 +122,9 @@ public class MockedServiceCollection
             .Setup(a => a.GetAccessToken(It.IsAny<AuthenticationMethod>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JwtToken());
         UserTokenProviderMock.Setup(utp => utp.GetUserToken()).Returns("[userToken]");
+        // Setup AppResources to return text resources from the internal dictionary
         AppResourcesMock
-            .Setup(a => a.GetTexts(Org, App, It.IsAny<String>()))
+            .Setup(a => a.GetTexts(Org, App, It.IsAny<string>()))
             .ReturnsAsync(
                 (string _, string _, string language) =>
                 {
@@ -117,6 +132,26 @@ public class MockedServiceCollection
                     {
                         return _textResources.GetValueOrDefault(language);
                     }
+                }
+            );
+        AppResourcesMock
+            .Setup(a => a.GetLayoutModelForTask(It.IsAny<string>()))
+            .Returns(
+                (string taskid) =>
+                {
+                    var layouts = _layoutSetComponents.ToList();
+                    var layoutForTask =
+                        layouts.Find(lsc => lsc.DefaultDataType.TaskId == taskid)
+                        ?? throw new Exception($"Layout for task {taskid} not found.");
+                    return new LayoutModel(
+                        layouts,
+                        new LayoutSet()
+                        {
+                            DataType = layoutForTask.DefaultDataType.Id,
+                            Id = layoutForTask.Id,
+                            Tasks = [taskid],
+                        }
+                    );
                 }
             );
     }
@@ -129,7 +164,12 @@ public class MockedServiceCollection
         }
     }
 
-    public DataType AddDataType<T>(string? dataTypeId = null, string[]? allowedContentTypes = null, int maxCount = 1)
+    public DataType AddDataType<T>(
+        string? dataTypeId = null,
+        string[]? allowedContentTypes = null,
+        int maxCount = 1,
+        string? taskId = null
+    )
         where T : class, new()
     {
         var classRef =
@@ -141,6 +181,7 @@ public class MockedServiceCollection
             AppLogic = new() { ClassRef = classRef },
             MaxCount = maxCount,
             AllowedContentTypes = allowedContentTypes?.ToList() ?? ["application/xml"],
+            TaskId = taskId ?? "Task_1",
         };
 
         AppModelMock.Setup(a => a.GetModelType(classRef)).Returns(typeof(T));
@@ -170,8 +211,45 @@ public class MockedServiceCollection
         }
     }
 
-    public ServiceProvider BuildServiceProvider() =>
-        ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(_services);
+    private readonly ConcurrentBag<LayoutSetComponent> _layoutSetComponents = new();
+
+    /// <summary>
+    /// Add single page layout set from JSON definition
+    /// </summary>
+    public void AddLayoutSet(DataType dataType, [StringSyntax("json")] string pageJson)
+    {
+        var layoutId = $"layoutSet-{dataType.TaskId}";
+        using var document = JsonDocument.Parse(pageJson);
+        var page = PageComponent.Parse(document.RootElement, "page1", layoutId);
+        AddLayoutSet(dataType, [page]);
+    }
+
+    public void AddLayoutSet(DataType dataType, IEnumerable<PageComponent> pages)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataType.TaskId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataType.Id);
+
+        // All pages will likely have the same LayoutId, but group by to be sure
+        foreach (var grouping in pages.GroupBy(p => p.LayoutId))
+        {
+            var layoutSet = new LayoutSet
+            {
+                Id = grouping.Key,
+                DataType = dataType.Id,
+                Tasks = [dataType.TaskId],
+            };
+
+            var layoutComponent = new LayoutSetComponent(
+                pages: grouping.ToList(),
+                id: layoutSet.Id,
+                defaultDataType: dataType
+            );
+
+            _layoutSetComponents.Add(layoutComponent);
+        }
+    }
+
+    public WrappedServiceProvider BuildServiceProvider() => new(this, _services.BuildServiceProvider());
 
     public void VerifyMocks()
     {
@@ -182,24 +260,103 @@ public class MockedServiceCollection
     }
 }
 
-public static class MockedServiceProviderExtensions
+public class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsyncDisposable
 {
-    internal static async Task<InstanceDataUnitOfWork> CreateInstanceDataMutatorWithDataAndLayout<T>(
-        this ServiceProvider serviceProvider,
+    public List<Activity> Traces => _serviceCollection.Traces;
+    public List<Metric> Metrics => _serviceCollection.Metrics;
+    public List<LogRecord> Logs => _serviceCollection.Logs;
+
+    private readonly TracerProvider _tracerProvider;
+    private readonly MeterProvider _meterProvider;
+    private readonly ServiceProvider _serviceProvider;
+    private readonly MockedServiceCollection _serviceCollection;
+
+    public WrappedServiceProvider(MockedServiceCollection serviceCollection, ServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+        _serviceCollection = serviceCollection;
+        var telemetry = serviceProvider.GetRequiredService<Telemetry>();
+        _tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(telemetry.ActivitySource.Name)
+            .AddInMemoryExporter(Traces)
+            .Build();
+        _meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(telemetry.ActivitySource.Name)
+            .AddInMemoryExporter(Metrics)
+            .Build();
+    }
+
+    public void DumpTracesAndMetrics()
+    {
+        if (_serviceCollection.OutputHelper is not { } outputHelper)
+        {
+            return;
+        }
+        _tracerProvider.ForceFlush();
+        _meterProvider.ForceFlush();
+
+        outputHelper.WriteLine("");
+        outputHelper.WriteLine("OTEL Data:");
+        outputHelper.WriteLine($"Traces collected: {Traces.Count}");
+        outputHelper.WriteLine($"Logs collected: {Logs.Count}");
+        outputHelper.WriteLine(
+            OtelVisualizers.VisualizeActivities(Traces, Logs, includeDuration: true, initialIndent: 1)
+        );
+        outputHelper.WriteLine("");
+        outputHelper.WriteLine($"Meters collected: {Metrics.Count}");
+        foreach (var metric in Metrics)
+        {
+            outputHelper.WriteLine($"{metric.Name}");
+        }
+    }
+
+    internal async Task<InstanceDataUnitOfWork> CreateInstanceDataUnitOfWork<T>(
+        T model,
+        DataType dataType,
+        string? language
+    )
+        where T : class, new()
+    {
+        var serializer = _serviceProvider.GetRequiredService<ModelSerializationService>();
+        var instanceGuid = Guid.NewGuid();
+        var dataGuid = Guid.NewGuid();
+        var partyId = 123456;
+        var data = new DataElement()
+        {
+            Id = dataGuid.ToString(),
+            InstanceGuid = instanceGuid.ToString(),
+            DataType = dataType.Id,
+            ContentType = dataType.AllowedContentTypes?.FirstOrDefault() ?? "application/xml",
+        };
+        var instance = new Instance()
+        {
+            Id = $"{partyId}/{instanceGuid}",
+            AppId = $"{MockedServiceCollection.Org}/{MockedServiceCollection.App}",
+            InstanceOwner = new InstanceOwner() { PartyId = partyId.ToString() },
+            Data = [data],
+            Process = new() { CurrentTask = new() { ElementId = dataType.TaskId } },
+        };
+
+        _serviceCollection.Storage.AddInstance(instance);
+        _serviceCollection.Storage.AddDataRaw(
+            dataGuid,
+            serializer.SerializeToStorage(model, dataType, data).data.ToArray()
+        );
+
+        var instanceCopy = JsonSerializer.Deserialize<Instance>(JsonSerializer.SerializeToUtf8Bytes(instance))!;
+
+        var initializer = _serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
+        return await initializer.Init(instanceCopy, dataType.TaskId, language);
+    }
+
+    internal async Task<InstanceDataUnitOfWork> CreateInstanceDataMutatorWithDataAndLayout<T>(
         T model,
         List<BaseComponent> components,
         string? language
     )
         where T : class, new()
     {
-        var appServices = serviceProvider.GetRequiredService<MockedServiceCollection>();
-        var serializer = serviceProvider.GetRequiredService<ModelSerializationService>();
-        var instanceGuid = Guid.NewGuid();
-        var dataGuid = Guid.NewGuid();
-        var partyId = 123456;
-        var dataTypeId = typeof(T).Name.ToLowerInvariant();
         var layoutSetName = "layoutSet1";
-        var taskId = "Task_1";
         var pages = components
             .GroupBy(c => c.PageId)
             .Select(group => new PageComponent
@@ -217,44 +374,44 @@ public static class MockedServiceProviderExtensions
                 TextResourceBindings = ImmutableDictionary<string, Expression>.Empty,
             });
 
-        DataType defaultDataType = appServices.AddDataType<T>();
+        DataType defaultDataType = _serviceCollection.AddDataType<T>();
+        _serviceCollection.AddLayoutSet(defaultDataType, pages);
 
-        var layoutModel = new LayoutModel(
-            [new LayoutSetComponent(pages.ToList(), layoutSetName, defaultDataType)],
-            new LayoutSet()
-            {
-                DataType = defaultDataType.Id,
-                Id = layoutSetName,
-                Tasks = [taskId],
-            }
-        );
-        appServices.AppResourcesMock.Setup(a => a.GetLayoutModelForTask(taskId)).Returns(layoutModel);
-
-        var data = new DataElement()
-        {
-            Id = dataGuid.ToString(),
-            InstanceGuid = instanceGuid.ToString(),
-            DataType = defaultDataType.Id,
-            ContentType = "application/xml",
-        };
-        var instance = new Instance()
-        {
-            Id = $"{partyId}/{instanceGuid}",
-            AppId = $"{MockedServiceCollection.Org}/{MockedServiceCollection.App}",
-            InstanceOwner = new InstanceOwner() { PartyId = partyId.ToString() },
-            Data = [data],
-            Process = new() { CurrentTask = new() { ElementId = taskId } },
-        };
-
-        appServices.Storage.AddInstance(instance);
-        appServices.Storage.AddDataRaw(
-            dataGuid,
-            serializer.SerializeToStorage(model, defaultDataType, data).data.ToArray()
-        );
-
-        var instanceCopy = JsonSerializer.Deserialize<Instance>(JsonSerializer.SerializeToUtf8Bytes(instance))!;
-
-        var initializer = serviceProvider.GetRequiredService<InstanceDataUnitOfWorkInitializer>();
-        return await initializer.Init(instanceCopy, taskId, language);
+        return await CreateInstanceDataUnitOfWork(model, defaultDataType, language);
     }
+
+    #region ServiceProvider interface implementation
+    public object? GetService(Type serviceType)
+    {
+        return _serviceProvider.GetService(serviceType);
+    }
+
+    public object? GetKeyedService(Type serviceType, object? serviceKey)
+    {
+        return _serviceProvider.GetKeyedService(serviceType, serviceKey);
+    }
+
+    public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
+    {
+        return _serviceProvider.GetRequiredKeyedService(serviceType, serviceKey);
+    }
+
+#pragma warning disable CA1816
+    public void Dispose()
+    {
+        DumpTracesAndMetrics();
+        _serviceProvider.Dispose();
+        _tracerProvider.Dispose();
+        _meterProvider.Dispose();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        DumpTracesAndMetrics();
+        await _serviceProvider.DisposeAsync();
+        _tracerProvider.Dispose();
+        _meterProvider.Dispose();
+    }
+#pragma warning restore CA1816
+    #endregion
 }

--- a/test/Altinn.App.Tests.Common/Utils/OtelVisualizers.cs
+++ b/test/Altinn.App.Tests.Common/Utils/OtelVisualizers.cs
@@ -7,12 +7,13 @@ namespace Altinn.App.Tests.Common.Utils;
 public static class OtelVisualizers
 {
     public static string VisualizeActivities(
-        IEnumerable<Activity> activities,
-        IEnumerable<LogRecord> logs,
+        List<Activity> activities,
+        List<LogRecord> logs,
         bool includeDuration = true,
         int initialIndent = 0
     )
     {
+        var allSpanIds = new HashSet<ActivitySpanId>(activities.Select(a => a.SpanId));
         var logsByActivityId = logs.GroupBy(l => l.SpanId)
             .ToDictionary(k => k.Key, v => v.OrderBy(l => l.Timestamp).ToList());
         var activityByParentId = activities
@@ -21,7 +22,7 @@ public static class OtelVisualizers
 
         // Find root activities: those whose parent span ID is not in our collection
         var rootActivities = activityByParentId
-            .Where(kvp => !activityByParentId.ContainsKey(kvp.Key))
+            .Where(kvp => !allSpanIds.Contains(kvp.Key))
             .SelectMany(kvp => kvp.Value);
 
         var sb = new StringBuilder();

--- a/test/Altinn.App.Tests.Common/Utils/OtelVisualizers.cs
+++ b/test/Altinn.App.Tests.Common/Utils/OtelVisualizers.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+using System.Text;
+using OpenTelemetry.Logs;
+
+namespace Altinn.App.Tests.Common.Utils;
+
+public static class OtelVisualizers
+{
+    public static string VisualizeActivities(
+        IEnumerable<Activity> activities,
+        IEnumerable<LogRecord> logs,
+        bool includeDuration = true,
+        int initialIndent = 0
+    )
+    {
+        var logsByActivityId = logs.GroupBy(l => l.SpanId)
+            .ToDictionary(k => k.Key, v => v.OrderBy(l => l.Timestamp).ToList());
+        var activityByParentId = activities
+            .GroupBy(a => a.ParentSpanId)
+            .ToDictionary(k => k.Key, g => g.OrderBy(a => a.StartTimeUtc).ToList());
+
+        var sb = new StringBuilder();
+        if (activityByParentId.TryGetValue(default, out var rootActivities))
+        {
+            foreach (var activity in rootActivities)
+            {
+                VisualizeActivity(sb, activityByParentId, logsByActivityId, activity, initialIndent, includeDuration);
+            }
+        }
+        else
+        {
+            sb.AppendLine("No root activities found.");
+        }
+
+        var remainingLogs = logsByActivityId.Values.SelectMany(l => l).OrderBy(l => l.Timestamp).ToList();
+        if (remainingLogs.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Orphaned Logs:");
+            foreach (var log in remainingLogs)
+            {
+                sb.AppendLine($"[{log.LogLevel}] {log.FormattedMessage}");
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static void VisualizeActivity(
+        StringBuilder sb,
+        Dictionary<ActivitySpanId, List<Activity>> activityByParentId,
+        Dictionary<ActivitySpanId, List<LogRecord>> logsByActivityId,
+        Activity activity,
+        int indent,
+        bool includeDuration
+    )
+    {
+        sb.Append(' ', indent);
+        if (includeDuration)
+        {
+            sb.AppendLine($"{activity.DisplayName}  [Duration: {activity.Duration.TotalMilliseconds} ms]");
+        }
+        else
+        {
+            sb.AppendLine($"{activity.DisplayName}");
+        }
+        foreach (var (key, value) in activity.Tags)
+        {
+            sb.Append(' ', indent + 1);
+            sb.AppendLine($"{key}: {value}");
+        }
+
+        if (activityByParentId.TryGetValue(activity.SpanId, out var children))
+        {
+            foreach (var child in children)
+            {
+                VisualizeActivity(sb, activityByParentId, logsByActivityId, child, indent + 2, includeDuration);
+            }
+        }
+
+        if (logsByActivityId.TryGetValue(activity.SpanId, out var logs) && logs.Count > 0)
+        {
+            sb.Append(' ', indent + 1);
+            sb.AppendLine("Logs:");
+            foreach (var log in logs)
+            {
+                sb.Append(' ', indent + 2);
+                sb.AppendLine($"[{log.LogLevel}] {log.FormattedMessage}");
+            }
+            logsByActivityId.Remove(activity.SpanId);
+        }
+    }
+}


### PR DESCRIPTION
* Use OpenTelemetry.Exporter.InMemory
* Add a bare bones visualizer to join traces and logs in a single ascii tree view

The `MockedServiceCollection.cs` started as an extension to a `ServiceCollection` to make test writing easier when lots of setup was required for the app, and our `WebApplicationFactory` seemed too heavy (and when it was too hard to exercise the relevant functionality in a full app). It kind of evolved into a simplified form of `WebApplicationFactory`, without all the heavy weight of the controllers, just revolving around creating a bare bones app with just the required data to write the test.

It might want a better name, now that it has evolved into more of a WebApplicationFactory light. `AppTestServiceCollection` might be a better name


### Example
The test `TranslateTextKey_WithDataSources` now displays both traces and logs on the following format where the logs of are grouped under the relevant parent trace as any other trace attribute. If you want to send this to Verify, you can send `includeDuration = false`, but it won't find all durations in eg. logs.
```
OTEL Data:
Traces collected: 3
Logs collected: 4
 SerializationService.SerializeXml  [Duration: 13,029 ms]
  Type: Altinn.App.Core.Tests.Internal.Texts.TranslationServiceInstanceTests+SkjemaModel
 DataClient.GetBinaryData  [Duration: 14,598 ms]
  Logs:
   [Information] Start processing HTTP request GET http://localhost:5101/storage/api/v1/instances/123456/48a0b4e9-3552-44fe-9b24-2e0b246b2ab0/data/afcaea47-ab8c-462a-b4b3-a82a25718557
   [Information] Sending HTTP request GET http://localhost:5101/storage/api/v1/instances/123456/48a0b4e9-3552-44fe-9b24-2e0b246b2ab0/data/afcaea47-ab8c-462a-b4b3-a82a25718557
   [Information] Received HTTP response headers after 2.3212ms - 200
   [Information] End processing HTTP request after 11.8505ms - 200
 SerializationService.DeserializeXml  [Duration: 1,81 ms]
  Type: Altinn.App.Core.Tests.Internal.Texts.TranslationServiceInstanceTests+SkjemaModel


Meters collected: 0

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an in-memory OpenTelemetry exporter to test dependencies.

* **Tests**
  * Enhanced test infrastructure with in-memory telemetry for traces, metrics, and logs and exposed collections for inspection.
  * Added a telemetry visualizer to render activity and log hierarchies.
  * Simplified test output capture and added helpers for building test providers, layout-based scenarios, and instance data setup for easier test composition and inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->