### PR TITLE
feat: support email user instantiation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Altinn.Common.EFormidlingClient" Version="1.3.3" />
     <PackageVersion Include="Altinn.Common.PEP" Version="4.2.2" />
     <PackageVersion Include="Altinn.Platform.Models" Version="1.6.1" />
-    <PackageVersion Include="Altinn.Platform.Storage.Interface" Version="4.3.0" />
+    <PackageVersion Include="Altinn.Platform.Storage.Interface" Version="4.4.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Net;
 using System.Text;
+using System.Text.Encodings.Web;
 using Altinn.App.Api.Extensions;
 using Altinn.App.Api.Helpers.Patch;
 using Altinn.App.Api.Helpers.RequestHandling;
@@ -1138,6 +1139,18 @@ public class InstancesController : ControllerBase
             string personOrOrganisationNumber = instanceOwner.PersonNumber ?? instanceOwner.OrganisationNumber;
             try
             {
+                if (!string.IsNullOrEmpty(instanceOwner.ExternalIdentifier))
+                {
+                    var partyId = await _altinnPartyClient.GetPartyIdByUrn(instanceOwner.ExternalIdentifier);
+                    if (partyId == null)
+                    {
+                        throw new ServiceException(
+                            HttpStatusCode.BadRequest,
+                            $"Failed to lookup party by external identifier: {instanceOwner.ExternalIdentifier}. No partyId found for the provided external identifier."
+                        );
+                    }
+                    return await _registerClient.GetPartyUnchecked(partyId.Value, this.HttpContext.RequestAborted);
+                }
                 if (!string.IsNullOrEmpty(instanceOwner.PersonNumber))
                 {
                     lookupNumber = "personNumber";
@@ -1149,6 +1162,22 @@ public class InstancesController : ControllerBase
                     return await _altinnPartyClient.LookupParty(
                         new PartyLookup { OrgNo = instanceOwner.OrganisationNumber }
                     );
+                }
+                else if (!string.IsNullOrEmpty(instanceOwner.Username))
+                {
+                    var email = instanceOwner.Username.StartsWith("epost:", StringComparison.InvariantCultureIgnoreCase)
+                        ? instanceOwner.Username[6..]
+                        : instanceOwner.Username;
+                    var urn = $"{AltinnUrns.SelfIdentifiedEmail}:{UrlEncoder.Default.Encode(email)}";
+                    var partyId = await _altinnPartyClient.GetPartyIdByUrn(urn);
+                    if (partyId == null)
+                    {
+                        throw new ServiceException(
+                            HttpStatusCode.BadRequest,
+                            $"Failed to lookup party by username: {instanceOwner.Username}. No partyId found for the provided idporten self identified email address."
+                        );
+                    }
+                    return await _registerClient.GetPartyUnchecked(partyId.Value, this.HttpContext.RequestAborted);
                 }
                 else
                 {

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -255,7 +255,13 @@ public class InstancesController : ControllerBase
 
             if (
                 lookup == null
-                || (lookup.PersonNumber == null && lookup.OrganisationNumber == null && lookup.PartyId == null)
+                || (
+                    lookup.PersonNumber == null
+                    && lookup.OrganisationNumber == null
+                    && lookup.PartyId == null
+                    && lookup.ExternalIdentifier == null
+                    && lookup.Username == null
+                )
             )
             {
                 return BadRequest(
@@ -483,7 +489,13 @@ public class InstancesController : ControllerBase
 
         if (
             lookup == null
-            || (lookup.PersonNumber == null && lookup.OrganisationNumber == null && lookup.PartyId == null)
+            || (
+                lookup.PersonNumber == null
+                && lookup.OrganisationNumber == null
+                && lookup.PartyId == null
+                && lookup.ExternalIdentifier == null
+                && lookup.Username == null
+            )
         )
         {
             return BadRequest(

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -291,10 +291,7 @@ public class InstancesController : ControllerBase
         try
         {
             party = await LookupParty(instanceTemplate.InstanceOwner) ?? throw new Exception("Unknown party");
-            instanceTemplate.InstanceOwner = InstantiationHelper.PartyToInstanceOwner(
-                party,
-                _authenticationContext
-            );
+            instanceTemplate.InstanceOwner = await InstantiationHelper.PartyToInstanceOwner(party, _authenticationContext);
         }
         catch (Exception partyLookupException)
         {
@@ -494,7 +491,7 @@ public class InstancesController : ControllerBase
         try
         {
             party = await LookupParty(instansiationInstance.InstanceOwner) ?? throw new Exception("Unknown party");
-            instansiationInstance.InstanceOwner = InstantiationHelper.PartyToInstanceOwner(
+            instansiationInstance.InstanceOwner = await InstantiationHelper.PartyToInstanceOwner(
                 party,
                 _authenticationContext
             );

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -291,7 +291,10 @@ public class InstancesController : ControllerBase
         try
         {
             party = await LookupParty(instanceTemplate.InstanceOwner) ?? throw new Exception("Unknown party");
-            instanceTemplate.InstanceOwner = await InstantiationHelper.PartyToInstanceOwner(party, _authenticationContext);
+            instanceTemplate.InstanceOwner = await InstantiationHelper.PartyToInstanceOwner(
+                party,
+                _authenticationContext
+            );
         }
         catch (Exception partyLookupException)
         {

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -291,7 +291,10 @@ public class InstancesController : ControllerBase
         try
         {
             party = await LookupParty(instanceTemplate.InstanceOwner) ?? throw new Exception("Unknown party");
-            instanceTemplate.InstanceOwner = InstantiationHelper.PartyToInstanceOwner(party);
+            instanceTemplate.InstanceOwner = InstantiationHelper.PartyToInstanceOwner(
+                party,
+                _authenticationContext
+            );
         }
         catch (Exception partyLookupException)
         {
@@ -491,7 +494,10 @@ public class InstancesController : ControllerBase
         try
         {
             party = await LookupParty(instansiationInstance.InstanceOwner) ?? throw new Exception("Unknown party");
-            instansiationInstance.InstanceOwner = InstantiationHelper.PartyToInstanceOwner(party);
+            instansiationInstance.InstanceOwner = InstantiationHelper.PartyToInstanceOwner(
+                party,
+                _authenticationContext
+            );
         }
         catch (Exception partyLookupException)
         {

--- a/src/Altinn.App.Api/Models/InstanceResponse.cs
+++ b/src/Altinn.App.Api/Models/InstanceResponse.cs
@@ -113,6 +113,7 @@ public sealed class InstanceResponse
                 PersonNumber = instance.InstanceOwner.PersonNumber,
                 OrganisationNumber = instance.InstanceOwner.OrganisationNumber,
                 Username = instance.InstanceOwner.Username,
+                ExternalIdentifier = instance.InstanceOwner.ExternalIdentifier,
                 Party = PartyResponse.From(instanceOwnerParty),
             },
             AppId = instance.AppId,
@@ -158,6 +159,11 @@ public sealed class InstanceOwnerResponse
     /// The username of the party. Null if the party is not self identified.
     /// </summary>
     public required string Username { get; init; }
+
+    /// <summary>
+    /// The external identifier of a self identified party. Null if the party is not self identified.
+    /// </summary>
+    public string ExternalIdentifier { get; init; }
 
     /// <summary>
     /// Party information for the instance owner.

--- a/src/Altinn.App.Core/Constants/AltinnUrns.cs
+++ b/src/Altinn.App.Core/Constants/AltinnUrns.cs
@@ -16,7 +16,9 @@ internal static class AltinnUrns
     public const string PersonId = "urn:altinn:person:identifier-no";
     public const string UserId = "urn:altinn:userid";
     public const string UserName = "urn:altinn:username";
+    public const string SelfIdentifiedEmail = "altinn:person:idporten-email";
     public const string PartyId = "urn:altinn:partyid";
+    public const string PartyUuid = "urn:altinn:partyuuid";
     public const string RepresentingPartyId = "urn:altinn:representingpartyid";
     public const string App = "urn:altinn:app";
     public const string AppResource = "urn:altinn:appresource";

--- a/src/Altinn.App.Core/Constants/AltinnUrns.cs
+++ b/src/Altinn.App.Core/Constants/AltinnUrns.cs
@@ -16,7 +16,7 @@ internal static class AltinnUrns
     public const string PersonId = "urn:altinn:person:identifier-no";
     public const string UserId = "urn:altinn:userid";
     public const string UserName = "urn:altinn:username";
-    public const string SelfIdentifiedEmail = "altinn:person:idporten-email";
+    public const string SelfIdentifiedEmail = "urn:altinn:person:idporten-email";
     public const string PartyId = "urn:altinn:partyid";
     public const string PartyUuid = "urn:altinn:partyuuid";
     public const string RepresentingPartyId = "urn:altinn:representingpartyid";

--- a/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
+++ b/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Altinn.App.Core.Features.Auth;
+using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -272,7 +273,7 @@ public static class InstantiationHelper
         if (authenticationContext.Current is not Authenticated.User user)
             return null;
 
-        var profile = await user.LookupProfile();
+        UserProfile profile = await user.LookupProfile();
         return profile.ExternalIdentity;
     }
 }

--- a/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
+++ b/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
@@ -223,7 +223,10 @@ public static class InstantiationHelper
     /// Get the correct <see cref="InstanceOwner" /> object from the <see cref="Party" /> object of the entity that should own the instance
     /// Use authenticationContext to get the external identity for self identified parties
     /// </summary>
-    public static async Task<InstanceOwner> PartyToInstanceOwner(Party party, IAuthenticationContext? authenticationContext = null)
+    public static async Task<InstanceOwner> PartyToInstanceOwner(
+        Party party,
+        IAuthenticationContext authenticationContext
+    )
     {
         if (!string.IsNullOrEmpty(party.SSN))
         {
@@ -244,7 +247,12 @@ public static class InstantiationHelper
             {
                 externalIdentifier = await GetExternalIdentityForSelfIdentifiedParty(party, authenticationContext);
             }
-            return new() { PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture), Username = party.Name, ExternalIdentifier = externalIdentifier };
+            return new()
+            {
+                PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture),
+                Username = party.Name,
+                ExternalIdentifier = externalIdentifier,
+            };
         }
         return new()
         {

--- a/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
+++ b/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using Altinn.App.Core.Features.Auth;
+using Altinn.App.Core.Features.Auth;
 using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
@@ -192,8 +194,9 @@ public static class InstantiationHelper
 
     /// <summary>
     /// Get the correct <see cref="InstanceOwner" /> object from the <see cref="Party" /> object of the entity that should own the instance
+    /// Use authenticationContext to get the external identity for self identified parties
     /// </summary>
-    public static InstanceOwner PartyToInstanceOwner(Party party)
+    public static InstanceOwner PartyToInstanceOwner(Party party, IAuthenticationContext? authenticationContext = null)
     {
         if (!string.IsNullOrEmpty(party.SSN))
         {
@@ -209,12 +212,32 @@ public static class InstantiationHelper
         }
         else if (party.PartyTypeName.Equals(PartyType.SelfIdentified))
         {
-            return new() { PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture), Username = party.Name };
+            string? externalIdentifier = null;
+            if (authenticationContext is not null)
+            {
+                externalIdentifier = GetExternalIdentityForSelfIdentifiedParty(party, authenticationContext).GetAwaiter().GetResult();
+            }
+            return new() { PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture), Username = party.Name, ExternalIdentifier = externalIdentifier };
         }
         return new()
         {
             PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture),
             // instanceOwnerPartyType == "unknown"
         };
+    }
+
+    internal static async Task<string?> GetExternalIdentityForSelfIdentifiedParty(
+        Party party,
+        IAuthenticationContext authenticationContext
+    )
+    {
+        if (party.PartyTypeName != PartyType.SelfIdentified)
+            return null;
+
+        if (authenticationContext.Current is not Authenticated.User user)
+            return null;
+
+        var profile = await user.LookupProfile();
+        return profile.ExternalIdentity;
     }
 }

--- a/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
+++ b/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
@@ -193,9 +193,37 @@ public static class InstantiationHelper
 
     /// <summary>
     /// Get the correct <see cref="InstanceOwner" /> object from the <see cref="Party" /> object of the entity that should own the instance
+    /// </summary>
+    public static InstanceOwner PartyToInstanceOwner(Party party)
+    {
+        if (!string.IsNullOrEmpty(party.SSN))
+        {
+            return new() { PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture), PersonNumber = party.SSN };
+        }
+        else if (!string.IsNullOrEmpty(party.OrgNumber))
+        {
+            return new()
+            {
+                PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture),
+                OrganisationNumber = party.OrgNumber,
+            };
+        }
+        else if (party.PartyTypeName.Equals(PartyType.SelfIdentified))
+        {
+            return new() { PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture), Username = party.Name };
+        }
+        return new()
+        {
+            PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture),
+            // instanceOwnerPartyType == "unknown"
+        };
+    }
+
+    /// <summary>
+    /// Get the correct <see cref="InstanceOwner" /> object from the <see cref="Party" /> object of the entity that should own the instance
     /// Use authenticationContext to get the external identity for self identified parties
     /// </summary>
-    public static InstanceOwner PartyToInstanceOwner(Party party, IAuthenticationContext? authenticationContext = null)
+    public static async Task<InstanceOwner> PartyToInstanceOwner(Party party, IAuthenticationContext? authenticationContext = null)
     {
         if (!string.IsNullOrEmpty(party.SSN))
         {
@@ -214,7 +242,7 @@ public static class InstantiationHelper
             string? externalIdentifier = null;
             if (authenticationContext is not null)
             {
-                externalIdentifier = GetExternalIdentityForSelfIdentifiedParty(party, authenticationContext).GetAwaiter().GetResult();
+                externalIdentifier = await GetExternalIdentityForSelfIdentifiedParty(party, authenticationContext);
             }
             return new() { PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture), Username = party.Name, ExternalIdentifier = externalIdentifier };
         }

--- a/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
+++ b/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using Altinn.App.Core.Features.Auth;
-using Altinn.App.Core.Features.Auth;
 using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;

--- a/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Events/EventsClient.cs
@@ -73,10 +73,13 @@ public class EventsClient : IEventsClient
         {
             alternativeSubject = $"/org/{instance.InstanceOwner.OrganisationNumber}";
         }
-
-        if (!string.IsNullOrWhiteSpace(instance.InstanceOwner.PersonNumber))
+        else if (!string.IsNullOrWhiteSpace(instance.InstanceOwner.PersonNumber))
         {
             alternativeSubject = $"/person/{instance.InstanceOwner.PersonNumber}";
+        }
+        else if (!string.IsNullOrWhiteSpace(instance.InstanceOwner.ExternalIdentifier))
+        {
+            alternativeSubject = instance.InstanceOwner.ExternalIdentifier;
         }
 
         var baseUrl = _generalSettings.FormattedExternalAppBaseUrl(new AppIdentifier(instance));

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -138,6 +138,7 @@ public class AltinnPartyClient : IAltinnPartyClient
         string endpointUrl = "access-management/parties/query";
         var query = new { data = new string[] { urn } };
         using var content = new StringContent(JsonSerializer.Serialize(query));
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
         ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
 
         string token = _userTokenProvider.GetUserToken();

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Constants;
 using Altinn.App.Core.Extensions;
@@ -128,5 +129,29 @@ public class AltinnPartyClient : IAltinnPartyClient
         );
 
         throw await PlatformHttpException.CreateAsync(response);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int?> GetPartyIdByUrn(string urn)
+    {
+        using var activity = _telemetry?.StartLookupPartyActivity();
+        string endpointUrl = "access-management/parties/query";
+        var query = new { data = new string[] { urn } };
+        using var content = new StringContent(JsonSerializer.Serialize(query));
+
+        var response = await _client.PostAsync(endpointUrl, content);
+        using var responseDocument = JsonDocument.Parse(await response.Content.ReadAsByteArrayAsync());
+        var listResponse = responseDocument.RootElement.GetProperty("data");
+        if (listResponse.GetArrayLength() == 0)
+        {
+            return null;
+        }
+        if (listResponse.GetArrayLength() > 1)
+        {
+            throw new InvalidOperationException($"Multiple parties found for URN {urn}");
+        }
+
+        var partyId = listResponse[0].GetProperty("partyId").GetInt32();
+        return partyId;
     }
 }

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -138,8 +138,27 @@ public class AltinnPartyClient : IAltinnPartyClient
         string endpointUrl = "access-management/parties/query";
         var query = new { data = new string[] { urn } };
         using var content = new StringContent(JsonSerializer.Serialize(query));
+        ApplicationMetadata application = await _appMetadata.GetApplicationMetadata();
 
-        var response = await _client.PostAsync(endpointUrl, content);
+        string token = _userTokenProvider.GetUserToken();
+
+        using HttpResponseMessage response = await _client.PostAsync(
+            token,
+            endpointUrl,
+            content,
+            _accessTokenGenerator.GenerateAccessToken(application.Org, application.AppIdentifier.App)
+        );
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            _logger.LogError(
+                "// Getting partyId by URN {Urn} failed with statuscode {StatusCode} - {Reason}",
+                urn,
+                response.StatusCode,
+                await response.Content.ReadAsStringAsync()
+            );
+            throw await PlatformHttpException.CreateAsync(response);
+        }
+
         using var responseDocument = JsonDocument.Parse(await response.Content.ReadAsByteArrayAsync());
         var listResponse = responseDocument.RootElement.GetProperty("data");
         if (listResponse.GetArrayLength() == 0)

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -224,14 +224,17 @@ public class LayoutEvaluatorState
                 ?? throw new InvalidOperationException("InstanceOwner or PartyId is null"),
             "appId" => Instance.AppId ?? throw new InvalidOperationException("AppId is null"),
             "instanceId" => Instance.Id ?? throw new InvalidOperationException("InstanceId is null"),
-            "instanceOwnerPartyType" => (
-                !string.IsNullOrWhiteSpace(Instance.InstanceOwner?.OrganisationNumber) ? "org"
-                : !string.IsNullOrWhiteSpace(Instance.InstanceOwner?.PersonNumber) ? "person"
-                : !string.IsNullOrWhiteSpace(Instance.InstanceOwner?.Username) ? "selfIdentified"
-                : "unknown"
-            ),
+            "instanceOwnerPartyType" => GetInstanceOwnerPartyType(Instance.InstanceOwner),
             _ => throw new ExpressionEvaluatorTypeErrorException($"Unknown Instance context property {key}"),
         };
+    }
+
+    private static string GetInstanceOwnerPartyType(InstanceOwner? instanceOwner)
+    {
+        return !string.IsNullOrWhiteSpace(instanceOwner?.OrganisationNumber) ? "org"
+            : !string.IsNullOrWhiteSpace(instanceOwner?.PersonNumber) ? "person"
+            : !string.IsNullOrWhiteSpace(instanceOwner?.Username) ? "selfIdentified"
+            : "unknown";
     }
 
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Registers/IAltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Internal/Registers/IAltinnPartyClient.cs
@@ -20,4 +20,11 @@ public interface IAltinnPartyClient
     /// <param name="partyLookup">A populated lookup object with information about what to look for.</param>
     /// <returns>The party lookup containing either SSN or organisation number.</returns>
     Task<Party> LookupParty(PartyLookup partyLookup);
+
+    /// <summary>
+    /// Looks up a partyId by a URN. The URN should be in the format urn:altinn:personnumber:12345678901 or urn:altinn:orgnumber:987654321.
+    /// </summary>
+    /// <param name="urn">The URN to look up.</param>
+    /// <returns>The partyId for the given URN, or null if not found.</returns>
+    Task<int?> GetPartyIdByUrn(string urn);
 }

--- a/src/Altinn.App.Core/Models/CloudEvent.cs
+++ b/src/Altinn.App.Core/Models/CloudEvent.cs
@@ -51,9 +51,9 @@ public class CloudEvent
     /// Gets or sets the alternative subject of the event.
     /// </summary>
     [JsonPropertyName("alternativesubject")]
-#nullable disable
-    public string AlternativeSubject { get; set; }
+    public string? AlternativeSubject { get; set; }
 
+#nullable disable
     /// <summary>
     /// Gets or sets the cloudEvent data content. The event payload.
     /// The payload depends on the type and the dataschema.

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.ReturnsOkResult_Raw.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_GetTests.ReturnsOkResult_Raw.verified.txt
@@ -6,6 +6,7 @@
       personNumber: 01039012345,
       organisationNumber: null,
       username: null,
+      externalIdentifier: null,
       party: {
         partyId: 501337,
         partyUuid: null,
@@ -92,6 +93,7 @@
       personNumber: 01039012345,
       organisationNumber: null,
       username: null,
+      externalIdentifier: null,
       party: {
         partyId: 501337,
         partyUuid: null,

--- a/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/InstancesController_PostNewInstanceTests.cs
@@ -118,6 +118,35 @@ public class InstancesController_PostNewInstanceTests : ApiTestBase, IClassFixtu
         TestData.DeleteInstanceAndData(org, app, instanceId);
     }
 
+    [Fact]
+    public async Task PostNewInstance_WithEmailUser_ShouldCreateInstanceAndNotFail()
+    {
+        // Setup test data
+        string org = "tdd";
+        string app = "contributer-restriction";
+        using HttpClient client = GetRootedOrgClient(org, app);
+
+        // Create instance data
+        var body = $$"""
+                {
+                    "instanceOwner": {
+                        "username": "post@altinn.no"
+                    }
+                }
+            """;
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync($"{org}/{app}/instances", content);
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+        OutputHelper.WriteLine(responseContent);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var instance = JsonSerializer.Deserialize<Instance>(responseContent, JsonSerializerOptions);
+        Assert.NotNull(instance);
+        Assert.Equal("epost:post@altinn.no", instance.InstanceOwner.Username);
+    }
+
     [Theory]
     [ClassData(typeof(TestAuthentication.AllTokens))]
     public async Task PostNewInstance_Simplified(TestJwtToken token)

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_Reject_ReturnsOk.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_Reject_ReturnsOk.verified.txt
@@ -79,6 +79,16 @@
       HasParent: false
     },
     {
+      Name: PartyClient.GetParty,
+      IdFormat: W3C,
+      Tags: [
+        {
+          instance.owner.party.id: 500600
+        }
+      ],
+      HasParent: true
+    },
+    {
       Name: Process.End,
       IdFormat: W3C,
       Tags: [

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -202,6 +202,16 @@
       HasParent: false
     },
     {
+      Name: PartyClient.GetParty,
+      IdFormat: W3C,
+      Tags: [
+        {
+          instance.owner.party.id: 500600
+        }
+      ],
+      HasParent: true
+    },
+    {
       Name: PdfGeneratorClient.GeneratePdf,
       IdFormat: W3C,
       HasParent: true

--- a/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
+++ b/test/Altinn.App.Api.Tests/CustomWebApplicationFactory.cs
@@ -230,26 +230,11 @@ public class ApiTestBase
 
     private void ConfigureFakeHttpClientHandler(IServiceCollection services)
     {
-        // Remove existing IHttpClientFactory and HttpClient
-        var httpClientFactoryDescriptor = services.Single(d => d.ServiceType == typeof(IHttpClientFactory));
-        services.Remove(httpClientFactoryDescriptor);
-
-        var httpClientDescriptor = services.Single(d => d.ServiceType == typeof(HttpClient));
-        services.Remove(httpClientDescriptor);
-
-        // Add the new HttpClient as singleton
-        services.AddSingleton<IHttpClientFactory>(sp =>
-        {
-            // Create an HttpClient using the mocked handler
-            var clientFactoryMock = new Mock<IHttpClientFactory>(MockBehavior.Strict);
-            clientFactoryMock
-                .Setup(f => f.CreateClient(It.IsAny<string>()))
-                .Returns(() => sp.GetRequiredService<HttpClient>());
-            return clientFactoryMock.Object;
-        });
-        services.AddTransient<HttpClient>(sp => new HttpClient(
-            new MockHttpMessageHandler(SendAsync, sp.GetRequiredService<ILogger<MockHttpMessageHandler>>())
-        ));
+        services.ConfigureHttpClientDefaults(c =>
+            c.ConfigurePrimaryHttpMessageHandler(
+                (sp) => new MockHttpMessageHandler(SendAsync, sp.GetRequiredService<ILogger<MockHttpMessageHandler>>())
+            )
+        );
     }
 
     protected async Task<TelemetrySnapshot> GetTelemetrySnapshot(int numberOfActivities, int numberOfMetrics)

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveCustomOpenApiSpec.verified.json
@@ -2126,7 +2126,7 @@
             "type": "string",
             "nullable": true
           },
-          "email": {
+          "externalIdentifier": {
             "type": "string",
             "nullable": true
           }

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -8632,7 +8632,7 @@
             "type": "string",
             "nullable": true
           },
-          "email": {
+          "externalIdentifier": {
             "type": "string",
             "nullable": true
           }
@@ -8667,6 +8667,11 @@
           "username": {
             "type": "string",
             "description": "The username of the party. Null if the party is not self identified.",
+            "nullable": true
+          },
+          "externalIdentifier": {
+            "type": "string",
+            "description": "The external identifier of a self identified party. Null if the party is not self identified.",
             "nullable": true
           },
           "party": {

--- a/test/Altinn.App.Api.Tests/Program.cs
+++ b/test/Altinn.App.Api.Tests/Program.cs
@@ -8,6 +8,7 @@ using Altinn.App.Api.Tests.Mocks.Event;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Cache;
+using Altinn.App.Core.Infrastructure.Clients.Register;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.AppModel;
 using Altinn.App.Core.Internal.Auth;
@@ -109,7 +110,10 @@ void ConfigureMockServices(IServiceCollection services, ConfigurationManager con
     services.AddTransient<IAppMetadata, AppMetadataMock>();
     services.AddSingleton<IAppConfigurationCache, AppConfigurationCacheMock>();
     services.AddTransient<IDataClient, DataClientMock>();
-    services.AddTransient<IAltinnPartyClient, AltinnPartyClientMock>();
+    services.AddTransient<AltinnPartyClientInterceptor>();
+    services
+        .AddHttpClient<IAltinnPartyClient, AltinnPartyClient>()
+        .ConfigurePrimaryHttpMessageHandler<AltinnPartyClientInterceptor>();
     services.AddTransient<IRegisterClient, RegisterClientMock>();
     services.AddTransient<IProfileClient, ProfileClientMock>();
     services.AddTransient<IInstanceEventClient, InstanceEventClientMock>();

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -1015,6 +1015,7 @@ namespace Altinn.App.Api.Models
     public sealed class InstanceOwnerResponse
     {
         public InstanceOwnerResponse() { }
+        public string ExternalIdentifier { get; init; }
         public required string OrganisationNumber { get; init; }
         public required Altinn.App.Api.Models.PartyResponse Party { get; init; }
         public required string PartyId { get; init; }

--- a/test/Altinn.App.Core.Tests/Helpers/InstantiationHelperTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/InstantiationHelperTests.cs
@@ -1,0 +1,268 @@
+using Altinn.App.Core.Features.Auth;
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Models;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Register.Enums;
+using Altinn.Platform.Register.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Moq;
+
+namespace Altinn.App.Core.Tests.Helpers;
+
+public class InstantiationHelperTests
+{
+    [Fact]
+    public async Task PartyToInstanceOwner_SelfIdentifiedWithEmail_ReturnsInstanceOwnerWithEmail()
+    {
+        // Arrange
+        var party = new Party
+        {
+            PartyId = 12345,
+            PartyTypeName = PartyType.SelfIdentified,
+            Name = "epost:test@example.com",
+        };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+        var authenticatedUser = CreateAuthenticatedUser(
+            userId: 1337,
+            partyId: 12345,
+            externalIdentity: "urn:altinn:person:idporten-email:test@example.com"
+        );
+        authenticationContextMock.SetupGet(a => a.Current).Returns(authenticatedUser);
+
+        // Act
+        InstanceOwner instanceOwner = await InstantiationHelper.PartyToInstanceOwner(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Equal("12345", instanceOwner.PartyId);
+        Assert.Equal("epost:test@example.com", instanceOwner.Username);
+        Assert.Equal("urn:altinn:person:idporten-email:test@example.com", instanceOwner.ExternalIdentifier);
+    }
+
+    [Fact]
+    public async Task PartyToInstanceOwner_SelfIdentifiedWithUsername_ReturnsInstanceOwnerWithUsername()
+    {
+        // Arrange
+        var party = new Party
+        {
+            PartyId = 12345,
+            PartyTypeName = PartyType.SelfIdentified,
+            Name = "Test User",
+        };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+        var authenticatedUser = CreateAuthenticatedUser(userId: 1337, partyId: 12345, externalIdentity: null);
+        authenticationContextMock.SetupGet(a => a.Current).Returns(authenticatedUser);
+
+        // Act
+        InstanceOwner instanceOwner = await InstantiationHelper.PartyToInstanceOwner(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Equal("12345", instanceOwner.PartyId);
+        Assert.Equal("Test User", instanceOwner.Username);
+        Assert.Null(instanceOwner.ExternalIdentifier);
+    }
+
+    [Fact]
+    public async Task PartyToInstanceOwner_PersonWithSSN_ReturnsInstanceOwnerWithPersonNumber()
+    {
+        // Arrange
+        var party = new Party
+        {
+            PartyId = 12345,
+            PartyTypeName = PartyType.Person,
+            SSN = "12345678901",
+        };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+
+        // Act
+        InstanceOwner instanceOwner = await InstantiationHelper.PartyToInstanceOwner(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Equal("12345", instanceOwner.PartyId);
+        Assert.Equal("12345678901", instanceOwner.PersonNumber);
+        Assert.Null(instanceOwner.ExternalIdentifier);
+        Assert.Null(instanceOwner.Username);
+    }
+
+    [Fact]
+    public async Task PartyToInstanceOwner_OrganisationWithOrgNumber_ReturnsInstanceOwnerWithOrganisationNumber()
+    {
+        // Arrange
+        var party = new Party
+        {
+            PartyId = 12345,
+            PartyTypeName = PartyType.Organisation,
+            OrgNumber = "991825827",
+        };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+
+        // Act
+        InstanceOwner instanceOwner = await InstantiationHelper.PartyToInstanceOwner(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Equal("12345", instanceOwner.PartyId);
+        Assert.Equal("991825827", instanceOwner.OrganisationNumber);
+        Assert.Null(instanceOwner.Username);
+        Assert.Null(instanceOwner.ExternalIdentifier);
+    }
+
+    [Fact]
+    public async Task GetExternalIdentityForSelfIdentifiedParty_WhenPartySelfIdentified_ReturnsExternalIdentity()
+    {
+        // Arrange
+        var party = new Party { PartyId = 12345, PartyTypeName = PartyType.SelfIdentified };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+        var authenticatedUser = CreateAuthenticatedUser(
+            userId: 1337,
+            partyId: 12345,
+            externalIdentity: "urn:altinn:person:idporten-email:test@example.com"
+        );
+        authenticationContextMock.SetupGet(a => a.Current).Returns(authenticatedUser);
+
+        // Act
+        var result = await InstantiationHelper.GetExternalIdentityForSelfIdentifiedParty(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Equal("urn:altinn:person:idporten-email:test@example.com", result);
+    }
+
+    [Fact]
+    public async Task GetExternalIdentityForSelfIdentifiedParty_WhenPartySelfIdentified_ButNoExternalIdentity_ReturnsNull()
+    {
+        // Arrange
+        var party = new Party { PartyId = 12345, PartyTypeName = PartyType.SelfIdentified };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+        var authenticatedUser = CreateAuthenticatedUser(userId: 1337, partyId: 12345, externalIdentity: null);
+        authenticationContextMock.SetupGet(a => a.Current).Returns(authenticatedUser);
+
+        // Act
+        var result = await InstantiationHelper.GetExternalIdentityForSelfIdentifiedParty(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetExternalIdentityForSelfIdentifiedParty_WhenPartyNotSelfIdentified_ReturnsNull()
+    {
+        // Arrange
+        var party = new Party { PartyId = 12345, PartyTypeName = PartyType.Person };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+
+        // Act
+        var result = await InstantiationHelper.GetExternalIdentityForSelfIdentifiedParty(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetExternalIdentityForSelfIdentifiedParty_WhenNotAuthenticatedAsUser_ReturnsNull()
+    {
+        // Arrange
+        var party = new Party { PartyId = 12345, PartyTypeName = PartyType.SelfIdentified };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+        var authenticatedOrg = CreateAuthenticatedOrg(orgNo: "991825827");
+        authenticationContextMock.SetupGet(a => a.Current).Returns(authenticatedOrg);
+
+        // Act
+        var result = await InstantiationHelper.GetExternalIdentityForSelfIdentifiedParty(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    private static Authenticated.User CreateAuthenticatedUser(int userId, int partyId, string? externalIdentity)
+    {
+        var party = new Party
+        {
+            PartyId = partyId,
+            PartyTypeName = PartyType.SelfIdentified,
+            Name = "Test User",
+        };
+
+        var userProfile = new UserProfile
+        {
+            UserId = userId,
+            PartyId = partyId,
+            ExternalIdentity = externalIdentity,
+            Party = party,
+        };
+
+        var token = TestAuthentication.GetSelfIdentifiedUserToken(userId: userId, partyId: partyId);
+
+        var auth = Authenticated.From(
+            tokenStr: token,
+            parsedToken: null,
+            isAuthenticated: true,
+            appMetadata: new ApplicationMetadata("tdd/test"),
+            getSelectedParty: () => partyId.ToString(),
+            getUserProfile: (id) => Task.FromResult<UserProfile?>(userProfile),
+            lookupUserParty: (id) => Task.FromResult<Party?>(party),
+            lookupOrgParty: (orgNo) => Task.FromResult(new Party()),
+            getPartyList: (id) => Task.FromResult<List<Party>?>(new List<Party>()),
+            validateSelectedParty: (uid, pid) => Task.FromResult<bool?>(true)
+        );
+
+        return (Authenticated.User)auth;
+    }
+
+    private static Authenticated.Org CreateAuthenticatedOrg(string orgNo)
+    {
+        var party = new Party
+        {
+            PartyId = 5001337,
+            PartyTypeName = PartyType.Organisation,
+            OrgNumber = orgNo,
+            Name = "Test Org",
+        };
+
+        var token = App.Tests.Common.Auth.TestAuthentication.GetOrgToken(orgNumber: orgNo);
+
+        var auth = Authenticated.From(
+            tokenStr: token,
+            parsedToken: null,
+            isAuthenticated: true,
+            appMetadata: new ApplicationMetadata("tdd/test"),
+            getSelectedParty: () => null,
+            getUserProfile: (id) => Task.FromResult<UserProfile?>(null),
+            lookupUserParty: (id) => Task.FromResult<Party?>(null),
+            lookupOrgParty: (orgNoParam) => Task.FromResult(party),
+            getPartyList: (id) => Task.FromResult<List<Party>?>(null),
+            validateSelectedParty: (uid, pid) => Task.FromResult<bool?>(null)
+        );
+
+        return (Authenticated.Org)auth;
+    }
+}

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeSelfIdentifiedEmail.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeSelfIdentifiedEmail.json
@@ -7,6 +7,7 @@
     "appId": "org/app-name",
     "instanceOwner": {
       "partyId": "12345",
+      "username": "epost:test@test.com",
       "externalIdentifier": "urn:altinn:person:idporten-email:test@test.com"
     }
   }

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeSelfIdentifiedEmail.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeSelfIdentifiedEmail.json
@@ -1,0 +1,13 @@
+{
+  "name": "PartyType is Self Identified with email",
+  "expression": ["instanceContext", "instanceOwnerPartyType"],
+  "expects": "selfIdentified",
+  "instance": {
+    "id": "d00ce51c-800b-416a-a906-ccab55f597e9",
+    "appId": "org/app-name",
+    "instanceOwner": {
+      "partyId": "12345",
+      "externalIdentifier": "urn:altinn:person:idporten-email:test@test.com"
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeSelfIdentifiedUsername.json
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/CommonTests/shared-tests/functions/instanceContext/partyTypeSelfIdentifiedUsername.json
@@ -1,5 +1,5 @@
 {
-  "name": "PartyType is Self Identified",
+  "name": "PartyType is Self Identified with username",
   "expression": ["instanceContext", "instanceOwnerPartyType"],
   "expects": "selfIdentified",
   "instance": {

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2168,6 +2168,7 @@ namespace Altinn.App.Core.Helpers
         public static Altinn.Platform.Register.Models.Party? GetPartyByPartyId(System.Collections.Generic.List<Altinn.Platform.Register.Models.Party>? partyList, int partyId) { }
         public static bool IsPartyAllowedToInstantiate(Altinn.Platform.Register.Models.Party? party, Altinn.Platform.Storage.Interface.Models.PartyTypesAllowed? partyTypesAllowed) { }
         public static Altinn.Platform.Storage.Interface.Models.InstanceOwner PartyToInstanceOwner(Altinn.Platform.Register.Models.Party party) { }
+        public static System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.InstanceOwner> PartyToInstanceOwner(Altinn.Platform.Register.Models.Party party, Altinn.App.Core.Features.Auth.IAuthenticationContext authenticationContext) { }
     }
     public static class JsonHelper
     {

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -4151,7 +4151,7 @@ namespace Altinn.App.Core.Models
     {
         public CloudEvent() { }
         [System.Text.Json.Serialization.JsonPropertyName("alternativesubject")]
-        public string AlternativeSubject { get; set; }
+        public string? AlternativeSubject { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("data")]
         public object Data { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("contenttype")]

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2483,6 +2483,7 @@ namespace Altinn.App.Core.Infrastructure.Clients.Register
     {
         public AltinnPartyClient(Microsoft.Extensions.Options.IOptions<Altinn.App.Core.Configuration.PlatformSettings> platformSettings, Microsoft.Extensions.Logging.ILogger<Altinn.App.Core.Infrastructure.Clients.Register.AltinnPartyClient> logger, System.Net.Http.HttpClient httpClient, Altinn.App.Core.Internal.App.IAppMetadata appMetadata, Altinn.App.Core.Internal.Auth.IUserTokenProvider userTokenProvider, Altinn.Common.AccessTokenClient.Services.IAccessTokenGenerator accessTokenGenerator, Altinn.App.Core.Features.Telemetry? telemetry = null) { }
         public System.Threading.Tasks.Task<Altinn.Platform.Register.Models.Party?> GetParty(int partyId) { }
+        public System.Threading.Tasks.Task<int?> GetPartyIdByUrn(string urn) { }
         public System.Threading.Tasks.Task<Altinn.Platform.Register.Models.Party> LookupParty(Altinn.Platform.Register.Models.PartyLookup partyLookup) { }
     }
     public class PersonClient : Altinn.App.Core.Internal.Registers.IPersonClient
@@ -3920,6 +3921,7 @@ namespace Altinn.App.Core.Internal.Registers
     public interface IAltinnPartyClient
     {
         System.Threading.Tasks.Task<Altinn.Platform.Register.Models.Party?> GetParty(int partyId);
+        System.Threading.Tasks.Task<int?> GetPartyIdByUrn(string urn);
         System.Threading.Tasks.Task<Altinn.Platform.Register.Models.Party> LookupParty(Altinn.Platform.Register.Models.PartyLookup partyLookup);
     }
     public interface IOrganizationClient

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            189
+            202
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            189
+            202
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=OldUser_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            189
+            202
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=ServiceOwner_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedNoPrefill_0_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            189
+            202
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.Full_auth=User_testCase=SimplifiedWithPrefill_0_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=ServiceOwner_scope=altinn-serviceowner-instances.read-altinn-serviceowner-instances.write_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=ServiceOwner_scope=altinn-serviceowner-instances.read-altinn-serviceowner-instances.write_1_Instantiation.verified.txt
@@ -46,7 +46,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=ServiceOwner_scope=custom-serviceowner-instances.read-custom-serviceowner-instances.write_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=ServiceOwner_scope=custom-serviceowner-instances.read-custom-serviceowner-instances.write_1_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=SystemUser_scope=altinn-instances.read-altinn-instances.write_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=SystemUser_scope=altinn-instances.read-altinn-instances.write_1_Instantiation.verified.txt
@@ -46,7 +46,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=SystemUser_scope=custom-instances.read-custom-instances.write_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=SystemUser_scope=custom-instances.read-custom-instances.write_1_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=altinn-instances.read-altinn-instances.write_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=altinn-instances.read-altinn-instances.write_1_Instantiation.verified.txt
@@ -46,7 +46,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=altinn-portal-enduser_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=altinn-portal-enduser_1_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=custom-instances.read-custom-instances.write_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesTests.Full_auth=User_scope=custom-instances.read-custom-instances.write_1_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=ServiceOwner_scope=custom-basic-serviceowner-instances.read-custom-basic-serviceowner-instances.write_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=ServiceOwner_scope=custom-basic-serviceowner-instances.read-custom-basic-serviceowner-instances.write_1_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=SystemUser_scope=custom-basic-instances.read-custom-basic-instances.write_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=SystemUser_scope=custom-basic-instances.read-custom-basic-instances.write_1_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=User_scope=custom-basic-instances.read-custom-basic-instances.write_1_Instantiation.verified.txt
+++ b/test/Altinn.App.Integration.Tests/CustomScopes/_snapshots/CustomScopesWithPlaceholderTests.Full_auth=User_scope=custom-basic-instances.read-custom-basic-instances.write_1_Instantiation.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            218
+            231
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500000_0_Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500000_0_Instance.verified.txt
@@ -46,7 +46,7 @@
             application/json
           ],
           Content-Length: [
-            189
+            202
           ]
         }
       },

--- a/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500002_0_Instance.verified.txt
+++ b/test/Altinn.App.Integration.Tests/PartyTypesAllowed/_snapshots/SubunitOnlyAppTests.Instantiate_partyId=500002_0_Instance.verified.txt
@@ -49,7 +49,7 @@
             application/json
           ],
           Content-Length: [
-            189
+            202
           ]
         }
       },

--- a/test/Altinn.App.Tests.Common/Data/Register/Party/510004.json
+++ b/test/Altinn.App.Tests.Common/Data/Register/Party/510004.json
@@ -1,0 +1,13 @@
+{
+    "partyId": "510004",
+    "partyTypeName": 3,
+    "orgNumber": null,
+    "ssn": null,
+    "unitType": null,
+    "name": "epost:post@altinn.no",
+    "isDeleted": false,
+    "onlyHierarchyElementWithNoAccess": false,
+    "person": null,
+    "organisation": null,
+    "childParties": null
+  }

--- a/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientInterceptor.cs
+++ b/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientInterceptor.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Text.Json;
+using Altinn.App.Core.Constants;
+using Altinn.App.Tests.Common.Data;
+
+namespace Altinn.App.Tests.Common.Mocks;
+
+public class AltinnPartyClientInterceptor : HttpMessageHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        var requestParts = request.RequestUri?.AbsolutePath.Split("/") ?? [];
+
+        return requestParts switch
+        {
+            ["", "register", "api", "v1", "parties", var partyIdString]
+                when int.TryParse(partyIdString, out var partyId) => GetPartyResponse(partyId),
+            ["", "register", "api", "v1", "access-management", "parties", "query"] => GetPartyQueryResponse(
+                await request.Content!.ReadAsStringAsync(cancellationToken)
+            ),
+            ["", "parties", "lookup"] => GetPartyLookupResponse(
+                await request.Content!.ReadAsStringAsync(cancellationToken)
+            ),
+            _ => throw new NotImplementedException(
+                $"The {nameof(AltinnPartyClientInterceptor)} is not implemented for paths like {request.RequestUri}.)"
+            ),
+        };
+    }
+
+    /// <summary>
+    /// Currently not required by any tests, but can be implemented if needed.
+    /// The implementation should be similar to
+    /// <see cref="AltinnPartyClientMock.LookupParty(Platform.Register.Models.PartyLookup)"/>
+    /// </summary>
+    private HttpResponseMessage GetPartyLookupResponse(string lookupContent)
+    {
+        throw new NotImplementedException();
+    }
+
+    private HttpResponseMessage GetPartyQueryResponse(string queryContent)
+    {
+        // This is a very simple implementation that only recognizes a single known URN. It can be extended to support more complex scenarios if needed.
+        using var document = JsonDocument.Parse(queryContent);
+        var knownUrn = AltinnUrns.SelfIdentifiedEmail + ":" + "post@altinn.no";
+        var knownPartyId = 510004;
+        if (document.RootElement.GetProperty("data").EnumerateArray().FirstOrDefault().GetString() == knownUrn)
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($$"""{"data": [{"partyId": {{knownPartyId}}}]}"""),
+            };
+        }
+        throw new NotImplementedException("Unknown URN in party query: " + queryContent);
+    }
+
+    private HttpResponseMessage GetPartyResponse(int partyId)
+    {
+        var path = CommonTestData.GetAltinnProfilePath();
+
+        var file = Path.Join(path, $"{partyId}.json");
+        if (!File.Exists(file))
+        {
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent($"Could not find party with id {partyId} in {path}"),
+            };
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(new FileStream(file, FileMode.Open)),
+        };
+    }
+}

--- a/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientMock.cs
+++ b/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientMock.cs
@@ -22,6 +22,11 @@ public class AltinnPartyClientMock : IAltinnPartyClient
         return await JsonSerializer.DeserializeAsync<Party>(fileHandle, _jsonSerializerOptions);
     }
 
+    public Task<int?> GetPartyIdByUrn(string urn)
+    {
+        throw new NotImplementedException();
+    }
+
     public async Task<Party> LookupParty(PartyLookup partyLookup)
     {
         var files = Directory.GetFiles(_partyFolder, "*.json");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add email to InstanceOwner when the party is self-identified and contains the email urn for external identifier

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API responses now include an external identifier for instance owners; instance creation can include self-identified external IDs.

* **Bug Fixes**
  * Instance owner resolution during creation now considers authentication context (async) to preserve external identity for self‑identified parties.

* **Tests**
  * Added and updated unit, integration, and fixture tests covering party-to-instance-owner resolution and externalIdentifier handling.

* **Documentation**
  * OpenAPI schema updated to expose externalIdentifier.

* **Chores**
  * Storage platform dependency bumped to 4.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->