### PR TITLE
Fix issue where serviceowner tokens were classified as `Authenticated.Org`

### DIFF
--- a/src/Altinn.App.Core/Features/Auth/Authenticated.cs
+++ b/src/Altinn.App.Core/Features/Auth/Authenticated.cs
@@ -877,25 +877,18 @@ public abstract class Authenticated
                     $"Invalid org claim for service owner token: {context.OrgClaim.Value}"
                 );
 
-            if (orgClaimValue == appMetadata.Org)
-            {
-                // In this case the token should have a serviceowner scope,
-                // due to the `urn:altinn:org` claim
-                if (!context.OrgNoClaim.IsValidString(out var orgNoClaimValue))
-                    throw new AuthenticationContextException("Missing org number claim for service owner token");
-                if (!context.AuthMethodClaim.IsValidString(out var authMethodClaimValue))
-                    throw new AuthenticationContextException(
-                        "Missing or invalid authentication method claim for service owner token"
-                    );
+            // In this case the token should have a serviceowner scope,
+            // due to the `urn:altinn:org` claim
+            if (!context.OrgNoClaim.IsValidString(out var orgNoClaimValue))
+                throw new AuthenticationContextException("Missing org number claim for service owner token");
+            if (!context.AuthMethodClaim.IsValidString(out var authMethodClaimValue))
+                throw new AuthenticationContextException(
+                    "Missing or invalid authentication method claim for service owner token"
+                );
 
-                ParseAuthLevel(context.AuthLevelClaim, out authLevel);
+            ParseAuthLevel(context.AuthLevelClaim, out authLevel);
 
-                return new ServiceOwner(orgClaimValue, orgNoClaimValue, authLevel, authMethodClaimValue, ref context);
-            }
-            else
-            {
-                return NewOrg(ref context);
-            }
+            return new ServiceOwner(orgClaimValue, orgNoClaimValue, authLevel, authMethodClaimValue, ref context);
         }
         else if (context.OrgNoClaim.Exists)
         {

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_ServiceOwner_Token_When_App_Metadata_Org_Differs_service_owner_mismatched_app_org.verified.txt
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.Can_Parse_Real_ServiceOwner_Token_When_App_Metadata_Org_Differs_service_owner_mismatched_app_org.verified.txt
@@ -1,0 +1,43 @@
+﻿{
+  Description: Maskinporten exchanged service owner token with mismatched app metadata org,
+  AppMetadataOrg: ttd,
+  AuthType: Altinn.App.Core.Features.Auth.Authenticated+ServiceOwner,
+  Auth: {
+    Name: digdir,
+    OrgNo: 991825827,
+    AuthenticationLevel: 3,
+    AuthenticationMethod: maskinporten,
+    TokenIssuer: Maskinporten,
+    TokenIsExchanged: true,
+    Scopes: altinn:serviceowner/instances.write altinn:serviceowner/instances.read,
+    ClientId: 044f5040-54e3-4a27-a221-a8514fd30ca9,
+    Token: eyJhbGciOiJSUzI1NiIsImtpZCI6IkQ4RDg2N0M3RDUyMTM2MEY0RjM1Q0Q1MTU4MEM0OUEwNTE2NUQ0RTEiLCJ4NXQiOiIyTmhueDlVaE5nOVBOYzFSV0F4Sm9GRmwxT0UiLCJ0eXAiOiJKV1QifQ.eyJzY29wZSI6ImFsdGlubjpzZXJ2aWNlb3duZXIvaW5zdGFuY2VzLndyaXRlIGFsdGlubjpzZXJ2aWNlb3duZXIvaW5zdGFuY2VzLnJlYWQiLCJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiZXhwIjoxNzM3ODE5Mzc2LCJpYXQiOjE3Mzc4MTc1NzYsImNsaWVudF9pZCI6IjA0NGY1MDQwLTU0ZTMtNGEyNy1hMjIxLWE4NTE0ZmQzMGNhOSIsImNvbnN1bWVyIjp7ImF1dGhvcml0eSI6ImlzbzY1MjMtYWN0b3JpZC11cGlzIiwiSUQiOiIwMTkyOjk5MTgyNTgyNyJ9LCJ1cm46YWx0aW5uOm9yZyI6ImRpZ2RpciIsInVybjphbHRpbm46b3JnTnVtYmVyIjoiOTkxODI1ODI3IiwidXJuOmFsdGlubjphdXRoZW50aWNhdGVtZXRob2QiOiJtYXNraW5wb3J0ZW4iLCJ1cm46YWx0aW5uOmF1dGhsZXZlbCI6MywiaXNzIjoiaHR0cHM6Ly9wbGF0Zm9ybS50dDAyLmFsdGlubi5uby9hdXRoZW50aWNhdGlvbi9hcGkvdjEvb3BlbmlkLyIsImp0aSI6IjFmN2RlMDFhLTgyYjMtNDc3Yi04MmQzLTBiY2I5NDkzOGVjNyIsIm5iZiI6MTczNzgxNzU3Nn0.G9uZ_YK2IxUgv8ySP3zy_IG0kOO3qJtEqHPds2f3jh1_YHcQlHEnQXUecUR-xD-Qi8qtI_GEJizA3l-zXc9DLkxgv4HVamzBrOcm9aQWqd3s8_OuI1nF4WjWrcw5FHpaXl1DqbgqPQI8rxOJhmW-H4rE944TKHLwvBlsX-9brYU_CC1WfnymFwODKsGhT1hm5ljQeV6O6j0GkNsRANiQlUnIMJcMVQEBtcuHGBLeNq-u5JSXzs17GLB371IN9Jb8IoYKu7njW3-Pat-QWebDYT9jdMQHOYslr0WByTvlnhL6Z7aQ8KbllbNw3GoYOvCBphVVpmk7aaqcchUiBh30-g
+  },
+  Jwt: {
+    client_id: 044f5040-54e3-4a27-a221-a8514fd30ca9,
+    consumer: {
+      ValueKind: Object
+    },
+    exp: 1737819376,
+    iat: 1737817576,
+    iss: https://platform.tt02.altinn.no/authentication/api/v1/openid/,
+    jti: 1f7de01a-82b3-477b-82d3-0bcb94938ec7,
+    nbf: 1737817576,
+    scope: altinn:serviceowner/instances.write altinn:serviceowner/instances.read,
+    token_type: Bearer,
+    urn:altinn:authenticatemethod: maskinporten,
+    urn:altinn:authlevel: 3,
+    urn:altinn:org: digdir,
+    urn:altinn:orgNumber: 991825827
+  },
+  Details: {
+    Party: {
+      PartyId: 1234,
+      PartyTypeName: Organisation,
+      OrgNumber: 991825827,
+      Name: Test AS,
+      IsDeleted: false,
+      OnlyHierarchyElementWithNoAccess: false
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
@@ -15,6 +15,9 @@ namespace Altinn.App.Core.Tests.Features.Auth;
 
 public class AuthenticatedTests
 {
+    private const string MaskinportenExchangedServiceOwnerToken =
+        "eyJhbGciOiJSUzI1NiIsImtpZCI6IkQ4RDg2N0M3RDUyMTM2MEY0RjM1Q0Q1MTU4MEM0OUEwNTE2NUQ0RTEiLCJ4NXQiOiIyTmhueDlVaE5nOVBOYzFSV0F4Sm9GRmwxT0UiLCJ0eXAiOiJKV1QifQ.eyJzY29wZSI6ImFsdGlubjpzZXJ2aWNlb3duZXIvaW5zdGFuY2VzLndyaXRlIGFsdGlubjpzZXJ2aWNlb3duZXIvaW5zdGFuY2VzLnJlYWQiLCJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiZXhwIjoxNzM3ODE5Mzc2LCJpYXQiOjE3Mzc4MTc1NzYsImNsaWVudF9pZCI6IjA0NGY1MDQwLTU0ZTMtNGEyNy1hMjIxLWE4NTE0ZmQzMGNhOSIsImNvbnN1bWVyIjp7ImF1dGhvcml0eSI6ImlzbzY1MjMtYWN0b3JpZC11cGlzIiwiSUQiOiIwMTkyOjk5MTgyNTgyNyJ9LCJ1cm46YWx0aW5uOm9yZyI6ImRpZ2RpciIsInVybjphbHRpbm46b3JnTnVtYmVyIjoiOTkxODI1ODI3IiwidXJuOmFsdGlubjphdXRoZW50aWNhdGVtZXRob2QiOiJtYXNraW5wb3J0ZW4iLCJ1cm46YWx0aW5uOmF1dGhsZXZlbCI6MywiaXNzIjoiaHR0cHM6Ly9wbGF0Zm9ybS50dDAyLmFsdGlubi5uby9hdXRoZW50aWNhdGlvbi9hcGkvdjEvb3BlbmlkLyIsImp0aSI6IjFmN2RlMDFhLTgyYjMtNDc3Yi04MmQzLTBiY2I5NDkzOGVjNyIsIm5iZiI6MTczNzgxNzU3Nn0.G9uZ_YK2IxUgv8ySP3zy_IG0kOO3qJtEqHPds2f3jh1_YHcQlHEnQXUecUR-xD-Qi8qtI_GEJizA3l-zXc9DLkxgv4HVamzBrOcm9aQWqd3s8_OuI1nF4WjWrcw5FHpaXl1DqbgqPQI8rxOJhmW-H4rE944TKHLwvBlsX-9brYU_CC1WfnymFwODKsGhT1hm5ljQeV6O6j0GkNsRANiQlUnIMJcMVQEBtcuHGBLeNq-u5JSXzs17GLB371IN9Jb8IoYKu7njW3-Pat-QWebDYT9jdMQHOYslr0WByTvlnhL6Z7aQ8KbllbNw3GoYOvCBphVVpmk7aaqcchUiBh30-g";
+
     // These are real tokens used from tt02/test login methods across Altinn, ID-porten and Maskinporten
     public static TheoryData<string, string, AuthenticationTypes, bool> Tokens =>
         new()
@@ -63,7 +66,7 @@ public class AuthenticatedTests
             },
             {
                 "Maskinporten exchanged service owner token",
-                "eyJhbGciOiJSUzI1NiIsImtpZCI6IkQ4RDg2N0M3RDUyMTM2MEY0RjM1Q0Q1MTU4MEM0OUEwNTE2NUQ0RTEiLCJ4NXQiOiIyTmhueDlVaE5nOVBOYzFSV0F4Sm9GRmwxT0UiLCJ0eXAiOiJKV1QifQ.eyJzY29wZSI6ImFsdGlubjpzZXJ2aWNlb3duZXIvaW5zdGFuY2VzLndyaXRlIGFsdGlubjpzZXJ2aWNlb3duZXIvaW5zdGFuY2VzLnJlYWQiLCJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiZXhwIjoxNzM3ODE5Mzc2LCJpYXQiOjE3Mzc4MTc1NzYsImNsaWVudF9pZCI6IjA0NGY1MDQwLTU0ZTMtNGEyNy1hMjIxLWE4NTE0ZmQzMGNhOSIsImNvbnN1bWVyIjp7ImF1dGhvcml0eSI6ImlzbzY1MjMtYWN0b3JpZC11cGlzIiwiSUQiOiIwMTkyOjk5MTgyNTgyNyJ9LCJ1cm46YWx0aW5uOm9yZyI6ImRpZ2RpciIsInVybjphbHRpbm46b3JnTnVtYmVyIjoiOTkxODI1ODI3IiwidXJuOmFsdGlubjphdXRoZW50aWNhdGVtZXRob2QiOiJtYXNraW5wb3J0ZW4iLCJ1cm46YWx0aW5uOmF1dGhsZXZlbCI6MywiaXNzIjoiaHR0cHM6Ly9wbGF0Zm9ybS50dDAyLmFsdGlubi5uby9hdXRoZW50aWNhdGlvbi9hcGkvdjEvb3BlbmlkLyIsImp0aSI6IjFmN2RlMDFhLTgyYjMtNDc3Yi04MmQzLTBiY2I5NDkzOGVjNyIsIm5iZiI6MTczNzgxNzU3Nn0.G9uZ_YK2IxUgv8ySP3zy_IG0kOO3qJtEqHPds2f3jh1_YHcQlHEnQXUecUR-xD-Qi8qtI_GEJizA3l-zXc9DLkxgv4HVamzBrOcm9aQWqd3s8_OuI1nF4WjWrcw5FHpaXl1DqbgqPQI8rxOJhmW-H4rE944TKHLwvBlsX-9brYU_CC1WfnymFwODKsGhT1hm5ljQeV6O6j0GkNsRANiQlUnIMJcMVQEBtcuHGBLeNq-u5JSXzs17GLB371IN9Jb8IoYKu7njW3-Pat-QWebDYT9jdMQHOYslr0WByTvlnhL6Z7aQ8KbllbNw3GoYOvCBphVVpmk7aaqcchUiBh30-g",
+                MaskinportenExchangedServiceOwnerToken,
                 AuthenticationTypes.ServiceOwner,
                 true
             },
@@ -197,17 +200,54 @@ public class AuthenticatedTests
         }
 
         var hash = Convert.ToBase64String(XxHash128.Hash(Encoding.UTF8.GetBytes(token)));
-        await Verify(
-                new
-                {
-                    Description = description,
-                    AuthType = auth.GetType().FullName,
-                    Auth = auth,
-                    Jwt = (Dictionary<string, object>)jwtToken.Payload,
-                    Details = details,
-                }
-            )
-            .UseTextForParameters($"type={tokenType}_{hash[0..4]}")
+        await VerifyAuthenticated(
+            new
+            {
+                Description = description,
+                AuthType = auth.GetType().FullName,
+                Auth = auth,
+                Jwt = (Dictionary<string, object>)jwtToken.Payload,
+                Details = details,
+            },
+            $"type={tokenType}_{hash[0..4]}"
+        );
+    }
+
+    [Fact]
+    public async Task Can_Parse_Real_ServiceOwner_Token_When_App_Metadata_Org_Differs()
+    {
+        const string appMetadataOrg = "ttd";
+        var handler = new JwtSecurityTokenHandler();
+        var jwtToken = handler.ReadJwtToken(MaskinportenExchangedServiceOwnerToken);
+
+        var auth = Parse(
+            "Maskinporten exchanged service owner token with mismatched app metadata org",
+            jwtToken,
+            MaskinportenExchangedServiceOwnerToken,
+            AuthenticationTypes.ServiceOwner,
+            appMetadataOrg
+        );
+
+        var serviceOwner = Assert.IsType<Authenticated.ServiceOwner>(auth);
+        var details = await serviceOwner.LoadDetails();
+
+        await VerifyAuthenticated(
+            new
+            {
+                Description = "Maskinporten exchanged service owner token with mismatched app metadata org",
+                AppMetadataOrg = appMetadataOrg,
+                AuthType = auth.GetType().FullName,
+                Auth = auth,
+                Jwt = (Dictionary<string, object>)jwtToken.Payload,
+                Details = details,
+            },
+            "service_owner_mismatched_app_org"
+        );
+    }
+
+    private Task VerifyAuthenticated(object target, string parameter) =>
+        Verify(target)
+            .UseTextForParameters(parameter)
             .DontIgnoreEmptyCollections()
             .DontScrubDateTimes()
             .DontScrubGuids()
@@ -216,7 +256,6 @@ public class AuthenticatedTests
                 s.Converters.Add(new ScopesConverter());
                 s.Converters.Add(new OrganisationNumberConverter());
             });
-    }
 
     private sealed class ScopesConverter : WriteOnlyJsonConverter<Scopes>
     {
@@ -234,7 +273,13 @@ public class AuthenticatedTests
         }
     }
 
-    private Authenticated Parse(string description, JwtSecurityToken jwtToken, string token, AuthenticationTypes type)
+    private Authenticated Parse(
+        string description,
+        JwtSecurityToken jwtToken,
+        string token,
+        AuthenticationTypes type,
+        string appMetadataOrg = "digdir"
+    )
     {
         string ReadClaim(string key)
         {
@@ -274,7 +319,7 @@ public class AuthenticatedTests
                         tokenStr: token,
                         parsedToken: null,
                         isAuthenticated: true,
-                        appMetadata: TestAuthentication.NewApplicationMetadata("digdir"),
+                        appMetadata: TestAuthentication.NewApplicationMetadata(appMetadataOrg),
                         getSelectedParty: () =>
                             ReadClaimInt(AltinnCoreClaimTypes.PartyID).ToString(CultureInfo.InvariantCulture),
                         getUserProfile: userId =>
@@ -326,7 +371,7 @@ public class AuthenticatedTests
                         tokenStr: token,
                         parsedToken: null,
                         isAuthenticated: true,
-                        appMetadata: TestAuthentication.NewApplicationMetadata("digdir"),
+                        appMetadata: TestAuthentication.NewApplicationMetadata(appMetadataOrg),
                         getSelectedParty: () =>
                             ReadClaimInt(AltinnCoreClaimTypes.PartyID).ToString(CultureInfo.InvariantCulture),
                         getUserProfile: userId =>
@@ -367,7 +412,7 @@ public class AuthenticatedTests
                         tokenStr: token,
                         parsedToken: null,
                         isAuthenticated: true,
-                        appMetadata: TestAuthentication.NewApplicationMetadata("digdir"),
+                        appMetadata: TestAuthentication.NewApplicationMetadata(appMetadataOrg),
                         getSelectedParty: null!,
                         getUserProfile: null!,
                         lookupUserParty: null!,
@@ -399,7 +444,7 @@ public class AuthenticatedTests
                         tokenStr: token,
                         parsedToken: null,
                         isAuthenticated: true,
-                        appMetadata: TestAuthentication.NewApplicationMetadata("digdir"),
+                        appMetadata: TestAuthentication.NewApplicationMetadata(appMetadataOrg),
                         getSelectedParty: null!,
                         getUserProfile: null!,
                         lookupUserParty: null!,
@@ -431,7 +476,7 @@ public class AuthenticatedTests
                         tokenStr: token,
                         parsedToken: null,
                         isAuthenticated: true,
-                        appMetadata: TestAuthentication.NewApplicationMetadata("digdir"),
+                        appMetadata: TestAuthentication.NewApplicationMetadata(appMetadataOrg),
                         getSelectedParty: null!,
                         getUserProfile: null!,
                         lookupUserParty: null!,
@@ -465,7 +510,7 @@ public class AuthenticatedTests
                         tokenStr: token,
                         parsedToken: null,
                         isAuthenticated: true,
-                        appMetadata: TestAuthentication.NewApplicationMetadata("digdir"),
+                        appMetadata: TestAuthentication.NewApplicationMetadata(appMetadataOrg),
                         getSelectedParty: null!,
                         getUserProfile: null!,
                         lookupUserParty: null!,

--- a/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Auth/AuthenticatedTests.cs
@@ -206,7 +206,7 @@ public class AuthenticatedTests
                 Description = description,
                 AuthType = auth.GetType().FullName,
                 Auth = auth,
-                Jwt = (Dictionary<string, object>)jwtToken.Payload,
+                Jwt = jwtToken.Payload,
                 Details = details,
             },
             $"type={tokenType}_{hash[0..4]}"
@@ -238,7 +238,7 @@ public class AuthenticatedTests
                 AppMetadataOrg = appMetadataOrg,
                 AuthType = auth.GetType().FullName,
                 Auth = auth,
-                Jwt = (Dictionary<string, object>)jwtToken.Payload,
+                Jwt = jwtToken.Payload,
                 Details = details,
             },
             "service_owner_mismatched_app_org"


### PR DESCRIPTION
## Description

- some service owners call APIs for apps that belong to other service owners (nhn -> fhi relationship for instance)
- XACML/authorization dictates what a serviceowner org is allowed to do
- `Authenticated` should reflect the current authentication method, which means that `org` claims are interpreted as serviceowner tokens. `Authenticated.ServiceOwner` means that the authenticated  client is a serviceowner, but may not be "the serviceowner" for this app or authorized for actions

So this change ensures that all clients with serviceowner token are represented as `Authenticated.ServiceOwner`

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consistency of service-owner authentication handling when an organization claim is present, ensuring uniform validation of required identity claims.
  * No user-facing behavior changes expected.

* **Tests**
  * Added real token test and fixture to cover service-owner scenarios with mismatched app metadata; updated test helpers for clearer verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->