### PR TITLE
Azure Key Vault IConfigurationProvider reload interval for live updates

### DIFF
--- a/src/Altinn.App.Api/Extensions/HostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/HostBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Altinn.App.Core.Extensions;
 using Altinn.App.Core.Internal.App;
+using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
 
 namespace Altinn.App.Api.Extensions;
@@ -40,7 +41,8 @@ public static class HostBuilderExtensions
 
         builder.Configuration.AddAzureKeyVault(
             new Uri(keyVaultUri),
-            new ClientSecretCredential(tenantId, clientId, clientSecret)
+            new ClientSecretCredential(tenantId, clientId, clientSecret),
+            new AzureKeyVaultConfigurationOptions { ReloadInterval = TimeSpan.FromMinutes(5) }
         );
     }
 }


### PR DESCRIPTION
## Description

Currently one has to redeploy/restart pod to get Azure Key Vault changes in an application, that seems a bit unnecessary.
Labelling as backport

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Azure Key Vault secrets now automatically reload every 5 minutes, ensuring configuration updates are reflected in your application without requiring manual restart.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->