### PR TITLE
Support delegating additional actions in runtime delegating signing.

### DIFF
--- a/src/Altinn.App.Core/Features/Signing/Models/SigneeContext.cs
+++ b/src/Altinn.App.Core/Features/Signing/Models/SigneeContext.cs
@@ -24,6 +24,12 @@ internal sealed class SigneeContext
     public CommunicationConfig? CommunicationConfig { get; init; }
 
     /// <summary>
+    /// Additional actions to delegate to this signee beyond the default read and sign.
+    /// </summary>
+    [JsonPropertyName("additionalActionsToDelegate")]
+    public List<string>? AdditionalActionsToDelegate { get; init; }
+
+    /// <summary>
     /// The state of the signee.
     /// </summary>
     [JsonPropertyName("signeeState")]

--- a/src/Altinn.App.Core/Features/Signing/ProvidedSignee.cs
+++ b/src/Altinn.App.Core/Features/Signing/ProvidedSignee.cs
@@ -12,6 +12,13 @@ public abstract class ProvidedSignee
     /// </summary>
     [JsonPropertyName("communicationConfig")]
     public CommunicationConfig? CommunicationConfig { get; init; }
+
+    /// <summary>
+    /// Additional actions to delegate to this signee. Read and sign are always delegated by default.
+    /// Use this to delegate additional actions, e.g. "reject". Custom action strings are also supported.
+    /// </summary>
+    [JsonPropertyName("additionalActionsToDelegate")]
+    public List<string>? AdditionalActionsToDelegate { get; init; }
 }
 
 /// <summary>

--- a/src/Altinn.App.Core/Features/Signing/Services/SigneeContextsManager.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigneeContextsManager.cs
@@ -162,6 +162,7 @@ internal sealed class SigneeContextsManager(
             TaskId = taskId,
             SigneeState = new SigneeContextState(),
             CommunicationConfig = providedSignee.CommunicationConfig,
+            AdditionalActionsToDelegate = providedSignee.AdditionalActionsToDelegate,
             Signee = signee,
         };
     }

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningDelegationService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningDelegationService.cs
@@ -68,7 +68,7 @@ internal sealed class SigningDelegationService(
                                 partyUuid.ToString()
                                 ?? throw new InvalidOperationException("Delegatee: PartyUuid is null"),
                         },
-                        Rights = CreateRights(appIdentifier, taskId),
+                        Rights = CreateRights(appIdentifier, taskId, signeeContext.AdditionalActionsToDelegate),
                     };
                     await accessManagementClient.DelegateRights(delegationRequest, ct);
                     state.IsAccessDelegated = true;
@@ -125,7 +125,7 @@ internal sealed class SigningDelegationService(
                                 partyUuid.ToString()
                                 ?? throw new InvalidOperationException("Delegatee: PartyUuid is null"),
                         },
-                        Rights = CreateRights(appIdentifier, taskId),
+                        Rights = CreateRights(appIdentifier, taskId, signeeContext.AdditionalActionsToDelegate),
                     };
                     await accessManagementClient.RevokeRights(delegationRequest, ct);
                     signeeContext.SigneeState.IsAccessDelegated = false;
@@ -155,7 +155,11 @@ internal sealed class SigningDelegationService(
         }
     }
 
-    private static List<RightRequest> CreateRights(AppIdentifier appIdentifier, string taskId)
+    private static List<RightRequest> CreateRights(
+        AppIdentifier appIdentifier,
+        string taskId,
+        List<string>? additionalActions
+    )
     {
         var resources = new List<Resource>
         {
@@ -164,7 +168,7 @@ internal sealed class SigningDelegationService(
             new TaskResource { Value = taskId },
         };
 
-        return
+        List<RightRequest> rights =
         [
             new RightRequest
             {
@@ -177,5 +181,21 @@ internal sealed class SigningDelegationService(
                 Action = new AltinnAction { Value = ActionType.Sign },
             },
         ];
+
+        if (additionalActions is not null)
+        {
+            foreach (string action in additionalActions)
+            {
+                rights.Add(
+                    new RightRequest
+                    {
+                        Resource = resources,
+                        Action = new AltinnAction { Value = action },
+                    }
+                );
+            }
+        }
+
+        return rights;
     }
 }

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigneeContextsManagerTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigneeContextsManagerTests.cs
@@ -530,4 +530,49 @@ public sealed class SigneeContextsManagerTests : IDisposable
 
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task GenerateSigneeContexts_WithAdditionalActionsToDelegate_ThreadsToSigneeContext()
+    {
+        // Arrange
+        var signatureConfiguration = new AltinnSignatureConfiguration
+        {
+            SigneeProviderId = "testProvider",
+            SigneeStatesDataTypeId = SigneeStatesDataTypeId,
+        };
+
+        var instance = new Instance
+        {
+            Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "Task_1" } },
+        };
+
+        var cachedInstanceMutator = new Mock<IInstanceDataMutator>();
+        cachedInstanceMutator.Setup(x => x.Instance).Returns(instance);
+
+        var personSignee = new ProvidedPerson
+        {
+            SocialSecurityNumber = "12345678901",
+            FullName = "Person One",
+            AdditionalActionsToDelegate = ["reject"],
+        };
+
+        var signeesResult = new SigneeProviderResult { Signees = [personSignee] };
+
+        _signeeProvider.Setup(x => x.Id).Returns("testProvider");
+        _signeeProvider.Setup(x => x.GetSignees(It.IsAny<GetSigneesParameters>())).ReturnsAsync(signeesResult);
+
+        // Act
+        var result = await _signeeContextsManager.GenerateSigneeContexts(
+            cachedInstanceMutator.Object,
+            signatureConfiguration,
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+        var additionalActions = result[0].AdditionalActionsToDelegate;
+        Assert.NotNull(additionalActions);
+        Assert.Equal("reject", Assert.Single(additionalActions));
+    }
 }

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningDelegationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningDelegationServiceTests.cs
@@ -540,4 +540,149 @@ public class SigningDelegationServiceTests
         // Assert
         Assert.False(success);
     }
+
+    [Fact]
+    public async Task DelegateSigneeRights_WithAdditionalActions_DelegatesAllRights()
+    {
+        // Arrange
+        DelegationRequest? capturedRequest = null;
+        var accessManagementClient = new Mock<IAccessManagementClient>();
+        accessManagementClient
+            .Setup(x => x.DelegateRights(It.IsAny<DelegationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<DelegationRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new DelegationResponse());
+        var logger = new Mock<ILogger<SigningDelegationService>>();
+        var service = new SigningDelegationService(accessManagementClient.Object, logger.Object);
+        var taskId = "taskId";
+        Guid instanceGuid = Guid.NewGuid();
+        var instanceId = "instanceOwnerPartyId" + "/" + instanceGuid;
+        Guid instanceOwnerPartyUuid = Guid.NewGuid();
+        var appIdentifier = new AppIdentifier("testOrg", "testApp");
+        var signeeContexts = new List<SigneeContext>()
+        {
+            new()
+            {
+                TaskId = taskId,
+                SigneeState = new SigneeState() { IsAccessDelegated = false },
+                Signee = _signee,
+                AdditionalActionsToDelegate = ["reject"],
+            },
+        };
+        var ct = new CancellationToken();
+
+        // Act
+        (signeeContexts, var success) = await service.DelegateSigneeRights(
+            taskId,
+            instanceId,
+            instanceOwnerPartyUuid,
+            appIdentifier,
+            signeeContexts,
+            ct
+        );
+
+        // Assert
+        Assert.True(success);
+        Assert.True(signeeContexts[0].SigneeState.IsAccessDelegated);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(3, capturedRequest!.Rights.Count);
+        Assert.Equal("read", capturedRequest.Rights[0].Action!.Value);
+        Assert.Equal("sign", capturedRequest.Rights[1].Action!.Value);
+        Assert.Equal("reject", capturedRequest.Rights[2].Action!.Value);
+    }
+
+    [Fact]
+    public async Task DelegateSigneeRights_WithNullAdditionalActions_DelegatesOnlyReadAndSign()
+    {
+        // Arrange
+        DelegationRequest? capturedRequest = null;
+        var accessManagementClient = new Mock<IAccessManagementClient>();
+        accessManagementClient
+            .Setup(x => x.DelegateRights(It.IsAny<DelegationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<DelegationRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new DelegationResponse());
+        var logger = new Mock<ILogger<SigningDelegationService>>();
+        var service = new SigningDelegationService(accessManagementClient.Object, logger.Object);
+        var taskId = "taskId";
+        Guid instanceGuid = Guid.NewGuid();
+        var instanceId = "instanceOwnerPartyId" + "/" + instanceGuid;
+        Guid instanceOwnerPartyUuid = Guid.NewGuid();
+        var appIdentifier = new AppIdentifier("testOrg", "testApp");
+        var signeeContexts = new List<SigneeContext>()
+        {
+            new()
+            {
+                TaskId = taskId,
+                SigneeState = new SigneeState() { IsAccessDelegated = false },
+                Signee = _signee,
+                AdditionalActionsToDelegate = null,
+            },
+        };
+        var ct = new CancellationToken();
+
+        // Act
+        (signeeContexts, var success) = await service.DelegateSigneeRights(
+            taskId,
+            instanceId,
+            instanceOwnerPartyUuid,
+            appIdentifier,
+            signeeContexts,
+            ct
+        );
+
+        // Assert
+        Assert.True(success);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(2, capturedRequest!.Rights.Count);
+        Assert.Equal("read", capturedRequest.Rights[0].Action!.Value);
+        Assert.Equal("sign", capturedRequest.Rights[1].Action!.Value);
+    }
+
+    [Fact]
+    public async Task RevokeSigneeRights_WithAdditionalActions_RevokesAllRights()
+    {
+        // Arrange
+        DelegationRequest? capturedRequest = null;
+        var accessManagementClient = new Mock<IAccessManagementClient>();
+        accessManagementClient
+            .Setup(x => x.RevokeRights(It.IsAny<DelegationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<DelegationRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new DelegationResponse());
+        var logger = new Mock<ILogger<SigningDelegationService>>();
+        var service = new SigningDelegationService(accessManagementClient.Object, logger.Object);
+        var taskId = "taskId";
+        Guid instanceGuid = Guid.NewGuid();
+        var instanceId = "instanceOwnerPartyId" + "/" + instanceGuid;
+        Guid instanceOwnerPartyUuid = Guid.NewGuid();
+        var appIdentifier = new AppIdentifier("testOrg", "testApp");
+        var signeeContexts = new List<SigneeContext>()
+        {
+            new()
+            {
+                TaskId = taskId,
+                SigneeState = new SigneeState() { IsAccessDelegated = true },
+                Signee = _signee,
+                AdditionalActionsToDelegate = ["reject"],
+            },
+        };
+        var ct = new CancellationToken();
+
+        // Act
+        (signeeContexts, var success) = await service.RevokeSigneeRights(
+            taskId,
+            instanceId,
+            instanceOwnerPartyUuid,
+            appIdentifier,
+            signeeContexts,
+            ct
+        );
+
+        // Assert
+        Assert.True(success);
+        Assert.False(signeeContexts[0].SigneeState.IsAccessDelegated);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(3, capturedRequest!.Rights.Count);
+        Assert.Equal("read", capturedRequest.Rights[0].Action!.Value);
+        Assert.Equal("sign", capturedRequest.Rights[1].Action!.Value);
+        Assert.Equal("reject", capturedRequest.Rights[2].Action!.Value);
+    }
 }

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningDelegationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningDelegationServiceTests.cs
@@ -620,7 +620,7 @@ public class SigningDelegationServiceTests
         var ct = new CancellationToken();
 
         // Act
-        (signeeContexts, var success) = await service.DelegateSigneeRights(
+        (_, bool success) = await service.DelegateSigneeRights(
             taskId,
             instanceId,
             instanceOwnerPartyUuid,

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2020,6 +2020,8 @@ namespace Altinn.App.Core.Features.Signing
     public abstract class ProvidedSignee
     {
         protected ProvidedSignee() { }
+        [System.Text.Json.Serialization.JsonPropertyName("additionalActionsToDelegate")]
+        public System.Collections.Generic.List<string>? AdditionalActionsToDelegate { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("communicationConfig")]
         public Altinn.App.Core.Features.Signing.CommunicationConfig? CommunicationConfig { get; init; }
     }


### PR DESCRIPTION
Support delegating additional actions in runtime delegating signing.

## Related Issue(s)
- https://github.com/Altinn/altinn-studio/issues/17672

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs/pull/2783)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signing delegation now supports specifying extra custom actions (e.g., "reject") to grant or revoke for delegated signers in addition to the default read and sign permissions.

* **Tests**
  * Added unit tests validating that additional delegated actions are included in delegation and revocation flows and that signer state updates as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->