### PR TITLE
Fix PDF filename variables for PDF service tasks without layout-set (auto PDF)

### DIFF
--- a/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -189,10 +189,6 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
 
         // Could use a double lock here, but a deadlock is more problematic than creating the state twice
         var layouts = _appResources.GetLayoutModelForTask(TaskId);
-        if (layouts is null)
-        {
-            return null;
-        }
 
         _layoutEvaluatorStateCache = new LayoutEvaluatorState(
             this,

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -293,11 +293,9 @@ public class PdfService : IPdfService
 
         if (_instanceDataUnitOfWorkInitializer != null && customFileNameTextResourceKey != null)
         {
-            string? taskId = instance.Process?.CurrentTask?.ElementId;
-
             InstanceDataUnitOfWork dataAccessor = await _instanceDataUnitOfWorkInitializer.Init(
                 instance,
-                taskId,
+                instance.Process?.CurrentTask?.ElementId,
                 language
             );
 

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -403,7 +403,7 @@ public class PdfService : IPdfService
     {
         LayoutEvaluatorState state =
             dataAccessor.GetLayoutEvaluatorState()
-            ?? throw new InvalidOperationException("LayoutEvaluatorState is null - no taskId available.");
+            ?? throw new InvalidOperationException("LayoutEvaluatorState should not be null. No current task?");
 
         DataElementIdentifier? dataElementIdentifier =
             subformDataElementId != null ? new DataElementIdentifier(subformDataElementId) : default;

--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -158,6 +158,7 @@ public class PdfService : IPdfService
 
         string fileName = await GetFileName(
             instance,
+            taskId,
             language,
             customFileNameTextResourceKey,
             subformPdfContext?.DataElementId
@@ -284,6 +285,7 @@ public class PdfService : IPdfService
 
     private async Task<string> GetFileName(
         Instance instance,
+        string taskId,
         string? language,
         string? customFileNameTextResourceKey,
         string? subformDataElementId
@@ -295,7 +297,7 @@ public class PdfService : IPdfService
         {
             InstanceDataUnitOfWork dataAccessor = await _instanceDataUnitOfWorkInitializer.Init(
                 instance,
-                instance.Process?.CurrentTask?.ElementId,
+                taskId,
                 language
             );
 

--- a/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceInstanceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceInstanceTests.cs
@@ -6,6 +6,7 @@ using Altinn.App.Core.Models.Layout.Components;
 using Altinn.App.Tests.Common.Fixtures;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit.Abstractions;
 
 namespace Altinn.App.Core.Tests.Internal.Texts;
@@ -76,5 +77,90 @@ public class TranslationServiceInstanceTests
         var translation = await translationService.TranslateTextKey("resourceKey", dataAccessor);
 
         Assert.Equal("AppName: Testapplikasjon, Value: 123Test", translation);
+    }
+
+    [Fact]
+    public async Task TranslateTextKey_WithDataModelDefault_WithoutLayoutSet_ThrowsException()
+    {
+        var fixture = new MockedServiceCollection();
+        fixture.OutputHelper = _output;
+        var language = "nb";
+
+        // Set up a text resource that uses dataModel.default
+        fixture.AddTextResource(
+            language,
+            new TextResourceElement()
+            {
+                Id = "testResource",
+                Value = "Value: {0}",
+                Variables = [new TextResourceVariable() { DataSource = "dataModel.default", Key = "Input1" }],
+            }
+        );
+
+        // Add a data type but NO layout set
+        var dataType = fixture.AddDataType<SkjemaModel>();
+
+        fixture.TryAddCommonServices();
+
+        // Override the mock to return null instead of throwing for GetLayoutModelForTask
+        fixture.AppResourcesMock.Setup(a => a.GetLayoutModelForTask(It.IsAny<string>())).Returns((LayoutModel?)null);
+
+        await using var provider = fixture.BuildServiceProvider();
+
+        var dataAccessor = await provider.CreateInstanceDataUnitOfWork(
+            new SkjemaModel() { Input1 = "test value" },
+            dataType,
+            language
+        );
+
+        var translationService = provider.GetRequiredService<ITranslationService>();
+
+        // Should throw because dataModel.default requires a layout-set to resolve the default data type
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            translationService.TranslateTextKey("testResource", dataAccessor)
+        );
+        Assert.Contains("dataModel.default", exception.Message);
+        Assert.Contains("no layout-set is available", exception.Message);
+    }
+
+    [Fact]
+    public async Task TranslateTextKey_WithExplicitDataType_WithoutLayoutSet_ReturnsValue()
+    {
+        var fixture = new MockedServiceCollection();
+        fixture.OutputHelper = _output;
+        var language = "nb";
+
+        var dataType = fixture.AddDataType<SkjemaModel>(dataTypeId: "SkjemaModel");
+
+        // Set up a text resource that uses an explicit data type (not "default")
+        fixture.AddTextResource(
+            language,
+            new TextResourceElement()
+            {
+                Id = "testResource",
+                Value = "Value: {0}",
+                Variables = [new TextResourceVariable() { DataSource = "dataModel.SkjemaModel", Key = "Input1" }],
+            }
+        );
+
+        fixture.TryAddCommonServices();
+
+        // Override the mock to return null instead of throwing for GetLayoutModelForTask
+        fixture.AppResourcesMock.Setup(a => a.GetLayoutModelForTask(It.IsAny<string>())).Returns((LayoutModel?)null);
+
+        await using var provider = fixture.BuildServiceProvider();
+
+        var dataAccessor = await provider.CreateInstanceDataUnitOfWork(
+            new SkjemaModel() { Input1 = "explicit type value" },
+            dataType,
+            language
+        );
+
+        var translationService = provider.GetRequiredService<ITranslationService>();
+
+        // Should succeed because we're using an explicit data type name, not "default"
+        var translation = await translationService.TranslateTextKey("testResource", dataAccessor);
+
+        Assert.Equal("Value: explicit type value", translation);
     }
 }

--- a/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceInstanceTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Texts/TranslationServiceInstanceTests.cs
@@ -103,7 +103,7 @@ public class TranslationServiceInstanceTests
         fixture.TryAddCommonServices();
 
         // Override the mock to return null instead of throwing for GetLayoutModelForTask
-        fixture.AppResourcesMock.Setup(a => a.GetLayoutModelForTask(It.IsAny<string>())).Returns((LayoutModel?)null);
+        fixture.AppResourcesMock.Setup(a => a.GetLayoutModelForTask(It.IsAny<string>())).Returns(default(LayoutModel));
 
         await using var provider = fixture.BuildServiceProvider();
 
@@ -146,7 +146,7 @@ public class TranslationServiceInstanceTests
         fixture.TryAddCommonServices();
 
         // Override the mock to return null instead of throwing for GetLayoutModelForTask
-        fixture.AppResourcesMock.Setup(a => a.GetLayoutModelForTask(It.IsAny<string>())).Returns((LayoutModel?)null);
+        fixture.AppResourcesMock.Setup(a => a.GetLayoutModelForTask(It.IsAny<string>())).Returns(default(LayoutModel));
 
         await using var provider = fixture.BuildServiceProvider();
 


### PR DESCRIPTION
Fix PDF filename variables for PDF service tasks without layout-set (auto PDF)

## Description
Returning a LayoutEvaluatorState even if no layout-set is found for the task. LayoutEvaluatorState already has LayoutState as a nullable, so I think it's fine? @ivarne 

## Related Issue(s)
- [#17522](https://github.com/Altinn/altinn-studio/issues/17522)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error detection and reporting with more descriptive messages when translating text in specific configuration scenarios.

* **Refactor**
  * Refactored internal logic to reduce code duplication and improve consistency across file naming and text translation operations for better maintainability.

* **Tests**
  * Added comprehensive new test cases covering translation service edge cases and configuration scenarios to improve test coverage and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->