### PR TITLE
Add "Unknown" `Authenticated` type, to support custom APIs with custom auth 

### DIFF
--- a/src/Altinn.App.Core/Features/Auth/Scopes.cs
+++ b/src/Altinn.App.Core/Features/Auth/Scopes.cs
@@ -171,4 +171,30 @@ public readonly struct Scopes : IEquatable<Scopes>
 
         return false;
     }
+
+    /// <summary>
+    /// Checks if any of the scopes are Altinn Studio instance-related scopes.
+    /// These are scopes that indicate the token is intended for Altinn Studio app/instance operations.
+    /// </summary>
+    /// <returns>True if any Altinn Studio instance scope is present</returns>
+    public bool HasAltinnInstanceScope()
+    {
+        if (string.IsNullOrWhiteSpace(_scope))
+            return false;
+
+        foreach (var scope in this)
+        {
+            if (
+                scope.Equals("altinn:instances.read", StringComparison.Ordinal)
+                || scope.Equals("altinn:instances.write", StringComparison.Ordinal)
+                || scope.Equals("altinn:serviceowner/instances.read", StringComparison.Ordinal)
+                || scope.Equals("altinn:serviceowner/instances.write", StringComparison.Ordinal)
+            )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=Unknown_RecL.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=Unknown_RecL.verified.txt
@@ -1,0 +1,24 @@
+﻿{
+  Description: Custom Maskinporten token,
+  AuthType: Altinn.App.Core.Features.Auth.Authenticated+Unknown,
+  Auth: {
+    TokenIssuer: Maskinporten,
+    TokenIsExchanged: false,
+    Scopes: dgm:police,
+    ClientId: f4811e18-05aa-4a50-b5d5-8490da78aace,
+    Token: eyJraWQiOiJiZFhMRVduRGpMSGpwRThPZnl5TUp4UlJLbVo3MUxCOHUxeUREbVBpdVQwIiwiYWxnIjoiUlMyNTYifQ.eyJzY29wZSI6ImRnbTpwb2xpY2UiLCJpc3MiOiJodHRwczovL3Rlc3QubWFza2lucG9ydGVuLm5vLyIsImNsaWVudF9hbXIiOiJwcml2YXRlX2tleV9qd3QiLCJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiZXhwIjoxNzY0NjI3MjAxLCJpYXQiOjE3NjQ2MjcwODEsImNsaWVudF9pZCI6ImY0ODExZTE4LTA1YWEtNGE1MC1iNWQ1LTg0OTBkYTc4YWFjZSIsImp0aSI6Ik1CSzQ2Tk9hdGx6VldVdjgzZ0VRalBsTVQ2Z0VpYlgzaWI5X3VaWVRwQVEiLCJjb25zdW1lciI6eyJhdXRob3JpdHkiOiJpc282NTIzLWFjdG9yaWQtdXBpcyIsIklEIjoiMDE5Mjo5OTE4MjU4MjcifX0.iZCrY4qGZrAiR2vGq4VuH7X8Ta9ZJU68F6hcQMAAijlEnqGs1PPvnQhLh4DZRI1QDvbub_k6zjmpYJvAPXKYb1hS9IdBbX3kWxX4dtPaiKcHHpz1W9i5t3pbKnxkoI1Tk7xfuY4Cv8hkz00VKZHWh631mSz9vG3w_3TeRW0g5NYCUVMJ7OmA3ZO9Y7f6IeYw3Z4-1LLVTLRSh1ie0-riCKBDpfPDTgCcRN_W5mio8CyWGey_l9kzVjwbLftix-FCNPIVe5GJIqQVU-RlfApmNFazgeCn8Yq5EOD9z7ypY3SFGMsKPsGQ86mRExCMituZ0w6nfMf2vebdch5G0OQvs_o5FIb8gg7E05ZlWI0Enh9HH3hyeYK8IhJZF0ODzb87i0-4h7v6orGtezz0qmpZ1WvwSdG2saHVlsCsa-pyBzGlAYYwYcjKOmP5u2NQgwPi8z--ZaokXHFjr2PSJJZXmbknGPOL0MulDd412eiW_7TTYfSq438KHf2amQ_DnOpD
+  },
+  Jwt: {
+    client_amr: private_key_jwt,
+    client_id: f4811e18-05aa-4a50-b5d5-8490da78aace,
+    consumer: {
+      ValueKind: Object
+    },
+    exp: 1764627201,
+    iat: 1764627081,
+    iss: https://test.maskinporten.no/,
+    jti: MBK46NOatlzVWUv83gEQjPlMT6gEibX3ib9_uZYTpAQ,
+    scope: dgm:police,
+    token_type: Bearer
+  }
+}

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=Unknown_qbyO.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_Tokens_type=Unknown_qbyO.verified.txt
@@ -1,0 +1,18 @@
+﻿{
+  Description: Custom token with unknown type,
+  AuthType: Altinn.App.Core.Features.Auth.Authenticated+Unknown,
+  Auth: {
+    TokenIssuer: Unknown,
+    TokenIsExchanged: false,
+    Scopes: digdir:dd:probatedeclarations,
+    Token: eyJhbGciOiJSUzI1NiIsImtpZCI6Im9lZC1hZG1pbi1jbGllbnQta2V5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Rlc3QubWFza2lucG9ydGVuLm5vLyIsInNjb3BlIjoiZGlnZGlyOmRkOnByb2JhdGVkZWNsYXJhdGlvbnMiLCJpc3MiOiI3ZDdjM2M4OC1kNGZlLTRkZDEtOTI0NC0wYzYzNWIxZGZkMDMiLCJleHAiOjE3NjQyNDk3NTksImlhdCI6MTc2NDI0OTc0OSwianRpIjoiYmI0NmJmYmQtMjM4ZS00ZTRlLWEyOGEtN2JjY2I5N2U3OTk5In0.mnYdN2OEzL3xRC37ZXbnsMqBCI1uQPxGBYhOKS85y0XnwvajUwi4e5yJ643MZy3L_N41b-U7pi4km-nfUmbCAIAjGwsTNO9mXyPCrp14Xf51RqoYHbEfvIkHxY0QbFkDijyGrNttSqI3UOhf3RnyT0Ev86IFSHc0zdqDqZoKjwshqAvok18YW6o_IyyNloCoKqLWYVVXy4Fg9eALph76QsqdEh9YAUojUN14ngG3Qs76xUAJefMmJcQWzgoBhwZlU0KiEMbwe8PdJuCaEd7dRX71wTMK8pKhZRIxXjVmNfTtgdgyW5YE37C9uTwMYyuZhJXJ3F6bWCS_joYrn7m-SQ
+  },
+  Jwt: {
+    aud: https://test.maskinporten.no/,
+    exp: 1764249759,
+    iat: 1764249749,
+    iss: 7d7c3c88-d4fe-4dd1-9244-0c635b1dfd03,
+    jti: bb46bfbd-238e-4e4e-a28a-7bccb97e7999,
+    scope: digdir:dd:probatedeclarations
+  }
+}

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
@@ -121,6 +121,18 @@ public class AuthenticatedTests
                 AuthenticationTypes.Org,
                 true
             },
+            {
+                "Custom token with unknown type",
+                "eyJhbGciOiJSUzI1NiIsImtpZCI6Im9lZC1hZG1pbi1jbGllbnQta2V5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Rlc3QubWFza2lucG9ydGVuLm5vLyIsInNjb3BlIjoiZGlnZGlyOmRkOnByb2JhdGVkZWNsYXJhdGlvbnMiLCJpc3MiOiI3ZDdjM2M4OC1kNGZlLTRkZDEtOTI0NC0wYzYzNWIxZGZkMDMiLCJleHAiOjE3NjQyNDk3NTksImlhdCI6MTc2NDI0OTc0OSwianRpIjoiYmI0NmJmYmQtMjM4ZS00ZTRlLWEyOGEtN2JjY2I5N2U3OTk5In0.mnYdN2OEzL3xRC37ZXbnsMqBCI1uQPxGBYhOKS85y0XnwvajUwi4e5yJ643MZy3L_N41b-U7pi4km-nfUmbCAIAjGwsTNO9mXyPCrp14Xf51RqoYHbEfvIkHxY0QbFkDijyGrNttSqI3UOhf3RnyT0Ev86IFSHc0zdqDqZoKjwshqAvok18YW6o_IyyNloCoKqLWYVVXy4Fg9eALph76QsqdEh9YAUojUN14ngG3Qs76xUAJefMmJcQWzgoBhwZlU0KiEMbwe8PdJuCaEd7dRX71wTMK8pKhZRIxXjVmNfTtgdgyW5YE37C9uTwMYyuZhJXJ3F6bWCS_joYrn7m-SQ",
+                AuthenticationTypes.Unknown,
+                true
+            },
+            {
+                "Custom Maskinporten token",
+                "eyJraWQiOiJiZFhMRVduRGpMSGpwRThPZnl5TUp4UlJLbVo3MUxCOHUxeUREbVBpdVQwIiwiYWxnIjoiUlMyNTYifQ.eyJzY29wZSI6ImRnbTpwb2xpY2UiLCJpc3MiOiJodHRwczovL3Rlc3QubWFza2lucG9ydGVuLm5vLyIsImNsaWVudF9hbXIiOiJwcml2YXRlX2tleV9qd3QiLCJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiZXhwIjoxNzY0NjI3MjAxLCJpYXQiOjE3NjQ2MjcwODEsImNsaWVudF9pZCI6ImY0ODExZTE4LTA1YWEtNGE1MC1iNWQ1LTg0OTBkYTc4YWFjZSIsImp0aSI6Ik1CSzQ2Tk9hdGx6VldVdjgzZ0VRalBsTVQ2Z0VpYlgzaWI5X3VaWVRwQVEiLCJjb25zdW1lciI6eyJhdXRob3JpdHkiOiJpc282NTIzLWFjdG9yaWQtdXBpcyIsIklEIjoiMDE5Mjo5OTE4MjU4MjcifX0.iZCrY4qGZrAiR2vGq4VuH7X8Ta9ZJU68F6hcQMAAijlEnqGs1PPvnQhLh4DZRI1QDvbub_k6zjmpYJvAPXKYb1hS9IdBbX3kWxX4dtPaiKcHHpz1W9i5t3pbKnxkoI1Tk7xfuY4Cv8hkz00VKZHWh631mSz9vG3w_3TeRW0g5NYCUVMJ7OmA3ZO9Y7f6IeYw3Z4-1LLVTLRSh1ie0-riCKBDpfPDTgCcRN_W5mio8CyWGey_l9kzVjwbLftix-FCNPIVe5GJIqQVU-RlfApmNFazgeCn8Yq5EOD9z7ypY3SFGMsKPsGQ86mRExCMituZ0w6nfMf2vebdch5G0OQvs_o5FIb8gg7E05ZlWI0Enh9HH3hyeYK8IhJZF0ODzb87i0-4h7v6orGtezz0qmpZ1WvwSdG2saHVlsCsa-pyBzGlAYYwYcjKOmP5u2NQgwPi8z--ZaokXHFjr2PSJJZXmbknGPOL0MulDd412eiW_7TTYfSq438KHf2amQ_DnOpD",
+                AuthenticationTypes.Unknown,
+                true
+            },
         };
 
     [Theory]
@@ -174,6 +186,10 @@ public class AuthenticatedTests
                 var systemUser = Assert.IsType<Authenticated.SystemUser>(auth);
                 Assert.Equal(token, auth.Token);
                 details = await systemUser.LoadDetails();
+                break;
+            case AuthenticationTypes.Unknown:
+                Assert.IsType<Authenticated.Unknown>(auth);
+                Assert.Equal(token, auth.Token);
                 break;
             default:
                 Assert.Fail("Unknown token type: " + tokenType);
@@ -438,6 +454,22 @@ public class AuthenticatedTests
                                 }
                             );
                         },
+                        getPartyList: null!,
+                        validateSelectedParty: null!
+                    );
+                }
+                break;
+            case AuthenticationTypes.Unknown:
+                {
+                    auth = Authenticated.From(
+                        tokenStr: token,
+                        parsedToken: null,
+                        isAuthenticated: true,
+                        appMetadata: TestAuthentication.NewApplicationMetadata("digdir"),
+                        getSelectedParty: null!,
+                        getUserProfile: null!,
+                        lookupUserParty: null!,
+                        lookupOrgParty: null!,
                         getPartyList: null!,
                         validateSelectedParty: null!
                     );

--- a/test/Altinn.App.Core.Tests/Features/Auth/ScopesTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Auth/ScopesTests.cs
@@ -83,4 +83,28 @@ public class ScopesTests
         }
         Assert.Equal(i, expectedScopes.Length);
     }
+
+    [Theory]
+    [InlineData("altinn:instances.read", true)]
+    [InlineData("altinn:instances.write", true)]
+    [InlineData("altinn:serviceowner/instances.read", true)]
+    [InlineData("altinn:serviceowner/instances.write", true)]
+    [InlineData("altinn:instances.read altinn:instances.write", true)]
+    [InlineData("other:scope altinn:instances.read", true)]
+    [InlineData("altinn:instances.read other:scope", true)]
+    [InlineData("ALTINN:instances.read", false)] // case sensitive
+    [InlineData("altinn:instance.read", false)] // typo
+    [InlineData("altinn:serviceowner/instance.read", false)] // typo
+    [InlineData("digdir:dd:probatedeclarations", false)]
+    [InlineData("custom:instances.read", false)]
+    [InlineData("altinn:correspondence.write", false)]
+    [InlineData("altinn:portal/enduser", false)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("  ", false)]
+    public void HasAltinnInstanceScope_Returns(string? inputScopes, bool expected)
+    {
+        var scopes = new Scopes(inputScopes);
+        Assert.Equal(expected, scopes.HasAltinnInstanceScope());
+    }
 }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -367,6 +367,7 @@ namespace Altinn.App.Core.Features.Auth
                 public Altinn.Platform.Register.Models.Party Party { get; init; }
             }
         }
+        public sealed class Unknown : Altinn.App.Core.Features.Auth.Authenticated { }
         public sealed class User : Altinn.App.Core.Features.Auth.Authenticated
         {
             public int AuthenticationLevel { get; }
@@ -411,6 +412,7 @@ namespace Altinn.App.Core.Features.Auth
         public override bool Equals(object? obj) { }
         public Altinn.App.Core.Features.Auth.Scopes.ScopeEnumerator GetEnumerator() { }
         public override int GetHashCode() { }
+        public bool HasAltinnInstanceScope() { }
         public bool HasScope(string scopeToFind) { }
         public bool HasScopeWithPrefix(string scopePrefix) { }
         public override string ToString() { }

--- a/test/Altinn.App.Tests.Common/Auth/TestAuthentication.cs
+++ b/test/Altinn.App.Tests.Common/Auth/TestAuthentication.cs
@@ -23,6 +23,7 @@ public enum AuthenticationTypes
     Org = 3,
     SystemUser = 4,
     ServiceOwner = 5,
+    Unknown = 99,
 }
 
 public sealed class TestJwtToken : IXunitSerializable


### PR DESCRIPTION
## Description

Some apps have completely custom APIs with custom auth, in these cases we may fail to identify/parse the token based on normal app usage, in which case I think it would be nice to have this "Unknown" type. This could be viewed as a breaking change, but I don't believe we have to alter/handle any of our switch statements any differently here as our own APIs are either invokved as `None` or with some valid/authorized party (in which case we know we have an expected `Authenticated` case). Any app that has custom APIs and custom auth will simply be able to use this abstraction without getting an exception

See the added tests
- The first token represents a completely custom/unknown issuer
- The second token is a Maskinporten token but not including a scope related to Altinn Studio (we match on relevant scopes)

Was a bit unsure of the classification here. It is technically a feature that solves what I would characterize as a bug? Re: related issue. Therefore not sure if we should backport this or not

## Related Issue(s)
- https://github.com/Altinn/altinn-studio/issues/17080

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for handling authentication requests with unknown authentication types.
  * Added capability to detect Altinn instance scopes in token validation.

* **Tests**
  * Added comprehensive test coverage for unknown authentication type scenarios.
  * Added test cases for scope detection validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->