### PR TITLE
fix: require localtest version >= 3 for instance lock endpoints

### DIFF
--- a/src/Altinn.App.Core/Internal/LocaltestValidation.cs
+++ b/src/Altinn.App.Core/Internal/LocaltestValidation.cs
@@ -74,7 +74,7 @@ internal sealed class LocaltestValidation : BackgroundService
                         case VersionResult.Ok { Version: var version }:
                         {
                             _logger.LogInformation("Localtest version: {Version}", version);
-                            if (version >= 2)
+                            if (version >= 3)
                                 return;
                             _logger.LogError(
                                 "Localtest version is not supported for this version of the app backend. Update your local copy of localtest (git pull)."

--- a/test/Altinn.App.Core.Tests/Internal/LocaltestValidationTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/LocaltestValidationTests.cs
@@ -79,7 +79,7 @@ public class LocaltestValidationTests
     }
 
     // The version that the LocaltestValidation service expects to see from the API.
-    private static readonly int _okExpectedVersion = 2;
+    private static readonly int _okExpectedVersion = 3;
 
     // Old version that the LocaltestValidation service will complain about.
     private static readonly int _oldExpectedVersion = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- https://github.com/Altinn/app-localtest/pull/198

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation logic for localtest version compatibility. Versions below 3 now generate error logs and trigger shutdown, while version 3 and above continue normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->