### PR TITLE
refactor: update limits on correspondence texts

### DIFF
--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotification.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotification.cs
@@ -25,7 +25,7 @@ public sealed record CorrespondenceNotification : MultipartCorrespondenceItem
     /// <p>Depending on the <see cref="NotificationTemplate"/> in use,
     /// this value may be padded according to the template logic.</p>
     /// </summary>
-    [StringLength(1024, MinimumLength = 0)]
+    [StringLength(10000, MinimumLength = 0)]
     public string? EmailBody { get; init; }
 
     /// <summary>
@@ -33,7 +33,7 @@ public sealed record CorrespondenceNotification : MultipartCorrespondenceItem
     /// <p>Depending on the <see cref="NotificationTemplate"/> in use,
     /// this value may be padded according to the template logic.</p>
     /// </summary>
-    [StringLength(160, MinimumLength = 0)]
+    [StringLength(2144, MinimumLength = 0)]
     public string? SmsBody { get; init; }
 
     /// <summary>
@@ -54,7 +54,7 @@ public sealed record CorrespondenceNotification : MultipartCorrespondenceItem
     /// <p>Depending on the <see cref="NotificationTemplate"/> in use,
     /// this value may be padded according to the template logic.</p>
     /// </summary>
-    [StringLength(1024, MinimumLength = 0)]
+    [StringLength(10000, MinimumLength = 0)]
     public string? ReminderEmailBody { get; init; }
 
     /// <summary>
@@ -62,7 +62,7 @@ public sealed record CorrespondenceNotification : MultipartCorrespondenceItem
     /// <p>Depending on the <see cref="NotificationTemplate"/> in use,
     /// this value may be padded according to the template logic.</p>
     /// </summary>
-    [StringLength(160, MinimumLength = 0)]
+    [StringLength(2144, MinimumLength = 0)]
     public string? ReminderSmsBody { get; init; }
 
     /// <summary>

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -848,23 +848,23 @@ namespace Altinn.App.Core.Features.Correspondence.Models
             "cipient instead.")]
         public System.Collections.Generic.IReadOnlyList<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipientWrapper>? CustomNotificationRecipients { get; init; }
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient? CustomRecipient { get; init; }
-        [System.ComponentModel.DataAnnotations.StringLength(1024, MinimumLength=0)]
+        [System.ComponentModel.DataAnnotations.StringLength(10000, MinimumLength=0)]
         public string? EmailBody { get; init; }
         [System.ComponentModel.DataAnnotations.StringLength(128, MinimumLength=0)]
         public string? EmailSubject { get; init; }
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? NotificationChannel { get; init; }
         public required Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationTemplate NotificationTemplate { get; init; }
-        [System.ComponentModel.DataAnnotations.StringLength(1024, MinimumLength=0)]
+        [System.ComponentModel.DataAnnotations.StringLength(10000, MinimumLength=0)]
         public string? ReminderEmailBody { get; init; }
         [System.ComponentModel.DataAnnotations.StringLength(128, MinimumLength=0)]
         public string? ReminderEmailSubject { get; init; }
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? ReminderNotificationChannel { get; init; }
-        [System.ComponentModel.DataAnnotations.StringLength(160, MinimumLength=0)]
+        [System.ComponentModel.DataAnnotations.StringLength(2144, MinimumLength=0)]
         public string? ReminderSmsBody { get; init; }
         public System.DateTimeOffset? RequestedSendTime { get; init; }
         public bool? SendReminder { get; init; }
         public string? SendersReference { get; init; }
-        [System.ComponentModel.DataAnnotations.StringLength(160, MinimumLength=0)]
+        [System.ComponentModel.DataAnnotations.StringLength(2144, MinimumLength=0)]
         public string? SmsBody { get; init; }
     }
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Correspondence has updated the limit on string lengths: https://github.com/Altinn/altinn-correspondence/blob/56cbe28f8cc07c5f84eadd9ac7b44b2cffe75409/src/Altinn.Correspondence.API/Models/InitializeCorrespondenceNotificationExt.cs

All changes are more lenient -> backwards compatible

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased maximum character limits for correspondence notification messages, including email and SMS notifications, to accommodate longer content in both regular and reminder communications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->