### PR TITLE
fix: pdf base64 encode tracestate header

### DIFF
--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -104,11 +104,21 @@ public class PdfGeneratorClient : IPdfGeneratorClient
                     if (k != "traceparent" && k != "tracestate")
                         _logger.LogWarning("Unexpected key '{Key}' when propagating trace context (expected W3C)", k);
 
+                    var value = v;
+                    if (k == "tracestate")
+                    {
+                        // tracestate will contain e.g. baggage which are arbitrary keyvalue pairs example kv: "dd=s:1;o:rum".
+                        // values can contain semicolon which is not allowed in cookie values
+                        // so we base64 encode the entire value to be safe
+                        // Frontend accounts for this when passing it back when on the PDF page
+                        value = Convert.ToBase64String(Encoding.UTF8.GetBytes(v));
+                    }
+
                     c.Add(
                         new PdfGeneratorCookieOptions
                         {
                             Name = $"altinn-telemetry-{k}",
-                            Value = v,
+                            Value = value,
                             Domain = uri.Host,
                         }
                     );


### PR DESCRIPTION
## Description
See comment, CDP/pdf3 complained about invalid cookies, was able to narrow it down to tracestate. Today we "trust" extend whatever W3C trace context is passed into app APIs. In this specific case, SBS system had baggage in spans which where propagated through tracestate header (as per spec). Values can contain semicolons. Cookie values can not contain semicolons (tested by invoking `Network.setCookies` through CDP manually)

```json
{
        "domain": "brg.apps.tt02.altinn.no",
        "name": "altinn-telemetry-tracestate",
        "sameSite": "Lax",
        "value": "dd=s:1;o:rum"
}
```

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace context handling in the PDF generation service to ensure proper encoding of telemetry data according to W3C standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->