### PR TITLE
Revert "fix: pdf base64 encode tracestate header (#1645)" to align with frontend

### DIFF
--- a/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Pdf/PdfGeneratorClient.cs
@@ -104,21 +104,11 @@ public class PdfGeneratorClient : IPdfGeneratorClient
                     if (k != "traceparent" && k != "tracestate")
                         _logger.LogWarning("Unexpected key '{Key}' when propagating trace context (expected W3C)", k);
 
-                    var value = v;
-                    if (k == "tracestate")
-                    {
-                        // tracestate will contain e.g. baggage which are arbitrary keyvalue pairs example kv: "dd=s:1;o:rum".
-                        // values can contain semicolon which is not allowed in cookie values
-                        // so we base64 encode the entire value to be safe
-                        // Frontend accounts for this when passing it back when on the PDF page
-                        value = Convert.ToBase64String(Encoding.UTF8.GetBytes(v));
-                    }
-
                     c.Add(
                         new PdfGeneratorCookieOptions
                         {
                             Name = $"altinn-telemetry-{k}",
-                            Value = value,
+                            Value = v,
                             Domain = uri.Host,
                         }
                     );


### PR DESCRIPTION
## Description

This reverts commit b93319ab7dd56419bab109008f9e8844cc607341.

Ended up reverting this for frontend too.
PDF will remove/ignore the cookie if it has invalid characters

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified trace context cookie handling in PDF generation service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->