### PR TITLE
Fix nullability issues in source generator

### DIFF
--- a/src/Altinn.App.Analyzers/ModelPathNode.cs
+++ b/src/Altinn.App.Analyzers/ModelPathNode.cs
@@ -110,6 +110,8 @@ public record ModelPathNode
             "global::System.DateTime" => true,
             "global::System.DateTimeOffset" => true,
             "global::System.TimeSpan" => true,
+            "global::System.DateOnly" => true,
+            "global::System.TimeOnly" => true,
             "global::System.Int32" => true,
             "global::System.Int64" => true,
             "global::System.UInt32" => true,

--- a/src/Altinn.App.Analyzers/ModelPathNode.cs
+++ b/src/Altinn.App.Analyzers/ModelPathNode.cs
@@ -101,4 +101,42 @@ public record ModelPathNode
     {
         return this is { JsonName: "altinnRowId", CSharpName: "AltinnRowId", TypeName: "global::System.Guid" };
     }
+
+    public bool IsCSharpValueType()
+    {
+        return TypeName switch
+        {
+            "global::System.Guid" => true,
+            "global::System.DateTime" => true,
+            "global::System.DateTimeOffset" => true,
+            "global::System.TimeSpan" => true,
+            "global::System.Int32" => true,
+            "global::System.Int64" => true,
+            "global::System.UInt32" => true,
+            "global::System.UInt64" => true,
+            "global::System.Single" => true,
+            "global::System.Double" => true,
+            "global::System.Decimal" => true,
+            "global::System.Boolean" => true,
+            "global::System.Char" => true,
+            "global::System.Byte" => true,
+            "global::System.SByte" => true,
+            "global::System.Int16" => true,
+            "global::System.UInt16" => true,
+            "int" => true,
+            "long" => true,
+            "uint" => true,
+            "ulong" => true,
+            "float" => true,
+            "double" => true,
+            "decimal" => true,
+            "bool" => true,
+            "char" => true,
+            "byte" => true,
+            "sbyte" => true,
+            "short" => true,
+            "ushort" => true,
+            _ => false,
+        };
+    }
 };

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/CopyGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/CopyGenerator.cs
@@ -104,7 +104,7 @@ internal static class CopyGenerator
                 {
                     if (list is null)
                     {
-                        return null;
+                        return null!;
                     }
                     // csharpier-ignore
                     {{node.ListType}} result = new (list.Count);

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/SetterGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/SetterGenerator.cs
@@ -90,7 +90,7 @@ internal static class SetterGenerator
             if (modelPathNode.Properties.Count == 0)
             {
                 // Simple list element - direct set
-                if (modelPathNode.IsNullable)
+                if (modelPathNode.IsNullable || modelPathNode.IsCSharpValueType())
                 {
                     builder.Append(
                         $$"""

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/Models/Skjema.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/Models/Skjema.cs
@@ -55,6 +55,19 @@ public class SkjemaInnhold
 
     [JsonPropertyName("withCollection")]
     public ICollection<Adresse>? WithCollection { get; set; }
+
+#nullable disable
+    // Test that non nullable lists does not cause problems. Old datamodels might have these and they should be supported even if they are not ideal.
+    [JsonPropertyName("withListOfString")]
+    public List<string> WithListOfString { get; set; }
+
+    [JsonPropertyName("withListOfInt")]
+    public List<int> WithListOfInt { get; set; }
+
+    [JsonPropertyName("withListOfNullableInt")]
+    public List<int?> ListNullableInt { get; set; }
+
+#nullable enable
 }
 
 public class Adresse

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
@@ -103,6 +103,9 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             "adresse" when literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
             "tidligere-adresse" => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
             "oldXmlValue" when literalIndex is -1 => GetRecursive(model.OldXmlValue, path, nextOffset),
+            "withListOfString" => GetRecursive(model.WithListOfString, path, literalIndex, nextOffset),
+            "withListOfInt" => GetRecursive(model.WithListOfInt, path, literalIndex, nextOffset),
+            "withListOfNullableInt" => GetRecursive(model.ListNullableInt, path, literalIndex, nextOffset),
             // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
@@ -188,6 +191,46 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
+    }
+
+    private static object? GetRecursive(
+        global::System.Collections.Generic.List<int> model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset
+    )
+    {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
+        if (model is null || literalIndex < 0 || literalIndex >= model.Count)
+        {
+            return null;
+        }
+
+        return model[literalIndex];
+    }
+
+    private static object? GetRecursive(
+        global::System.Collections.Generic.List<int?> model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset
+    )
+    {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
+        if (model is null || literalIndex < 0 || literalIndex >= model.Count)
+        {
+            return null;
+        }
+
+        return model[literalIndex];
     }
 
     #endregion Getters
@@ -361,6 +404,30 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                     nextOffset,
                     value
                 );
+            case "withListOfString":
+                return SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaInnhold_WithListOfString(
+                    model,
+                    path,
+                    literalIndex,
+                    nextOffset,
+                    value
+                );
+            case "withListOfInt":
+                return SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaInnhold_WithListOfInt(
+                    model,
+                    path,
+                    literalIndex,
+                    nextOffset,
+                    value
+                );
+            case "withListOfNullableInt":
+                return SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaInnhold_ListNullableInt(
+                    model,
+                    path,
+                    literalIndex,
+                    nextOffset,
+                    value
+                );
             default:
                 return false;
         }
@@ -398,6 +465,42 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
     {
         model.OldXmlValue ??= new();
         return SetRecursive(model.OldXmlValue, path, nextOffset, value);
+    }
+
+    private static bool SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaInnhold_WithListOfString(
+        global::Altinn.App.SourceGenerator.Integration.Tests.Models.SkjemaInnhold model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int nextOffset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        model.WithListOfString ??= new();
+        return SetRecursive(model.WithListOfString, path, literalIndex, nextOffset, value);
+    }
+
+    private static bool SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaInnhold_WithListOfInt(
+        global::Altinn.App.SourceGenerator.Integration.Tests.Models.SkjemaInnhold model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int nextOffset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        model.WithListOfInt ??= new();
+        return SetRecursive(model.WithListOfInt, path, literalIndex, nextOffset, value);
+    }
+
+    private static bool SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaInnhold_ListNullableInt(
+        global::Altinn.App.SourceGenerator.Integration.Tests.Models.SkjemaInnhold model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int nextOffset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        model.ListNullableInt ??= new();
+        return SetRecursive(model.ListNullableInt, path, literalIndex, nextOffset, value);
     }
 
     private static bool SetRecursive(
@@ -534,6 +637,54 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             default:
                 return false;
         }
+    }
+
+    private static bool SetRecursive(
+        global::System.Collections.Generic.List<int> model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model is null || literalIndex < 0)
+        {
+            return false;
+        }
+        if (model.Count <= literalIndex)
+        {
+            return false;
+        }
+        if (value.TryDeserialize<int>(out var result))
+        {
+            model[literalIndex] = result;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool SetRecursive(
+        global::System.Collections.Generic.List<int?> model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model is null || literalIndex < 0)
+        {
+            return false;
+        }
+        if (model.Count <= literalIndex)
+        {
+            return false;
+        }
+        if (value.TryDeserialize<int?>(out var result))
+        {
+            model[literalIndex] = result;
+            return true;
+        }
+        return false;
     }
 
     #endregion Setters
@@ -781,6 +932,147 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
                     );
                 }
                 return;
+            case "withListOfString":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 16;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
+                return;
+            case "withListOfInt":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 13;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
+                return;
+            case "withListOfNullableInt":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 21;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
+                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -932,7 +1224,7 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
     {
         if (list is null)
         {
-            return null;
+            return null!;
         }
         // csharpier-ignore
         global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Integration.Tests.Models.SkjemaInnhold?> result = new (list.Count);
@@ -965,6 +1257,9 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             Adresse = CopyRecursive(data.Adresse),
             TidligereAdresse = CopyRecursive(data.TidligereAdresse),
             OldXmlValue = CopyRecursive(data.OldXmlValue),
+            WithListOfString = CopyRecursive(data.WithListOfString),
+            WithListOfInt = CopyRecursive(data.WithListOfInt),
+            ListNullableInt = CopyRecursive(data.ListNullableInt),
         };
     }
 
@@ -996,7 +1291,7 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
     {
         if (list is null)
         {
-            return null;
+            return null!;
         }
         // csharpier-ignore
         global::System.Collections.Generic.List<string> result = new (list.Count);
@@ -1016,7 +1311,7 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
     {
         if (list is null)
         {
-            return null;
+            return null!;
         }
         // csharpier-ignore
         global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Integration.Tests.Models.Adresse> result = new (list.Count);
@@ -1044,6 +1339,46 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             // Initialize properties
             valueNullable = data.valueNullable,
         };
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
+    private static global::System.Collections.Generic.List<int> CopyRecursive(
+        global::System.Collections.Generic.List<int> list
+    )
+    {
+        if (list is null)
+        {
+            return null!;
+        }
+        // csharpier-ignore
+        global::System.Collections.Generic.List<int> result = new (list.Count);
+
+        foreach (var item in list)
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
+    private static global::System.Collections.Generic.List<int?> CopyRecursive(
+        global::System.Collections.Generic.List<int?> list
+    )
+    {
+        if (list is null)
+        {
+            return null!;
+        }
+        // csharpier-ignore
+        global::System.Collections.Generic.List<int?> result = new (list.Count);
+
+        foreach (var item in list)
+        {
+            result.Add(item);
+        }
+
+        return result;
     }
 
     #endregion Copy
@@ -1174,6 +1509,24 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             case "oldXmlValue":
                 RemoveRecursive(model.OldXmlValue, path, nextOffset, rowRemovalOption);
                 break;
+            case "withListOfString" when (nextOffset is -1) && (literalIndex is -1):
+                model.WithListOfString = default;
+                break;
+            case "withListOfString":
+                RemoveRecursive(model.WithListOfString, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
+            case "withListOfInt" when (nextOffset is -1) && (literalIndex is -1):
+                model.WithListOfInt = default;
+                break;
+            case "withListOfInt":
+                RemoveRecursive(model.WithListOfInt, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
+            case "withListOfNullableInt" when (nextOffset is -1) && (literalIndex is -1):
+                model.ListNullableInt = default;
+                break;
+            case "withListOfNullableInt":
+                RemoveRecursive(model.ListNullableInt, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
             default:
                 // throw new ArgumentException("{path} is not a valid path.");
                 return;
@@ -1297,6 +1650,66 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             default:
                 // throw new ArgumentException("{path} is not a valid path.");
                 return;
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::System.Collections.Generic.List<int> model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        int index,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        if (index < 0 || index >= model.Count)
+        {
+            return;
+        }
+        if (offset == -1)
+        {
+            switch (rowRemovalOption)
+            {
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.DeleteRow:
+                    model.RemoveAt(index);
+                    break;
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.SetToNull:
+                    model[index] = default!;
+                    break;
+            }
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::System.Collections.Generic.List<int?> model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        int index,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        if (index < 0 || index >= model.Count)
+        {
+            return;
+        }
+        if (offset == -1)
+        {
+            switch (rowRemovalOption)
+            {
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.DeleteRow:
+                    model.RemoveAt(index);
+                    break;
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.SetToNull:
+                    model[index] = default!;
+                    break;
+            }
         }
     }
 
@@ -1640,6 +2053,30 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
 //               "IsJsonValueType": true,
 //             }
 //           ]
+//         },
+//         {
+//           "JsonName": "withListOfString",
+//           "CSharpName": "WithListOfString",
+//           "IsNullable": false,
+//           "TypeName": "string",
+//           "IsJsonValueType": true,
+//           "ListType": "global::System.Collections.Generic.List<string>",
+//         },
+//         {
+//           "JsonName": "withListOfInt",
+//           "CSharpName": "WithListOfInt",
+//           "IsNullable": false,
+//           "TypeName": "int",
+//           "IsJsonValueType": true,
+//           "ListType": "global::System.Collections.Generic.List<int>",
+//         },
+//         {
+//           "JsonName": "withListOfNullableInt",
+//           "CSharpName": "ListNullableInt",
+//           "IsNullable": true,
+//           "TypeName": "int",
+//           "IsJsonValueType": true,
+//           "ListType": "global::System.Collections.Generic.List<int?>",
 //         }
 //       ]
 //     },

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
@@ -101,9 +101,13 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             "navn" when nextOffset is -1 && literalIndex is -1 => model.Navn,
             "alder" when nextOffset is -1 && literalIndex is -1 => model.Alder,
             "deltar" when nextOffset is -1 && literalIndex is -1 => model.Deltar,
+            "nonNullableInt" when nextOffset is -1 && literalIndex is -1 => model.NonNullableInt,
             "adresse" when literalIndex is -1 => GetRecursive(model.Adresse, path, nextOffset),
             "tidligere-adresse" => GetRecursive(model.TidligereAdresse, path, literalIndex, nextOffset),
             "oldXmlValue" when literalIndex is -1 => GetRecursive(model.OldXmlValue, path, nextOffset),
+            "withListOfString" => GetRecursive(model.WithListOfString, path, literalIndex, nextOffset),
+            "withListOfInt" => GetRecursive(model.WithListOfInt, path, literalIndex, nextOffset),
+            "withListOfNullableInt" => GetRecursive(model.ListNullableInt, path, literalIndex, nextOffset),
             // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
@@ -189,6 +193,46 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
+    }
+
+    private static object? GetRecursive(
+        global::System.Collections.Generic.List<int> model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset
+    )
+    {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
+        if (model is null || literalIndex < 0 || literalIndex >= model.Count)
+        {
+            return null;
+        }
+
+        return model[literalIndex];
+    }
+
+    private static object? GetRecursive(
+        global::System.Collections.Generic.List<int?> model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset
+    )
+    {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
+        if (model is null || literalIndex < 0 || literalIndex >= model.Count)
+        {
+            return null;
+        }
+
+        return model[literalIndex];
     }
 
     #endregion Getters
@@ -340,6 +384,13 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     return true;
                 }
                 return false;
+            case "nonNullableInt" when nextOffset is -1 && literalIndex is -1:
+                if (value.TryDeserialize<int>(out var result_NonNullableInt))
+                {
+                    model.NonNullableInt = result_NonNullableInt;
+                    return true;
+                }
+                return false;
             case "adresse" when literalIndex is -1:
                 return SetRecursive_WithObjectCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_Adresse(
                     model,
@@ -359,6 +410,30 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 return SetRecursive_WithObjectCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_OldXmlValue(
                     model,
                     path,
+                    nextOffset,
+                    value
+                );
+            case "withListOfString":
+                return SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_WithListOfString(
+                    model,
+                    path,
+                    literalIndex,
+                    nextOffset,
+                    value
+                );
+            case "withListOfInt":
+                return SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_WithListOfInt(
+                    model,
+                    path,
+                    literalIndex,
+                    nextOffset,
+                    value
+                );
+            case "withListOfNullableInt":
+                return SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_ListNullableInt(
+                    model,
+                    path,
+                    literalIndex,
                     nextOffset,
                     value
                 );
@@ -399,6 +474,42 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
     {
         model.OldXmlValue ??= new();
         return SetRecursive(model.OldXmlValue, path, nextOffset, value);
+    }
+
+    private static bool SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_WithListOfString(
+        global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int nextOffset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        model.WithListOfString ??= new();
+        return SetRecursive(model.WithListOfString, path, literalIndex, nextOffset, value);
+    }
+
+    private static bool SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_WithListOfInt(
+        global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int nextOffset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        model.WithListOfInt ??= new();
+        return SetRecursive(model.WithListOfInt, path, literalIndex, nextOffset, value);
+    }
+
+    private static bool SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_ListNullableInt(
+        global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int nextOffset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        model.ListNullableInt ??= new();
+        return SetRecursive(model.ListNullableInt, path, literalIndex, nextOffset, value);
     }
 
     private static bool SetRecursive(
@@ -535,6 +646,54 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             default:
                 return false;
         }
+    }
+
+    private static bool SetRecursive(
+        global::System.Collections.Generic.List<int> model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model is null || literalIndex < 0)
+        {
+            return false;
+        }
+        if (model.Count <= literalIndex)
+        {
+            return false;
+        }
+        if (value.TryDeserialize<int>(out var result))
+        {
+            model[literalIndex] = result;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool SetRecursive(
+        global::System.Collections.Generic.List<int?> model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model is null || literalIndex < 0)
+        {
+            return false;
+        }
+        if (model.Count <= literalIndex)
+        {
+            return false;
+        }
+        if (value.TryDeserialize<int?>(out var result))
+        {
+            model[literalIndex] = result;
+            return true;
+        }
+        return false;
     }
 
     #endregion Setters
@@ -697,6 +856,10 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 6;
                 return;
+            case "nonNullableInt":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 14;
+                return;
             case "adresse":
                 segment.CopyTo(buffer.Slice(bufferOffset));
                 bufferOffset += 7;
@@ -780,6 +943,147 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                         buffer,
                         ref bufferOffset
                     );
+                }
+                return;
+            case "withListOfString":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 16;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
+                return;
+            case "withListOfInt":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 13;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
+                return;
+            case "withListOfNullableInt":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 21;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
                 }
                 return;
             default:
@@ -933,7 +1237,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
     {
         if (list is null)
         {
-            return null;
+            return null!;
         }
         // csharpier-ignore
         global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold?> result = new (list.Count);
@@ -963,9 +1267,13 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             Navn = data.Navn,
             Alder = data.Alder,
             Deltar = data.Deltar,
+            NonNullableInt = data.NonNullableInt,
             Adresse = CopyRecursive(data.Adresse),
             TidligereAdresse = CopyRecursive(data.TidligereAdresse),
             OldXmlValue = CopyRecursive(data.OldXmlValue),
+            WithListOfString = CopyRecursive(data.WithListOfString),
+            WithListOfInt = CopyRecursive(data.WithListOfInt),
+            ListNullableInt = CopyRecursive(data.ListNullableInt),
         };
     }
 
@@ -997,7 +1305,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
     {
         if (list is null)
         {
-            return null;
+            return null!;
         }
         // csharpier-ignore
         global::System.Collections.Generic.List<string> result = new (list.Count);
@@ -1017,7 +1325,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
     {
         if (list is null)
         {
-            return null;
+            return null!;
         }
         // csharpier-ignore
         global::System.Collections.Generic.List<global::Altinn.App.SourceGenerator.Tests.Adresse> result = new (list.Count);
@@ -1045,6 +1353,46 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             // Initialize properties
             valueNullable = data.valueNullable,
         };
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
+    private static global::System.Collections.Generic.List<int> CopyRecursive(
+        global::System.Collections.Generic.List<int> list
+    )
+    {
+        if (list is null)
+        {
+            return null!;
+        }
+        // csharpier-ignore
+        global::System.Collections.Generic.List<int> result = new (list.Count);
+
+        foreach (var item in list)
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
+    private static global::System.Collections.Generic.List<int?> CopyRecursive(
+        global::System.Collections.Generic.List<int?> list
+    )
+    {
+        if (list is null)
+        {
+            return null!;
+        }
+        // csharpier-ignore
+        global::System.Collections.Generic.List<int?> result = new (list.Count);
+
+        foreach (var item in list)
+        {
+            result.Add(item);
+        }
+
+        return result;
     }
 
     #endregion Copy
@@ -1157,6 +1505,9 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             case "deltar" when (nextOffset is -1) && (literalIndex is -1):
                 model.Deltar = default;
                 break;
+            case "nonNullableInt" when (nextOffset is -1) && (literalIndex is -1):
+                model.NonNullableInt = default;
+                break;
             case "adresse" when (nextOffset is -1) && (literalIndex is -1):
                 model.Adresse = default;
                 break;
@@ -1174,6 +1525,24 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 break;
             case "oldXmlValue":
                 RemoveRecursive(model.OldXmlValue, path, nextOffset, rowRemovalOption);
+                break;
+            case "withListOfString" when (nextOffset is -1) && (literalIndex is -1):
+                model.WithListOfString = default;
+                break;
+            case "withListOfString":
+                RemoveRecursive(model.WithListOfString, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
+            case "withListOfInt" when (nextOffset is -1) && (literalIndex is -1):
+                model.WithListOfInt = default;
+                break;
+            case "withListOfInt":
+                RemoveRecursive(model.WithListOfInt, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
+            case "withListOfNullableInt" when (nextOffset is -1) && (literalIndex is -1):
+                model.ListNullableInt = default;
+                break;
+            case "withListOfNullableInt":
+                RemoveRecursive(model.ListNullableInt, path, nextOffset, literalIndex, rowRemovalOption);
                 break;
             default:
                 // throw new ArgumentException("{path} is not a valid path.");
@@ -1298,6 +1667,66 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             default:
                 // throw new ArgumentException("{path} is not a valid path.");
                 return;
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::System.Collections.Generic.List<int> model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        int index,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        if (index < 0 || index >= model.Count)
+        {
+            return;
+        }
+        if (offset == -1)
+        {
+            switch (rowRemovalOption)
+            {
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.DeleteRow:
+                    model.RemoveAt(index);
+                    break;
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.SetToNull:
+                    model[index] = default!;
+                    break;
+            }
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::System.Collections.Generic.List<int?> model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        int index,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        if (index < 0 || index >= model.Count)
+        {
+            return;
+        }
+        if (offset == -1)
+        {
+            switch (rowRemovalOption)
+            {
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.DeleteRow:
+                    model.RemoveAt(index);
+                    break;
+                case global::Altinn.App.Core.Helpers.RowRemovalOption.SetToNull:
+                    model[index] = default!;
+                    break;
+            }
         }
     }
 
@@ -1536,6 +1965,13 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //           "IsJsonValueType": true,
 //         },
 //         {
+//           "JsonName": "nonNullableInt",
+//           "CSharpName": "NonNullableInt",
+//           "IsNullable": false,
+//           "TypeName": "int",
+//           "IsJsonValueType": true,
+//         },
+//         {
 //           "JsonName": "adresse",
 //           "CSharpName": "Adresse",
 //           "IsNullable": true,
@@ -1641,6 +2077,30 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //               "IsJsonValueType": true,
 //             }
 //           ]
+//         },
+//         {
+//           "JsonName": "withListOfString",
+//           "CSharpName": "WithListOfString",
+//           "IsNullable": false,
+//           "TypeName": "string",
+//           "IsJsonValueType": true,
+//           "ListType": "global::System.Collections.Generic.List<string>",
+//         },
+//         {
+//           "JsonName": "withListOfInt",
+//           "CSharpName": "WithListOfInt",
+//           "IsNullable": false,
+//           "TypeName": "int",
+//           "IsJsonValueType": true,
+//           "ListType": "global::System.Collections.Generic.List<int>",
+//         },
+//         {
+//           "JsonName": "withListOfNullableInt",
+//           "CSharpName": "ListNullableInt",
+//           "IsNullable": true,
+//           "TypeName": "int",
+//           "IsJsonValueType": true,
+//           "ListType": "global::System.Collections.Generic.List<int?>",
 //         }
 //       ]
 //     },

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.cs
@@ -98,6 +98,9 @@ public class FullTests(ITestOutputHelper output)
                 [JsonPropertyName("deltar")]
                 public bool? Deltar { get; set; }
 
+                [JsonPropertyName("nonNullableInt")]
+                public int NonNullableInt { get; set; }
+
                 [JsonPropertyName("adresse")]
                 public Adresse? Adresse { get; set; }
 
@@ -109,6 +112,19 @@ public class FullTests(ITestOutputHelper output)
 
                 [JsonPropertyName("withCollection")]
                 public ICollection<Adresse>? WithCollection { get; set; }
+
+                #nullable disable
+                // Test that non nullable lists does not cause problems. Old datamodels might have these and they should be supported even if they are not ideal.
+                [JsonPropertyName("withListOfString")]
+                public List<string> WithListOfString { get; set; }
+
+                [JsonPropertyName("withListOfInt")]
+                public List<int> WithListOfInt { get; set; }
+
+                [JsonPropertyName("withListOfNullableInt")]
+                public List<int?> ListNullableInt { get; set; }
+
+                #nullable enable
             }
 
             public class Adresse

--- a/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
@@ -784,7 +784,7 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
     {
         if (list is null)
         {
-            return null;
+            return null!;
         }
         // csharpier-ignore
         global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold result = new (list.Count);

--- a/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.cs
@@ -7,6 +7,9 @@ using Xunit.Abstractions;
 
 namespace Altinn.App.SourceGenerator.Tests;
 
+/// <summary>
+/// Somewhat silly tests that uses reflection instead of roslyn parser to create the input for the source text generator, but it is a good way to quickly create test cases without having to write a lot of code to parse the syntax tree and convert it to the model used by the generator.
+/// </summary>
 public class SourceTextGeneratorTests(ITestOutputHelper outputHelper)
 {
     [Fact]


### PR DESCRIPTION
Vi fikk noen nullability issues for apper som ikke genererer modeller med nullable reference types enabled.

For å fikse det må vi håndtere value types annerledes og legge til en `!` på copy generatoren.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognizes C# value types during type classification to improve serialization and assignment behavior.

* **Bug Fixes**
  * Refined nullability handling in generated code to suppress nullable warnings and align annotations.
  * Broadened direct-assignment logic to handle value-type elements and non-nullable lists more robustly.

* **Tests**
  * Added tests and model properties covering non-nullable lists and value-type scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->