### PR TITLE
Add fields parameter to party query endpoint URL

### DIFF
--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -135,7 +135,7 @@ public class AltinnPartyClient : IAltinnPartyClient
     public async Task<int?> GetPartyIdByUrn(string urn)
     {
         using var activity = _telemetry?.StartLookupPartyActivity();
-        string endpointUrl = "access-management/parties/query?fields=id,user.id";
+        string endpointUrl = "apps/parties/query?fields=id,user.id";
         var query = new { data = new string[] { urn } };
         using var content = new StringContent(JsonSerializer.Serialize(query));
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");

--- a/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
+++ b/src/Altinn.App.Core/Infrastructure/Clients/Register/AltinnPartyClient.cs
@@ -135,7 +135,7 @@ public class AltinnPartyClient : IAltinnPartyClient
     public async Task<int?> GetPartyIdByUrn(string urn)
     {
         using var activity = _telemetry?.StartLookupPartyActivity();
-        string endpointUrl = "access-management/parties/query";
+        string endpointUrl = "access-management/parties/query?fields=id,user.id";
         var query = new { data = new string[] { urn } };
         using var content = new StringContent(JsonSerializer.Serialize(query));
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");

--- a/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientInterceptor.cs
+++ b/test/Altinn.App.Tests.Common/Mocks/AltinnPartyClientInterceptor.cs
@@ -18,7 +18,7 @@ public class AltinnPartyClientInterceptor : HttpMessageHandler
         {
             ["", "register", "api", "v1", "parties", var partyIdString]
                 when int.TryParse(partyIdString, out var partyId) => GetPartyResponse(partyId),
-            ["", "register", "api", "v1", "access-management", "parties", "query"] => GetPartyQueryResponse(
+            ["", "register", "api", "v1", "apps", "parties", "query"] => GetPartyQueryResponse(
                 await request.Content!.ReadAsStringAsync(cancellationToken)
             ),
             ["", "parties", "lookup"] => GetPartyLookupResponse(


### PR DESCRIPTION
Altinn register seems to require that we request `user.id` when using `urn:altinn:person:legacy-selfidentified:` urns for lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Party lookup queries now request only the specific fields needed (party id and associated user id), reducing data transferred.
  * Resulting performance improvements make searching for and loading party-related information noticeably snappier with lower network usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->