### PR TITLE
Add utilites for reading using xsd files from the models

### DIFF
--- a/src/Altinn.App.Api/Controllers/ResourceController.cs
+++ b/src/Altinn.App.Api/Controllers/ResourceController.cs
@@ -36,6 +36,23 @@ public class ResourceController : ControllerBase
     }
 
     /// <summary>
+    /// Get the xsd schema for the model
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK, "application/xml")]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [Route("{org}/{app}/api/xsdschema/{id}")]
+    public ActionResult GetModelXsdSchema([FromRoute] string id)
+    {
+        string? schema = _appResourceService.GetXsdSchema(id);
+        if (schema == null)
+        {
+            return NotFound();
+        }
+        return Content(schema, "application/xml", System.Text.Encoding.UTF8);
+    }
+
+    /// <summary>
     /// Get the form layout
     /// </summary>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
@@ -80,6 +97,9 @@ public class ResourceController : ControllerBase
     [ProducesResponseType(typeof(string), StatusCodes.Status200OK, "application/json")]
     [HttpGet]
     [Route("{org}/{app}/api/layoutsettings")]
+    [Obsolete(
+        "This endpoint is no longer available. Use /{org}/{app}/api/layoutsettings/{id} to get layout settings for a specific layout set."
+    )]
     public ActionResult GetLayoutSettings(string org, string app)
     {
         string? settings = _appResourceService.GetLayoutSettingsString();

--- a/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
+++ b/src/Altinn.App.Core/Implementation/AppResourcesSI.cs
@@ -523,4 +523,20 @@ public class AppResourcesSI : IAppResources
 
         return filedata;
     }
+
+    /// <inheritdoc />
+    public string? GetXsdSchema(string dataTypeId)
+    {
+        string legalPath = Path.Join(_settings.AppBasePath, _settings.ModelsFolder);
+        string filename = Path.Join(legalPath, $"{dataTypeId}.xsd");
+        PathHelper.EnsureLegalPath(legalPath, filename);
+
+        string? filedata = null;
+        if (File.Exists(filename))
+        {
+            filedata = File.ReadAllText(filename, Encoding.UTF8);
+        }
+
+        return filedata;
+    }
 }

--- a/src/Altinn.App.Core/Internal/App/IAppResources.cs
+++ b/src/Altinn.App.Core/Internal/App/IAppResources.cs
@@ -166,4 +166,9 @@ public interface IAppResources
     /// Gets the validation configuration for a given data type
     /// </summary>
     string? GetValidationConfiguration(string dataTypeId);
+
+    /// <summary>
+    /// Gets the xsd schema for the provided dataTypeId.
+    /// </summary>
+    string? GetXsdSchema(string dataTypeId);
 }

--- a/test/Altinn.App.Api.Tests/Controllers/ResourceControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ResourceControllerTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit.Abstractions;
+
+namespace Altinn.App.Api.Tests.Controllers;
+
+public class ResourceControllerTests : ApiTestBase, IClassFixture<WebApplicationFactory<Program>>
+{
+    public ResourceControllerTests(WebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+        : base(factory, outputHelper) { }
+
+    private const string Org = "tdd";
+    private const string App = "contributer-restriction";
+    private const string DefaultDataTypeId = "Skjema";
+
+    [Fact]
+    public async Task GetModelJsonSchema_ReturnsOk()
+    {
+        var client = GetRootedClient(Org, App);
+        using var response = await client.GetAsync($"/{Org}/{App}/api/jsonschema/{DefaultDataTypeId}");
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.NotNull(content);
+        Assert.Contains("\"$comment\"", content); // TODO: Update when the schema in the test project has more content.
+    }
+
+    [Fact]
+    public async Task GetModelJsonSchema_InvalidDataTypeId_ReturnsNotFound()
+    {
+        var client = GetRootedClient(Org, App);
+        await Assert.ThrowsAsync<FileNotFoundException>(async () =>
+        {
+            using var response = await client.GetAsync($"/{Org}/{App}/api/jsonschema/InvalidDataTypeId");
+            // TODO: Should probably return 404 NotFound instead of throwing FileNotFoundException,
+            // but adding test for current behaviour.
+            // Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+        });
+    }
+
+    [Fact]
+    public async Task GetXmlSchema_ReturnsOk()
+    {
+        var client = GetRootedClient(Org, App);
+        using var response = await client.GetAsync($"/{Org}/{App}/api/xsdschema/{DefaultDataTypeId}");
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.NotNull(content);
+        Assert.Contains("<xs:schema xmlns:xs=", content); // TODO: Update when the schema in the test project has more content.
+    }
+
+    [Fact]
+    public async Task GetXmlSchema_InvalidDataTypeId_ReturnsNotFound()
+    {
+        var client = GetRootedClient(Org, App);
+        using var response = await client.GetAsync($"/{Org}/{App}/api/xsdschema/InvalidDataTypeId");
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/models/Skjema.schema.json
+++ b/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/models/Skjema.schema.json
@@ -1,0 +1,3 @@
+{
+    "$comment": "TODO: ensure content if required for test"
+}

--- a/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/models/Skjema.xsd
+++ b/test/Altinn.App.Api.Tests/Data/apps/tdd/contributer-restriction/models/Skjema.xsd
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- TODO: make sure this is in sync with actual model-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+</xs:schema>

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -5085,6 +5085,82 @@
         }
       }
     },
+    "/{org}/{app}/api/xsdschema/{id}": {
+      "get": {
+        "tags": [
+          "Resource"
+        ],
+        "summary": "Get the xsd schema for the model",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "org",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "app",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/{org}/{app}/api/layouts": {
       "get": {
         "tags": [
@@ -5213,7 +5289,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/{org}/{app}/api/layoutsettings/{id}": {

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -528,6 +528,8 @@ namespace Altinn.App.Api.Controllers
         [Microsoft.AspNetCore.Mvc.HttpGet]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(string), 200, "application/json", new string[0])]
         [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/api/layoutsettings")]
+        [System.Obsolete("This endpoint is no longer available. Use /{org}/{app}/api/layoutsettings/{id} to" +
+            " get layout settings for a specific layout set.")]
         public Microsoft.AspNetCore.Mvc.ActionResult GetLayoutSettings(string org, string app) { }
         [Microsoft.AspNetCore.Mvc.HttpGet]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(string), 200, "application/json", new string[0])]
@@ -548,6 +550,11 @@ namespace Altinn.App.Api.Controllers
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(string), 200, "application/json", new string[0])]
         [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/api/jsonschema/{id}")]
         public Microsoft.AspNetCore.Mvc.ActionResult GetModelJsonSchema([Microsoft.AspNetCore.Mvc.FromRoute] string id) { }
+        [Microsoft.AspNetCore.Mvc.HttpGet]
+        [Microsoft.AspNetCore.Mvc.ProducesResponseType(404)]
+        [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(string), 200, "application/xml", new string[0])]
+        [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/api/xsdschema/{id}")]
+        public Microsoft.AspNetCore.Mvc.ActionResult GetModelXsdSchema([Microsoft.AspNetCore.Mvc.FromRoute] string id) { }
         [Microsoft.AspNetCore.Mvc.HttpGet]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(204)]
         [Microsoft.AspNetCore.Mvc.ProducesResponseType(typeof(Microsoft.AspNetCore.Mvc.FileContentResult), 200, "application/json", new string[0])]

--- a/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/AppResourcesSITests.cs
@@ -1,4 +1,3 @@
-#nullable disable
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features.ExternalApi;
 using Altinn.App.Core.Implementation;
@@ -30,7 +29,7 @@ public class AppResourcesSITests
         AppResourcesSI appResources = new(
             settings,
             appMetadata,
-            null,
+            null!,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -81,7 +80,7 @@ public class AppResourcesSITests
         AppResourcesSI appResources = new(
             settings,
             appMetadata,
-            null,
+            null!,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -135,7 +134,7 @@ public class AppResourcesSITests
         AppResourcesSI appResources = new(
             settings,
             appMetadata,
-            null,
+            null!,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -190,7 +189,7 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
+            null!,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -206,7 +205,7 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
+            null!,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -222,7 +221,7 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
+            null!,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -240,7 +239,7 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
+            null!,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -257,7 +256,7 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
+            null!,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -275,7 +274,7 @@ public class AppResourcesSITests
         IAppResources appResources = new AppResourcesSI(
             settings,
             appMetadata,
-            null,
+            null!,
             new NullLogger<AppResourcesSI>(),
             _telemetry.Object
         );
@@ -305,7 +304,7 @@ public class AppResourcesSITests
 
     private static IAppMetadata SetupAppMetadata(
         IOptions<AppSettings> appsettings,
-        IFrontendFeatures frontendFeatures = null
+        IFrontendFeatures? frontendFeatures = null
     )
     {
         var featureManagerMock = new Mock<IFeatureManager>();

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2353,6 +2353,7 @@ namespace Altinn.App.Core.Implementation
         public byte[] GetText(string org, string app, string textResource) { }
         public System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.TextResource?> GetTexts(string org, string app, string language) { }
         public string? GetValidationConfiguration(string dataTypeId) { }
+        public string? GetXsdSchema(string dataTypeId) { }
     }
     public class DefaultAppEvents : Altinn.App.Core.Internal.App.IAppEvents
     {
@@ -2928,6 +2929,7 @@ namespace Altinn.App.Core.Internal.App
         byte[] GetText(string org, string app, string textResource);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.TextResource?> GetTexts(string org, string app, string language);
         string? GetValidationConfiguration(string dataTypeId);
+        string? GetXsdSchema(string dataTypeId);
     }
     public interface IApplicationClient
     {

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Metadata_Custom_0_Metadata.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Metadata_Custom_0_Metadata.verified.txt
@@ -408,6 +408,15 @@
         }
       },
       {
+        endpoint: GET {org}/{app}/api/xsdschema/{id},
+        metadata: {
+          errorMessageTextResourceKeyUser: null,
+          errorMessageTextResourceKeyServiceOwner: null,
+          requiredScopesUsers: null,
+          requiredScopesServiceOwners: null
+        }
+      },
+      {
         endpoint: GET {org}/{app}/instances/{instanceOwnerId:int}/{instanceId:guid}/data/{dataGuid:guid}/validate,
         metadata: {
           errorMessageTextResourceKeyUser: authorization.scopes.insufficient,

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Metadata_Standard_0_Metadata.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Metadata_Standard_0_Metadata.verified.txt
@@ -383,6 +383,15 @@
         }
       },
       {
+        endpoint: GET {org}/{app}/api/xsdschema/{id},
+        metadata: {
+          errorMessageTextResourceKeyUser: null,
+          errorMessageTextResourceKeyServiceOwner: null,
+          requiredScopesUsers: null,
+          requiredScopesServiceOwners: null
+        }
+      },
+      {
         endpoint: GET {org}/{app}/instances/{instanceOwnerId:int}/{instanceId:guid}/data/{dataGuid:guid}/validate,
         metadata: {
           errorMessageTextResourceKeyUser: null,


### PR DESCRIPTION
Brreg wants to write a validator that uses the xsd file instead of data annotations. This PR adds tooling for reading the xsd files for models


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to retrieve XML schemas for data models via /{org}/{app}/api/xsdschema/{id}.

* **Documentation**
  * Marked GetLayoutSettings as deprecated; use /{org}/{app}/api/layoutsettings/{id} for specific layout sets.
  * Marked the pages/order operation as deprecated in the public API docs.

* **Tests**
  * Added tests and supporting JSON/XSD test files covering schema endpoints and error cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->