### PR TITLE
fix: remove unnecessary exceptions when prefilling

### DIFF
--- a/src/Altinn.App.Core/Implementation/PrefillSI.cs
+++ b/src/Altinn.App.Core/Implementation/PrefillSI.cs
@@ -294,22 +294,6 @@ public class PrefillSI : IPrefill
             string source = keyValuePair.Value;
             string target = keyValuePair.Key.Replace("-", string.Empty);
 
-            if (string.IsNullOrEmpty(source))
-            {
-                string errorMessage =
-                    $"Could not prefill, a source value was not set for target: {target.Replace(Environment.NewLine, "")}";
-                _logger.LogError(errorMessage);
-                throw new Exception(errorMessage);
-            }
-
-            if (string.IsNullOrEmpty(target))
-            {
-                string errorMessage =
-                    $"Could not prefill, a target value was not set for source: {source.Replace(Environment.NewLine, "")}";
-                _logger.LogError(errorMessage);
-                throw new Exception(errorMessage);
-            }
-
             JToken? sourceValue = null;
             if (sourceObject != null)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Both exceptions thrown are unnecessary:
- It should be possible to prefill a value with null or an empty string (this exception also causes InstantiationButton's mapping to fail if the field's value is an empty string or null, as described in https://github.com/Altinn/app-lib-dotnet/issues/1686 )
- If target is null or empty, assigning a value will fail later anyways


## Related Issue(s)
- #1686

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data prefilling robustness by removing overly strict validation that was preventing assignment of values in certain scenarios. The system now gracefully handles edge cases where source or target values are empty, allowing the prefill process to continue without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->