### PR TITLE
Use TaskId on IInstanceDataAccessor in SingingService.

### DIFF
--- a/src/Altinn.App.Api/Controllers/SigningController.cs
+++ b/src/Altinn.App.Api/Controllers/SigningController.cs
@@ -107,7 +107,6 @@ public class SigningController : ControllerBase
         List<SigneeContext> signeeContexts = await _signingService.GetSigneeContexts(
             instanceDataAccessor,
             signingConfiguration,
-            taskId,
             ct
         );
 

--- a/src/Altinn.App.Core/Features/Signing/Services/ISigningService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/ISigningService.cs
@@ -33,7 +33,6 @@ internal interface ISigningService
     Task<List<SigneeContext>> GetSigneeContexts(
         IInstanceDataAccessor instanceDataAccessor,
         AltinnSignatureConfiguration signatureConfiguration,
-        string? taskIdOverride = null,
         CancellationToken ct = default
     );
 

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
@@ -161,7 +161,6 @@ internal sealed class SigningService(
     public async Task<List<SigneeContext>> GetSigneeContexts(
         IInstanceDataAccessor instanceDataAccessor,
         AltinnSignatureConfiguration signatureConfiguration,
-        string? taskIdOverride = null,
         CancellationToken ct = default
     )
     {
@@ -179,7 +178,7 @@ internal sealed class SigningService(
         );
 
         signeeContexts = await _signDocumentManager.SynchronizeSigneeContextsWithSignDocuments(
-            taskIdOverride ?? instanceDataAccessor.Instance.Process.CurrentTask.ElementId,
+            instanceDataAccessor.TaskId ?? instanceDataAccessor.Instance.Process.CurrentTask.ElementId,
             signeeContexts,
             signDocuments,
             ct

--- a/src/Altinn.App.Core/Features/Validation/Default/SignatureHashValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/SignatureHashValidator.cs
@@ -72,7 +72,6 @@ internal sealed class SignatureHashValidator(
         List<SigneeContext> signeeContextsResults = await signingService.GetSigneeContexts(
             dataAccessor,
             signingConfiguration,
-            null,
             cancellationToken
         );
 

--- a/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/SigningTaskValidator.cs
@@ -93,7 +93,6 @@ internal sealed class SigningTaskValidator : IValidator
         List<SigneeContext> signeeContextsResult = await _signingService.GetSigneeContexts(
             dataAccessor,
             signingConfiguration,
-            null,
             CancellationToken.None
         );
 

--- a/test/Altinn.App.Api.Tests/Controllers/SigningControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/SigningControllerTests.cs
@@ -229,7 +229,6 @@ public class SigningControllerTests
                 s.GetSigneeContexts(
                     It.IsAny<InstanceDataUnitOfWork>(),
                     _altinnTaskExtension.SignatureConfiguration!,
-                    null,
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -333,7 +332,6 @@ public class SigningControllerTests
                 s.GetSigneeContexts(
                     It.IsAny<InstanceDataUnitOfWork>(),
                     _altinnTaskExtension.SignatureConfiguration!,
-                    null,
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -415,7 +413,6 @@ public class SigningControllerTests
                 s.GetSigneeContexts(
                     It.IsAny<InstanceDataUnitOfWork>(),
                     _altinnTaskExtension.SignatureConfiguration!,
-                    null,
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -494,7 +491,6 @@ public class SigningControllerTests
                 s.GetSigneeContexts(
                     It.IsAny<InstanceDataUnitOfWork>(),
                     _altinnTaskExtension.SignatureConfiguration!,
-                    null,
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -949,7 +945,6 @@ public class SigningControllerTests
                 s.GetSigneeContexts(
                     It.IsAny<InstanceDataUnitOfWork>(),
                     altinnTaskExtensionTask2.SignatureConfiguration!,
-                    "task2",
                     It.IsAny<CancellationToken>()
                 )
             )
@@ -979,7 +974,6 @@ public class SigningControllerTests
                 s.GetSigneeContexts(
                     It.IsAny<InstanceDataUnitOfWork>(),
                     altinnTaskExtensionTask2.SignatureConfiguration!,
-                    "task2",
                     It.IsAny<CancellationToken>()
                 ),
             Times.Once

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
@@ -238,7 +238,6 @@ public sealed class SigningServiceTests : IDisposable
         List<SigneeContext> result = await _signingService.GetSigneeContexts(
             cachedInstanceMutator.Object,
             signatureConfiguration,
-            null,
             CancellationToken.None
         );
 
@@ -333,6 +332,7 @@ public sealed class SigningServiceTests : IDisposable
         var cachedInstanceMutator = new Mock<IInstanceDataMutator>();
 
         cachedInstanceMutator.Setup(x => x.Instance).Returns(instance);
+        cachedInstanceMutator.Setup(x => x.TaskId).Returns(instance.Process.CurrentTask.ElementId);
 
         var signeeStateDataElementIdentifier = new DataElementIdentifier(signeeStateDataElement.Id);
         var signeeContexts = new List<SigneeContext>()
@@ -421,6 +421,7 @@ public sealed class SigningServiceTests : IDisposable
 
         // Assert
         cachedInstanceMutator.Verify(x => x.Instance);
+        cachedInstanceMutator.Verify(x => x.TaskId);
 
         // Verify that the data elements are removed
         cachedInstanceMutator.Verify(x => x.RemoveDataElement(signeeStateDataElement), Times.Once);
@@ -481,6 +482,7 @@ public sealed class SigningServiceTests : IDisposable
             Data = [],
         };
         cachedInstanceMutator.Setup(x => x.Instance).Returns(instance);
+        cachedInstanceMutator.Setup(x => x.TaskId).Returns(instance.Process.CurrentTask.ElementId);
 
         _signDocumentManager
             .Setup(x =>
@@ -511,6 +513,7 @@ public sealed class SigningServiceTests : IDisposable
         );
 
         cachedInstanceMutator.Verify(x => x.Instance);
+        cachedInstanceMutator.Verify(x => x.TaskId);
         cachedInstanceMutator.VerifyNoOtherCalls();
     }
 

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/SignatureHashValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/SignatureHashValidatorTests.cs
@@ -397,7 +397,6 @@ public class SignatureHashValidatorTests
                 x.GetSigneeContexts(
                     It.Is<IInstanceDataAccessor>(d => d == _dataAccessorMock.Object),
                     It.Is<AltinnSignatureConfiguration>(c => c == signingConfiguration),
-                    null,
                     It.IsAny<CancellationToken>()
                 )
             )

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/SigningTaskValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/SigningTaskValidatorTests.cs
@@ -72,12 +72,7 @@ public class SigningTaskValidatorTest
         _appMetadataMock.Setup(am => am.GetApplicationMetadata()).ReturnsAsync(appMetadata);
         _signingServiceMock
             .Setup(ss =>
-                ss.GetSigneeContexts(
-                    It.IsAny<IInstanceDataAccessor>(),
-                    signingConfiguration,
-                    null,
-                    CancellationToken.None
-                )
+                ss.GetSigneeContexts(It.IsAny<IInstanceDataAccessor>(), signingConfiguration, CancellationToken.None)
             )
             .ReturnsAsync(signeeContexts);
 
@@ -131,12 +126,7 @@ public class SigningTaskValidatorTest
         _appMetadataMock.Setup(am => am.GetApplicationMetadata()).ReturnsAsync(appMetadata);
         _signingServiceMock
             .Setup(ss =>
-                ss.GetSigneeContexts(
-                    It.IsAny<IInstanceDataAccessor>(),
-                    signingConfiguration,
-                    null,
-                    CancellationToken.None
-                )
+                ss.GetSigneeContexts(It.IsAny<IInstanceDataAccessor>(), signingConfiguration, CancellationToken.None)
             )
             .ReturnsAsync(signeeContexts);
 
@@ -187,12 +177,7 @@ public class SigningTaskValidatorTest
         _appMetadataMock.Setup(am => am.GetApplicationMetadata()).ReturnsAsync(appMetadata);
         _signingServiceMock
             .Setup(ss =>
-                ss.GetSigneeContexts(
-                    It.IsAny<IInstanceDataAccessor>(),
-                    signingConfiguration,
-                    null,
-                    CancellationToken.None
-                )
+                ss.GetSigneeContexts(It.IsAny<IInstanceDataAccessor>(), signingConfiguration, CancellationToken.None)
             )
             .ThrowsAsync(exception);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the signing service API by removing an optional task override parameter. The signing task identifier is now determined directly from the instance data accessor instead of accepting an external override.

* **Tests**
  * Updated test mocks and calls to align with the signing service API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->