### PR TITLE
Feat/instantiation notif callback

### DIFF
--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -537,9 +537,26 @@ public class InstancesController : ControllerBase
         try
         {
             party = await LookupParty(instansiationInstance.InstanceOwner) ?? throw new Exception("Unknown party");
+
+            _logger.LogInformation(
+                "Resolved party: PartyId={PartyId}, PartyTypeName={PartyTypeName}, OrgNumber={OrgNumber}, SSN={SSN}",
+                party.PartyId,
+                party.PartyTypeName,
+                party.OrgNumber ?? "(null)",
+                party.SSN != null ? "***set***" : "(null)"
+            );
+
             instansiationInstance.InstanceOwner = await InstantiationHelper.PartyToInstanceOwner(
                 party,
                 _authenticationContext
+            );
+
+            _logger.LogInformation(
+                "InstanceOwner after PartyToInstanceOwner: PartyId={PartyId}, PersonNumber={PersonNumber}, OrgNumber={OrgNumber}, ExternalIdentifier={ExternalIdentifier}",
+                instansiationInstance.InstanceOwner.PartyId,
+                instansiationInstance.InstanceOwner.PersonNumber != null ? "***set***" : "(null)",
+                instansiationInstance.InstanceOwner.OrganisationNumber ?? "(null)",
+                instansiationInstance.InstanceOwner.ExternalIdentifier ?? "(null)"
             );
         }
         catch (Exception partyLookupException)
@@ -548,6 +565,10 @@ public class InstancesController : ControllerBase
             {
                 if (sexp.StatusCode.Equals(HttpStatusCode.Unauthorized))
                 {
+                    _logger.LogWarning(
+                        "Party lookup returned Unauthorized (401) for InstanceOwner={@InstanceOwner}",
+                        instansiationInstance.InstanceOwner
+                    );
                     return StatusCode(StatusCodes.Status403Forbidden);
                 }
             }
@@ -566,13 +587,30 @@ public class InstancesController : ControllerBase
 
         EnforcementResult enforcementResult = await AuthorizeAction(org, app, party.PartyId, null, "instantiate");
 
+        _logger.LogInformation(
+            "Authorization result for party {PartyId}: Authorized={Authorized}, EnforcementResult={@EnforcementResult}",
+            party.PartyId,
+            enforcementResult.Authorized,
+            enforcementResult
+        );
+
         if (!enforcementResult.Authorized)
         {
+            _logger.LogWarning(
+                "Party {PartyId} was denied 'instantiate' on {Org}/{App}. EnforcementResult: {@EnforcementResult}",
+                party.PartyId, org, app, enforcementResult
+            );
             return Forbidden(enforcementResult);
         }
 
         if (!InstantiationHelper.IsPartyAllowedToInstantiate(party, application.PartyTypesAllowed))
         {
+            _logger.LogWarning(
+                "Party {PartyId} (PartyTypeName={PartyTypeName}) is not in partyTypesAllowed. PartyTypesAllowed={@PartyTypesAllowed}",
+                party.PartyId,
+                party.PartyTypeName,
+                application.PartyTypesAllowed
+            );
             return StatusCode(
                 StatusCodes.Status403Forbidden,
                 $"Party {party.PartyId} is not allowed to instantiate this application {org}/{app}"
@@ -592,8 +630,14 @@ public class InstancesController : ControllerBase
         // Run custom app logic to validate instantiation
         var instantiationValidator = _appImplementationFactory.GetRequired<IInstantiationValidator>();
         InstantiationValidationResult? validationResult = await instantiationValidator.Validate(instanceTemplate);
+
         if (validationResult != null && !validationResult.Valid)
         {
+            _logger.LogWarning(
+                "InstantiationValidator rejected instantiation for party {PartyId}: {@ValidationResult}",
+                party.PartyId,
+                validationResult
+            );
             await TranslateValidationResult(validationResult, language);
             return StatusCode(StatusCodes.Status403Forbidden, validationResult);
         }

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -598,7 +598,10 @@ public class InstancesController : ControllerBase
         {
             _logger.LogWarning(
                 "Party {PartyId} was denied 'instantiate' on {Org}/{App}. EnforcementResult: {@EnforcementResult}",
-                party.PartyId, org, app, enforcementResult
+                party.PartyId,
+                org,
+                app,
+                enforcementResult
             );
             return Forbidden(enforcementResult);
         }

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -588,10 +588,12 @@ public class InstancesController : ControllerBase
         EnforcementResult enforcementResult = await AuthorizeAction(org, app, party.PartyId, null, "instantiate");
 
         _logger.LogInformation(
-            "Authorization result for party {PartyId}: Authorized={Authorized}, EnforcementResult={@EnforcementResult}",
+            "Authorization details for party {PartyId}: Authorized={Authorized}, FailedObligations={FailedObligations}",
             party.PartyId,
             enforcementResult.Authorized,
-            enforcementResult
+            enforcementResult.FailedObligations == null
+                ? "(null)"
+                : string.Join(", ", enforcementResult.FailedObligations.Select(kv => $"{kv.Key}={kv.Value}"))
         );
 
         if (!enforcementResult.Authorized)

--- a/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
+++ b/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.App.Api.Controllers;
@@ -8,15 +9,36 @@ namespace Altinn.App.Api.Controllers;
 [ApiController]
 [ApiExplorerSettings(IgnoreApi = true)]
 [Route("{org}/{app}/notifications")]
-public class NotificationCallbackController
+public class NotificationCallbackController(ILogger<NotificationCallbackController> logger)
 {
     /// <summary>
     /// Callback endpoint to check whether remaining notifications on application instatiation should be cancelled
     /// </summary>
-    /// <returns>Boolean</returns>
-    [HttpGet("instance")]
-    public ActionResult<bool> ShouldCancel()
+    /// <returns><see cref="NotificationCallbackResponse"/></returns>
+    [HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
+    public ActionResult<NotificationCallbackResponse> ShouldCancel(
+        [FromRoute] string org,
+        [FromRoute] string app,
+        [FromRoute] int instanceOwnerPartyId,
+        [FromRoute] Guid instanceGuid
+    )
     {
-        return true;
+        logger.LogInformation(
+            $"Received callback for org:{org}, app:{app}, instanceOwnerPartyId:{instanceOwnerPartyId}, instanceGuid:{instanceGuid}."
+        );
+        NotificationCallbackResponse response = new() { SendNotification = false };
+        return response;
     }
+}
+
+/// <summary>
+/// Callback response indication whether instantiation notifications should be cancelled or not
+/// </summary>
+public sealed class NotificationCallbackResponse
+{
+    /// <summary>
+    /// True if the notification should be sent, false if it chould be cancelled
+    /// </summary>
+    [JsonPropertyName("sendNotification")]
+    public bool SendNotification { get; set; }
 }

--- a/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
+++ b/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
@@ -15,7 +15,7 @@ public class NotificationCallbackController
     /// </summary>
     /// <returns>Boolean</returns>
     [HttpGet("instance")]
-    public async Task<ActionResult<bool>> ShouldCancel()
+    public ActionResult<bool> ShouldCancel()
     {
         return true;
     }

--- a/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
+++ b/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
@@ -1,4 +1,7 @@
 using System.Text.Json.Serialization;
+using Altinn.App.Core.Features.Notifications.Cancellation;
+using Altinn.App.Core.Internal.Instances;
+using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.App.Api.Controllers;
@@ -9,35 +12,39 @@ namespace Altinn.App.Api.Controllers;
 [ApiController]
 [ApiExplorerSettings(IgnoreApi = true)]
 [Route("{org}/{app}/notifications")]
-public class NotificationCallbackController(ILogger<NotificationCallbackController> logger)
+public class NotificationCallbackController(ILogger<NotificationCallbackController> logger, ICancelInstantiationNotification instantiationNotification, IInstanceClient instanceClient)
 {
     /// <summary>
-    /// Callback endpoint to check whether remaining notifications on application instatiation should be cancelled
+    /// Callback endpoint to check whether remaining notifications on application instantiation should be sent or not
     /// </summary>
     /// <returns><see cref="NotificationCallbackResponse"/></returns>
     [HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
-    public ActionResult<NotificationCallbackResponse> ShouldCancel(
+    public async Task<ActionResult<NotificationCallbackResponse>> NotificationCallback(
         [FromRoute] string org,
         [FromRoute] string app,
         [FromRoute] int instanceOwnerPartyId,
         [FromRoute] Guid instanceGuid
     )
     {
+        Instance instance = await instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
         logger.LogInformation(
             $"Received callback for org:{org}, app:{app}, instanceOwnerPartyId:{instanceOwnerPartyId}, instanceGuid:{instanceGuid}."
         );
-        NotificationCallbackResponse response = new() { SendNotification = false };
+
+        bool shouldSend = instantiationNotification.ShouldSend(instance);
+
+        NotificationCallbackResponse response = new() { SendNotification = shouldSend };
         return response;
     }
 }
 
 /// <summary>
-/// Callback response indication whether instantiation notifications should be cancelled or not
+/// Callback response indicating whether instantiation notifications should be sent or not
 /// </summary>
 public sealed class NotificationCallbackResponse
 {
     /// <summary>
-    /// True if the notification should be sent, false if it chould be cancelled
+    /// True if the notification should be sent, false if it should be cancelled
     /// </summary>
     [JsonPropertyName("sendNotification")]
     public bool SendNotification { get; set; }

--- a/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
+++ b/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.App.Api.Controllers;
+
+/// <summary>
+/// Endpoint(s) for the Altinn Notification microservice callback
+/// </summary>
+[ApiController]
+[ApiExplorerSettings(IgnoreApi = true)]
+[Route("{org}/{app}/notifications")]
+public class NotificationCallbackController
+{
+    /// <summary>
+    /// Callback endpoint to check whether remaining notifications on application instatiation should be cancelled
+    /// </summary>
+    /// <returns>Boolean</returns>
+    [HttpGet("instance")]
+    public async Task<ActionResult<bool>> ShouldCancel()
+    {
+        return true;
+    }
+}

--- a/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
+++ b/src/Altinn.App.Api/Controllers/NotificationCallbackController.cs
@@ -12,7 +12,11 @@ namespace Altinn.App.Api.Controllers;
 [ApiController]
 [ApiExplorerSettings(IgnoreApi = true)]
 [Route("{org}/{app}/notifications")]
-public class NotificationCallbackController(ILogger<NotificationCallbackController> logger, ICancelInstantiationNotification instantiationNotification, IInstanceClient instanceClient)
+public class NotificationCallbackController(
+    ILogger<NotificationCallbackController> logger,
+    ICancelInstantiationNotification instantiationNotification,
+    IInstanceClient instanceClient
+)
 {
     /// <summary>
     /// Callback endpoint to check whether remaining notifications on application instantiation should be sent or not

--- a/src/Altinn.App.Core/Constants/AltinnUrns.cs
+++ b/src/Altinn.App.Core/Constants/AltinnUrns.cs
@@ -17,6 +17,7 @@ internal static class AltinnUrns
     public const string UserId = "urn:altinn:userid";
     public const string UserName = "urn:altinn:username";
     public const string SelfIdentifiedEmail = "urn:altinn:person:idporten-email";
+    public const string LegacySelfIdentified = "urn:altinn:person:legacy-selfidentified";
     public const string PartyId = "urn:altinn:partyid";
     public const string PartyUuid = "urn:altinn:partyuuid";
     public const string RepresentingPartyId = "urn:altinn:representingpartyid";

--- a/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Core/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Altinn.App.Core.Features.DataProcessing;
 using Altinn.App.Core.Features.ExternalApi;
 using Altinn.App.Core.Features.FileAnalyzis;
 using Altinn.App.Core.Features.Notifications;
+using Altinn.App.Core.Features.Notifications.Cancellation;
 using Altinn.App.Core.Features.Notifications.Email;
 using Altinn.App.Core.Features.Notifications.Future;
 using Altinn.App.Core.Features.Notifications.Sms;
@@ -283,6 +284,7 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient<ISmsNotificationClient, SmsNotificationClient>();
         services.AddHttpClient<INotificationOrderClient, NotificationOrderClient>();
         services.TryAddTransient<INotificationService, NotificationService>();
+        services.TryAddTransient<ICancelInstantiationNotification, SendOnProcessNotEnded>();
     }
 
     private static void AddPdfServices(IServiceCollection services)

--- a/src/Altinn.App.Core/Features/Notifications/Cancellation/CancelOnProcessEnd.cs
+++ b/src/Altinn.App.Core/Features/Notifications/Cancellation/CancelOnProcessEnd.cs
@@ -1,0 +1,18 @@
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.Core.Features.Notifications.Cancellation;
+
+/// <summary>
+/// Default implementation - send notification unless the process has already ended
+/// </summary>
+public class SendOnProcessNotEnded : ICancelInstantiationNotification
+{
+    /// <summary>
+    /// Send if the process has not yet ended
+    /// </summary>
+    public bool ShouldSend(Instance instance)
+    {
+        bool processHasEnded = instance.Process.Ended is not null;
+        return !processHasEnded;
+    }
+}

--- a/src/Altinn.App.Core/Features/Notifications/Cancellation/ICancelInstantiationNotification.cs
+++ b/src/Altinn.App.Core/Features/Notifications/Cancellation/ICancelInstantiationNotification.cs
@@ -1,0 +1,14 @@
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.Core.Features.Notifications.Cancellation;
+
+/// <summary>
+/// Interface for determining whether a scheduled instantiation notification should be sent
+/// </summary>
+public interface ICancelInstantiationNotification
+{
+    /// <summary>
+    /// Contains the logic for whether the notification should be sent
+    /// </summary>
+    bool ShouldSend(Instance instance);
+}

--- a/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
+++ b/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
@@ -152,7 +152,7 @@ internal sealed class NotificationService : INotificationService
         Uri? conditionEndpoint = null;
         if (instansiationNotification.RequestedSendTime is not null)
         {
-            conditionEndpoint = new Uri(callBackBaseUrl?.TrimEnd('/') + "/notifications/instance");
+            conditionEndpoint = new Uri(callBackBaseUrl?.TrimEnd('/') + "/notifications/" + instance.Id);
         }
 
         if (instanceOwner.OrganisationNumber is not null)

--- a/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
+++ b/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
@@ -218,7 +218,7 @@ internal sealed class NotificationService : INotificationService
                 ConditionEndpoint = conditionEndpoint,
                 Recipient = new NotificationRecipient
                 {
-                    RecipientSelfIdentifiedUser = new RecipientSelfIdentifiedUser
+                    RecipientExternalIdentity = new RecipientExternalIdentity
                     {
                         ExternalIdentity = instanceOwner.ExternalIdentifier,
                         ChannelSchema = NotificationChannel.Email, // Only email is supported for self identified users

--- a/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
+++ b/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
@@ -1,3 +1,4 @@
+using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features.Notifications.Texts;
 using Altinn.App.Core.Internal.AltinnCdn;
 using Altinn.App.Core.Internal.App;
@@ -9,6 +10,7 @@ using Altinn.App.Core.Models.Notifications.Future;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Options;
 
 namespace Altinn.App.Core.Features.Notifications;
 
@@ -19,13 +21,15 @@ internal sealed class NotificationService : INotificationService
     private readonly IAltinnCdnClient _cdnClient;
     private readonly IAppMetadata _appMetadata;
     private readonly IAltinnPartyClient _altinnPartyClient;
+    private readonly GeneralSettings _generalSettings;
 
     public NotificationService(
         INotificationOrderClient notificationOrderClient,
         IProfileClient profileClient,
         IAltinnCdnClient cdnClient,
         IAppMetadata appMetadata,
-        IAltinnPartyClient altinnPartyClient
+        IAltinnPartyClient altinnPartyClient,
+        IOptions<GeneralSettings> generalSettings
     )
     {
         _notificationOrderClient = notificationOrderClient;
@@ -33,6 +37,7 @@ internal sealed class NotificationService : INotificationService
         _cdnClient = cdnClient;
         _appMetadata = appMetadata;
         _altinnPartyClient = altinnPartyClient;
+        _generalSettings = generalSettings.Value;
     }
 
     public async Task NotifyInstanceOwnerOnInstansiation(
@@ -46,6 +51,7 @@ internal sealed class NotificationService : INotificationService
         string? language = await DetermineLanguage(instanceOwner, instansiationNotification.Language, ct);
         AltinnCdnOrgName? serviceOwnerName = await _cdnClient.GetOrgNameByAppId(instance.AppId, ct);
         ApplicationMetadata? appMetadata = await _appMetadata.GetApplicationMetadata();
+        string baseUrl = _generalSettings.FormattedExternalAppBaseUrl(new AppIdentifier(instance.AppId));
 
         NotificationOrderRequest orderRequest = CreateNotificationOrderRequest(
             language,
@@ -53,7 +59,8 @@ internal sealed class NotificationService : INotificationService
             appMetadata,
             party.Name,
             serviceOwnerName,
-            instansiationNotification
+            instansiationNotification,
+            baseUrl
         );
 
         await _notificationOrderClient.Order(orderRequest, ct);
@@ -65,7 +72,8 @@ internal sealed class NotificationService : INotificationService
         ApplicationMetadata? applicationMetadata,
         string? instanceOwnerName,
         AltinnCdnOrgName? serviceOwnerName,
-        InstansiationNotification instansiationNotification
+        InstansiationNotification instansiationNotification,
+        string? callBackBaseUrl
     )
     {
         InstanceOwner instanceOwner = instance.InstanceOwner;
@@ -139,6 +147,13 @@ internal sealed class NotificationService : INotificationService
         NotificationChannel requestedChannel = instansiationNotification.NotificationChannel;
 
         AppResourceId resourceId = AppResourceId.FromAppIdentifier(new(instance.AppId));
+        DateTime requestedSendTimeOrDefault = instansiationNotification.RequestedSendTime ?? DateTime.Now.AddMinutes(5);
+
+        Uri? conditionEndpoint = null;
+        if (instansiationNotification.RequestedSendTime is not null)
+        {
+            conditionEndpoint = new Uri(callBackBaseUrl.TrimEnd('/') + "/notifications/instance");
+        }
 
         if (instanceOwner.OrganisationNumber is not null)
         {
@@ -146,6 +161,8 @@ internal sealed class NotificationService : INotificationService
             {
                 SendersReference = instance.Id + instanceOwner.OrganisationNumber,
                 IdempotencyId = instance.Id + instanceOwner.OrganisationNumber,
+                RequestedSendTime = requestedSendTimeOrDefault,
+                ConditionEndpoint = conditionEndpoint,
                 Recipient = new NotificationRecipient
                 {
                     RecipientOrganization = new RecipientOrganization
@@ -166,6 +183,8 @@ internal sealed class NotificationService : INotificationService
             {
                 SendersReference = instance.Id + instanceOwner.PersonNumber,
                 IdempotencyId = instance.Id + instanceOwner.PersonNumber,
+                RequestedSendTime = requestedSendTimeOrDefault,
+                ConditionEndpoint = conditionEndpoint,
                 Recipient = new NotificationRecipient
                 {
                     RecipientPerson = new RecipientPerson
@@ -186,6 +205,8 @@ internal sealed class NotificationService : INotificationService
             {
                 SendersReference = instance.Id + instanceOwner.ExternalIdentifier,
                 IdempotencyId = instance.Id + instanceOwner.ExternalIdentifier,
+                RequestedSendTime = requestedSendTimeOrDefault,
+                ConditionEndpoint = conditionEndpoint,
                 Recipient = new NotificationRecipient
                 {
                     RecipientSelfIdentifiedUser = new RecipientSelfIdentifiedUser

--- a/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
+++ b/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
@@ -10,6 +10,7 @@ using Altinn.App.Core.Models.Notifications.Future;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Altinn.App.Core.Features.Notifications;
@@ -21,6 +22,7 @@ internal sealed class NotificationService : INotificationService
     private readonly IAltinnCdnClient _cdnClient;
     private readonly IAppMetadata _appMetadata;
     private readonly IAltinnPartyClient _altinnPartyClient;
+    private readonly ILogger<NotificationService> _logger;
     private readonly GeneralSettings _generalSettings;
 
     public NotificationService(
@@ -29,7 +31,8 @@ internal sealed class NotificationService : INotificationService
         IAltinnCdnClient cdnClient,
         IAppMetadata appMetadata,
         IAltinnPartyClient altinnPartyClient,
-        IOptions<GeneralSettings> generalSettings
+        IOptions<GeneralSettings> generalSettings,
+        ILogger<NotificationService> logger
     )
     {
         _notificationOrderClient = notificationOrderClient;
@@ -37,6 +40,7 @@ internal sealed class NotificationService : INotificationService
         _cdnClient = cdnClient;
         _appMetadata = appMetadata;
         _altinnPartyClient = altinnPartyClient;
+        _logger = logger;
         _generalSettings = generalSettings.Value;
     }
 
@@ -61,6 +65,11 @@ internal sealed class NotificationService : INotificationService
             serviceOwnerName,
             instansiationNotification,
             baseUrl
+        );
+
+        _logger.LogInformation(
+            "Sending notification order: {OrderRequest}",
+            System.Text.Json.JsonSerializer.Serialize(orderRequest)
         );
 
         await _notificationOrderClient.Order(orderRequest, ct);

--- a/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
+++ b/src/Altinn.App.Core/Features/Notifications/NotificationService.cs
@@ -152,7 +152,7 @@ internal sealed class NotificationService : INotificationService
         Uri? conditionEndpoint = null;
         if (instansiationNotification.RequestedSendTime is not null)
         {
-            conditionEndpoint = new Uri(callBackBaseUrl.TrimEnd('/') + "/notifications/instance");
+            conditionEndpoint = new Uri(callBackBaseUrl?.TrimEnd('/') + "/notifications/instance");
         }
 
         if (instanceOwner.OrganisationNumber is not null)

--- a/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
+++ b/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Altinn.App.Core.Constants;
 using Altinn.App.Core.Features.Auth;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Enums;
@@ -253,8 +254,8 @@ public static class InstantiationHelper
             {
                 null or "" => null,
                 string name when name.StartsWith("epost:", StringComparison.InvariantCulture) =>
-                    $"urn:altinn:person:idporten-email:{name["epost:".Length..]}",
-                string name => $"urn:altinn:person:legacy-selfidentified:{name}",
+                    $"{AltinnUrns.SelfIdentifiedEmail}:{name["epost:".Length..]}",
+                string name => $"{AltinnUrns.LegacySelfIdentified}:{name}",
             };
 
             return new()

--- a/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
+++ b/src/Altinn.App.Core/Helpers/InstantiationHelper.cs
@@ -248,6 +248,15 @@ public static class InstantiationHelper
             {
                 externalIdentifier = await GetExternalIdentityForSelfIdentifiedParty(party, authenticationContext);
             }
+
+            externalIdentifier ??= party.Name switch
+            {
+                null or "" => null,
+                string name when name.StartsWith("epost:", StringComparison.InvariantCulture) =>
+                    $"urn:altinn:person:idporten-email:{name["epost:".Length..]}",
+                string name => $"urn:altinn:person:legacy-selfidentified:{name}",
+            };
+
             return new()
             {
                 PartyId = party.PartyId.ToString(CultureInfo.InvariantCulture),

--- a/src/Altinn.App.Core/Models/Notifications/Future/InstansiationNotification.cs
+++ b/src/Altinn.App.Core/Models/Notifications/Future/InstansiationNotification.cs
@@ -23,6 +23,15 @@ public sealed class InstansiationNotification
     public string? Language { get; set; }
 
     /// <summary>
+    /// Gets or sets the earliest time the notification(s) should be sent.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to the current UTC time, meaning the notification will be sent as soon as possible.
+    /// </remarks>
+    [JsonPropertyName("requestedSendTime")]
+    public DateTime? RequestedSendTime { get; init; } = null;
+
+    /// <summary>
     /// Gets or sets custom sms text and sender name for the notification.
     /// If not set, a default message will be used.
     /// </summary>

--- a/src/Altinn.App.Core/Models/Notifications/Future/NotificationOrderRequest.cs
+++ b/src/Altinn.App.Core/Models/Notifications/Future/NotificationOrderRequest.cs
@@ -15,6 +15,7 @@ public sealed record NotificationOrderRequest
     /// in the Dialogporten service, enabling integration between notifications and Dialogporten.
     /// </remarks>
     [JsonPropertyName("dialogportenAssociation")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DialogportenIdentifiers? DialogportenAssociation { get; set; }
 
     /// <summary>
@@ -53,6 +54,7 @@ public sealed record NotificationOrderRequest
     /// apply by the time the send time is reached.
     /// </remarks>
     [JsonPropertyName("conditionEndpoint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Uri? ConditionEndpoint { get; init; }
 
     /// <summary>
@@ -80,12 +82,14 @@ public class DialogportenIdentifiers
     /// Gets or sets the identifier for a specific dialog within Dialogporten.
     /// </summary>
     [JsonPropertyName("dialogId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? DialogId { get; set; }
 
     /// <summary>
     /// Gets or sets the identifier for a specific transmission within Dialogporten.
     /// </summary>
     [JsonPropertyName("transmissionId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? TransmissionId { get; set; }
 }
 
@@ -98,12 +102,14 @@ public sealed record NotificationRecipient
     /// Gets or sets a recipient identified by a direct email address.
     /// </summary>
     [JsonPropertyName("recipientEmail")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public RecipientEmail? RecipientEmail { get; init; }
 
     /// <summary>
     /// Gets or sets a recipient identified by a direct phone number.
     /// </summary>
     [JsonPropertyName("recipientSms")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public RecipientSms? RecipientSms { get; init; }
 
     /// <summary>
@@ -113,6 +119,7 @@ public sealed record NotificationRecipient
     /// Contact information will be retrieved from the Common Contact Register (KRR).
     /// </remarks>
     [JsonPropertyName("recipientPerson")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public RecipientPerson? RecipientPerson { get; init; }
 
     /// <summary>
@@ -122,6 +129,7 @@ public sealed record NotificationRecipient
     /// Contact information will be retrieved from the Central Coordinating Register for Legal Entities (Enhetsregisteret).
     /// </remarks>
     [JsonPropertyName("recipientOrganization")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public RecipientOrganization? RecipientOrganization { get; init; }
 
     /// <summary>
@@ -132,6 +140,7 @@ public sealed record NotificationRecipient
     /// Contact information will be retrieved from Altinn Profile using the external identity.
     /// </remarks>
     [JsonPropertyName("recipientSelfIdentifiedUser")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public RecipientSelfIdentifiedUser? RecipientSelfIdentifiedUser { get; init; }
 }
 
@@ -186,6 +195,7 @@ public sealed record RecipientPerson
     /// Gets or sets an optional Altinn resource identifier used for authorization and auditing.
     /// </summary>
     [JsonPropertyName("resourceId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ResourceId { get; init; }
 
     /// <summary>
@@ -208,12 +218,14 @@ public sealed record RecipientPerson
     /// Gets or sets email content and delivery options. Required when the channel scheme includes email.
     /// </summary>
     [JsonPropertyName("emailSettings")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public EmailSendingOptions? EmailSettings { get; init; }
 
     /// <summary>
     /// Gets or sets SMS content and delivery options. Required when the channel scheme includes SMS.
     /// </summary>
     [JsonPropertyName("smsSettings")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public SmsSendingOptions? SmsSettings { get; init; }
 }
 
@@ -232,6 +244,7 @@ public sealed record RecipientOrganization
     /// Gets or sets an optional Altinn resource identifier used for authorization and auditing.
     /// </summary>
     [JsonPropertyName("resourceId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ResourceId { get; init; }
 
     /// <summary>
@@ -244,12 +257,14 @@ public sealed record RecipientOrganization
     /// Gets or sets email content and delivery options. Required when the channel scheme includes email.
     /// </summary>
     [JsonPropertyName("emailSettings")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public EmailSendingOptions? EmailSettings { get; init; }
 
     /// <summary>
     /// Gets or sets SMS content and delivery options. Required when the channel scheme includes SMS.
     /// </summary>
     [JsonPropertyName("smsSettings")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public SmsSendingOptions? SmsSettings { get; init; }
 }
 
@@ -276,6 +291,7 @@ public sealed record RecipientSelfIdentifiedUser
     /// Gets or sets an optional Altinn resource identifier used for authorization and auditing.
     /// </summary>
     [JsonPropertyName("resourceId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ResourceId { get; init; }
 
     /// <summary>
@@ -288,12 +304,14 @@ public sealed record RecipientSelfIdentifiedUser
     /// Gets or sets email content and delivery options. Required when the channel scheme includes email.
     /// </summary>
     [JsonPropertyName("emailSettings")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public EmailSendingOptions? EmailSettings { get; init; }
 
     /// <summary>
     /// Gets or sets SMS content and delivery options. Required when the channel scheme includes SMS.
     /// </summary>
     [JsonPropertyName("smsSettings")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public SmsSendingOptions? SmsSettings { get; init; }
 }
 
@@ -314,6 +332,7 @@ public record NotificationReminder
     /// A unique identifier used by the sender to correlate this reminder with their internal systems.
     /// </remarks>
     [JsonPropertyName("sendersReference")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? SendersReference { get; init; }
 
     /// <summary>
@@ -325,12 +344,14 @@ public record NotificationReminder
     /// This allows for dynamic decision-making about whether the reminder is still relevant.
     /// </remarks>
     [JsonPropertyName("conditionEndpoint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Uri? ConditionEndpoint { get; init; }
 
     /// <summary>
     /// Gets or sets the number of days to delay this reminder.
     /// </summary>
     [JsonPropertyName("delayDays")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? DelayDays { get; init; }
 
     /// <summary>
@@ -342,6 +363,7 @@ public record NotificationReminder
     /// Defaults to the current UTC time if not specified.
     /// </remarks>
     [JsonPropertyName("requestedSendTime")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTime? RequestedSendTime { get; init; }
 
     /// <summary>
@@ -365,6 +387,7 @@ public sealed record EmailSendingOptions
     /// Gets or sets an optional sender email address to display to the recipient.
     /// </summary>
     [JsonPropertyName("senderEmailAddress")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? SenderEmailAddress { get; init; }
 
     /// <summary>
@@ -401,6 +424,7 @@ public sealed record SmsSendingOptions
     /// Gets or sets an optional sender name or number displayed to the recipient.
     /// </summary>
     [JsonPropertyName("sender")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Sender { get; init; }
 
     /// <summary>

--- a/src/Altinn.App.Core/Models/Notifications/Future/NotificationOrderRequest.cs
+++ b/src/Altinn.App.Core/Models/Notifications/Future/NotificationOrderRequest.cs
@@ -139,9 +139,9 @@ public sealed record NotificationRecipient
     /// <remarks>
     /// Contact information will be retrieved from Altinn Profile using the external identity.
     /// </remarks>
-    [JsonPropertyName("recipientSelfIdentifiedUser")]
+    [JsonPropertyName("recipientExternalIdentity")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public RecipientSelfIdentifiedUser? RecipientSelfIdentifiedUser { get; init; }
+    public RecipientExternalIdentity? RecipientExternalIdentity { get; init; }
 }
 
 /// <summary>
@@ -272,7 +272,7 @@ public sealed record RecipientOrganization
 /// Identifies a notification recipient by an external identity, used for self-identified users
 /// who authenticate via ID-porten email login.
 /// </summary>
-public sealed record RecipientSelfIdentifiedUser
+public sealed record RecipientExternalIdentity
 {
     /// <summary>
     /// Gets or sets the recipient's external identity in URN format.

--- a/src/Altinn.App.Core/Models/Notifications/Future/NotificationOrderRequest.cs
+++ b/src/Altinn.App.Core/Models/Notifications/Future/NotificationOrderRequest.cs
@@ -42,7 +42,7 @@ public sealed record NotificationOrderRequest
     /// Defaults to the current UTC time, meaning the notification will be sent as soon as possible.
     /// </remarks>
     [JsonPropertyName("requestedSendTime")]
-    public DateTime RequestedSendTime { get; init; } = DateTime.UtcNow.AddMinutes(1);
+    public DateTime RequestedSendTime { get; init; }
 
     /// <summary>
     /// Gets or sets an optional endpoint the Altinn Notifications service will call to determine

--- a/test/Altinn.App.Api.Tests/Controllers/NotificationCallbackControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/NotificationCallbackControllerTests.cs
@@ -1,0 +1,121 @@
+using Altinn.App.Api.Controllers;
+using Altinn.App.Core.Features.Notifications.Cancellation;
+using Altinn.App.Core.Internal.Instances;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit.Abstractions;
+
+namespace Altinn.App.Api.Tests.Controllers;
+
+public class NotificationCallbackControllerTests
+{
+    private readonly Mock<ICancelInstantiationNotification> _instantiationNotificationMock = new(MockBehavior.Strict);
+    private readonly Mock<IInstanceClient> _instanceClientMock = new(MockBehavior.Strict);
+    private readonly ServiceCollection _serviceCollection = new();
+
+    public NotificationCallbackControllerTests(ITestOutputHelper output)
+    {
+        _serviceCollection.AddTransient<NotificationCallbackController>();
+        _serviceCollection.AddSingleton(_instantiationNotificationMock.Object);
+        _serviceCollection.AddSingleton(_instanceClientMock.Object);
+        _serviceCollection.AddFakeLoggingWithXunit(output);
+    }
+
+    [Fact]
+    public async Task NotificationCallback_WhenShouldSendIsTrue_ReturnsSendNotificationTrue()
+    {
+        // Arrange
+        var instance = new Instance { Process = new ProcessState { Ended = null } };
+
+        _instanceClientMock
+            .Setup(x => x.GetInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Guid>()))
+            .ReturnsAsync(instance);
+
+        _instantiationNotificationMock.Setup(x => x.ShouldSend(instance)).Returns(true);
+
+        await using var sp = _serviceCollection.BuildStrictServiceProvider();
+        var controller = sp.GetRequiredService<NotificationCallbackController>();
+
+        // Act
+        var actionResult = await controller.NotificationCallback("ttd", "app", 1337, Guid.NewGuid());
+
+        // Assert
+        var response = actionResult.Value;
+        Assert.NotNull(response);
+        Assert.True(response.SendNotification);
+    }
+
+    [Fact]
+    public async Task NotificationCallback_WhenShouldSendIsFalse_ReturnsSendNotificationFalse()
+    {
+        // Arrange
+        var instance = new Instance { Process = new ProcessState { Ended = DateTime.UtcNow } };
+
+        _instanceClientMock
+            .Setup(x => x.GetInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Guid>()))
+            .ReturnsAsync(instance);
+
+        _instantiationNotificationMock.Setup(x => x.ShouldSend(instance)).Returns(false);
+
+        await using var sp = _serviceCollection.BuildStrictServiceProvider();
+        var controller = sp.GetRequiredService<NotificationCallbackController>();
+
+        // Act
+        var actionResult = await controller.NotificationCallback("ttd", "app", 1337, Guid.NewGuid());
+
+        // Assert
+        var response = actionResult.Value;
+        Assert.NotNull(response);
+        Assert.False(response.SendNotification);
+    }
+
+    [Fact]
+    public async Task NotificationCallback_PassesCorrectParametersToInstanceClient()
+    {
+        // Arrange
+        var org = "ttd";
+        var app = "my-app";
+        var instanceOwnerPartyId = 1337;
+        var instanceGuid = Guid.NewGuid();
+
+        var instance = new Instance { Process = new ProcessState() };
+
+        _instanceClientMock
+            .Setup(x => x.GetInstance(app, org, instanceOwnerPartyId, instanceGuid))
+            .ReturnsAsync(instance);
+
+        _instantiationNotificationMock.Setup(x => x.ShouldSend(instance)).Returns(true);
+
+        await using var sp = _serviceCollection.BuildStrictServiceProvider();
+        var controller = sp.GetRequiredService<NotificationCallbackController>();
+
+        // Act
+        await controller.NotificationCallback(org, app, instanceOwnerPartyId, instanceGuid);
+
+        // Assert
+        _instanceClientMock.Verify(x => x.GetInstance(app, org, instanceOwnerPartyId, instanceGuid), Times.Once);
+    }
+
+    [Fact]
+    public async Task NotificationCallback_PassesInstanceToShouldSend()
+    {
+        // Arrange
+        var instance = new Instance { Process = new ProcessState() };
+
+        _instanceClientMock
+            .Setup(x => x.GetInstance(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Guid>()))
+            .ReturnsAsync(instance);
+
+        _instantiationNotificationMock.Setup(x => x.ShouldSend(instance)).Returns(true);
+
+        await using var sp = _serviceCollection.BuildStrictServiceProvider();
+        var controller = sp.GetRequiredService<NotificationCallbackController>();
+
+        // Act
+        await controller.NotificationCallback("ttd", "app", 1337, Guid.NewGuid());
+
+        // Assert
+        _instantiationNotificationMock.Verify(x => x.ShouldSend(instance), Times.Once);
+    }
+}

--- a/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
+++ b/test/Altinn.App.Api.Tests/OpenApi/OpenApiSpecChangeDetection.SaveJsonSwagger.verified.json
@@ -8971,6 +8971,11 @@
             "type": "string",
             "nullable": true
           },
+          "requestedSendTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
           "customSms": {
             "$ref": "#/components/schemas/CustomSms"
           },

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -374,7 +374,7 @@ namespace Altinn.App.Api.Controllers
     {
         public NotificationCallbackController() { }
         [Microsoft.AspNetCore.Mvc.HttpGet("instance")]
-        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<bool>> ShouldCancel() { }
+        public Microsoft.AspNetCore.Mvc.ActionResult<bool> ShouldCancel() { }
     }
     [Microsoft.AspNetCore.Mvc.ApiController]
     [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/api/options")]

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -372,9 +372,9 @@ namespace Altinn.App.Api.Controllers
     [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/notifications")]
     public class NotificationCallbackController
     {
-        public NotificationCallbackController(Microsoft.Extensions.Logging.ILogger<Altinn.App.Api.Controllers.NotificationCallbackController> logger) { }
+        public NotificationCallbackController(Microsoft.Extensions.Logging.ILogger<Altinn.App.Api.Controllers.NotificationCallbackController> logger, Altinn.App.Core.Features.Notifications.Cancellation.ICancelInstantiationNotification instantiationNotification, Altinn.App.Core.Internal.Instances.IInstanceClient instanceClient) { }
         [Microsoft.AspNetCore.Mvc.HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
-        public Microsoft.AspNetCore.Mvc.ActionResult<Altinn.App.Api.Controllers.NotificationCallbackResponse> ShouldCancel([Microsoft.AspNetCore.Mvc.FromRoute] string org, [Microsoft.AspNetCore.Mvc.FromRoute] string app, [Microsoft.AspNetCore.Mvc.FromRoute] int instanceOwnerPartyId, [Microsoft.AspNetCore.Mvc.FromRoute] System.Guid instanceGuid) { }
+        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<Altinn.App.Api.Controllers.NotificationCallbackResponse>> NotificationCallback([Microsoft.AspNetCore.Mvc.FromRoute] string org, [Microsoft.AspNetCore.Mvc.FromRoute] string app, [Microsoft.AspNetCore.Mvc.FromRoute] int instanceOwnerPartyId, [Microsoft.AspNetCore.Mvc.FromRoute] System.Guid instanceGuid) { }
     }
     public sealed class NotificationCallbackResponse
     {

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -372,9 +372,15 @@ namespace Altinn.App.Api.Controllers
     [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/notifications")]
     public class NotificationCallbackController
     {
-        public NotificationCallbackController() { }
-        [Microsoft.AspNetCore.Mvc.HttpGet("instance")]
-        public Microsoft.AspNetCore.Mvc.ActionResult<bool> ShouldCancel() { }
+        public NotificationCallbackController(Microsoft.Extensions.Logging.ILogger<Altinn.App.Api.Controllers.NotificationCallbackController> logger) { }
+        [Microsoft.AspNetCore.Mvc.HttpGet("{instanceOwnerPartyId:int}/{instanceGuid:guid}")]
+        public Microsoft.AspNetCore.Mvc.ActionResult<Altinn.App.Api.Controllers.NotificationCallbackResponse> ShouldCancel([Microsoft.AspNetCore.Mvc.FromRoute] string org, [Microsoft.AspNetCore.Mvc.FromRoute] string app, [Microsoft.AspNetCore.Mvc.FromRoute] int instanceOwnerPartyId, [Microsoft.AspNetCore.Mvc.FromRoute] System.Guid instanceGuid) { }
+    }
+    public sealed class NotificationCallbackResponse
+    {
+        public NotificationCallbackResponse() { }
+        [System.Text.Json.Serialization.JsonPropertyName("sendNotification")]
+        public bool SendNotification { get; set; }
     }
     [Microsoft.AspNetCore.Mvc.ApiController]
     [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/api/options")]

--- a/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Api.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -368,6 +368,15 @@ namespace Altinn.App.Api.Controllers
         public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<Altinn.App.Api.Models.LookupPersonResponse>> LookupPerson([Microsoft.AspNetCore.Mvc.FromBody] Altinn.App.Api.Models.LookupPersonRequest lookupPersonRequest, System.Threading.CancellationToken cancellationToken) { }
     }
     [Microsoft.AspNetCore.Mvc.ApiController]
+    [Microsoft.AspNetCore.Mvc.ApiExplorerSettings(IgnoreApi=true)]
+    [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/notifications")]
+    public class NotificationCallbackController
+    {
+        public NotificationCallbackController() { }
+        [Microsoft.AspNetCore.Mvc.HttpGet("instance")]
+        public System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.ActionResult<bool>> ShouldCancel() { }
+    }
+    [Microsoft.AspNetCore.Mvc.ApiController]
     [Microsoft.AspNetCore.Mvc.Route("{org}/{app}/api/options")]
     public class OptionsController : Microsoft.AspNetCore.Mvc.ControllerBase
     {

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Cancellation/CancelOnProcessEndTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Cancellation/CancelOnProcessEndTests.cs
@@ -1,0 +1,35 @@
+using Altinn.App.Core.Features.Notifications.Cancellation;
+using Altinn.Platform.Storage.Interface.Models;
+
+namespace Altinn.App.Core.Tests.Features.Notifications.Cancellation;
+
+public class SendOnProcessNotEndedTests
+{
+    private readonly SendOnProcessNotEnded _sut = new();
+
+    [Fact]
+    public void ShouldSend_WhenProcessHasNotEnded_ReturnsTrue()
+    {
+        // Arrange
+        var instance = new Instance { Process = new ProcessState { Ended = null } };
+
+        // Act
+        bool result = _sut.ShouldSend(instance);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldSend_WhenProcessHasEnded_ReturnsFalse()
+    {
+        // Arrange
+        var instance = new Instance { Process = new ProcessState { Ended = DateTime.UtcNow } };
+
+        // Act
+        bool result = _sut.ShouldSend(instance);
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/test/Altinn.App.Core.Tests/Features/Notifications/NotificationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/NotificationServiceTests.cs
@@ -11,6 +11,7 @@ using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Notifications.Future;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Altinn.App.Core.Tests.Features.Notifications;
@@ -22,6 +23,7 @@ public class NotificationServiceTests
     private readonly Mock<IAltinnCdnClient> _cdnClientMock = new();
     private readonly Mock<IAltinnPartyClient> _partyClientMock = new();
     private readonly Mock<IAppMetadata> _appMetadataMock = new();
+    private readonly Mock<ILogger<NotificationService>> _logger = new();
 
     private NotificationService CreateSut() =>
         new(
@@ -30,7 +32,8 @@ public class NotificationServiceTests
             _cdnClientMock.Object,
             _appMetadataMock.Object,
             _partyClientMock.Object,
-            Microsoft.Extensions.Options.Options.Create(new GeneralSettings())
+            Microsoft.Extensions.Options.Options.Create(new GeneralSettings()),
+            _logger.Object
         );
 
     #region Helpers

--- a/test/Altinn.App.Core.Tests/Features/Notifications/NotificationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/NotificationServiceTests.cs
@@ -357,7 +357,7 @@ public class NotificationServiceTests
             callBackBaseUrl: null
         );
 
-        Assert.Equal("urn:altinn:resource:app_ttd_my-app", result.Recipient.RecipientSelfIdentifiedUser?.ResourceId);
+        Assert.Equal("urn:altinn:resource:app_ttd_my-app", result.Recipient.RecipientExternalIdentity?.ResourceId);
     }
 
     [Fact]

--- a/test/Altinn.App.Core.Tests/Features/Notifications/NotificationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/NotificationServiceTests.cs
@@ -424,7 +424,7 @@ public class NotificationServiceTests
 
         Assert.Equal(scheduledTime, result.RequestedSendTime);
         Assert.Equal(
-            "https://ttd.apps.tt02.altinn.no/ttd/my-app/notifications/instance",
+            "https://ttd.apps.tt02.altinn.no/ttd/my-app/notifications/1337/abc-123",
             result.ConditionEndpoint?.ToString()
         );
     }

--- a/test/Altinn.App.Core.Tests/Features/Notifications/NotificationServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/NotificationServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Altinn.App.Core.Configuration;
 using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Notifications;
 using Altinn.App.Core.Internal.AltinnCdn;
@@ -28,7 +29,8 @@ public class NotificationServiceTests
             _profileClientMock.Object,
             _cdnClientMock.Object,
             _appMetadataMock.Object,
-            _partyClientMock.Object
+            _partyClientMock.Object,
+            Microsoft.Extensions.Options.Options.Create(new GeneralSettings())
         );
 
     #region Helpers
@@ -312,7 +314,8 @@ public class NotificationServiceTests
             applicationMetadata: null,
             instanceOwnerName: "Firma AS",
             serviceOwnerName: null,
-            instansiationNotification: DefaultNotification()
+            instansiationNotification: DefaultNotification(),
+            callBackBaseUrl: null
         );
 
         Assert.Equal("urn:altinn:resource:app_ttd_my-app", result.Recipient.RecipientOrganization?.ResourceId);
@@ -329,7 +332,8 @@ public class NotificationServiceTests
             applicationMetadata: null,
             instanceOwnerName: "Ola Nordmann",
             serviceOwnerName: null,
-            instansiationNotification: DefaultNotification()
+            instansiationNotification: DefaultNotification(),
+            callBackBaseUrl: null
         );
 
         Assert.Equal("urn:altinn:resource:app_ttd_my-app", result.Recipient.RecipientPerson?.ResourceId);
@@ -346,7 +350,8 @@ public class NotificationServiceTests
             applicationMetadata: null,
             instanceOwnerName: null,
             serviceOwnerName: null,
-            instansiationNotification: DefaultNotification()
+            instansiationNotification: DefaultNotification(),
+            callBackBaseUrl: null
         );
 
         Assert.Equal("urn:altinn:resource:app_ttd_my-app", result.Recipient.RecipientSelfIdentifiedUser?.ResourceId);
@@ -364,8 +369,63 @@ public class NotificationServiceTests
                 applicationMetadata: null,
                 instanceOwnerName: null,
                 serviceOwnerName: null,
-                instansiationNotification: DefaultNotification()
+                instansiationNotification: DefaultNotification(),
+                callBackBaseUrl: null
             )
+        );
+    }
+
+    #endregion
+
+    #region RequestedSendTime and ConditionEndpoint
+
+    [Fact]
+    public void CreateNotificationOrderRequest_NoRequestedSendTime_DefaultsToFiveMinutesFromNow_AndNoConditionEndpoint()
+    {
+        var instance = CreateTestInstance(appId: "ttd/my-app", personNumber: "01010112345");
+        var before = DateTime.Now.AddMinutes(5);
+
+        var result = NotificationService.CreateNotificationOrderRequest(
+            language: LanguageConst.Nb,
+            instance: instance,
+            applicationMetadata: null,
+            instanceOwnerName: null,
+            serviceOwnerName: null,
+            instansiationNotification: DefaultNotification(), // RequestedSendTime is null
+            callBackBaseUrl: null
+        );
+
+        var after = DateTime.Now.AddMinutes(5);
+
+        Assert.Null(result.ConditionEndpoint);
+        Assert.InRange(result.RequestedSendTime, before, after);
+    }
+
+    [Fact]
+    public void CreateNotificationOrderRequest_WithRequestedSendTime_UsesItAndSetsConditionEndpoint()
+    {
+        var instance = CreateTestInstance(appId: "ttd/my-app", personNumber: "01010112345");
+        var scheduledTime = DateTime.UtcNow.AddDays(1);
+        var notification = new InstansiationNotification
+        {
+            NotificationChannel = NotificationChannel.Email,
+            RequestedSendTime = scheduledTime,
+        };
+
+        var result = NotificationService.CreateNotificationOrderRequest(
+            language: LanguageConst.Nb,
+            instance: instance,
+            applicationMetadata: null,
+            instanceOwnerName: null,
+            serviceOwnerName: null,
+            instansiationNotification: notification,
+            callBackBaseUrl: "https://ttd.apps.tt02.altinn.no/ttd/my-app"
+        );
+
+        Assert.Equal(scheduledTime, result.RequestedSendTime);
+        Assert.Equal(
+            "https://ttd.apps.tt02.altinn.no/ttd/my-app/notifications/instance",
+            result.ConditionEndpoint?.ToString()
         );
     }
 

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Order/NotificationRecipientSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Order/NotificationRecipientSerializationTests.cs
@@ -27,7 +27,7 @@ public class NotificationRecipientSerializationTests
         Assert.False(root.TryGetProperty("recipientEmail", out _));
         Assert.False(root.TryGetProperty("recipientSms", out _));
         Assert.False(root.TryGetProperty("recipientOrganization", out _));
-        Assert.False(root.TryGetProperty("recipientSelfIdentifiedUser", out _));
+        Assert.False(root.TryGetProperty("recipientExternalIdentity", out _));
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class NotificationRecipientSerializationTests
     {
         var recipient = new NotificationRecipient
         {
-            RecipientSelfIdentifiedUser = new RecipientSelfIdentifiedUser
+            RecipientExternalIdentity = new RecipientExternalIdentity
             {
                 ExternalIdentity = "urn:altinn:person:idporten-email:test@example.com",
                 EmailSettings = new EmailSendingOptions { Subject = "Test", Body = "Test body" },
@@ -46,7 +46,7 @@ public class NotificationRecipientSerializationTests
         using JsonDocument doc = JsonDocument.Parse(json);
         JsonElement root = doc.RootElement;
 
-        Assert.True(root.TryGetProperty("recipientSelfIdentifiedUser", out _));
+        Assert.True(root.TryGetProperty("recipientExternalIdentity", out _));
         Assert.False(root.TryGetProperty("recipientEmail", out _));
         Assert.False(root.TryGetProperty("recipientSms", out _));
         Assert.False(root.TryGetProperty("recipientPerson", out _));
@@ -74,6 +74,6 @@ public class NotificationRecipientSerializationTests
         Assert.False(root.TryGetProperty("recipientEmail", out _));
         Assert.False(root.TryGetProperty("recipientSms", out _));
         Assert.False(root.TryGetProperty("recipientPerson", out _));
-        Assert.False(root.TryGetProperty("recipientSelfIdentifiedUser", out _));
+        Assert.False(root.TryGetProperty("recipientExternalIdentity", out _));
     }
 }

--- a/test/Altinn.App.Core.Tests/Features/Notifications/Order/NotificationRecipientSerializationTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Notifications/Order/NotificationRecipientSerializationTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using Altinn.App.Core.Models.Notifications.Future;
+
+namespace Altinn.App.Core.Tests.Features.Notifications.Order;
+
+public class NotificationRecipientSerializationTests
+{
+    private static readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void Serialize_WithOnlyRecipientPerson_OmitsNullFields()
+    {
+        var recipient = new NotificationRecipient
+        {
+            RecipientPerson = new RecipientPerson
+            {
+                NationalIdentityNumber = "12345678901",
+                EmailSettings = new EmailSendingOptions { Subject = "Test", Body = "Test body" },
+            },
+        };
+
+        string json = JsonSerializer.Serialize(recipient, _options);
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("recipientPerson", out _));
+        Assert.False(root.TryGetProperty("recipientEmail", out _));
+        Assert.False(root.TryGetProperty("recipientSms", out _));
+        Assert.False(root.TryGetProperty("recipientOrganization", out _));
+        Assert.False(root.TryGetProperty("recipientSelfIdentifiedUser", out _));
+    }
+
+    [Fact]
+    public void Serialize_WithOnlyRecipientSelfIdentifiedUser_OmitsNullFields()
+    {
+        var recipient = new NotificationRecipient
+        {
+            RecipientSelfIdentifiedUser = new RecipientSelfIdentifiedUser
+            {
+                ExternalIdentity = "urn:altinn:person:idporten-email:test@example.com",
+                EmailSettings = new EmailSendingOptions { Subject = "Test", Body = "Test body" },
+            },
+        };
+
+        string json = JsonSerializer.Serialize(recipient, _options);
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("recipientSelfIdentifiedUser", out _));
+        Assert.False(root.TryGetProperty("recipientEmail", out _));
+        Assert.False(root.TryGetProperty("recipientSms", out _));
+        Assert.False(root.TryGetProperty("recipientPerson", out _));
+        Assert.False(root.TryGetProperty("recipientOrganization", out _));
+    }
+
+    [Fact]
+    public void Serialize_WithOnlyRecipientOrganization_OmitsNullFields()
+    {
+        var recipient = new NotificationRecipient
+        {
+            RecipientOrganization = new RecipientOrganization
+            {
+                OrgNumber = "991825827",
+                ChannelSchema = NotificationChannel.Email,
+                EmailSettings = new EmailSendingOptions { Subject = "Test", Body = "Test body" },
+            },
+        };
+
+        string json = JsonSerializer.Serialize(recipient, _options);
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("recipientOrganization", out _));
+        Assert.False(root.TryGetProperty("recipientEmail", out _));
+        Assert.False(root.TryGetProperty("recipientSms", out _));
+        Assert.False(root.TryGetProperty("recipientPerson", out _));
+        Assert.False(root.TryGetProperty("recipientSelfIdentifiedUser", out _));
+    }
+}

--- a/test/Altinn.App.Core.Tests/Helpers/InstantiationHelperTests.cs
+++ b/test/Altinn.App.Core.Tests/Helpers/InstantiationHelperTests.cs
@@ -50,7 +50,7 @@ public class InstantiationHelperTests
         {
             PartyId = 12345,
             PartyTypeName = PartyType.SelfIdentified,
-            Name = "Test User",
+            Name = "testuser",
         };
 
         var authenticationContextMock = new Mock<IAuthenticationContext>();
@@ -65,8 +65,64 @@ public class InstantiationHelperTests
 
         // Assert
         Assert.Equal("12345", instanceOwner.PartyId);
-        Assert.Equal("Test User", instanceOwner.Username);
-        Assert.Null(instanceOwner.ExternalIdentifier);
+        Assert.Equal("testuser", instanceOwner.Username);
+        // When authenticated as the user but no externalIdentity in token,
+        // fallback constructs URN from party.Name
+        Assert.Equal("urn:altinn:person:legacy-selfidentified:testuser", instanceOwner.ExternalIdentifier);
+    }
+
+    [Fact]
+    public async Task PartyToInstanceOwner_SelfIdentifiedWithEmail_ThirdPartyInstantiation_ReturnsExternalIdentifier()
+    {
+        // Arrange
+        var party = new Party
+        {
+            PartyId = 12345,
+            PartyTypeName = PartyType.SelfIdentified,
+            Name = "epost:test@example.com",
+        };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+        var authenticatedOrg = CreateAuthenticatedOrg(orgNo: "991825827");
+        authenticationContextMock.SetupGet(a => a.Current).Returns(authenticatedOrg);
+
+        // Act
+        InstanceOwner instanceOwner = await InstantiationHelper.PartyToInstanceOwner(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Equal("12345", instanceOwner.PartyId);
+        Assert.Equal("epost:test@example.com", instanceOwner.Username);
+        Assert.Equal("urn:altinn:person:idporten-email:test@example.com", instanceOwner.ExternalIdentifier);
+    }
+
+    [Fact]
+    public async Task PartyToInstanceOwner_SelfIdentifiedWithLegacyUsername_ThirdPartyInstantiation_ReturnsExternalIdentifier()
+    {
+        // Arrange
+        var party = new Party
+        {
+            PartyId = 12345,
+            PartyTypeName = PartyType.SelfIdentified,
+            Name = "jensjensen",
+        };
+
+        var authenticationContextMock = new Mock<IAuthenticationContext>();
+        var authenticatedOrg = CreateAuthenticatedOrg(orgNo: "991825827");
+        authenticationContextMock.SetupGet(a => a.Current).Returns(authenticatedOrg);
+
+        // Act
+        InstanceOwner instanceOwner = await InstantiationHelper.PartyToInstanceOwner(
+            party,
+            authenticationContextMock.Object
+        );
+
+        // Assert
+        Assert.Equal("12345", instanceOwner.PartyId);
+        Assert.Equal("jensjensen", instanceOwner.Username);
+        Assert.Equal("urn:altinn:person:legacy-selfidentified:jensjensen", instanceOwner.ExternalIdentifier);
     }
 
     [Fact]

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -1636,6 +1636,18 @@ namespace Altinn.App.Core.Features.Maskinporten.Models
         public Microsoft.IdentityModel.Tokens.JsonWebKey GetJsonWebKey() { }
     }
 }
+namespace Altinn.App.Core.Features.Notifications.Cancellation
+{
+    public interface ICancelInstantiationNotification
+    {
+        bool ShouldSend(Altinn.Platform.Storage.Interface.Models.Instance instance);
+    }
+    public class SendOnProcessNotEnded : Altinn.App.Core.Features.Notifications.Cancellation.ICancelInstantiationNotification
+    {
+        public SendOnProcessNotEnded() { }
+        public bool ShouldSend(Altinn.Platform.Storage.Interface.Models.Instance instance) { }
+    }
+}
 namespace Altinn.App.Core.Features.Notifications
 {
     public interface INotificationService

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -4981,14 +4981,14 @@ namespace Altinn.App.Core.Models.Notifications.Future
         [System.Text.Json.Serialization.JsonPropertyName("recipientEmail")]
         public Altinn.App.Core.Models.Notifications.Future.RecipientEmail? RecipientEmail { get; init; }
         [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        [System.Text.Json.Serialization.JsonPropertyName("recipientExternalIdentity")]
+        public Altinn.App.Core.Models.Notifications.Future.RecipientExternalIdentity? RecipientExternalIdentity { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("recipientOrganization")]
         public Altinn.App.Core.Models.Notifications.Future.RecipientOrganization? RecipientOrganization { get; init; }
         [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("recipientPerson")]
         public Altinn.App.Core.Models.Notifications.Future.RecipientPerson? RecipientPerson { get; init; }
-        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-        [System.Text.Json.Serialization.JsonPropertyName("recipientSelfIdentifiedUser")]
-        public Altinn.App.Core.Models.Notifications.Future.RecipientSelfIdentifiedUser? RecipientSelfIdentifiedUser { get; init; }
         [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("recipientSms")]
         public Altinn.App.Core.Models.Notifications.Future.RecipientSms? RecipientSms { get; init; }
@@ -5019,6 +5019,23 @@ namespace Altinn.App.Core.Models.Notifications.Future
         [System.Text.Json.Serialization.JsonPropertyName("emailSettings")]
         public required Altinn.App.Core.Models.Notifications.Future.EmailSendingOptions Settings { get; init; }
     }
+    public sealed class RecipientExternalIdentity : System.IEquatable<Altinn.App.Core.Models.Notifications.Future.RecipientExternalIdentity>
+    {
+        public RecipientExternalIdentity() { }
+        [System.Text.Json.Serialization.JsonPropertyName("channelSchema")]
+        public Altinn.App.Core.Models.Notifications.Future.NotificationChannel ChannelSchema { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        [System.Text.Json.Serialization.JsonPropertyName("emailSettings")]
+        public Altinn.App.Core.Models.Notifications.Future.EmailSendingOptions? EmailSettings { get; init; }
+        [System.Text.Json.Serialization.JsonPropertyName("externalIdentity")]
+        public required string ExternalIdentity { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        [System.Text.Json.Serialization.JsonPropertyName("resourceId")]
+        public string? ResourceId { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        [System.Text.Json.Serialization.JsonPropertyName("smsSettings")]
+        public Altinn.App.Core.Models.Notifications.Future.SmsSendingOptions? SmsSettings { get; init; }
+    }
     public sealed class RecipientOrganization : System.IEquatable<Altinn.App.Core.Models.Notifications.Future.RecipientOrganization>
     {
         public RecipientOrganization() { }
@@ -5048,23 +5065,6 @@ namespace Altinn.App.Core.Models.Notifications.Future
         public bool IgnoreReservation { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("nationalIdentityNumber")]
         public required string NationalIdentityNumber { get; init; }
-        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-        [System.Text.Json.Serialization.JsonPropertyName("resourceId")]
-        public string? ResourceId { get; init; }
-        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-        [System.Text.Json.Serialization.JsonPropertyName("smsSettings")]
-        public Altinn.App.Core.Models.Notifications.Future.SmsSendingOptions? SmsSettings { get; init; }
-    }
-    public sealed class RecipientSelfIdentifiedUser : System.IEquatable<Altinn.App.Core.Models.Notifications.Future.RecipientSelfIdentifiedUser>
-    {
-        public RecipientSelfIdentifiedUser() { }
-        [System.Text.Json.Serialization.JsonPropertyName("channelSchema")]
-        public Altinn.App.Core.Models.Notifications.Future.NotificationChannel ChannelSchema { get; init; }
-        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-        [System.Text.Json.Serialization.JsonPropertyName("emailSettings")]
-        public Altinn.App.Core.Models.Notifications.Future.EmailSendingOptions? EmailSettings { get; init; }
-        [System.Text.Json.Serialization.JsonPropertyName("externalIdentity")]
-        public required string ExternalIdentity { get; init; }
         [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("resourceId")]
         public string? ResourceId { get; init; }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -4879,8 +4879,10 @@ namespace Altinn.App.Core.Models.Notifications.Future
     public class DialogportenIdentifiers
     {
         public DialogportenIdentifiers() { }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("dialogId")]
         public string? DialogId { get; set; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("transmissionId")]
         public string? TransmissionId { get; set; }
     }
@@ -4898,6 +4900,7 @@ namespace Altinn.App.Core.Models.Notifications.Future
         public required string Body { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("contentType")]
         public Altinn.App.Core.Models.Notifications.Future.EmailContentType ContentType { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("senderEmailAddress")]
         public string? SenderEmailAddress { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("sendingTimePolicy")]
@@ -4936,8 +4939,10 @@ namespace Altinn.App.Core.Models.Notifications.Future
     public sealed class NotificationOrderRequest : System.IEquatable<Altinn.App.Core.Models.Notifications.Future.NotificationOrderRequest>
     {
         public NotificationOrderRequest() { }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("conditionEndpoint")]
         public System.Uri? ConditionEndpoint { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("dialogportenAssociation")]
         public Altinn.App.Core.Models.Notifications.Future.DialogportenIdentifiers? DialogportenAssociation { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("idempotencyId")]
@@ -4972,28 +4977,37 @@ namespace Altinn.App.Core.Models.Notifications.Future
     public sealed class NotificationRecipient : System.IEquatable<Altinn.App.Core.Models.Notifications.Future.NotificationRecipient>
     {
         public NotificationRecipient() { }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("recipientEmail")]
         public Altinn.App.Core.Models.Notifications.Future.RecipientEmail? RecipientEmail { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("recipientOrganization")]
         public Altinn.App.Core.Models.Notifications.Future.RecipientOrganization? RecipientOrganization { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("recipientPerson")]
         public Altinn.App.Core.Models.Notifications.Future.RecipientPerson? RecipientPerson { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("recipientSelfIdentifiedUser")]
         public Altinn.App.Core.Models.Notifications.Future.RecipientSelfIdentifiedUser? RecipientSelfIdentifiedUser { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("recipientSms")]
         public Altinn.App.Core.Models.Notifications.Future.RecipientSms? RecipientSms { get; init; }
     }
     public class NotificationReminder : System.IEquatable<Altinn.App.Core.Models.Notifications.Future.NotificationReminder>
     {
         public NotificationReminder() { }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("conditionEndpoint")]
         public System.Uri? ConditionEndpoint { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("delayDays")]
         public int? DelayDays { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("recipient")]
         public required Altinn.App.Core.Models.Notifications.Future.NotificationRecipient Recipient { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("requestedSendTime")]
         public System.DateTime? RequestedSendTime { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("sendersReference")]
         public string? SendersReference { get; init; }
     }
@@ -5010,12 +5024,15 @@ namespace Altinn.App.Core.Models.Notifications.Future
         public RecipientOrganization() { }
         [System.Text.Json.Serialization.JsonPropertyName("channelSchema")]
         public required Altinn.App.Core.Models.Notifications.Future.NotificationChannel ChannelSchema { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("emailSettings")]
         public Altinn.App.Core.Models.Notifications.Future.EmailSendingOptions? EmailSettings { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("orgNumber")]
         public required string OrgNumber { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("resourceId")]
         public string? ResourceId { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("smsSettings")]
         public Altinn.App.Core.Models.Notifications.Future.SmsSendingOptions? SmsSettings { get; init; }
     }
@@ -5024,14 +5041,17 @@ namespace Altinn.App.Core.Models.Notifications.Future
         public RecipientPerson() { }
         [System.Text.Json.Serialization.JsonPropertyName("channelSchema")]
         public Altinn.App.Core.Models.Notifications.Future.NotificationChannel ChannelSchema { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("emailSettings")]
         public Altinn.App.Core.Models.Notifications.Future.EmailSendingOptions? EmailSettings { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("ignoreReservation")]
         public bool IgnoreReservation { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("nationalIdentityNumber")]
         public required string NationalIdentityNumber { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("resourceId")]
         public string? ResourceId { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("smsSettings")]
         public Altinn.App.Core.Models.Notifications.Future.SmsSendingOptions? SmsSettings { get; init; }
     }
@@ -5040,12 +5060,15 @@ namespace Altinn.App.Core.Models.Notifications.Future
         public RecipientSelfIdentifiedUser() { }
         [System.Text.Json.Serialization.JsonPropertyName("channelSchema")]
         public Altinn.App.Core.Models.Notifications.Future.NotificationChannel ChannelSchema { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("emailSettings")]
         public Altinn.App.Core.Models.Notifications.Future.EmailSendingOptions? EmailSettings { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("externalIdentity")]
         public required string ExternalIdentity { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("resourceId")]
         public string? ResourceId { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("smsSettings")]
         public Altinn.App.Core.Models.Notifications.Future.SmsSendingOptions? SmsSettings { get; init; }
     }
@@ -5069,6 +5092,7 @@ namespace Altinn.App.Core.Models.Notifications.Future
         public SmsSendingOptions() { }
         [System.Text.Json.Serialization.JsonPropertyName("body")]
         public required string Body { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         [System.Text.Json.Serialization.JsonPropertyName("sender")]
         public string? Sender { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("sendingTimePolicy")]

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -4916,6 +4916,8 @@ namespace Altinn.App.Core.Models.Notifications.Future
         public string? Language { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("notificationChannel")]
         public Altinn.App.Core.Models.Notifications.Future.NotificationChannel NotificationChannel { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("requestedSendTime")]
+        public System.DateTime? RequestedSendTime { get; init; }
     }
     public enum NotificationChannel
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds an optional RequestedSendTime field to InstansiationNotification, allowing service owners to schedule the notification to be sent at a specific time after an instance is created, rather than immediately.
When RequestedSendTime is set, the notification order request sent to the Altinn Notifications microservice includes a ConditionEndpoint pointing to a new callback endpoint (/{org}/{app}/notifications/instance). The Notifications microservice will call this endpoint before sending the notification to verify whether it should still be delivered.
The default behaviour cancels notifications if the process has ended.
When RequestedSendTime is not set, the notification is sent immediately (defaulting to 5 minutes from instantiation time) and no condition endpoint is included in the request.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
