### PR TITLE
Fix PdfService file name logic. Make null handling in DataElementIdetifier safer

### DIFF
--- a/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
+++ b/src/Altinn.App.Core/Internal/Pdf/PdfService.cs
@@ -408,7 +408,9 @@ public class PdfService : IPdfService
             ?? throw new InvalidOperationException("LayoutEvaluatorState should not be null. No current task?");
 
         DataElementIdentifier? dataElementIdentifier =
-            subformDataElementId != null ? new DataElementIdentifier(subformDataElementId) : default;
+            subformDataElementId != null
+                ? new DataElementIdentifier(subformDataElementId)
+                : (DataElementIdentifier?)null;
 
         var componentContext = new ComponentContext(
             state,

--- a/src/Altinn.App.Core/Models/DataElementIdentifier.cs
+++ b/src/Altinn.App.Core/Models/DataElementIdentifier.cs
@@ -55,14 +55,15 @@ public readonly struct DataElementIdentifier : IEquatable<DataElementIdentifier>
     /// <summary>
     /// Implicit conversion to allow DataElements to be used as DataElementIds
     /// </summary>
-    public static implicit operator DataElementIdentifier(DataElement dataElement) => new(dataElement);
+    public static implicit operator DataElementIdentifier(DataElement dataElement) =>
+        dataElement is null ? throw new ArgumentNullException(nameof(dataElement)) : new(dataElement);
 
     /// <summary>
     /// Implicit conversion to allow DataElements to be used as DataElementIds,
     /// but accept and return null values
     /// </summary>
     public static implicit operator DataElementIdentifier?(DataElement? dataElement) =>
-        dataElement is null ? default : new(dataElement);
+        dataElement is null ? null : new(dataElement);
 
     /// <summary>
     /// Make the ToString method return the ID

--- a/src/Altinn.App.Core/Models/DataElementIdentifier.cs
+++ b/src/Altinn.App.Core/Models/DataElementIdentifier.cs
@@ -55,8 +55,7 @@ public readonly struct DataElementIdentifier : IEquatable<DataElementIdentifier>
     /// <summary>
     /// Implicit conversion to allow DataElements to be used as DataElementIds
     /// </summary>
-    public static implicit operator DataElementIdentifier(DataElement dataElement) =>
-        dataElement is null ? throw new ArgumentNullException(nameof(dataElement)) : new(dataElement);
+    public static implicit operator DataElementIdentifier(DataElement dataElement) => new(dataElement);
 
     /// <summary>
     /// Implicit conversion to allow DataElements to be used as DataElementIds,

--- a/test/Altinn.App.Core.Tests/Models/DataElementIdentifierTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/DataElementIdentifierTests.cs
@@ -1,7 +1,7 @@
 using Altinn.App.Core.Models;
 using Altinn.Platform.Storage.Interface.Models;
 
-namespace Altinn.App.PlatformServices.Tests.Models;
+namespace Altinn.App.Core.Tests.Models;
 
 public class DataElementIdentifierTests
 {

--- a/test/Altinn.App.Core.Tests/Models/DataElementIdentifierTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/DataElementIdentifierTests.cs
@@ -1,0 +1,124 @@
+using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.PlatformServices.Tests.Models;
+
+public class DataElementIdentifierTests
+{
+    [Fact]
+    public void NullableDataElementIdentifier_Default_ShouldBeNull()
+    {
+        DataElementIdentifier? identifier = default;
+
+        Assert.True(identifier is null);
+        Assert.False(identifier.HasValue);
+    }
+
+    [Fact]
+    public void NullableDataElementIdentifier_Null_ShouldBeNull()
+    {
+        DataElementIdentifier? identifier = null;
+
+        Assert.True(identifier is null);
+        Assert.False(identifier.HasValue);
+    }
+
+    [Fact]
+    public void NullableDataElementIdentifier_FromNullDataElement_ShouldBeNull()
+    {
+        DataElement? dataElement = null;
+        DataElementIdentifier? identifier = dataElement;
+
+        Assert.True(identifier is null);
+        Assert.False(identifier.HasValue);
+    }
+
+    [Fact]
+    public void NullableDataElementIdentifier_FromDataElement_ShouldHaveValue()
+    {
+        var guid = Guid.NewGuid();
+        DataElement dataElement = new() { Id = guid.ToString(), DataType = "Model" };
+        DataElementIdentifier? identifier = dataElement;
+
+        Assert.True(identifier.HasValue);
+        Assert.Equal(guid, identifier.Value.Guid);
+        Assert.Equal(guid.ToString(), identifier.Value.Id);
+        Assert.Equal("Model", identifier.Value.DataTypeId);
+    }
+
+    [Fact]
+    public void DataElementIdentifier_FromNullDataElement_ShouldThrowArgumentNullException()
+    {
+        DataElement? dataElement = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            DataElementIdentifier identifier = dataElement!;
+        });
+    }
+
+    [Fact]
+    public void DataElementIdentifier_FromDataElement_ShouldWork()
+    {
+        var guid = Guid.NewGuid();
+        DataElement dataElement = new() { Id = guid.ToString(), DataType = "Model" };
+        DataElementIdentifier identifier = dataElement;
+
+        Assert.Equal(guid, identifier.Guid);
+        Assert.Equal(guid.ToString(), identifier.Id);
+        Assert.Equal("Model", identifier.DataTypeId);
+    }
+
+    [Fact]
+    public void DataElementIdentifier_FromString_ShouldWork()
+    {
+        var guid = Guid.NewGuid();
+        var identifier = new DataElementIdentifier(guid.ToString());
+
+        Assert.Equal(guid, identifier.Guid);
+        Assert.Equal(guid.ToString(), identifier.Id);
+        Assert.Null(identifier.DataTypeId);
+    }
+
+    [Fact]
+    public void DataElementIdentifier_FromGuid_ShouldWork()
+    {
+        var guid = Guid.NewGuid();
+        var identifier = new DataElementIdentifier(guid);
+
+        Assert.Equal(guid, identifier.Guid);
+        Assert.Equal(guid.ToString(), identifier.Id);
+        Assert.Null(identifier.DataTypeId);
+    }
+
+    [Fact]
+    public void DataElementIdentifier_Equality_ShouldCompareByGuid()
+    {
+        var guid = Guid.NewGuid();
+        var identifier1 = new DataElementIdentifier(guid);
+        var identifier2 = new DataElementIdentifier(guid.ToString());
+
+        Assert.True(identifier1 == identifier2);
+        Assert.True(identifier1.Equals(identifier2));
+        Assert.Equal(identifier1.GetHashCode(), identifier2.GetHashCode());
+    }
+
+    [Fact]
+    public void DataElementIdentifier_Inequality_ShouldCompareByGuid()
+    {
+        var identifier1 = new DataElementIdentifier(Guid.NewGuid());
+        var identifier2 = new DataElementIdentifier(Guid.NewGuid());
+
+        Assert.True(identifier1 != identifier2);
+        Assert.False(identifier1.Equals(identifier2));
+    }
+
+    [Fact]
+    public void DataElementIdentifier_ToString_ShouldReturnId()
+    {
+        var guid = Guid.NewGuid();
+        var identifier = new DataElementIdentifier(guid);
+
+        Assert.Equal(guid.ToString(), identifier.ToString());
+    }
+}

--- a/test/Altinn.App.Core.Tests/Models/DataElementIdentifierTests.cs
+++ b/test/Altinn.App.Core.Tests/Models/DataElementIdentifierTests.cs
@@ -47,11 +47,13 @@ public class DataElementIdentifierTests
     }
 
     [Fact]
-    public void DataElementIdentifier_FromNullDataElement_ShouldThrowArgumentNullException()
+    public void DataElementIdentifier_FromNullDataElement_ShouldThrowNullReferenceException()
     {
         DataElement? dataElement = null;
 
-        Assert.Throws<ArgumentNullException>(() =>
+        // The non-nullable implicit operator doesn't guard against null input,
+        // so it throws NullReferenceException when accessing dataElement.Id
+        Assert.Throws<NullReferenceException>(() =>
         {
             DataElementIdentifier identifier = dataElement!;
         });


### PR DESCRIPTION
Fix PdfService file name logic. Make null handling in DataElementIdetifier safer

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-handling for data element conversions so null inputs are preserved (no unexpected default instances).

* **Tests**
  * Added comprehensive tests for nullable and non-nullable data element conversions, equality, and string/identifier construction.

* **Refactor**
  * Minor internal cleanup to PDF-related null handling with no user-facing behavior change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->