### PR TITLE
Modify some cases for TryDeserialize

### DIFF
--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionValue.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionValue.cs
@@ -517,19 +517,6 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
             case JsonValueKind.Number when IsSupportedNumericType(underlyingType):
                 result = Convert.ChangeType(Number, underlyingType, CultureInfo.InvariantCulture);
                 return true;
-            case JsonValueKind.Number when underlyingType == typeof(bool):
-                switch (Number)
-                {
-                    case 1:
-                        result = true;
-                        return true;
-                    case 0:
-                        result = false;
-                        return true;
-                    default:
-                        result = null;
-                        return false;
-                }
             case JsonValueKind.Number when underlyingType == typeof(string):
                 result = Number.ToString(CultureInfo.InvariantCulture);
                 return true;
@@ -551,24 +538,7 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
                     return false;
                 }
             }
-            case JsonValueKind.String:
-                // Fallback to JSON deserialization when the fast path fails (i.e., deserialize string to DateTime or similar)
-                try
-                {
-                    var json = $"\"{String}\""; // Wrap in quotes to ensure it's deserialized as a string (e.g., for DateTime)
-                    result = JsonSerializer.Deserialize(json, type);
-                    return true;
-                }
-                catch (JsonException)
-                {
-                    result = null;
-                    return false;
-                }
-                catch (NotSupportedException)
-                {
-                    result = null;
-                    return false;
-                }
+
         }
 
         // Add special handling for bool to support loose conversion rules
@@ -593,12 +563,35 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
             return true;
         }
 
+        if(ValueKind == JsonValueKind.String)
+        {
+             // Fallback to JSON deserialization when the fast path fails (i.e., deserialize string to DateTime or similar)
+            try
+            {
+                var json = JsonSerializer.Serialize(String, _unsafeSerializerOptionsForSerializingDates); // Wrap in quotes to ensure it's deserialized as a string (e.g., for DateTime)
+                result = JsonSerializer.Deserialize(json, type);
+                return true;
+            }
+            catch (JsonException)
+            {
+                result = null;
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                result = null;
+                return false;
+            }
+        }
+
         result = null;
         return false;
     }
 
     private static bool IsSupportedNumericType(Type type)
     {
+        // TODO: consider supporting enums as numeric types as well, but currently we
+        // don't use C# enums in datamodels, so it isn't very urgent.
         return type == typeof(double)
             || type == typeof(int)
             || type == typeof(float)

--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionValue.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionValue.cs
@@ -538,7 +538,6 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
                     return false;
                 }
             }
-
         }
 
         // Add special handling for bool to support loose conversion rules
@@ -563,9 +562,9 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
             return true;
         }
 
-        if(ValueKind == JsonValueKind.String)
+        if (ValueKind == JsonValueKind.String)
         {
-             // Fallback to JSON deserialization when the fast path fails (i.e., deserialize string to DateTime or similar)
+            // Fallback to JSON deserialization when the fast path fails (i.e., deserialize string to DateTime or similar)
             try
             {
                 var json = JsonSerializer.Serialize(String, _unsafeSerializerOptionsForSerializingDates); // Wrap in quotes to ensure it's deserialized as a string (e.g., for DateTime)

--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionValue.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionValue.cs
@@ -296,7 +296,7 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
     /// <summary>
     /// Get the value as a string that can be used for equality comparisons in ["equals"] expressions.
     ///
-    /// Has special handeling for strings that are "true", "false", or "null" to make them equal to the primitive types
+    /// Has special handling for strings that are "true", "false", or "null" to make them equal to the primitive types
     /// </summary>
     /// <returns></returns>
     /// <exception cref="NotImplementedException"></exception>
@@ -517,6 +517,22 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
             case JsonValueKind.Number when IsSupportedNumericType(underlyingType):
                 result = Convert.ChangeType(Number, underlyingType, CultureInfo.InvariantCulture);
                 return true;
+            case JsonValueKind.Number when underlyingType == typeof(bool):
+                switch (Number)
+                {
+                    case 1:
+                        result = true;
+                        return true;
+                    case 0:
+                        result = false;
+                        return true;
+                    default:
+                        result = null;
+                        return false;
+                }
+            case JsonValueKind.Number when underlyingType == typeof(string):
+                result = Number.ToString(CultureInfo.InvariantCulture);
+                return true;
             case JsonValueKind.String when underlyingType == typeof(string):
                 result = String;
                 return true;
@@ -529,8 +545,30 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
                     result = Convert.ChangeType(parsedNumber.Value, underlyingType, CultureInfo.InvariantCulture);
                     return true;
                 }
-                break;
+                else
+                {
+                    result = null;
+                    return false;
+                }
             }
+            case JsonValueKind.String:
+                // Fallback to JSON deserialization when the fast path fails (i.e., deserialize string to DateTime or similar)
+                try
+                {
+                    var json = $"\"{String}\""; // Wrap in quotes to ensure it's deserialized as a string (e.g., for DateTime)
+                    result = JsonSerializer.Deserialize(json, type);
+                    return true;
+                }
+                catch (JsonException)
+                {
+                    result = null;
+                    return false;
+                }
+                catch (NotSupportedException)
+                {
+                    result = null;
+                    return false;
+                }
         }
 
         // Add special handling for bool to support loose conversion rules
@@ -554,23 +592,9 @@ public readonly struct ExpressionValue : IEquatable<ExpressionValue>
             result = boolValue.Value;
             return true;
         }
-        // Fallback to JSON deserialization when the fast path fails (i.e., deserialize string to DateTime or similar)
-        try
-        {
-            var json = ToString();
-            result = JsonSerializer.Deserialize(json, type);
-            return true;
-        }
-        catch (JsonException)
-        {
-            result = null;
-            return false;
-        }
-        catch (NotSupportedException)
-        {
-            result = null;
-            return false;
-        }
+
+        result = null;
+        return false;
     }
 
     private static bool IsSupportedNumericType(Type type)

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/ExpressionEvaluatorTests/ExpressionValueTests.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/ExpressionEvaluatorTests/ExpressionValueTests.cs
@@ -251,7 +251,7 @@ public class ExpressionValueTests(ITestOutputHelper outputHelper)
         TestTryDeserialize("true", true, true);
         TestTryDeserialize("trUe", true, true);
         TestTryDeserialize("falSe", false, true);
-        
+
         TestTryDeserialize<bool?>("0", false, true);
         TestTryDeserialize<bool?>("1", true, true);
         TestTryDeserialize<bool?>("2", null, false);
@@ -261,9 +261,6 @@ public class ExpressionValueTests(ITestOutputHelper outputHelper)
         TestTryDeserialize<bool?>("true", true, true);
         TestTryDeserialize<bool?>("faLse", false, true);
         TestTryDeserialize<bool?>("trUe", true, true);
-        TestTryDeserialize<bool?>("2", null, false);
-        TestTryDeserialize<bool?>("-1", null, false);
-        TestTryDeserialize<bool?>("0.1", null, false);
         TestTryDeserialize(true, true, true);
         TestTryDeserialize(false, false, true);
         TestTryDeserialize(ExpressionValue.Null, (string?)null, true);
@@ -276,7 +273,7 @@ public class ExpressionValueTests(ITestOutputHelper outputHelper)
         TestTryDeserialize<int?>(ExpressionValue.False, 0, true);
         TestTryDeserialize<int?>(ExpressionValue.True, 1, true);
         // Not sure what the correct string representation should be for JsonTokenType.True and JsonTokenType.False:
-        // There are meany possibilites "true", "True", "sann", "ja", "ok", "1"
+        // There are many possibilites "true", "True", "sann", "ja", "ok", "1"
         TestTryDeserialize<string?>(ExpressionValue.False, null, false);
         TestTryDeserialize<string?>(ExpressionValue.True, null, false);
         TestTryDeserialize<string?>(ExpressionValue.Null, null, true);

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/ExpressionEvaluatorTests/ExpressionValueTests.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/ExpressionEvaluatorTests/ExpressionValueTests.cs
@@ -242,6 +242,28 @@ public class ExpressionValueTests(ITestOutputHelper outputHelper)
         TestTryDeserialize<bool?>(2, null, false);
         TestTryDeserialize<bool?>(-1, null, false);
         TestTryDeserialize<bool?>(0.1, null, false);
+        TestTryDeserialize("0", false, true);
+        TestTryDeserialize("1", true, true);
+        TestTryDeserialize("2", false, false);
+        TestTryDeserialize("-1", false, false);
+        TestTryDeserialize("0.1", false, false);
+        TestTryDeserialize("false", false, true);
+        TestTryDeserialize("true", true, true);
+        TestTryDeserialize("trUe", true, true);
+        TestTryDeserialize("falSe", false, true);
+        
+        TestTryDeserialize<bool?>("0", false, true);
+        TestTryDeserialize<bool?>("1", true, true);
+        TestTryDeserialize<bool?>("2", null, false);
+        TestTryDeserialize<bool?>("-1", null, false);
+        TestTryDeserialize<bool?>("0.1", null, false);
+        TestTryDeserialize<bool?>("false", false, true);
+        TestTryDeserialize<bool?>("true", true, true);
+        TestTryDeserialize<bool?>("faLse", false, true);
+        TestTryDeserialize<bool?>("trUe", true, true);
+        TestTryDeserialize<bool?>("2", null, false);
+        TestTryDeserialize<bool?>("-1", null, false);
+        TestTryDeserialize<bool?>("0.1", null, false);
         TestTryDeserialize(true, true, true);
         TestTryDeserialize(false, false, true);
         TestTryDeserialize(ExpressionValue.Null, (string?)null, true);

--- a/test/Altinn.App.Core.Tests/LayoutExpressions/ExpressionEvaluatorTests/ExpressionValueTests.cs
+++ b/test/Altinn.App.Core.Tests/LayoutExpressions/ExpressionEvaluatorTests/ExpressionValueTests.cs
@@ -229,7 +229,19 @@ public class ExpressionValueTests(ITestOutputHelper outputHelper)
     {
         TestTryDeserialize(2, 2.0, true);
         TestTryDeserialize(2.5, 2.5, true);
+        TestTryDeserialize(3.0, "3", true);
+        TestTryDeserialize(3.1, "3.1", true);
         TestTryDeserialize("test", "test", true);
+        TestTryDeserialize(0, false, true);
+        TestTryDeserialize(1, true, true);
+        TestTryDeserialize(2, false, false);
+        TestTryDeserialize(-1, false, false);
+        TestTryDeserialize(0.1, false, false);
+        TestTryDeserialize<bool?>(0, false, true);
+        TestTryDeserialize<bool?>(1, true, true);
+        TestTryDeserialize<bool?>(2, null, false);
+        TestTryDeserialize<bool?>(-1, null, false);
+        TestTryDeserialize<bool?>(0.1, null, false);
         TestTryDeserialize(true, true, true);
         TestTryDeserialize(false, false, true);
         TestTryDeserialize(ExpressionValue.Null, (string?)null, true);
@@ -241,6 +253,8 @@ public class ExpressionValueTests(ITestOutputHelper outputHelper)
         TestTryDeserialize<int?>(ExpressionValue.Null, null, true);
         TestTryDeserialize<int?>(ExpressionValue.False, 0, true);
         TestTryDeserialize<int?>(ExpressionValue.True, 1, true);
+        // Not sure what the correct string representation should be for JsonTokenType.True and JsonTokenType.False:
+        // There are meany possibilites "true", "True", "sann", "ja", "ok", "1"
         TestTryDeserialize<string?>(ExpressionValue.False, null, false);
         TestTryDeserialize<string?>(ExpressionValue.True, null, false);
         TestTryDeserialize<string?>(ExpressionValue.Null, null, true);
@@ -257,7 +271,7 @@ public class ExpressionValueTests(ITestOutputHelper outputHelper)
 
     private void TestTryDeserialize<T>(ExpressionValue value, T? expected, bool success)
     {
-        outputHelper.WriteLine(value.ToString());
+        outputHelper.WriteLine($"{value} -> {typeof(T).Name} {expected}: expects {(success ? "success" : "failure")}");
         if (value.TryDeserialize(out T? result))
         {
             Assert.True(success);


### PR DESCRIPTION
New cases handled for TryDeserialize 
* JsonValueKind.Number => bool
* JsonValueKind.Number => bool?
* JsonValueKind.Number => string
* Ensure failiure for JsonValueKind.String => numeric C# type when parsing of the number fails.
* Only use the `JsonSerializer.Deserialize` fallback when the json value is a string. (we should handle number and bool explicitly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expression value deserialization: added numeric→string handling, stricter string→numeric parsing with explicit failure paths, removed unconditional fallback deserialization, and limited fallback to string inputs only; clearer boolean coercion with nullable outcomes for unsupported values.
* **Tests**
  * Expanded deserialization tests for additional numeric, string, and boolean scenarios and improved test diagnostic output.
* **Documentation**
  * Fixed a documentation typo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->