### PR TITLE
Remove extraneous senders from Fiks Arkiv Payload

### DIFF
--- a/src/Altinn.App.Clients.Fiks/Constants/FiksArkivConstants.cs
+++ b/src/Altinn.App.Clients.Fiks/Constants/FiksArkivConstants.cs
@@ -8,7 +8,6 @@ namespace Altinn.App.Clients.Fiks.Constants;
 public static class FiksArkivConstants
 {
     internal const string AltinnSystemId = "Altinn Studio";
-    internal const string AltinnOrgNo = "991825827";
 
     /// <summary>
     /// Known filenames used in Fiks Arkiv messages.

--- a/src/Altinn.App.Clients.Fiks/Factories/KorrespondansepartFactory.cs
+++ b/src/Altinn.App.Clients.Fiks/Factories/KorrespondansepartFactory.cs
@@ -43,21 +43,6 @@ internal static class KorrespondansepartFactory
     }
 
     /// <summary>
-    /// Creates a Korrespondansepart of type InternAvsender (Internal Sender).
-    /// </summary>
-    public static Korrespondansepart CreateInternalSender(string partyId, string partyName) =>
-        new()
-        {
-            Korrespondanseparttype = new Korrespondanseparttype
-            {
-                KodeProperty = KorrespondanseparttypeKoder.InternAvsender.Verdi,
-                Beskrivelse = KorrespondanseparttypeKoder.InternAvsender.Beskrivelse,
-            },
-            KorrespondansepartNavn = partyName.EnsureNotNullOrEmpty("FiksArkiv->InternalSender.Name"),
-            KorrespondansepartID = partyId.EnsureNotNullOrEmpty("FiksArkiv->InternalSender.ID"),
-        };
-
-    /// <summary>
     /// Creates a Korrespondansepart of type Mottaker (Recipient).
     /// </summary>
     /// <remarks>

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivConfigResolver.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivConfigResolver.cs
@@ -12,7 +12,6 @@ using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Internal.Language;
 using Altinn.App.Core.Internal.Registers;
 using Altinn.App.Core.Internal.Texts;
-using Altinn.App.Core.Models;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
@@ -215,32 +214,6 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
             organizationId: recipient.OrgNumber,
             reference: GetCorrelationId(instance)
         );
-
-    /// <inheritdoc />
-    public async Task<Korrespondansepart> GetServiceOwnerParty(CancellationToken cancellationToken = default)
-    {
-        ApplicationMetadata appMetadata = await _appMetadata.GetApplicationMetadata();
-        AltinnCdnOrgDetails? orgDetails = null;
-
-        try
-        {
-            AltinnCdnOrgs altinnCdnOrgs = await _altinnCdnClient.GetOrgs(cancellationToken);
-            orgDetails = altinnCdnOrgs.Orgs?.GetValueOrDefault(appMetadata.Org);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Unable to get service owner details: {Exception}", e);
-        }
-
-        return KorrespondansepartFactory.CreateSender(
-            partyId: orgDetails?.Orgnr ?? appMetadata.Org ?? appMetadata.Id,
-            partyName: orgDetails?.Name?.Nb
-                ?? orgDetails?.Name?.Nn
-                ?? orgDetails?.Name?.En
-                ?? appMetadata.Org
-                ?? appMetadata.Id
-        );
-    }
 
     /// <inheritdoc />
     public async Task<Klassifikasjon> GetInstanceOwnerClassification(

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivConfigResolver.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivConfigResolver.cs
@@ -5,7 +5,6 @@ using Altinn.App.Clients.Fiks.Factories;
 using Altinn.App.Clients.Fiks.FiksArkiv.Models;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features.Auth;
-using Altinn.App.Core.Internal.AltinnCdn;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Expressions;
@@ -30,7 +29,6 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
     private readonly ILogger<FiksArkivConfigResolver> _logger;
     private readonly GeneralSettings _generalSettings;
     private readonly IAltinnPartyClient _altinnPartyClient;
-    private readonly IAltinnCdnClient _altinnCdnClient;
 
     public FiksArkivConfigResolver(
         IOptions<FiksArkivSettings> fiksArkivSettings,
@@ -40,7 +38,6 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
         ILayoutEvaluatorStateInitializer layoutStateInitializer,
         IOptions<GeneralSettings> generalSettings,
         IAltinnPartyClient altinnPartyClient,
-        IAltinnCdnClient altinnCdnClient,
         ILogger<FiksArkivConfigResolver> logger
     )
     {
@@ -51,7 +48,6 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
         _layoutStateInitializer = layoutStateInitializer;
         _generalSettings = generalSettings.Value;
         _altinnPartyClient = altinnPartyClient;
-        _altinnCdnClient = altinnCdnClient;
         _logger = logger;
     }
 
@@ -323,7 +319,6 @@ internal sealed class FiksArkivConfigResolver : IFiksArkivConfigResolver
         var binding =
             configValue.DataModelBinding
             ?? throw new FiksArkivException($"Neither value nor data binding was supplied for config: {configValue}");
-        ;
         var dataElement = instance.GetRequiredDataElement(binding.DataType);
         var data = await layoutState.GetModelData(binding, dataElement, null); // Note: Doesn't accept cancellation token.. yet
 

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivDefaultPayloadGenerator.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivDefaultPayloadGenerator.cs
@@ -126,20 +126,11 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         // Recipient
         journalEntry.Korrespondansepart.Add(recipientParty);
 
-        // Sender(s)
-        journalEntry.Korrespondansepart.Add(serviceOwnerParty);
+        // Sender
         if (instanceOwnerParty is not null)
         {
             journalEntry.Korrespondansepart.Add(instanceOwnerParty);
         }
-
-        // Internal sender
-        journalEntry.Korrespondansepart.Add(
-            KorrespondansepartFactory.CreateInternalSender(
-                partyId: FiksArkivConstants.AltinnOrgNo,
-                partyName: FiksArkivConstants.AltinnSystemId
-            )
-        );
 
         // Main form data file
         journalEntry.Dokumentbeskrivelse.Add(GetDocumentDescription(archiveDocuments.PrimaryDocument));

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivDefaultPayloadGenerator.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/FiksArkivDefaultPayloadGenerator.cs
@@ -2,7 +2,6 @@ using System.Text;
 using Altinn.App.Clients.Fiks.Constants;
 using Altinn.App.Clients.Fiks.Exceptions;
 using Altinn.App.Clients.Fiks.Extensions;
-using Altinn.App.Clients.Fiks.Factories;
 using Altinn.App.Clients.Fiks.FiksArkiv.Models;
 using Altinn.App.Clients.Fiks.FiksIO.Models;
 using Altinn.App.Core.Features.Auth;
@@ -74,7 +73,6 @@ internal sealed class FiksArkivDefaultPayloadGenerator : IFiksArkivPayloadGenera
         var defaultDocumentTitle = await _fiksArkivConfigResolver.GetApplicationTitle(cancellationToken);
         var documentMetadata = await _fiksArkivConfigResolver.GetArchiveDocumentMetadata(instance, cancellationToken);
         var recipientParty = _fiksArkivConfigResolver.GetRecipientParty(instance, recipient);
-        var serviceOwnerParty = await _fiksArkivConfigResolver.GetServiceOwnerParty(cancellationToken);
         var instanceOwnerParty = await _fiksArkivConfigResolver.GetInstanceOwnerParty(instance, cancellationToken);
         var instanceOwnerClassification = await _fiksArkivConfigResolver.GetInstanceOwnerClassification(
             _authenticationContext.Current,

--- a/src/Altinn.App.Clients.Fiks/FiksArkiv/IFiksArkivConfigResolver.cs
+++ b/src/Altinn.App.Clients.Fiks/FiksArkiv/IFiksArkivConfigResolver.cs
@@ -49,11 +49,6 @@ public interface IFiksArkivConfigResolver
     Korrespondansepart GetRecipientParty(Instance instance, FiksArkivRecipient recipient);
 
     /// <summary>
-    /// Gets the service owner party (korrespondansepart).
-    /// </summary>
-    Task<Korrespondansepart> GetServiceOwnerParty(CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Gets the instance owner party (korrespondansepart).
     /// </summary>
     Task<Korrespondansepart?> GetInstanceOwnerParty(Instance instance, CancellationToken cancellationToken = default);

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.1.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.1.verified.txt
@@ -95,22 +95,6 @@
       </korrespondanseparttype>
       <korrespondansepartNavn>Recipient Name</korrespondansepartNavn>
     </korrespondansepart>
-    <korrespondansepart>
-      <korrespondansepartID>org-number</korrespondansepartID>
-      <korrespondanseparttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Avsender</beskrivelse>
-      </korrespondanseparttype>
-      <korrespondansepartNavn>Org Name</korrespondansepartNavn>
-    </korrespondansepart>
-    <korrespondansepart>
-      <korrespondansepartID>991825827</korrespondansepartID>
-      <korrespondanseparttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">IA</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Intern avsender</beskrivelse>
-      </korrespondanseparttype>
-      <korrespondansepartNavn>Altinn Studio</korrespondansepartNavn>
-    </korrespondansepart>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>
       <noekkel xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">12345/88d9baf8-2f9f-4e66-9a2f-7d345e60ed90</noekkel>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.2.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.2.verified.txt
@@ -180,22 +180,6 @@
       </korrespondanseparttype>
       <korrespondansepartNavn>Recipient Name</korrespondansepartNavn>
     </korrespondansepart>
-    <korrespondansepart>
-      <korrespondansepartID>org-number</korrespondansepartID>
-      <korrespondanseparttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Avsender</beskrivelse>
-      </korrespondanseparttype>
-      <korrespondansepartNavn>Org Name</korrespondansepartNavn>
-    </korrespondansepart>
-    <korrespondansepart>
-      <korrespondansepartID>991825827</korrespondansepartID>
-      <korrespondanseparttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">IA</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Intern avsender</beskrivelse>
-      </korrespondanseparttype>
-      <korrespondansepartNavn>Altinn Studio</korrespondansepartNavn>
-    </korrespondansepart>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>
       <noekkel xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">custom-case-file-id</noekkel>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.3.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.3.verified.txt
@@ -70,14 +70,6 @@
       <deresReferanse>Ref-001</deresReferanse>
     </korrespondansepart>
     <korrespondansepart>
-      <korrespondansepartID>org-number</korrespondansepartID>
-      <korrespondanseparttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Avsender</beskrivelse>
-      </korrespondanseparttype>
-      <korrespondansepartNavn>Org Name</korrespondansepartNavn>
-    </korrespondansepart>
-    <korrespondansepart>
       <korrespondansepartID>altinn-party-id</korrespondansepartID>
       <korrespondanseparttype>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
@@ -90,14 +82,6 @@
       <poststed>City</poststed>
       <telefonnummer>phone-no</telefonnummer>
       <telefonnummer>mobile-no</telefonnummer>
-    </korrespondansepart>
-    <korrespondansepart>
-      <korrespondansepartID>991825827</korrespondansepartID>
-      <korrespondanseparttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">IA</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Intern avsender</beskrivelse>
-      </korrespondanseparttype>
-      <korrespondansepartNavn>Altinn Studio</korrespondansepartNavn>
     </korrespondansepart>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.4.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/.Verify/FiksArkivDefaultPayloadGeneratorTest.GeneratePayload_GeneratesCorrectPayload.4.verified.txt
@@ -67,14 +67,6 @@
       <korrespondansepartNavn>Recipient Name</korrespondansepartNavn>
     </korrespondansepart>
     <korrespondansepart>
-      <korrespondansepartID>org-number</korrespondansepartID>
-      <korrespondanseparttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Avsender</beskrivelse>
-      </korrespondanseparttype>
-      <korrespondansepartNavn>Org Name</korrespondansepartNavn>
-    </korrespondansepart>
-    <korrespondansepart>
       <korrespondansepartID>altinn-party-id</korrespondansepartID>
       <korrespondanseparttype>
         <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">EA</kode>
@@ -84,14 +76,6 @@
       <organisasjonid>org-number</organisasjonid>
       <telefonnummer>duplicate-phone-no</telefonnummer>
       <telefonnummer>duplicate-mobile-no</telefonnummer>
-    </korrespondansepart>
-    <korrespondansepart>
-      <korrespondansepartID>991825827</korrespondansepartID>
-      <korrespondanseparttype>
-        <kode xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">IA</kode>
-        <beskrivelse xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">Intern avsender</beskrivelse>
-      </korrespondanseparttype>
-      <korrespondansepartNavn>Altinn Studio</korrespondansepartNavn>
     </korrespondansepart>
     <referanseEksternNoekkel>
       <fagsystem xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1">ttd/test-app</fagsystem>

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivConfigResolverTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivConfigResolverTest.cs
@@ -6,7 +6,6 @@ using Altinn.App.Clients.Fiks.FiksArkiv.Models;
 using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Auth;
-using Altinn.App.Core.Internal.AltinnCdn;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Internal.Language;
@@ -445,62 +444,6 @@ public class FiksArkivConfigResolverTest
         var result = fixture.FiksArkivConfigResolver.GetRecipientParty(instance, recipient);
 
         // Assert
-        Assert.NotNull(result);
-        var serialized = result.SerializeXml(indent: true);
-        var xml = Encoding.UTF8.GetString(serialized.Span);
-        await Verify(xml).UseDefaultSettings(testCaseNumber);
-    }
-
-    [Theory]
-    [InlineData(1, "ttd/test-app", "ttd", "Name-nb", "Name-nn", "Name-en", "123456789")]
-    [InlineData(2, "ttd/test-app", null, "Name-nb", "Name-nn", "Name-en", "123456789")]
-    [InlineData(3, "ttd/test-app", "ttd", null, "Name-nn", "Name-en", "123456789")]
-    [InlineData(4, "ttd/test-app", "ttd", "Name-nb", null, "Name-en", "123456789")]
-    [InlineData(5, "ttd/test-app", "ttd", "Name-nb", "Name-nn", null, "123456789")]
-    [InlineData(6, "ttd/test-app", "ttd", "Name-nb", "Name-nn", "Name-en", null)]
-    [InlineData(7, "ttd/test-app", "ttd", null, null, null, "123456789")]
-    public async Task GetServiceOwnerParty_ReturnsExpectedValue(
-        int testCaseNumber,
-        string appMetaId,
-        string? appMetaOrg,
-        string? orgNameNb,
-        string? orgNameNn,
-        string? orgNameEn,
-        string? orgNumber
-    )
-    {
-        // Arrange
-        var appMetadata = new ApplicationMetadata(appMetaId) { Org = appMetaOrg };
-        var orgs = new AltinnCdnOrgs()
-        {
-            Orgs = new Dictionary<string, AltinnCdnOrgDetails>
-            {
-                [appMetaOrg ?? "unknown"] = new()
-                {
-                    Orgnr = orgNumber,
-                    Name = new AltinnCdnOrgName
-                    {
-                        Nb = orgNameNb,
-                        Nn = orgNameNn,
-                        En = orgNameEn,
-                    },
-                },
-            },
-        };
-
-        await using var fixture = TestFixture.Create(services =>
-        {
-            services.AddFiksArkiv();
-            services.AddSingleton(
-                Mock.Of<IAltinnCdnClient>(x => x.GetOrgs(It.IsAny<CancellationToken>()) == Task.FromResult(orgs))
-            );
-        });
-        fixture.AppMetadataMock.Setup(x => x.GetApplicationMetadata()).ReturnsAsync(appMetadata);
-
-        // Act
-        var result = await fixture.FiksArkivConfigResolver.GetServiceOwnerParty();
-
-        // // Assert
         Assert.NotNull(result);
         var serialized = result.SerializeXml(indent: true);
         var xml = Encoding.UTF8.GetString(serialized.Span);

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
@@ -58,7 +58,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
                 attachmentSettings: [Factories.DocumentSettings("ref-data-as-pdf")],
                 archiveDocumentMetadata: null,
                 recipientParty: Factories.RecipientParty("recipient-id", "Recipient Name"),
-                serviceOwnerParty: Factories.ServiceOwnerParty("org-number", "Org Name"),
                 instanceOwnerParty: null,
                 instanceOwnerClassification: Factories.InstanceOwnerClassification(Auth.User)
             ),
@@ -80,7 +79,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
                     "Custom Journal Entry Title"
                 ),
                 recipientParty: Factories.RecipientParty("recipient-id", "Recipient Name"),
-                serviceOwnerParty: Factories.ServiceOwnerParty("org-number", "Org Name"),
                 instanceOwnerParty: null,
                 instanceOwnerClassification: Factories.InstanceOwnerClassification(Auth.SystemUser)
             ),
@@ -92,7 +90,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
                 attachmentSettings: [Factories.DocumentSettings("doesnt-exist")],
                 archiveDocumentMetadata: null,
                 recipientParty: Factories.RecipientParty("recipient-id", "Recipient Name", "123456789", "Ref-001"),
-                serviceOwnerParty: Factories.ServiceOwnerParty("org-number", "Org Name"),
                 instanceOwnerParty: Factories.InstanceOwnerOwnerParty(
                     "altinn-party-id",
                     "Instance Owner Person Name",
@@ -120,7 +117,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
                     caseFileId: null
                 ),
                 recipientParty: Factories.RecipientParty("recipient-id", "Recipient Name"),
-                serviceOwnerParty: Factories.ServiceOwnerParty("org-number", "Org Name"),
                 instanceOwnerParty: Factories.InstanceOwnerOwnerParty(
                     "altinn-party-id",
                     "Instance Owner Org Name",
@@ -191,7 +187,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
             IReadOnlyList<FiksArkivDataTypeSettings>? attachmentSettings,
             FiksArkivDocumentMetadata? archiveDocumentMetadata,
             Korrespondansepart recipientParty,
-            Korrespondansepart serviceOwnerParty,
             Korrespondansepart? instanceOwnerParty,
             Klassifikasjon instanceOwnerClassification,
             string applicationTitle = "Test app",
@@ -347,9 +342,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
             string? orgNumber = null,
             string? reference = null
         ) => KorrespondansepartFactory.CreateRecipient(id, name, orgNumber, reference);
-
-        public static Korrespondansepart ServiceOwnerParty(string id, string name) =>
-            KorrespondansepartFactory.CreateSender(id, name);
 
         public static Korrespondansepart InstanceOwnerOwnerParty(
             string id,

--- a/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
+++ b/test/Altinn.App.Clients.Fiks.Tests/FiksArkiv/FiksArkivDefaultPayloadGeneratorTest.cs
@@ -1,6 +1,3 @@
-using System.Reflection;
-using System.Xml;
-using System.Xml.Schema;
 using Altinn.App.Clients.Fiks.Constants;
 using Altinn.App.Clients.Fiks.Exceptions;
 using Altinn.App.Clients.Fiks.Extensions;
@@ -170,7 +167,7 @@ public class FiksArkivDefaultPayloadGeneratorTest
     [Fact]
     public async Task GeneratePayload_ThrowsException_ForUnsupportedMessageType()
     {
-        var fixture = PayloadGeneratorFixture.Create(null!, null!, null, null!, null!, null, null!, null!);
+        var fixture = PayloadGeneratorFixture.Create(null!, null!, null, null!, null!, null!, null!);
 
         var ex = await Assert.ThrowsAsync<FiksArkivException>(() =>
             fixture.GeneratePayload(Factories.Instance(null!, []), "non-create-type")
@@ -207,7 +204,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
                     attachmentSettings,
                     archiveDocumentMetadata,
                     recipientParty,
-                    serviceOwnerParty,
                     instanceOwnerParty,
                     instanceOwnerClassification,
                     applicationTitle,
@@ -249,7 +245,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
             IReadOnlyList<FiksArkivDataTypeSettings>? attachmentSettings,
             FiksArkivDocumentMetadata? archiveDocumentMetadata,
             Korrespondansepart recipientParty,
-            Korrespondansepart serviceOwnerParty,
             Korrespondansepart? instanceOwnerParty,
             Klassifikasjon instanceOwnerClassification,
             string applicationTitle = "Test app",
@@ -278,9 +273,6 @@ public class FiksArkivDefaultPayloadGeneratorTest
             configResolverMock
                 .Setup(x => x.GetRecipientParty(It.IsAny<Instance>(), It.IsAny<FiksArkivRecipient>()))
                 .Returns(recipientParty);
-            configResolverMock
-                .Setup(x => x.GetServiceOwnerParty(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(serviceOwnerParty);
             configResolverMock
                 .Setup(x => x.GetInstanceOwnerParty(It.IsAny<Instance>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(instanceOwnerParty);

--- a/test/Altinn.App.Clients.Fiks.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Clients.Fiks.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -73,7 +73,6 @@ namespace Altinn.App.Clients.Fiks.FiksArkiv
         System.Threading.Tasks.Task<KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Korrespondansepart?> GetInstanceOwnerParty(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivRecipient> GetRecipient(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Threading.CancellationToken cancellationToken = default);
         KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Korrespondansepart GetRecipientParty(Altinn.Platform.Storage.Interface.Models.Instance instance, Altinn.App.Clients.Fiks.FiksArkiv.Models.FiksArkivRecipient recipient);
-        System.Threading.Tasks.Task<KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Korrespondansepart> GetServiceOwnerParty(System.Threading.CancellationToken cancellationToken = default);
     }
     public interface IFiksArkivHost
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed the extraneous senders (service owner as "Avsender" and Altinn Studio as "Intern avsender", respectively) so that, by default, only the instance owner is set as "Avsender" in the generated payload for Fiks Arkiv.

## Related Issue(s)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified Fiks Arkiv behavior: removed service-owner/internal sender lookup so generated archive payloads contain fewer correspondence parties (fewer senders).
* **Tests**
  * Updated test fixtures and expectations to match the reduced set of correspondence parties in generated payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->