### PR TITLE
tests: Fix Otel issues with MockedServiceProvider

### DIFF
--- a/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
+++ b/test/Altinn.App.Tests.Common/Fixtures/MockedServiceCollection.cs
@@ -35,7 +35,7 @@ using Xunit.Abstractions;
 
 namespace Altinn.App.Tests.Common.Fixtures;
 
-public class MockedServiceCollection
+public sealed class MockedServiceCollection
 {
     public const string Org = "ttd";
     public const string App = "mocked-app";
@@ -260,7 +260,7 @@ public class MockedServiceCollection
     }
 }
 
-public class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsyncDisposable
+public sealed class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsyncDisposable
 {
     public List<Activity> Traces => _serviceCollection.Traces;
     public List<Metric> Metrics => _serviceCollection.Metrics;
@@ -269,6 +269,7 @@ public class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsync
     private readonly TracerProvider _tracerProvider;
     private readonly MeterProvider _meterProvider;
     private readonly ServiceProvider _serviceProvider;
+    private readonly LoggerProvider _loggerProvider;
     private readonly MockedServiceCollection _serviceCollection;
 
     public WrappedServiceProvider(MockedServiceCollection serviceCollection, ServiceProvider serviceProvider)
@@ -284,6 +285,7 @@ public class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsync
             .AddMeter(telemetry.ActivitySource.Name)
             .AddInMemoryExporter(Metrics)
             .Build();
+        _loggerProvider = serviceProvider.GetRequiredService<LoggerProvider>();
     }
 
     public void DumpTracesAndMetrics()
@@ -294,6 +296,7 @@ public class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsync
         }
         _tracerProvider.ForceFlush();
         _meterProvider.ForceFlush();
+        _loggerProvider.ForceFlush();
 
         outputHelper.WriteLine("");
         outputHelper.WriteLine("OTEL Data:");
@@ -399,30 +402,30 @@ public class WrappedServiceProvider : IKeyedServiceProvider, IDisposable, IAsync
 
     private bool _dumpedTracesAndMetrics;
 
-#pragma warning disable CA1816
     public void Dispose()
     {
+        _serviceProvider.Dispose();
         if (!_dumpedTracesAndMetrics)
         {
             _dumpedTracesAndMetrics = true;
             DumpTracesAndMetrics();
         }
-        _serviceProvider.Dispose();
+        _loggerProvider.Dispose();
         _tracerProvider.Dispose();
         _meterProvider.Dispose();
     }
 
     public async ValueTask DisposeAsync()
     {
+        await _serviceProvider.DisposeAsync();
         if (!_dumpedTracesAndMetrics)
         {
             _dumpedTracesAndMetrics = true;
             DumpTracesAndMetrics();
         }
-        await _serviceProvider.DisposeAsync();
+        _loggerProvider.Dispose();
         _tracerProvider.Dispose();
         _meterProvider.Dispose();
     }
-#pragma warning restore CA1816
     #endregion
 }

--- a/test/Altinn.App.Tests.Common/Utils/OtelVisualizers.cs
+++ b/test/Altinn.App.Tests.Common/Utils/OtelVisualizers.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using OpenTelemetry.Logs;
 
 namespace Altinn.App.Tests.Common.Utils;
@@ -75,10 +76,10 @@ public static class OtelVisualizers
         {
             sb.AppendLine($"{activity.DisplayName}");
         }
-        foreach (var (key, value) in activity.Tags)
+        foreach (var (key, value) in activity.TagObjects)
         {
             sb.Append(' ', indent + 1);
-            sb.AppendLine($"{key}: {value}");
+            sb.AppendLine($"{key}: {JsonSerializer.Serialize(value)}");
         }
 
         if (activityByParentId.TryGetValue(activity.SpanId, out var children))


### PR DESCRIPTION
* Flush logs and dispose service provider (we probably don't need both) before visualising traces and logs
* Render any object in Span Tags as json in the visualization.

* See also discussion in https://github.com/Altinn/app-lib-dotnet/pull/1588


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test utilities with improved logging support and tracing capabilities.
  * Refined internal testing infrastructure for better handling of diagnostic data.

* **Chores**
  * Sealed internal test utility classes for improved API stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->