### PR TITLE
Feat/methods to access xsd

### DIFF
--- a/src/Altinn.App.Api/packaging/Altinn.App.Api.Experimental.props
+++ b/src/Altinn.App.Api/packaging/Altinn.App.Api.Experimental.props
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    This props file is included in the Altinn.App.Api nuget package and will
+    apply to the App projects when they reference said nuget package.
+   -->
+  <PropertyGroup>
+    <IsAltinnApp>true</IsAltinnApp>
+  </PropertyGroup>
+  <ItemGroup>
+    <!--
+      This props file is included in the build/ path of the Altinn.App.Api nuget package
+      but the Rosly analyzer is included transitively, for example in unit test projects or similar.
+      We only need to do app-based analysis on actual app projects, so this let's us distinguish
+      in the Roslyn Analyzer code.
+    -->
+    <CompilerVisibleProperty Include="IsAltinnApp" />
+  </ItemGroup>
+  <ItemGroup>
+    <!--
+      We include config files as addition files so that they are more easily referenced
+      in analyzers and source generators.
+    -->
+    <AdditionalFiles Include="config/**" />
+    <AdditionalFiles Include="ui/**/*.json" />
+  </ItemGroup>
+</Project>

--- a/src/Altinn.App.Core/Configuration/AppSettings.cs
+++ b/src/Altinn.App.Core/Configuration/AppSettings.cs
@@ -216,6 +216,11 @@ public class AppSettings
     public bool ExpressionValidation { get; set; }
 
     /// <summary>
+    /// Enable the functionality to validate form data against corresponding XSD if present
+    /// </summary>
+    public bool XsdValidation { get; set; }
+
+    /// <summary>
     /// Enables OpenTelemetry as a substitute for Application Insights SDK
     /// Improves instrumentation throughout the Altinn app libraries.
     /// </summary>

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -243,6 +243,11 @@ public static class ServiceCollectionExtensions
         {
             services.AddTransient<IValidator, ExpressionValidator>();
         }
+
+        if (appSettings?.XsdValidation is true)
+        {
+            services.AddTransient<IValidator, XsdValidator>();
+        }
     }
 
     /// <summary>

--- a/src/Altinn.App.Core/Features/Validation/Default/XsdValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/XsdValidator.cs
@@ -76,7 +76,7 @@ public class XsdValidator : IValidator
             var schema = _appResourceService.GetXsdSchema(dataType.Id);
             if (schema is null)
             {
-                _logger.LogWarning(
+                _logger.LogInformation(
                     "No XSD schema found for data type {DataTypeId}, skipping XSD validation",
                     dataType.Id
                 );

--- a/src/Altinn.App.Core/Features/Validation/Default/XsdValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/XsdValidator.cs
@@ -1,0 +1,120 @@
+using System.Xml;
+using System.Xml.Schema;
+using Altinn.App.Core.Helpers;
+using Altinn.App.Core.Helpers.Serialization;
+using Altinn.App.Core.Internal.App;
+using Altinn.App.Core.Models;
+using Altinn.App.Core.Models.Validation;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.App.Core.Features.Validation.Default;
+
+/// <summary>
+/// Validates form data against the XSD schema for the data model, if it exists
+/// </summary>
+public class XsdValidator : IValidator
+{
+    private readonly ILogger<XsdValidator> _logger;
+    private readonly IAppResources _appResourceService;
+    private readonly IAppMetadata _appMetadata;
+    private readonly ModelSerializationService _modelSerializationService;
+
+    /// <summary>
+    /// Constructor for the expression validator
+    /// </summary>
+    public XsdValidator(
+        ILogger<XsdValidator> logger,
+        IAppResources appResourceService,
+        IAppMetadata appMetadata,
+        ModelSerializationService modelSerializationService
+    )
+    {
+        _logger = logger;
+        _appResourceService = appResourceService;
+        _appMetadata = appMetadata;
+        _modelSerializationService = modelSerializationService;
+    }
+
+    /// <summary>
+    /// We implement <see cref="ShouldRunForTask"/> instead
+    /// </summary>
+    public string TaskId => "*";
+
+    /// <summary>
+    /// Only run for tasks that specifies a layout set
+    /// </summary>
+    public bool ShouldRunForTask(string taskId) =>
+        _appMetadata
+            .GetApplicationMetadata()
+            .Result.DataTypes.Exists(dt => dt.TaskId == taskId && dt.AppLogic?.ClassRef is not null);
+
+    /// <inheritdoc />
+    public string ValidationSource => "Xsd";
+
+    /// <inheritdoc />
+    public bool NoIncrementalValidation => true;
+
+    /// <summary>
+    /// This is not used for incremental validation
+    /// </summary>
+    public Task<bool> HasRelevantChanges(
+        IInstanceDataAccessor dataAccessor,
+        string taskId,
+        DataElementChanges changes
+    ) => Task.FromResult(true);
+
+    /// <inheritdoc />
+    public async Task<List<ValidationIssue>> Validate(
+        IInstanceDataAccessor dataAccessor,
+        string taskId,
+        string? language
+    )
+    {
+        var validationIssues = new List<ValidationIssue>();
+        foreach (var (dataType, dataElement) in dataAccessor.GetDataElementsForTask(taskId))
+        {
+            var schema = _appResourceService.GetXsdSchema(dataType.Id);
+            if (schema is null)
+            {
+                _logger.LogWarning(
+                    "No XSD schema found for data type {DataTypeId}, skipping XSD validation",
+                    dataType.Id
+                );
+                continue;
+            }
+            var formData = await dataAccessor.GetFormData(dataElement);
+            ObjectUtils.RemoveAltinnRowId(formData);
+
+            var serializedFormData = _modelSerializationService.SerializeToXml(formData);
+            var parsedSchema = new XmlSchemaSet();
+            using (var xsdReader = XmlReader.Create(new StringReader(schema)))
+            {
+                parsedSchema.Add(null, xsdReader);
+            }
+            var settings = new XmlReaderSettings { ValidationType = ValidationType.Schema, Schemas = parsedSchema };
+            settings.ValidationEventHandler += (sender, e) =>
+            {
+                validationIssues.Add(
+                    new ValidationIssue()
+                    {
+                        Code = "Xsd",
+                        CustomTextKey = "backend.xsd_validation",
+                        DataElementId = dataElement.Id,
+                        Severity = ValidationIssueSeverity.Error,
+                        CustomTextParameters = new Dictionary<string, string>()
+                        {
+                            { "schema", dataType.Id },
+                            { "message", e.Message },
+                        },
+                    }
+                );
+            };
+
+            using var xmlStream = new MemoryStream(serializedFormData.ToArray(), writable: false);
+            using var reader = XmlReader.Create(xmlStream, settings);
+            while (reader.Read()) { }
+        }
+
+        return validationIssues;
+    }
+}

--- a/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
@@ -324,10 +324,18 @@ internal sealed class TranslationService : ITranslationService
                     Id = "backend.xsd_validation",
                     Value = language switch
                     {
-                        LanguageConst.Nb => "Et felt bryter reglene satt av XSD",
-                        LanguageConst.Nn => "Eit felt bryt reglane sette av XSD",
-                        _ => "A field is in violation of the rules set by the XSD schema",
+                        LanguageConst.Nb => "Et felt bryter reglene satt av XSD. Melding: {0]",
+                        LanguageConst.Nn => "Eit felt bryt reglane sette av XSD. Melding: {0}",
+                        _ => "A field is in violation of the rules set by the XSD schema. Message: {0}",
                     },
+                    Variables = [
+                        new TextResourceVariable()
+                        {
+                            DataSource = "customTextParameters",
+                            Key = "message",
+                            DefaultValue = ""
+                        }
+                    ]
                 };
         }
 

--- a/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
@@ -324,9 +324,9 @@ internal sealed class TranslationService : ITranslationService
                     Id = "backend.xsd_validation",
                     Value = language switch
                     {
-                        LanguageConst.Nb => "Ett eller flere felter bryter reglene satt av XSD",
-                        LanguageConst.Nn => "Eitt eller fleire felt bryt reglane sette av XSD",
-                        _ => "One or more field is violating a rule in the XSD",
+                        LanguageConst.Nb => "Et felt bryter reglene satt av XSD",
+                        LanguageConst.Nn => "Eit felt bryt reglane sette av XSD",
+                        _ => "A field is in violation of the rules set by the XSD schema",
                     },
                 };
         }

--- a/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
+++ b/src/Altinn.App.Core/Internal/Texts/TranslationService.cs
@@ -318,6 +318,17 @@ internal sealed class TranslationService : ITranslationService
                         _ => "Dokumentet er en forhåndsvisning",
                     },
                 };
+            case "backend.xsd_validation":
+                return new TextResourceElement()
+                {
+                    Id = "backend.xsd_validation",
+                    Value = language switch
+                    {
+                        LanguageConst.Nb => "Ett eller flere felter bryter reglene satt av XSD",
+                        LanguageConst.Nn => "Eitt eller fleire felt bryt reglane sette av XSD",
+                        _ => "One or more field is violating a rule in the XSD",
+                    },
+                };
         }
 
         return null;


### PR DESCRIPTION
Uses the new methods to access XSD to add opt-in validation based on XSD rules, if user has a schema with the same name as the data model.

## Description
- Added a new class XsdValidator:IValidator
- Added default description of error in TranslationService.cs
- Added a new setting in appsettings `XsdValidation`

## Verification
- [x ] **Your** code builds clean without any errors or warnings
- [x ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<img width="1281" height="340" alt="image" src="https://github.com/user-attachments/assets/b97c0202-45a2-456f-a07d-8c92454b6610" />
