### PR TITLE
Improve Layout component hierarchy

### DIFF
--- a/src/Altinn.App.Core/Models/Layout/Components/Base/BaseComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/Components/Base/BaseComponent.cs
@@ -63,17 +63,6 @@ public abstract class BaseComponent
     public required IReadOnlyDictionary<string, Expression> TextResourceBindings { get; init; }
 
     /// <summary>
-    /// Creates a context for the component based on the provided parameters.
-    /// </summary>
-    /// <returns>A <see cref="ComponentContext"/> instance representing the current context of the component.</returns>
-    public abstract Task<ComponentContext> GetContext(
-        LayoutEvaluatorState state,
-        DataElementIdentifier defaultDataElementIdentifier,
-        int[]? rowIndexes,
-        Dictionary<string, LayoutSetComponent> layoutsLookup
-    );
-
-    /// <summary>
     /// Get the data model bindings that should be removed when the component is hidden,
     /// or should be kept when the component is not hidden.
     /// </summary>
@@ -89,20 +78,6 @@ public abstract class BaseComponent
 
         return references;
     }
-
-    /// <summary>
-    /// Claims child components based on the provided references and updates the lookup dictionaries.
-    /// </summary>
-    /// <param name="unclaimedComponents">
-    /// A dictionary of unclaimed components, where keys are component IDs and values are the corresponding component instances.
-    /// </param>
-    /// <param name="claimedComponents">
-    /// A dictionary to track claimed components, where the keys are component IDs and values are the IDs of the components that claimed them.
-    /// </param>
-    public abstract void ClaimChildren(
-        Dictionary<string, BaseComponent> unclaimedComponents,
-        Dictionary<string, string> claimedComponents
-    );
 
     /// <summary>
     /// Parse the Id property from a JsonElement

--- a/src/Altinn.App.Core/Models/Layout/Components/Base/BaseLayoutComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/Components/Base/BaseLayoutComponent.cs
@@ -1,0 +1,35 @@
+using Altinn.App.Core.Internal.Expressions;
+using Altinn.App.Core.Models.Expressions;
+
+namespace Altinn.App.Core.Models.Layout.Components.Base;
+
+/// <summary>
+/// Components that can be be directly read from a layout with extra tools related to layout parsing
+/// </summary>
+public abstract class BaseLayoutComponent : BaseComponent
+{
+    /// <summary>
+    /// Creates a context for the component based on the provided parameters.
+    /// </summary>
+    /// <returns>A <see cref="ComponentContext"/> instance representing the current context of the component.</returns>
+    public abstract Task<ComponentContext> GetContext(
+        LayoutEvaluatorState state,
+        DataElementIdentifier defaultDataElementIdentifier,
+        int[]? rowIndexes,
+        Dictionary<string, LayoutSetComponent> layoutsLookup
+    );
+
+    /// <summary>
+    /// Claims child components based on the provided references and updates the lookup dictionaries.
+    /// </summary>
+    /// <param name="unclaimedComponents">
+    /// A dictionary of unclaimed components, where keys are component IDs and values are the corresponding component instances.
+    /// </param>
+    /// <param name="claimedComponents">
+    /// A dictionary to track claimed components, where the keys are component IDs and values are the IDs of the components that claimed them.
+    /// </param>
+    public abstract void ClaimChildren(
+        Dictionary<string, BaseLayoutComponent> unclaimedComponents,
+        Dictionary<string, string> claimedComponents
+    );
+}

--- a/src/Altinn.App.Core/Models/Layout/Components/Base/BaseLayoutComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/Components/Base/BaseLayoutComponent.cs
@@ -11,6 +11,10 @@ public abstract class BaseLayoutComponent : BaseComponent
     /// <summary>
     /// Creates a context for the component based on the provided parameters.
     /// </summary>
+    /// <param name="state">The current layout evaluator state.</param>
+    /// <param name="defaultDataElementIdentifier">The default data element identifier for the layout.</param>
+    /// <param name="rowIndexes">The current row indexes for components within repeating groups, or null for non-repeating contexts.</param>
+    /// <param name="layoutsLookup">A lookup dictionary for resolving layout set components.</param>
     /// <returns>A <see cref="ComponentContext"/> instance representing the current context of the component.</returns>
     public abstract Task<ComponentContext> GetContext(
         LayoutEvaluatorState state,

--- a/src/Altinn.App.Core/Models/Layout/Components/Base/BaseLayoutComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/Components/Base/BaseLayoutComponent.cs
@@ -4,7 +4,7 @@ using Altinn.App.Core.Models.Expressions;
 namespace Altinn.App.Core.Models.Layout.Components.Base;
 
 /// <summary>
-/// Components that can be be directly read from a layout with extra tools related to layout parsing
+/// Components that can be directly read from a layout with extra tools related to layout parsing
 /// </summary>
 public abstract class BaseLayoutComponent : BaseComponent
 {

--- a/src/Altinn.App.Core/Models/Layout/Components/Base/NoReferenceComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/Components/Base/NoReferenceComponent.cs
@@ -6,13 +6,13 @@ namespace Altinn.App.Core.Models.Layout.Components.Base;
 /// <summary>
 /// Simple base component that does not have any references to other components.
 /// </summary>
-public abstract class NoReferenceComponent : BaseComponent
+public abstract class NoReferenceComponent : BaseLayoutComponent
 {
     /// <summary>
     /// No children to claim for NoReferenceComponent
     /// </summary>
     public override void ClaimChildren(
-        Dictionary<string, BaseComponent> unclaimedComponents,
+        Dictionary<string, BaseLayoutComponent> unclaimedComponents,
         Dictionary<string, string> claimedComponents
     ) { }
 

--- a/src/Altinn.App.Core/Models/Layout/Components/Base/SimpleReferenceComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/Components/Base/SimpleReferenceComponent.cs
@@ -6,21 +6,21 @@ namespace Altinn.App.Core.Models.Layout.Components.Base;
 /// <summary>
 /// Utility class for components that references other components without any repeating logic, such as Grid, Accordion, or Tabs.
 /// </summary>
-public abstract class SimpleReferenceComponent : BaseComponent
+public abstract class SimpleReferenceComponent : BaseLayoutComponent
 {
     /// <summary>
     /// Collection of IDs for children that should be claimed.
     /// </summary>
     public required IReadOnlyCollection<string> ChildReferences { get; init; }
 
-    private IReadOnlyDictionary<string, BaseComponent>? _claimedChildrenLookup;
+    private IReadOnlyDictionary<string, BaseLayoutComponent>? _claimedChildrenLookup;
 
     // used for some tests to ensure hierarchy is correct
     internal IEnumerable<BaseComponent>? AllChildren => _claimedChildrenLookup?.Values;
 
     /// <inheritdoc />
     public override void ClaimChildren(
-        Dictionary<string, BaseComponent> unclaimedComponents,
+        Dictionary<string, BaseLayoutComponent> unclaimedComponents,
         Dictionary<string, string> claimedComponents
     )
     {
@@ -31,7 +31,7 @@ public abstract class SimpleReferenceComponent : BaseComponent
             );
         }
 
-        var components = new Dictionary<string, BaseComponent>();
+        var components = new Dictionary<string, BaseLayoutComponent>();
         foreach (var componentId in ChildReferences)
         {
             if (unclaimedComponents.Remove(componentId, out var component))
@@ -66,7 +66,7 @@ public abstract class SimpleReferenceComponent : BaseComponent
     ///
     /// Will be populated after the <see cref="ClaimChildren"/> method is called.
     /// </summary>
-    public IReadOnlyDictionary<string, BaseComponent> ClaimedChildrenLookup =>
+    public IReadOnlyDictionary<string, BaseLayoutComponent> ClaimedChildrenLookup =>
         _claimedChildrenLookup
         ?? throw new InvalidOperationException(
             "ClaimChildren has not been called. This is a bug in the component initialization process."

--- a/src/Altinn.App.Core/Models/Layout/Components/PageComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/Components/PageComponent.cs
@@ -34,7 +34,7 @@ public sealed class PageComponent : Base.BaseComponent
         }
         var hidden = ParseHiddenExpression(dataElement);
 
-        List<Base.BaseComponent> componentList = [];
+        List<Base.BaseLayoutComponent> componentList = [];
 
         foreach (var componentElement in componentsElement.EnumerateArray())
         {
@@ -59,7 +59,7 @@ public sealed class PageComponent : Base.BaseComponent
                 );
             }
 
-            Base.BaseComponent component = type.ToLowerInvariant() switch
+            Base.BaseLayoutComponent component = type.ToLowerInvariant() switch
             {
                 "group" when maxCount == 1 => NonRepeatingGroupComponent.Parse(componentElement, pageId, layoutId),
                 "group" => RepeatingGroupComponent.Parse(componentElement, pageId, layoutId, maxCount),
@@ -70,17 +70,18 @@ public sealed class PageComponent : Base.BaseComponent
                 "tabs" => TabsComponent.Parse(componentElement, pageId, layoutId),
                 "cards" => CardsComponent.Parse(componentElement, pageId, layoutId),
                 "likert" => LikertComponent.Parse(componentElement, pageId, layoutId),
-                "checkboxes" => OptionsComponent.Parse(componentElement, pageId, layoutId),
-                "radiobuttons" => OptionsComponent.Parse(componentElement, pageId, layoutId),
-                "dropdown" => OptionsComponent.Parse(componentElement, pageId, layoutId),
-                "multipleselect" => OptionsComponent.Parse(componentElement, pageId, layoutId),
+                "checkboxes" or "radiobuttons" or "dropdown" or "multipleselect" => OptionsComponent.Parse(
+                    componentElement,
+                    pageId,
+                    layoutId
+                ),
                 _ => UnknownComponent.Parse(componentElement, pageId, layoutId),
             };
 
             componentList.Add(component);
         }
 
-        var pageComponentLookup = new Dictionary<string, Base.BaseComponent>(StringComparer.Ordinal);
+        var pageComponentLookup = new Dictionary<string, Base.BaseLayoutComponent>(StringComparer.Ordinal);
         foreach (var c in componentList)
         {
             if (!pageComponentLookup.TryAdd(c.Id, c))
@@ -119,10 +120,12 @@ public sealed class PageComponent : Base.BaseComponent
     /// <summary>
     /// List of the components that are part of this page.
     /// </summary>
-    public required IReadOnlyList<Base.BaseComponent> Components { get; init; }
+    public required IReadOnlyList<Base.BaseLayoutComponent> Components { get; init; }
 
-    /// <inheritdoc />
-    public override async Task<ComponentContext> GetContext(
+    /// <summary>
+    /// Get the context for this page component
+    /// </summary>
+    public async Task<ComponentContext> GetContextForPage(
         LayoutEvaluatorState state,
         DataElementIdentifier defaultDataElementIdentifier,
         int[]? rowIndexes,
@@ -138,17 +141,5 @@ public sealed class PageComponent : Base.BaseComponent
         }
 
         return new ComponentContext(state, this, rowIndexes, defaultDataElementIdentifier, childContexts);
-    }
-
-    /// <summary>
-    /// For PageComponent, you need to call RunClaimChidren to claim children for all components on the page.
-    /// </summary>
-    /// <exception cref="NotImplementedException"></exception>
-    public override void ClaimChildren(
-        Dictionary<string, Base.BaseComponent> unclaimedComponents,
-        Dictionary<string, string> claimedComponents
-    )
-    {
-        throw new NotImplementedException();
     }
 }

--- a/src/Altinn.App.Core/Models/Layout/Components/SubFormComponent.cs
+++ b/src/Altinn.App.Core/Models/Layout/Components/SubFormComponent.cs
@@ -8,7 +8,7 @@ namespace Altinn.App.Core.Models.Layout.Components;
 /// <summary>
 /// Component for handling subforms
 /// </summary>
-public sealed class SubFormComponent : Base.BaseComponent
+public sealed class SubFormComponent : Base.BaseLayoutComponent
 {
     /// <summary>Constructor</summary>
     /// <remarks>
@@ -74,7 +74,7 @@ public sealed class SubFormComponent : Base.BaseComponent
             // We don't have any need for a "SubFormRow" context.
             foreach (var subformPage in layoutSet.Pages)
             {
-                childContexts.Add(await subformPage.GetContext(state, dataElement, null, layoutsLookup));
+                childContexts.Add(await subformPage.GetContextForPage(state, dataElement, null, layoutsLookup));
             }
         }
 
@@ -83,7 +83,7 @@ public sealed class SubFormComponent : Base.BaseComponent
 
     /// <inheritdoc />
     public override void ClaimChildren(
-        Dictionary<string, Base.BaseComponent> unclaimedComponents,
+        Dictionary<string, Base.BaseLayoutComponent> unclaimedComponents,
         Dictionary<string, string> claimedComponents
     )
     {

--- a/src/Altinn.App.Core/Models/Layout/LayoutModel.cs
+++ b/src/Altinn.App.Core/Models/Layout/LayoutModel.cs
@@ -43,7 +43,7 @@ public sealed class LayoutModel
         var pageContexts = new List<ComponentContext>();
         foreach (var page in _defaultLayoutSet.Pages)
         {
-            pageContexts.Add(await page.GetContext(state, defaultElementId.Value, null, _layoutsLookup));
+            pageContexts.Add(await page.GetContextForPage(state, defaultElementId.Value, null, _layoutsLookup));
         }
 
         return pageContexts;

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -4528,8 +4528,6 @@ namespace Altinn.App.Core.Models.Layout.Components.Base
         public required Altinn.App.Core.Models.Expressions.Expression Required { get; init; }
         public required System.Collections.Generic.IReadOnlyDictionary<string, Altinn.App.Core.Models.Expressions.Expression> TextResourceBindings { get; init; }
         public required string Type { get; init; }
-        public abstract void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents);
-        public abstract System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext> GetContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? rowIndexes, System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.LayoutSetComponent> layoutsLookup);
         public virtual System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Altinn.App.Core.Models.Layout.DataReference>> GetDataReferencesToRemoveWhenHidden(Altinn.App.Core.Models.Expressions.ComponentContext context) { }
         protected static System.Collections.Generic.List<string> ParseChildReferences(System.Text.Json.JsonElement componentElement, string layoutId, string pageId) { }
         protected static System.Collections.Generic.IReadOnlyDictionary<string, Altinn.App.Core.Models.Layout.ModelBinding> ParseDataModelBindings(System.Text.Json.JsonElement element) { }
@@ -4542,19 +4540,24 @@ namespace Altinn.App.Core.Models.Layout.Components.Base
         protected static System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Expressions.Expression> ParseTextResourceBindings(System.Text.Json.JsonElement element) { }
         protected static string ParseType(System.Text.Json.JsonElement componentElement) { }
     }
-    public abstract class NoReferenceComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseComponent
+    public abstract class BaseLayoutComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseComponent
+    {
+        protected BaseLayoutComponent() { }
+        public abstract void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents);
+        public abstract System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext> GetContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? rowIndexes, System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.LayoutSetComponent> layoutsLookup);
+    }
+    public abstract class NoReferenceComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent
     {
         protected NoReferenceComponent() { }
-        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
+        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
         public override System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext> GetContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? rowIndexes, System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.LayoutSetComponent> layoutsLookup) { }
     }
     public class RepeatingGroupRowComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseComponent
     {
-        public RepeatingGroupRowComponent() { }
-        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
-        public override System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext> GetContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? rowIndexes, System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.LayoutSetComponent> layoutsLookup) { }
+        [System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+        public RepeatingGroupRowComponent(Altinn.App.Core.Models.Layout.Components.Base.RepeatingReferenceComponent repeatingReferenceComponent, int index) { }
     }
-    public abstract class RepeatingReferenceComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseComponent
+    public abstract class RepeatingReferenceComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent
     {
         protected RepeatingReferenceComponent() { }
         public required System.Collections.Generic.IReadOnlyList<string> AfterChildReferences { get; init; }
@@ -4562,15 +4565,15 @@ namespace Altinn.App.Core.Models.Layout.Components.Base
         public required Altinn.App.Core.Models.Layout.ModelBinding GroupModelBinding { get; init; }
         public required Altinn.App.Core.Models.Expressions.Expression HiddenRow { get; init; }
         public required System.Collections.Generic.IReadOnlyList<string> RepeatingChildReferences { get; init; }
-        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
+        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
         public override System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext> GetContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? rowIndexes, System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.LayoutSetComponent> layoutsLookup) { }
     }
-    public abstract class SimpleReferenceComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseComponent
+    public abstract class SimpleReferenceComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent
     {
         protected SimpleReferenceComponent() { }
         public required System.Collections.Generic.IReadOnlyCollection<string> ChildReferences { get; init; }
-        public System.Collections.Generic.IReadOnlyDictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent> ClaimedChildrenLookup { get; }
-        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent> ClaimedChildrenLookup { get; }
+        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
         public override System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext> GetContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? rowIndexes, System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.LayoutSetComponent> layoutsLookup) { }
     }
 }
@@ -4635,9 +4638,8 @@ namespace Altinn.App.Core.Models.Layout.Components
     public sealed class PageComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseComponent
     {
         public PageComponent() { }
-        public required System.Collections.Generic.IReadOnlyList<Altinn.App.Core.Models.Layout.Components.Base.BaseComponent> Components { get; init; }
-        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
-        public override System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext> GetContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? rowIndexes, System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.LayoutSetComponent> layoutsLookup) { }
+        public required System.Collections.Generic.IReadOnlyList<Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent> Components { get; init; }
+        public System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext> GetContextForPage(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? rowIndexes, System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.LayoutSetComponent> layoutsLookup) { }
         public static Altinn.App.Core.Models.Layout.Components.PageComponent Parse(System.Text.Json.JsonElement outerElement, string pageId, string layoutId) { }
     }
     public sealed class RepeatingGroupComponent : Altinn.App.Core.Models.Layout.Components.Base.RepeatingReferenceComponent
@@ -4648,11 +4650,11 @@ namespace Altinn.App.Core.Models.Layout.Components
         public required System.Collections.Generic.IReadOnlyList<Altinn.App.Core.Models.Layout.Components.GridComponent.GridRowConfig> RowsBefore { get; init; }
         public static Altinn.App.Core.Models.Layout.Components.RepeatingGroupComponent Parse(System.Text.Json.JsonElement componentElement, string pageId, string layoutId, int maxCount) { }
     }
-    public sealed class SubFormComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseComponent
+    public sealed class SubFormComponent : Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent
     {
         public SubFormComponent() { }
         public required string LayoutSetId { get; init; }
-        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
+        public override void ClaimChildren(System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.Components.Base.BaseLayoutComponent> unclaimedComponents, System.Collections.Generic.Dictionary<string, string> claimedComponents) { }
         public override System.Threading.Tasks.Task<Altinn.App.Core.Models.Expressions.ComponentContext> GetContext(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.DataElementIdentifier defaultDataElementIdentifier, int[]? rowIndexes, System.Collections.Generic.Dictionary<string, Altinn.App.Core.Models.Layout.LayoutSetComponent> layoutsLookup) { }
         public static Altinn.App.Core.Models.Layout.Components.SubFormComponent Parse(System.Text.Json.JsonElement componentElement, string pageId, string layoutId) { }
     }

--- a/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
+++ b/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
@@ -187,7 +187,7 @@ public static class MockedServiceProviderExtensions
     internal static async Task<InstanceDataUnitOfWork> CreateInstanceDataMutatorWithDataAndLayout<T>(
         this ServiceProvider serviceProvider,
         T model,
-        List<BaseComponent> components,
+        List<BaseLayoutComponent> components,
         string? language
     )
         where T : class, new()


### PR DESCRIPTION
Previously I added `GetContext` and `ClaimChildren` directly to the `BaseComponent` class, but those methods are only valid during parsing and context generation, and some components (RowComponent and PageComponent) does not participate in those stages

A separate `BaseLayoutComponent` makes more sense and avoids a few methods that can't be implemented for some subclasses because they inherit directly from BaseComponent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized component/layout hierarchy and simplified how page and repeating-group contexts are produced and claimed.
  * Introduced a distinct layout-backed component layer and constructor-based row creation for repeating groups for more consistent behavior.
  * No user-facing feature changes; improves reliability and maintainability of form/layout processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->