### PR TITLE
Deny writes to ref-data-as-pdf through API. Considered to be the apps…

### DIFF
--- a/src/Altinn.App.Core/Internal/Data/DataElementAccessChecker.cs
+++ b/src/Altinn.App.Core/Internal/Data/DataElementAccessChecker.cs
@@ -97,7 +97,7 @@ internal class DataElementAccessChecker : IDataElementAccessChecker
     {
         auth ??= _authenticationContext.Current;
 
-        if (dataType.Id == PdfService.PdfElementType)
+        if (dataType.Id.Equals(PdfService.PdfElementType, StringComparison.OrdinalIgnoreCase))
         {
             return new ProblemDetails
             {

--- a/src/Altinn.App.Core/Internal/Data/DataElementAccessChecker.cs
+++ b/src/Altinn.App.Core/Internal/Data/DataElementAccessChecker.cs
@@ -2,6 +2,7 @@ using Altinn.App.Core.Features.Auth;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Auth;
+using Altinn.App.Core.Internal.Pdf;
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Http;
@@ -96,6 +97,16 @@ internal class DataElementAccessChecker : IDataElementAccessChecker
     {
         auth ??= _authenticationContext.Current;
 
+        if (dataType.Id == PdfService.PdfElementType)
+        {
+            return new ProblemDetails
+            {
+                Title = "Forbidden",
+                Detail = $"Data element of type {dataType.Id} cannot be modified",
+                Status = StatusCodes.Status403Forbidden,
+            };
+        }
+
         if (await HasRequiredActionAuthorization(instance, dataType.ActionRequiredToWrite) is false)
         {
             return new ProblemDetails
@@ -122,6 +133,7 @@ internal class DataElementAccessChecker : IDataElementAccessChecker
             {
                 Title = "Forbidden",
                 Detail = "User is not a valid contributor to the data type",
+                Status = StatusCodes.Status403Forbidden,
             };
         }
 

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -28,7 +28,7 @@ public class PdfService : IPdfService
     private readonly ITranslationService _translationService;
     private readonly GeneralSettings _generalSettings;
     private readonly Telemetry? _telemetry;
-    private const string PdfElementType = "ref-data-as-pdf";
+    internal const string PdfElementType = "ref-data-as-pdf";
     private const string PdfContentType = "application/pdf";
 
     /// <summary>


### PR DESCRIPTION
Deny writes to ref-data-as-pdf through API. Considered to be the app´s data type.

Not using app:owned, since that would require us to change config in all apps. With this solution it´s enough that they update the NuGet.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- [#17269](https://github.com/Altinn/altinn-studio/issues/17269)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF data elements are now protected from modification; create/update/delete attempts are blocked and return a 403 Forbidden response.
* **Tests**
  * Added tests verifying PDF elements cannot be created, updated, or deleted and that appropriate 403 responses and messages are returned.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->