### PR TITLE
fix: check prop name without case-sensitivity.

### DIFF
--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -261,6 +261,7 @@ public static partial class ObjectUtils
 
     private static bool PropertyIsAltinnRowGuid(PropertyInfo prop)
     {
-        return prop.PropertyType == typeof(Guid) && string.Equals(prop.Name, "AltinnRowId", StringComparison.OrdinalIgnoreCase);
+        return prop.PropertyType == typeof(Guid)
+            && string.Equals(prop.Name, "AltinnRowId", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Altinn.App.Core/Helpers/ObjectUtils.cs
+++ b/src/Altinn.App.Core/Helpers/ObjectUtils.cs
@@ -261,6 +261,6 @@ public static partial class ObjectUtils
 
     private static bool PropertyIsAltinnRowGuid(PropertyInfo prop)
     {
-        return prop.PropertyType == typeof(Guid) && prop.Name == "AltinnRowId";
+        return prop.PropertyType == typeof(Guid) && string.Equals(prop.Name, "AltinnRowId", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Description
Comapre strings without case-sensitivity. 
We've seen some examples where the prop name starts with a lowercase `a`, while the if check only accepts an uppercase `A`.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
