### PR TITLE
Make a copy of activites before visualization

### DIFF
--- a/test/Altinn.App.Tests.Common/Utils/OtelVisualizers.cs
+++ b/test/Altinn.App.Tests.Common/Utils/OtelVisualizers.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Text;
-using System.Text.Json;
 using OpenTelemetry.Logs;
 
 namespace Altinn.App.Tests.Common.Utils;
@@ -14,6 +13,9 @@ public static class OtelVisualizers
         int initialIndent = 0
     )
     {
+        // The current open telemetry setup collects all spans, and might collect from other tests running in parallel.
+        // To avoid issues with collection modification during enumeration, we create copies of the lists before processing.
+        activities = Copy(activities);
         var allActivitySpans = new HashSet<ActivitySpanId>(activities.Select(a => a.SpanId));
         var logsByActivityId = logs.GroupBy(l => l.SpanId)
             .ToDictionary(k => k.Key, v => v.OrderBy(l => l.Timestamp).ToList());
@@ -58,6 +60,20 @@ public static class OtelVisualizers
         return sb.ToString();
     }
 
+    // The current open telemetry setup, collects all spans, and might collect from other tests running in parallel.
+    // Parallel executions only add new spans, so using indexes should be safe(ish), unless the list implementation has
+    // race conditions if read while growing.
+    private static List<Activity> Copy(List<Activity> list)
+    {
+        var count = list.Count;
+        var copy = new List<Activity>(count);
+        for (int i = 0; i < count; i++)
+        {
+            copy.Add(list[i]);
+        }
+        return copy;
+    }
+
     private static void VisualizeActivity(
         StringBuilder sb,
         Dictionary<ActivitySpanId, List<Activity>> activityByParentId,
@@ -79,7 +95,26 @@ public static class OtelVisualizers
         foreach (var (key, value) in activity.TagObjects)
         {
             sb.Append(' ', indent + 1);
-            sb.AppendLine($"{key}: {JsonSerializer.Serialize(value)}");
+            if (value is IEnumerable<string> enumerable)
+            {
+                sb.AppendLine($"{key}:");
+                var count = 0;
+                foreach (var item in enumerable)
+                {
+                    sb.Append(' ', indent + 2);
+                    sb.AppendLine($"- {item}");
+                    count++;
+                }
+                if (count == 0)
+                {
+                    sb.Append(' ', indent + 2);
+                    sb.AppendLine("(empty list)");
+                }
+            }
+            else
+            {
+                sb.AppendLine($"{key}: {value}");
+            }
         }
 
         if (activityByParentId.TryGetValue(activity.SpanId, out var children))


### PR DESCRIPTION
OpenTelemetry.MemoryExporter does not isolate tests, and keeps adding telemetry from other tests causing race conditions. Not sure what the correct fix is, but this prevents race conditions.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test visualization utility for enhanced reliability during parallel test execution and optimized data display formatting for list and key-value pair rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->