### PR TITLE
Fix binary compatibility for IDataClient and IInstanceClient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,9 @@ We have Architecture Decision Records in the `/doc/adr/` folder.
 - Uses **semantic versioning** with MinVer
 - Avoid breaking changes (we plan to release major versions yearly. Some breaking changes can be done inbetween but must be manually verified)
 - PR titles become release notes
+- Normal interfaces in Altinn.App.Core must be binary compatible within a major version so that users can have local pacages that still work (never remove a method)
+- Interfaces marked with the `ImplementableByApps` attribute must not change.
+
 
 ### Platform Integrations
 The libraries integrate with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ We have Architecture Decision Records in the `/doc/adr/` folder.
 - Uses **semantic versioning** with MinVer
 - Avoid breaking changes (we plan to release major versions yearly. Some breaking changes can be done inbetween but must be manually verified)
 - PR titles become release notes
-- Normal interfaces in Altinn.App.Core must be binary compatible within a major version so that users can have local pacages that still work (never remove a method)
+- Normal interfaces in Altinn.App.Core must be binary compatible within a major version so that users can have local packages that still work (never remove a method)
 - Interfaces marked with the `ImplementableByApps` attribute must not change.
 
 

--- a/src/Altinn.App.Api/Controllers/ActionsController.cs
+++ b/src/Altinn.App.Api/Controllers/ActionsController.cs
@@ -99,7 +99,14 @@ public class ActionsController : ControllerBase
             );
         }
 
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         if (instance?.Process is null)
         {
             return Conflict($"Process is not started.");

--- a/src/Altinn.App.Api/Controllers/DataController.cs
+++ b/src/Altinn.App.Api/Controllers/DataController.cs
@@ -900,14 +900,26 @@ public class DataController : ControllerBase
         DataElement dataElement
     )
     {
-        Stream dataStream = await _dataClient.GetBinaryData(instanceOwnerPartyId, instanceGuid, dataGuid);
+        Stream dataStream = await _dataClient.GetBinaryData(
+            instanceOwnerPartyId,
+            instanceGuid,
+            dataGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         if (dataStream is not null)
         {
             string? userOrgClaim = User.GetOrg();
             if (userOrgClaim is null || !org.Equals(userOrgClaim, StringComparison.OrdinalIgnoreCase))
             {
-                await _instanceClient.UpdateReadStatus(instanceOwnerPartyId, instanceGuid, "read");
+                await _instanceClient.UpdateReadStatus(
+                    instanceOwnerPartyId,
+                    instanceGuid,
+                    "read",
+                    authenticationMethod: null,
+                    CancellationToken.None
+                );
             }
 
             return File(dataStream, dataElement.ContentType, dataElement.Filename);
@@ -940,7 +952,12 @@ public class DataController : ControllerBase
     )
     {
         // Get Form Data from data service. Assumes that the data element is form data.
-        object appModel = await _dataClient.GetFormData(instance, dataElement);
+        object appModel = await _dataClient.GetFormData(
+            instance,
+            dataElement,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         if (appModel is null)
         {
@@ -971,7 +988,13 @@ public class DataController : ControllerBase
         {
             try
             {
-                await _dataClient.UpdateFormData(instance, appModel, dataElement);
+                await _dataClient.UpdateFormData(
+                    instance,
+                    appModel,
+                    dataElement,
+                    authenticationMethod: null,
+                    CancellationToken.None
+                );
             }
             catch (PlatformHttpException e) when (e.Response.StatusCode is HttpStatusCode.Forbidden)
             {
@@ -989,7 +1012,13 @@ public class DataController : ControllerBase
         string? userOrgClaim = User.GetOrg();
         if (userOrgClaim is null || !org.Equals(userOrgClaim, StringComparison.OrdinalIgnoreCase))
         {
-            await _instanceClient.UpdateReadStatus(instanceOwnerId, instanceGuid, "read");
+            await _instanceClient.UpdateReadStatus(
+                instanceOwnerId,
+                instanceGuid,
+                "read",
+                authenticationMethod: null,
+                CancellationToken.None
+            );
         }
 
         return Ok(appModel);
@@ -1051,7 +1080,9 @@ public class DataController : ControllerBase
             Request.ContentType,
             contentDispositionHeader.FileName.ToString(),
             dataGuid,
-            new MemoryAsStream(bytes)
+            new MemoryAsStream(bytes),
+            authenticationMethod: null,
+            CancellationToken.None
         );
 
         SelfLinkHelper.SetDataAppSelfLinks(instanceOwnerPartyId, instanceGuid, dataElement, Request);
@@ -1166,7 +1197,14 @@ public class DataController : ControllerBase
     {
         try
         {
-            var instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            var instance = await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
             if (instance is null)
             {
                 return new ProblemDetails()
@@ -1228,7 +1266,14 @@ public class DataController : ControllerBase
         try
         {
             var application = await _appMetadata.GetApplicationMetadata();
-            var instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            var instance = await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
             if (instance is null)
             {
                 return new ProblemDetails()
@@ -1292,7 +1337,14 @@ public class DataController : ControllerBase
     {
         try
         {
-            var instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            var instance = await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
             if (instance is null)
             {
                 return new ProblemDetails()

--- a/src/Altinn.App.Api/Controllers/DataTagsController.cs
+++ b/src/Altinn.App.Api/Controllers/DataTagsController.cs
@@ -68,7 +68,14 @@ public partial class DataTagsController : ControllerBase
         [FromRoute] Guid dataGuid
     )
     {
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         if (instance is null)
         {
             return Problem(
@@ -127,7 +134,14 @@ public partial class DataTagsController : ControllerBase
             );
         }
 
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         if (instance is null)
         {
             return Problem(
@@ -153,7 +167,12 @@ public partial class DataTagsController : ControllerBase
         if (!dataElement.Tags.Contains(tag))
         {
             dataElement.Tags.Add(tag);
-            dataElement = await _dataClient.Update(instance, dataElement);
+            dataElement = await _dataClient.Update(
+                instance,
+                dataElement,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
         }
 
         TagsList tagsList = new() { Tags = dataElement.Tags };
@@ -191,7 +210,14 @@ public partial class DataTagsController : ControllerBase
         [FromRoute] string tag
     )
     {
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         if (instance is null)
         {
             return Problem(
@@ -216,7 +242,7 @@ public partial class DataTagsController : ControllerBase
 
         if (dataElement.Tags.Remove(tag))
         {
-            await _dataClient.Update(instance, dataElement);
+            await _dataClient.Update(instance, dataElement, authenticationMethod: null, CancellationToken.None);
         }
 
         return NoContent();
@@ -260,7 +286,14 @@ public partial class DataTagsController : ControllerBase
             );
         }
 
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         if (instance is null)
         {
             return Problem(
@@ -285,7 +318,12 @@ public partial class DataTagsController : ControllerBase
 
         // Set dataElement tags to be the new tags
         dataElement.Tags = [.. tags.Distinct(StringComparer.Ordinal)];
-        var updatedElement = await _dataClient.Update(instance, dataElement);
+        var updatedElement = await _dataClient.Update(
+            instance,
+            dataElement,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         if (updatedElement is null)
         {
             return Problem(

--- a/src/Altinn.App.Api/Controllers/FileScanController.cs
+++ b/src/Altinn.App.Api/Controllers/FileScanController.cs
@@ -43,7 +43,14 @@ public class FileScanController : ControllerBase
         [FromRoute] Guid instanceGuid
     )
     {
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         if (instance == null)
         {
             return NotFound();

--- a/src/Altinn.App.Api/Controllers/InstancesController.cs
+++ b/src/Altinn.App.Api/Controllers/InstancesController.cs
@@ -377,7 +377,13 @@ public class InstancesController : ControllerBase
             change = result.ProcessStateChange;
 
             // create the instance
-            instance = await _instanceClient.CreateInstance(org, app, instanceTemplate);
+            instance = await _instanceClient.CreateInstance(
+                org,
+                app,
+                instanceTemplate,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
         }
         catch (Exception exception)
         {
@@ -395,7 +401,9 @@ public class InstancesController : ControllerBase
                 await _instanceClient.DeleteInstance(
                     int.Parse(instance.InstanceOwner.PartyId, CultureInfo.InvariantCulture),
                     Guid.Parse(instance.Id.Split("/")[1]),
-                    hard: true
+                    hard: true,
+                    authenticationMethod: null,
+                    CancellationToken.None
                 );
                 return StatusCode(prefillProblem.Status ?? 500, prefillProblem);
             }
@@ -405,7 +413,9 @@ public class InstancesController : ControllerBase
                 app,
                 org,
                 int.Parse(instance.InstanceOwner.PartyId, CultureInfo.InvariantCulture),
-                Guid.Parse(instance.Id.Split("/")[1])
+                Guid.Parse(instance.Id.Split("/")[1]),
+                authenticationMethod: null,
+                CancellationToken.None
             );
 
             // notify app and store events
@@ -668,7 +678,14 @@ public class InstancesController : ControllerBase
 
                 try
                 {
-                    source = await _instanceClient.GetInstance(app, org, party.PartyId, sourceInstanceGuid);
+                    source = await _instanceClient.GetInstance(
+                        app,
+                        org,
+                        party.PartyId,
+                        sourceInstanceGuid,
+                        authenticationMethod: null,
+                        CancellationToken.None
+                    );
                 }
                 catch (PlatformHttpException exception)
                 {
@@ -684,14 +701,20 @@ public class InstancesController : ControllerBase
                 }
             }
 
-            instance = await _instanceClient.CreateInstance(org, app, instanceTemplate);
+            instance = await _instanceClient.CreateInstance(
+                org,
+                app,
+                instanceTemplate,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
 
             if (isCopyRequest && source is not null)
             {
                 await CopyDataFromSourceInstance(application, instance, source);
             }
 
-            instance = await _instanceClient.GetInstance(instance);
+            instance = await _instanceClient.GetInstance(instance, authenticationMethod: null, CancellationToken.None);
             await _processEngine.HandleEventsAndUpdateStorage(
                 instance,
                 instansiationInstance.Prefill,
@@ -835,11 +858,21 @@ public class InstancesController : ControllerBase
 
         ProcessChangeResult startResult = await _processEngine.GenerateProcessStartEvents(processStartRequest);
 
-        targetInstance = await _instanceClient.CreateInstance(org, app, targetInstance);
+        targetInstance = await _instanceClient.CreateInstance(
+            org,
+            app,
+            targetInstance,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         await CopyDataFromSourceInstance(application, targetInstance, sourceInstance);
 
-        targetInstance = await _instanceClient.GetInstance(targetInstance);
+        targetInstance = await _instanceClient.GetInstance(
+            targetInstance,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         await _processEngine.HandleEventsAndUpdateStorage(targetInstance, null, startResult.ProcessStateChange?.Events);
 
@@ -872,7 +905,12 @@ public class InstancesController : ControllerBase
     {
         try
         {
-            Instance instance = await _instanceClient.AddCompleteConfirmation(instanceOwnerPartyId, instanceGuid);
+            Instance instance = await _instanceClient.AddCompleteConfirmation(
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
             SelfLinkHelper.SetInstanceAppSelfLinks(instance, Request);
 
             return Ok(instance);
@@ -915,7 +953,14 @@ public class InstancesController : ControllerBase
             );
         }
 
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         string? orgClaim = User.GetOrg();
         if (!instance.Org.Equals(orgClaim, StringComparison.OrdinalIgnoreCase))
@@ -928,7 +973,9 @@ public class InstancesController : ControllerBase
             Instance updatedInstance = await _instanceClient.UpdateSubstatus(
                 instanceOwnerPartyId,
                 instanceGuid,
-                substatus
+                substatus,
+                authenticationMethod: null,
+                CancellationToken.None
             );
             SelfLinkHelper.SetInstanceAppSelfLinks(instance, Request);
 
@@ -964,7 +1011,13 @@ public class InstancesController : ControllerBase
     {
         try
         {
-            Instance deletedInstance = await _instanceClient.DeleteInstance(instanceOwnerPartyId, instanceGuid, hard);
+            Instance deletedInstance = await _instanceClient.DeleteInstance(
+                instanceOwnerPartyId,
+                instanceGuid,
+                hard,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
             SelfLinkHelper.SetInstanceAppSelfLinks(deletedInstance, Request);
 
             return Ok(deletedInstance);
@@ -1000,7 +1053,11 @@ public class InstancesController : ControllerBase
             { "status.isSoftDeleted", "false" },
         };
 
-        List<Instance> activeInstances = await _instanceClient.GetInstances(queryParams);
+        List<Instance> activeInstances = await _instanceClient.GetInstances(
+            queryParams,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         if (activeInstances.Count == 0)
         {
@@ -1038,7 +1095,14 @@ public class InstancesController : ControllerBase
     {
         try
         {
-            return await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            return await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
         }
         catch (PlatformHttpException platformHttpException)
         {
@@ -1098,7 +1162,12 @@ public class InstancesController : ControllerBase
             {
                 DataType dt = dts.First(dt => dt.Id.Equals(de.DataType, StringComparison.Ordinal));
 
-                object data = await _dataClient.GetFormData(sourceInstance, de);
+                object data = await _dataClient.GetFormData(
+                    sourceInstance,
+                    de,
+                    authenticationMethod: null,
+                    CancellationToken.None
+                );
 
                 if (application.CopyInstanceSettings.ExcludedDataFields != null)
                 {
@@ -1116,7 +1185,13 @@ public class InstancesController : ControllerBase
 
                 ObjectUtils.InitializeAltinnRowId(data);
 
-                await _dataClient.InsertFormData(targetInstance, dt.Id, data);
+                await _dataClient.InsertFormData(
+                    targetInstance,
+                    dt.Id,
+                    data,
+                    authenticationMethod: null,
+                    CancellationToken.None
+                );
 
                 await UpdatePresentationTextsOnInstance(application.PresentationFields, targetInstance, dt.Id, data);
                 await UpdateDataValuesOnInstance(application.DataFields, targetInstance, dt.Id, data);
@@ -1151,7 +1226,9 @@ public class InstancesController : ControllerBase
                 using var binaryDataStream = await _dataClient.GetBinaryData(
                     instanceOwnerPartyId,
                     sourceInstanceGuid,
-                    Guid.Parse(de.Id)
+                    Guid.Parse(de.Id),
+                    authenticationMethod: null,
+                    CancellationToken.None
                 );
 
                 await _dataClient.InsertBinaryData(
@@ -1159,7 +1236,10 @@ public class InstancesController : ControllerBase
                     de.DataType,
                     de.ContentType,
                     de.Filename,
-                    binaryDataStream
+                    binaryDataStream,
+                    generatedFromTask: null,
+                    authenticationMethod: null,
+                    CancellationToken.None
                 );
             }
         }
@@ -1502,7 +1582,9 @@ public class InstancesController : ControllerBase
             await _instanceClient.UpdatePresentationTexts(
                 int.Parse(instance.Id.Split("/")[0], CultureInfo.InvariantCulture),
                 Guid.Parse(instance.Id.Split("/")[1]),
-                new PresentationTexts { Texts = updatedValues }
+                new PresentationTexts { Texts = updatedValues },
+                authenticationMethod: null,
+                CancellationToken.None
             );
         }
     }
@@ -1521,7 +1603,9 @@ public class InstancesController : ControllerBase
             await _instanceClient.UpdateDataValues(
                 int.Parse(instance.Id.Split("/")[0], CultureInfo.InvariantCulture),
                 Guid.Parse(instance.Id.Split("/")[1]),
-                new DataValues { Values = updatedValues }
+                new DataValues { Values = updatedValues },
+                authenticationMethod: null,
+                CancellationToken.None
             );
         }
     }

--- a/src/Altinn.App.Api/Controllers/PaymentController.cs
+++ b/src/Altinn.App.Api/Controllers/PaymentController.cs
@@ -60,7 +60,14 @@ public class PaymentController : ControllerBase
         [FromQuery] string? language = null
     )
     {
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         AltinnPaymentConfiguration? paymentConfiguration = _processReader
             .GetAltinnTaskExtension(instance.Process.CurrentTask.ElementId)
             ?.PaymentConfiguration;
@@ -109,7 +116,14 @@ public class PaymentController : ControllerBase
             );
         }
 
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         OrderDetails orderDetails = await orderDetailsCalculator.CalculateOrderDetails(instance, language);
 
         return Ok(orderDetails);

--- a/src/Altinn.App.Api/Controllers/PdfController.cs
+++ b/src/Altinn.App.Api/Controllers/PdfController.cs
@@ -73,7 +73,14 @@ public class PdfController : ControllerBase
         [FromRoute] Guid instanceGuid
     )
     {
-        var instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        var instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         string? taskId = instance.Process?.CurrentTask?.ElementId;
         if (instance == null || taskId == null)
         {
@@ -100,7 +107,14 @@ public class PdfController : ControllerBase
         [FromRoute] Guid dataGuid
     )
     {
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         if (instance == null)
         {
             return NotFound("Did not find instance");

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -293,7 +293,7 @@ public class ProcessController : ControllerBase
                 instanceOwnerPartyId,
                 instanceGuid,
                 authenticationMethod: null,
-                CancellationToken.None
+                ct
             );
 
             var processNextRequest = new ProcessNextRequest

--- a/src/Altinn.App.Api/Controllers/ProcessController.cs
+++ b/src/Altinn.App.Api/Controllers/ProcessController.cs
@@ -88,7 +88,14 @@ public class ProcessController : ControllerBase
     {
         try
         {
-            Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            Instance instance = await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
             AppProcessState appProcessState = await ConvertAndAuthorizeActions(instance, instance.Process);
 
             return Ok(appProcessState);
@@ -133,7 +140,14 @@ public class ProcessController : ControllerBase
 
         try
         {
-            instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            instance = await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
 
             var request = new ProcessStartRequest()
             {
@@ -202,7 +216,14 @@ public class ProcessController : ControllerBase
 
         try
         {
-            instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            instance = await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
 
             if (instance.Process == null)
             {
@@ -266,7 +287,14 @@ public class ProcessController : ControllerBase
     {
         try
         {
-            Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            Instance instance = await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
 
             var processNextRequest = new ProcessNextRequest
             {
@@ -328,7 +356,14 @@ public class ProcessController : ControllerBase
 
         try
         {
-            instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            instance = await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
         }
         catch (PlatformHttpException e)
         {

--- a/src/Altinn.App.Api/Controllers/SigningController.cs
+++ b/src/Altinn.App.Api/Controllers/SigningController.cs
@@ -78,7 +78,14 @@ public class SigningController : ControllerBase
         [FromQuery] string? taskId = null
     )
     {
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         _logger.LogInformation(
             "Getting signees state for org {Org} with instance {InstanceGuid} of app {App} for party {PartyId}",
@@ -185,7 +192,14 @@ public class SigningController : ControllerBase
         [FromQuery] string? taskId = null
     )
     {
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         string? finalTaskId = taskId ?? instance.Process?.CurrentTask?.ElementId;
         if (string.IsNullOrEmpty(finalTaskId) || !VerifyIsSigningTask(finalTaskId))
@@ -261,7 +275,14 @@ public class SigningController : ControllerBase
         [FromQuery] string? taskId = null
     )
     {
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         string? finalTaskId = taskId ?? instance.Process?.CurrentTask?.ElementId;
         if (string.IsNullOrEmpty(finalTaskId) || !VerifyIsSigningTask(finalTaskId))

--- a/src/Altinn.App.Api/Controllers/UserDefinedMetadataController.cs
+++ b/src/Altinn.App.Api/Controllers/UserDefinedMetadataController.cs
@@ -73,7 +73,14 @@ public class UserDefinedMetadataController : ControllerBase
         [FromRoute] Guid dataGuid
     )
     {
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         DataElement? dataElement = instance.Data.Find(m =>
             m.Id.Equals(dataGuid.ToString(), StringComparison.OrdinalIgnoreCase)
         );
@@ -121,7 +128,14 @@ public class UserDefinedMetadataController : ControllerBase
             return BadRequest($"The following keys are duplicated: {string.Join(", ", duplicatedKeys)}");
         }
 
-        Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+        Instance instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerPartyId,
+            instanceGuid,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         DataElement? dataElement = instance.Data.Find(m =>
             m.Id.Equals(dataGuid.ToString(), StringComparison.OrdinalIgnoreCase)
         );
@@ -162,7 +176,12 @@ public class UserDefinedMetadataController : ControllerBase
         }
 
         dataElement.UserDefinedMetadata = userDefinedMetadataDto.UserDefinedMetadata;
-        dataElement = await _dataClient.Update(instance, dataElement);
+        dataElement = await _dataClient.Update(
+            instance,
+            dataElement,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         UserDefinedMetadataDto responseUserDefinedMetadataDto = new()
         {

--- a/src/Altinn.App.Api/Controllers/ValidateController.cs
+++ b/src/Altinn.App.Api/Controllers/ValidateController.cs
@@ -69,7 +69,14 @@ public class ValidateController : ControllerBase
     {
         try
         {
-            Instance instance = await _instanceClient.GetInstance(app, org, instanceOwnerPartyId, instanceGuid);
+            Instance instance = await _instanceClient.GetInstance(
+                app,
+                org,
+                instanceOwnerPartyId,
+                instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
 
             string? taskId = instance.Process?.CurrentTask?.ElementId;
             if (taskId == null)
@@ -131,7 +138,14 @@ public class ValidateController : ControllerBase
         [FromQuery] string? language = null
     )
     {
-        Instance? instance = await _instanceClient.GetInstance(app, org, instanceOwnerId, instanceId);
+        Instance? instance = await _instanceClient.GetInstance(
+            app,
+            org,
+            instanceOwnerId,
+            instanceId,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         if (instance == null)
         {
             return NotFound();

--- a/src/Altinn.App.Core/EFormidling/Implementation/DefaultEFormidlingService.cs
+++ b/src/Altinn.App.Core/EFormidling/Implementation/DefaultEFormidlingService.cs
@@ -252,7 +252,9 @@ public class DefaultEFormidlingService : IEFormidlingService
             await using Stream stream = await _dataClient.GetBinaryData(
                 instanceOwnerPartyId,
                 instanceGuid,
-                new Guid(dataElement.Id)
+                new Guid(dataElement.Id),
+                authenticationMethod: null,
+                CancellationToken.None
             );
 
             Debug.Assert(_eFormidlingClient is not null, "This is validated before use");

--- a/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
+++ b/src/Altinn.App.Core/Features/Action/SigningUserAction.cs
@@ -144,7 +144,11 @@ internal class SigningUserAction : IUserAction
 
             // Reloading instance data because we know that storage has added a binary data element to the instance.
             // This is a workaround until we have a better solution for this. Don't take it as inspiration.
-            Instance instance = await _instanceClient.GetInstance(context.Instance);
+            Instance instance = await _instanceClient.GetInstance(
+                context.Instance,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
             context.DataMutator.Instance.Data = instance.Data;
         }
         catch (PlatformHttpException)

--- a/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
+++ b/src/Altinn.App.Core/Features/Action/UniqueSignatureAuthorizer.cs
@@ -65,7 +65,9 @@ public class UniqueSignatureAuthorizer : IUserActionAuthorizer
                 appMetadata.AppIdentifier.App,
                 appMetadata.AppIdentifier.Org,
                 context.InstanceIdentifier.InstanceOwnerPartyId,
-                context.InstanceIdentifier.InstanceGuid
+                context.InstanceIdentifier.InstanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
             );
             var dataTypes = flowElement
                 .ExtensionElements
@@ -100,7 +102,9 @@ public class UniqueSignatureAuthorizer : IUserActionAuthorizer
         await using var data = await _dataClient.GetBinaryData(
             instanceIdentifier.InstanceOwnerPartyId,
             instanceIdentifier.InstanceGuid,
-            Guid.Parse(dataElement.Id)
+            Guid.Parse(dataElement.Id),
+            authenticationMethod: null,
+            CancellationToken.None
         );
         try
         {

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningReceiptService.cs
@@ -208,7 +208,9 @@ internal sealed class SigningReceiptService(
                         await dataClient.GetDataBytes(
                             instanceIdentifier.InstanceOwnerPartyId,
                             instanceIdentifier.InstanceGuid,
-                            Guid.Parse(element.Id)
+                            Guid.Parse(element.Id),
+                            authenticationMethod: null,
+                            CancellationToken.None
                         )
                     )
                     .Build()

--- a/src/Altinn.App.Core/Implementation/DefaultAppEvents.cs
+++ b/src/Altinn.App.Core/Implementation/DefaultAppEvents.cs
@@ -60,7 +60,7 @@ public class DefaultAppEvents : IAppEvents
             return;
         }
 
-        instance = await _instanceClient.GetInstance(instance);
+        instance = await _instanceClient.GetInstance(instance, authenticationMethod: null, CancellationToken.None);
         List<DataElement> elementsToDelete = instance.Data.Where(e => typesToDelete.Contains(e.DataType)).ToList();
 
         List<Task> deleteTasks = new();
@@ -71,7 +71,9 @@ public class DefaultAppEvents : IAppEvents
                     int.Parse(instance.InstanceOwner.PartyId, CultureInfo.InvariantCulture),
                     Guid.Parse(item.InstanceGuid),
                     Guid.Parse(item.Id),
-                    true
+                    true,
+                    authenticationMethod: null,
+                    CancellationToken.None
                 )
             );
         }

--- a/src/Altinn.App.Core/Internal/Data/DataService.cs
+++ b/src/Altinn.App.Core/Internal/Data/DataService.cs
@@ -62,7 +62,10 @@ internal class DataService : IDataService
             dataTypeId,
             "application/json",
             dataTypeId + ".json",
-            referenceStream
+            referenceStream,
+            generatedFromTask: null,
+            authenticationMethod: null,
+            cancellationToken: CancellationToken.None
         );
     }
 
@@ -82,7 +85,9 @@ internal class DataService : IDataService
             "application/json",
             dataTypeId + ".json",
             dataElementId,
-            referenceStream
+            referenceStream,
+            authenticationMethod: null,
+            CancellationToken.None
         );
     }
 
@@ -93,7 +98,9 @@ internal class DataService : IDataService
             instanceIdentifier.InstanceOwnerPartyId,
             instanceIdentifier.InstanceGuid,
             dataElementId,
-            false
+            false,
+            authenticationMethod: null,
+            CancellationToken.None
         );
     }
 
@@ -102,7 +109,9 @@ internal class DataService : IDataService
         Stream dataStream = await _dataClient.GetBinaryData(
             instanceIdentifier.InstanceOwnerPartyId,
             instanceIdentifier.InstanceGuid,
-            new Guid(dataElement.Id)
+            new Guid(dataElement.Id),
+            authenticationMethod: null,
+            CancellationToken.None
         );
         if (dataStream == null)
         {

--- a/src/Altinn.App.Core/Internal/Data/IDataClient.cs
+++ b/src/Altinn.App.Core/Internal/Data/IDataClient.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace Altinn.App.Core.Internal.Data;
 
-// [Obsolete] TODO: Remvoe default impememtations without authentication method and cancellation token when breaking binanry compatibility in next major version.
+// [Obsolete] TODO: Remove default implementations without authentication method and cancellation token when breaking binary compatibility in the next major version.
 
 /// <summary>
 /// Interface for data handling
@@ -498,7 +498,7 @@ public interface IDataClient
         DeleteData(org, app, instanceOwnerPartyId, instanceGuid, dataGuid, false);
 
     /// <summary>
-    /// Method that removes a data elemen from disk/storage immediatly or marks it as deleted.
+    /// Method that removes a data element from disk/storage immediately or marks it as deleted.
     /// </summary>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="app">Application identifier which is unique within an organisation.</param>
@@ -521,7 +521,7 @@ public interface IDataClient
     ) => DeleteData(instanceOwnerPartyId, instanceGuid, dataGuid, delay, authenticationMethod, cancellationToken);
 
     /// <summary>
-    /// Method that removes a data elemen from disk/storage immediatly or marks it as deleted.
+    /// Method that removes a data element from disk/storage immediately or marks it as deleted.
     /// </summary>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="app">Application identifier which is unique within an organisation.</param>
@@ -540,7 +540,7 @@ public interface IDataClient
     ) => DeleteData(org, app, instanceOwnerPartyId, instanceGuid, dataGuid, delay, null, default);
 
     /// <summary>
-    /// Method that removes a data elemen from disk/storage immediatly or marks it as deleted.
+    /// Method that removes a data element from disk/storage immediately or marks it as deleted.
     /// </summary>
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
     /// <param name="instanceGuid">The instance id</param>
@@ -558,7 +558,7 @@ public interface IDataClient
     );
 
     /// <summary>
-    /// Method that removes a data elemen from disk/storage immediatly or marks it as deleted.
+    /// Method that removes a data element from disk/storage immediately or marks it as deleted.
     /// </summary>
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
     /// <param name="instanceGuid">The instance id</param>
@@ -696,7 +696,7 @@ public interface IDataClient
     /// <summary>
     /// Insert a binary data element.
     /// </summary>
-    /// <param name="instanceId">isntanceId = {instanceOwnerPartyId}/{instanceGuid}</param>
+    /// <param name="instanceId">instanceId = {instanceOwnerPartyId}/{instanceGuid}</param>
     /// <param name="dataType">data type</param>
     /// <param name="contentType">content type</param>
     /// <param name="filename">filename</param>
@@ -718,7 +718,7 @@ public interface IDataClient
     /// <summary>
     /// Insert a binary data element.
     /// </summary>
-    /// <param name="instanceId">isntanceId = {instanceOwnerPartyId}/{instanceGuid}</param>
+    /// <param name="instanceId">instanceId = {instanceOwnerPartyId}/{instanceGuid}</param>
     /// <param name="dataType">data type</param>
     /// <param name="contentType">content type</param>
     /// <param name="filename">filename</param>
@@ -736,7 +736,7 @@ public interface IDataClient
     /// <summary>
     /// Insert a binary data element.
     /// </summary>
-    /// <param name="instanceId">isntanceId = {instanceOwnerPartyId}/{instanceGuid}</param>
+    /// <param name="instanceId">instanceId = {instanceOwnerPartyId}/{instanceGuid}</param>
     /// <param name="dataType">data type</param>
     /// <param name="contentType">content type</param>
     /// <param name="filename">filename</param>

--- a/src/Altinn.App.Core/Internal/Data/IDataClient.cs
+++ b/src/Altinn.App.Core/Internal/Data/IDataClient.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Http;
 
 namespace Altinn.App.Core.Internal.Data;
 
+// [Obsolete] TODO: Remvoe default impememtations without authentication method and cancellation token when breaking binanry compatibility in next major version.
+
 /// <summary>
 /// Interface for data handling
 /// </summary>
@@ -38,6 +40,30 @@ public interface IDataClient
         where T : notnull;
 
     /// <summary>
+    /// Stores the form model
+    /// </summary>
+    /// <typeparam name="T">The type</typeparam>
+    /// <param name="dataToSerialize">The app model to serialize</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="type">The type for serialization</param>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="dataType">The data type to create, must be a valid data type defined in application metadata</param>
+    [Obsolete("Use InsertFormData with Instance parameter instead")]
+    Task<DataElement> InsertFormData<T>(
+        T dataToSerialize,
+        Guid instanceGuid,
+        Type type,
+        string org,
+        string app,
+        int instanceOwnerPartyId,
+        string dataType
+    )
+        where T : notnull =>
+        InsertFormData(dataToSerialize, instanceGuid, type, org, app, instanceOwnerPartyId, dataType, null, default);
+
+    /// <summary>
     /// Stores the form
     /// </summary>
     /// <typeparam name="T">The model type</typeparam>
@@ -69,6 +95,19 @@ public interface IDataClient
     }
 
     /// <summary>
+    /// Stores the form
+    /// </summary>
+    /// <typeparam name="T">The model type</typeparam>
+    /// <param name="instance">The instance that the data element belongs to</param>
+    /// <param name="dataTypeString">The data type with requirements</param>
+    /// <param name="dataToSerialize">The data element instance</param>
+    /// <param name="type">The class type describing the data</param>
+    /// <returns>The data element metadata</returns>
+    [Obsolete("Use the overload without Type parameter")]
+    Task<DataElement> InsertFormData<T>(Instance instance, string dataTypeString, T dataToSerialize, Type type)
+        where T : notnull => InsertFormData(instance, dataTypeString, dataToSerialize, type, null, default);
+
+    /// <summary>
     /// Creates a new data element for the given instance and data model
     /// </summary>
     /// <param name="instance">The instance to add the element to</param>
@@ -84,6 +123,16 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Creates a new data element for the given instance and data model
+    /// </summary>
+    /// <param name="instance">The instance to add the element to</param>
+    /// <param name="dataTypeId">The id of the data type to add</param>
+    /// <param name="dataToSerialize">An instance of the class for the form data</param>
+    /// <returns></returns>
+    Task<DataElement> InsertFormData(Instance instance, string dataTypeId, object dataToSerialize) =>
+        InsertFormData(instance, dataTypeId, dataToSerialize, null, default);
 
     /// <summary>
     /// updates the form data
@@ -115,6 +164,30 @@ public interface IDataClient
     /// <summary>
     /// updates the form data
     /// </summary>
+    /// <typeparam name="T">The type</typeparam>
+    /// <param name="dataToSerialize">The form data to serialize</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="type">The type for serialization</param>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="dataId">the data id</param>
+    [Obsolete("Use the UpdateFormData method with Instance parameter instead")]
+    Task<DataElement> UpdateData<T>(
+        T dataToSerialize,
+        Guid instanceGuid,
+        Type type,
+        string org,
+        string app,
+        int instanceOwnerPartyId,
+        Guid dataId
+    )
+        where T : notnull =>
+        UpdateData(dataToSerialize, instanceGuid, type, org, app, instanceOwnerPartyId, dataId, null, default);
+
+    /// <summary>
+    /// updates the form data
+    /// </summary>
     /// <param name="instance">The instance</param>
     /// <param name="dataToSerialize">The form data to serialize</param>
     /// <param name="dataElement">The data element</param>
@@ -127,6 +200,15 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// updates the form data
+    /// </summary>
+    /// <param name="instance">The instance</param>
+    /// <param name="dataToSerialize">The form data to serialize</param>
+    /// <param name="dataElement">The data element</param>
+    Task<DataElement> UpdateFormData(Instance instance, object dataToSerialize, DataElement dataElement) =>
+        UpdateFormData(instance, dataToSerialize, dataElement, null, default);
 
     /// <summary>
     /// Gets the form data
@@ -152,6 +234,25 @@ public interface IDataClient
     );
 
     /// <summary>
+    /// Gets the form data
+    /// </summary>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="type">The type for serialization</param>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="dataId">the data id</param>
+    [Obsolete("Use the overload with Instance parameter instead")]
+    Task<object> GetFormData(
+        Guid instanceGuid,
+        Type type,
+        string org,
+        string app,
+        int instanceOwnerPartyId,
+        Guid dataId
+    ) => GetFormData(instanceGuid, type, org, app, instanceOwnerPartyId, dataId, null, default);
+
+    /// <summary>
     /// Gets the deserialized form data
     /// </summary>
     /// <param name="instance">The instance</param>
@@ -167,8 +268,17 @@ public interface IDataClient
     );
 
     /// <summary>
+    /// Gets the deserialized form data
+    /// </summary>
+    /// <param name="instance">The instance</param>
+    /// <param name="dataElement">The data element</param>
+    /// <returns></returns>
+    Task<object> GetFormData(Instance instance, DataElement dataElement) =>
+        GetFormData(instance, dataElement, null, default);
+
+    /// <summary>
     /// Gets the data as is. Note: This method buffers the entire response in memory before returning the stream.
-    /// For memory-efficient processing of large files, use <see cref="GetBinaryDataStream"/> instead.
+    /// For memory-efficient processing of large files, use <see cref="GetBinaryDataStream(int, Guid, Guid, StorageAuthenticationMethod?, TimeSpan?, CancellationToken)"/> instead.
     /// </summary>
     /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
     /// <param name="app">Application identifier which is unique within an organisation.</param>
@@ -189,6 +299,19 @@ public interface IDataClient
     ) => GetBinaryData(instanceOwnerPartyId, instanceGuid, dataId, authenticationMethod, cancellationToken);
 
     /// <summary>
+    /// Gets the data as is. Note: This method buffers the entire response in memory before returning the stream.
+    /// For memory-efficient processing of large files, use <see cref="GetBinaryDataStream(int,Guid,Guid,Altinn.App.Core.Features.StorageAuthenticationMethod?,TimeSpan?,CancellationToken)"/> instead.
+    /// </summary>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataId">the data id</param>
+    [Obsolete("Org and App parameters are not used, use the overload without these parameters")]
+    Task<Stream> GetBinaryData(string org, string app, int instanceOwnerPartyId, Guid instanceGuid, Guid dataId) =>
+        GetBinaryData(instanceOwnerPartyId, instanceGuid, dataId, null, default);
+
+    /// <summary>
     /// Gets the data as is.
     /// </summary>
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
@@ -203,6 +326,15 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Gets the data as is.
+    /// </summary>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataId">the data id</param>
+    Task<Stream> GetBinaryData(int instanceOwnerPartyId, Guid instanceGuid, Guid dataId) =>
+        GetBinaryData(instanceOwnerPartyId, instanceGuid, dataId, null, default);
 
     /// <summary>
     /// Gets the data as an unbuffered stream for memory-efficient processing of large files.
@@ -223,6 +355,17 @@ public interface IDataClient
         TimeSpan? timeout = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Gets the data as an unbuffered stream for memory-efficient processing of large files.
+    /// Throws <see cref="Altinn.App.Core.Helpers.PlatformHttpException"/> if the data element is not found or other HTTP errors occur.
+    /// </summary>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataId">the data id</param>
+    /// <exception cref="Altinn.App.Core.Helpers.PlatformHttpException">Thrown when the data element is not found or other HTTP errors occur</exception>
+    Task<Stream> GetBinaryDataStream(int instanceOwnerPartyId, Guid instanceGuid, Guid dataId) =>
+        GetBinaryDataStream(instanceOwnerPartyId, instanceGuid, dataId, null, null, default);
 
     /// <summary>
     /// Similar to GetBinaryData, but returns the raw bytes instead of a cached stream
@@ -249,6 +392,19 @@ public interface IDataClient
     /// <summary>
     /// Similar to GetBinaryData, but returns the raw bytes instead of a cached stream
     /// </summary>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataId">the data id</param>
+    /// <returns>The raw HttpResponseMessage from the call to platform</returns>
+    [Obsolete("Org and App parameters are not used, use the overload without these parameters")]
+    Task<byte[]> GetDataBytes(string org, string app, int instanceOwnerPartyId, Guid instanceGuid, Guid dataId) =>
+        GetDataBytes(org, app, instanceOwnerPartyId, instanceGuid, dataId, null, default);
+
+    /// <summary>
+    /// Similar to GetBinaryData, but returns the raw bytes instead of a cached stream
+    /// </summary>
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
     /// <param name="instanceGuid">The instance id</param>
     /// <param name="dataId">the data id</param>
@@ -262,6 +418,16 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Similar to GetBinaryData, but returns the raw bytes instead of a cached stream
+    /// </summary>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataId">the data id</param>
+    /// <returns>The raw bytes from storage</returns>
+    Task<byte[]> GetDataBytes(int instanceOwnerPartyId, Guid instanceGuid, Guid dataId) =>
+        GetDataBytes(instanceOwnerPartyId, instanceGuid, dataId, null, default);
 
     /// <summary>
     /// Method that gets metadata on form attachments ordered by attachmentType
@@ -286,6 +452,18 @@ public interface IDataClient
     /// <summary>
     /// Method that gets metadata on form attachments ordered by attachmentType
     /// </summary>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <returns>A list with attachments metadata ordered by attachmentType</returns>
+    [Obsolete("Org and App parameters are not used, use the overload without these parameters")]
+    Task<List<AttachmentList>> GetBinaryDataList(string org, string app, int instanceOwnerPartyId, Guid instanceGuid) =>
+        GetBinaryDataList(instanceOwnerPartyId, instanceGuid, null, default);
+
+    /// <summary>
+    /// Method that gets metadata on form attachments ordered by attachmentType
+    /// </summary>
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
     /// <param name="instanceGuid">The instance id</param>
     /// <param name="authenticationMethod">An optional specification of the authentication method to use for requests</param>
@@ -297,6 +475,15 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Method that gets metadata on form attachments ordered by attachmentType
+    /// </summary>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <returns>A list with attachments metadata ordered by attachmentType</returns>
+    Task<List<AttachmentList>> GetBinaryDataList(int instanceOwnerPartyId, Guid instanceGuid) =>
+        GetBinaryDataList(instanceOwnerPartyId, instanceGuid, null, default);
 
     /// <summary>
     /// Method that removes a form attachments from disk/storage
@@ -336,6 +523,25 @@ public interface IDataClient
     /// <summary>
     /// Method that removes a data elemen from disk/storage immediatly or marks it as deleted.
     /// </summary>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataGuid">The attachment id</param>
+    /// <param name="delay">A boolean indicating whether or not the delete should be executed immediately or delayed</param>
+    [Obsolete("Use the overload without org and app parameters")]
+    Task<bool> DeleteData(
+        string org,
+        string app,
+        int instanceOwnerPartyId,
+        Guid instanceGuid,
+        Guid dataGuid,
+        bool delay
+    ) => DeleteData(org, app, instanceOwnerPartyId, instanceGuid, dataGuid, delay, null, default);
+
+    /// <summary>
+    /// Method that removes a data elemen from disk/storage immediatly or marks it as deleted.
+    /// </summary>
     /// <param name="instanceOwnerPartyId">The instance owner id</param>
     /// <param name="instanceGuid">The instance id</param>
     /// <param name="dataGuid">The attachment id</param>
@@ -350,6 +556,16 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Method that removes a data elemen from disk/storage immediatly or marks it as deleted.
+    /// </summary>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataGuid">The attachment id</param>
+    /// <param name="delay">A boolean indicating whether or not the delete should be executed immediately or delayed</param>
+    Task<bool> DeleteData(int instanceOwnerPartyId, Guid instanceGuid, Guid dataGuid, bool delay) =>
+        DeleteData(instanceOwnerPartyId, instanceGuid, dataGuid, delay, null, default);
 
     /// <summary>
     /// Method that saves a form attachments to disk/storage and returns the new data element.
@@ -373,6 +589,25 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Method that saves a form attachments to disk/storage and returns the new data element.
+    /// </summary>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataType">The data type to create, must be a valid data type defined in application metadata</param>
+    /// <param name="request">Http request containing the attachment to be saved</param>
+    [Obsolete("The overload that takes a HttpRequest is deprecated, use the overload that takes a Stream instead")]
+    Task<DataElement> InsertBinaryData(
+        string org,
+        string app,
+        int instanceOwnerPartyId,
+        Guid instanceGuid,
+        string dataType,
+        HttpRequest request
+    ) => InsertBinaryData(org, app, instanceOwnerPartyId, instanceGuid, dataType, request, null, default);
 
     /// <summary>
     /// Method that updates a form attachments to disk/storage and returns the updated data element.
@@ -403,6 +638,28 @@ public interface IDataClient
     /// <summary>
     /// Method that updates a form attachments to disk/storage and returns the updated data element.
     /// </summary>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceOwnerPartyId">The instance owner id</param>
+    /// <param name="instanceGuid">The instance id</param>
+    /// <param name="dataGuid">The data id</param>
+    /// <param name="request">Http request containing the attachment to be saved</param>
+    [Obsolete(
+        message: "Deprecated please use UpdateBinaryData(InstanceIdentifier, string, string, Guid, Stream) instead",
+        error: false
+    )]
+    Task<DataElement> UpdateBinaryData(
+        string org,
+        string app,
+        int instanceOwnerPartyId,
+        Guid instanceGuid,
+        Guid dataGuid,
+        HttpRequest request
+    ) => UpdateBinaryData(org, app, instanceOwnerPartyId, instanceGuid, dataGuid, request, null, default);
+
+    /// <summary>
+    /// Method that updates a form attachments to disk/storage and returns the updated data element.
+    /// </summary>
     /// <param name="instanceIdentifier">Instance identifier instanceOwnerPartyId and instanceGuid</param>
     /// <param name="contentType">Content type of the updated binary data</param>
     /// <param name="filename">Filename of the updated binary data</param>
@@ -419,6 +676,22 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Method that updates a form attachments to disk/storage and returns the updated data element.
+    /// </summary>
+    /// <param name="instanceIdentifier">Instance identifier instanceOwnerPartyId and instanceGuid</param>
+    /// <param name="contentType">Content type of the updated binary data</param>
+    /// <param name="filename">Filename of the updated binary data</param>
+    /// <param name="dataGuid">Guid of the data element to update</param>
+    /// <param name="stream">Updated binary data</param>
+    Task<DataElement> UpdateBinaryData(
+        InstanceIdentifier instanceIdentifier,
+        string? contentType,
+        string? filename,
+        Guid dataGuid,
+        Stream stream
+    ) => UpdateBinaryData(instanceIdentifier, contentType, filename, dataGuid, stream, null, default);
 
     /// <summary>
     /// Insert a binary data element.
@@ -443,6 +716,40 @@ public interface IDataClient
     );
 
     /// <summary>
+    /// Insert a binary data element.
+    /// </summary>
+    /// <param name="instanceId">isntanceId = {instanceOwnerPartyId}/{instanceGuid}</param>
+    /// <param name="dataType">data type</param>
+    /// <param name="contentType">content type</param>
+    /// <param name="filename">filename</param>
+    /// <param name="stream">the stream to stream</param>
+    /// <param name="generatedFromTask">Optional field to set what task the binary data was generated from</param>
+    Task<DataElement> InsertBinaryData(
+        string instanceId,
+        string dataType,
+        string contentType,
+        string? filename,
+        Stream stream,
+        string? generatedFromTask
+    ) => InsertBinaryData(instanceId, dataType, contentType, filename, stream, generatedFromTask, null, default);
+
+    /// <summary>
+    /// Insert a binary data element.
+    /// </summary>
+    /// <param name="instanceId">isntanceId = {instanceOwnerPartyId}/{instanceGuid}</param>
+    /// <param name="dataType">data type</param>
+    /// <param name="contentType">content type</param>
+    /// <param name="filename">filename</param>
+    /// <param name="stream">the stream to stream</param>
+    Task<DataElement> InsertBinaryData(
+        string instanceId,
+        string dataType,
+        string contentType,
+        string? filename,
+        Stream stream
+    ) => InsertBinaryData(instanceId, dataType, contentType, filename, stream, null, null, default);
+
+    /// <summary>
     /// Updates the data element metadata object.
     /// </summary>
     /// <param name="instance">The instance which is not updated</param>
@@ -456,6 +763,15 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Updates the data element metadata object.
+    /// </summary>
+    /// <param name="instance">The instance which is not updated</param>
+    /// <param name="dataElement">The data element with values to update</param>
+    /// <returns>the updated data element</returns>
+    Task<DataElement> Update(Instance instance, DataElement dataElement) =>
+        Update(instance, dataElement, null, default);
 
     /// <summary>
     /// Lock data element in storage
@@ -472,6 +788,14 @@ public interface IDataClient
     );
 
     /// <summary>
+    /// Lock data element in storage
+    /// </summary>
+    /// <param name="instanceIdentifier">InstanceIdentifier identifying the instance containing the DataElement to lock</param>
+    /// <param name="dataGuid">Id of the DataElement to lock</param>
+    Task<DataElement> LockDataElement(InstanceIdentifier instanceIdentifier, Guid dataGuid) =>
+        LockDataElement(instanceIdentifier, dataGuid, null, default);
+
+    /// <summary>
     /// Unlock data element in storage
     /// </summary>
     /// <param name="instanceIdentifier">InstanceIdentifier identifying the instance containing the DataElement to unlock</param>
@@ -484,6 +808,14 @@ public interface IDataClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Unlock data element in storage
+    /// </summary>
+    /// <param name="instanceIdentifier">InstanceIdentifier identifying the instance containing the DataElement to unlock</param>
+    /// <param name="dataGuid">Id of the DataElement to unlock</param>
+    Task<DataElement> UnlockDataElement(InstanceIdentifier instanceIdentifier, Guid dataGuid) =>
+        UnlockDataElement(instanceIdentifier, dataGuid, null, default);
 }
 
 /// <summary>

--- a/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
+++ b/src/Altinn.App.Core/Internal/Data/InstanceDataUnitOfWork.cs
@@ -696,7 +696,9 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             await _instanceClient.UpdatePresentationTexts(
                 int.Parse(Instance.Id.Split("/")[0], CultureInfo.InvariantCulture),
                 Guid.Parse(Instance.Id.Split("/")[1]),
-                new PresentationTexts { Texts = updatedTexts }
+                new PresentationTexts { Texts = updatedTexts },
+                authenticationMethod: null,
+                CancellationToken.None
             );
 
             // Maintain local copy of presentation texts
@@ -725,7 +727,9 @@ internal sealed class InstanceDataUnitOfWork : IInstanceDataMutator
             await _instanceClient.UpdateDataValues(
                 int.Parse(Instance.Id.Split("/")[0], CultureInfo.InvariantCulture),
                 Guid.Parse(Instance.Id.Split("/")[1]),
-                new DataValues { Values = updatedValues }
+                new DataValues { Values = updatedValues },
+                authenticationMethod: null,
+                CancellationToken.None
             );
 
             // Maintain local copy of data values

--- a/src/Altinn.App.Core/Internal/Instances/IInstanceClient.cs
+++ b/src/Altinn.App.Core/Internal/Instances/IInstanceClient.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Primitives;
 
 namespace Altinn.App.Core.Internal.Instances;
 
+// [Obsolete] TODO: Remvoe default impememtations without authentication method and cancellation token when breaking binanry compatibility in next major version.
+
 /// <summary>
 /// Interface for handling form data related operations
 /// </summary>
@@ -23,6 +25,12 @@ public interface IInstanceClient
     );
 
     /// <summary>
+    /// Gets the instance
+    /// </summary>
+    Task<Instance> GetInstance(string app, string org, int instanceOwnerPartyId, Guid instanceId) =>
+        GetInstance(app, org, instanceOwnerPartyId, instanceId, null, default);
+
+    /// <summary>
     /// Gets the instance anew. Instance must have set appId, instanceOwner.PartyId and Id.
     /// </summary>
     Task<Instance> GetInstance(
@@ -30,6 +38,11 @@ public interface IInstanceClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// Gets the instance anew. Instance must have set appId, instanceOwner.PartyId and Id.
+    /// </summary>
+    Task<Instance> GetInstance(Instance instance) => GetInstance(instance, null, default);
 
     /// <summary>
     /// Gets a list of instances based on a dictionary of provided query parameters.
@@ -41,6 +54,12 @@ public interface IInstanceClient
     );
 
     /// <summary>
+    /// Gets a list of instances based on a dictionary of provided query parameters.
+    /// </summary>
+    Task<List<Instance>> GetInstances(Dictionary<string, StringValues> queryParams) =>
+        GetInstances(queryParams, null, default);
+
+    /// <summary>
     /// Updates the process model of the instance and returns the updated instance.
     /// </summary>
     Task<Instance> UpdateProcess(
@@ -48,6 +67,11 @@ public interface IInstanceClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// Updates the process model of the instance and returns the updated instance.
+    /// </summary>
+    Task<Instance> UpdateProcess(Instance instance) => UpdateProcess(instance, null, default);
 
     /// <summary>
     /// Updates the process model of the instance and the instance events and returns the updated instance.
@@ -58,6 +82,12 @@ public interface IInstanceClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// Updates the process model of the instance and the instance events and returns the updated instance.
+    /// </summary>
+    Task<Instance> UpdateProcessAndEvents(Instance instance, List<InstanceEvent> events) =>
+        UpdateProcessAndEvents(instance, events, null, default);
 
     /// <summary>
     /// Creates an instance of an application with no data.
@@ -75,6 +105,16 @@ public interface IInstanceClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// Creates an instance of an application with no data.
+    /// </summary>
+    /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+    /// <param name="app">Application identifier which is unique within an organisation.</param>
+    /// <param name="instanceTemplate">the instance template to create (must have instanceOwner with partyId, personNumber or organisationNumber set)</param>
+    /// <returns>The created instance</returns>
+    Task<Instance> CreateInstance(string org, string app, Instance instanceTemplate) =>
+        CreateInstance(org, app, instanceTemplate, null, default);
 
     /// <summary>
     /// Add complete confirmation.
@@ -97,6 +137,20 @@ public interface IInstanceClient
     );
 
     /// <summary>
+    /// Add complete confirmation.
+    /// </summary>
+    /// <remarks>
+    /// Add to an instance that a given stakeholder considers the instance as no longer needed by them. The stakeholder has
+    /// collected all the data and information they needed from the instance and expect no additional data to be added to it.
+    /// The body of the request isn't used for anything despite this being a POST operation.
+    /// </remarks>
+    /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
+    /// <param name="instanceGuid">The id of the instance to confirm as complete.</param>
+    /// <returns>Returns the updated instance.</returns>
+    Task<Instance> AddCompleteConfirmation(int instanceOwnerPartyId, Guid instanceGuid) =>
+        AddCompleteConfirmation(instanceOwnerPartyId, instanceGuid, null, default);
+
+    /// <summary>
     /// Update read status.
     /// </summary>
     /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
@@ -114,6 +168,16 @@ public interface IInstanceClient
     );
 
     /// <summary>
+    /// Update read status.
+    /// </summary>
+    /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
+    /// <param name="instanceGuid">The id of the instance to confirm as complete.</param>
+    /// <param name="readStatus">The new instance read status.</param>
+    /// <returns>Returns the updated instance.</returns>
+    Task<Instance> UpdateReadStatus(int instanceOwnerPartyId, Guid instanceGuid, string readStatus) =>
+        UpdateReadStatus(instanceOwnerPartyId, instanceGuid, readStatus, null, default);
+
+    /// <summary>
     /// Update substatus.
     /// </summary>
     /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
@@ -129,6 +193,16 @@ public interface IInstanceClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// Update substatus.
+    /// </summary>
+    /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
+    /// <param name="instanceGuid">The id of the instance to be updated.</param>
+    /// <param name="substatus">The new substatus.</param>
+    /// <returns>Returns the updated instance.</returns>
+    Task<Instance> UpdateSubstatus(int instanceOwnerPartyId, Guid instanceGuid, Substatus substatus) =>
+        UpdateSubstatus(instanceOwnerPartyId, instanceGuid, substatus, null, default);
 
     /// <summary>
     /// Update presentation texts.
@@ -151,6 +225,22 @@ public interface IInstanceClient
     );
 
     /// <summary>
+    /// Update presentation texts.
+    /// </summary>
+    /// <remarks>
+    /// The provided presentation texts will be merged with the existing collection of presentation texts on the instance.
+    /// </remarks>
+    /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
+    /// <param name="instanceGuid">The id of the instance to update presentation texts for.</param>
+    /// <param name="presentationTexts">The presentation texts</param>
+    /// <returns>Returns the updated instance.</returns>
+    Task<Instance> UpdatePresentationTexts(
+        int instanceOwnerPartyId,
+        Guid instanceGuid,
+        PresentationTexts presentationTexts
+    ) => UpdatePresentationTexts(instanceOwnerPartyId, instanceGuid, presentationTexts, null, default);
+
+    /// <summary>
     /// Update data values.
     /// </summary>
     /// <remarks>
@@ -169,6 +259,19 @@ public interface IInstanceClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// Update data values.
+    /// </summary>
+    /// <remarks>
+    /// The provided data values will be merged with the existing collection of data values on the instance.
+    /// </remarks>
+    /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
+    /// <param name="instanceGuid">The id of the instance to update data values for.</param>
+    /// <param name="dataValues">The data values</param>
+    /// <returns>Returns the updated instance.</returns>
+    Task<Instance> UpdateDataValues(int instanceOwnerPartyId, Guid instanceGuid, DataValues dataValues) =>
+        UpdateDataValues(instanceOwnerPartyId, instanceGuid, dataValues, null, default);
 
     /// <summary>
     /// Update data data values.
@@ -199,6 +302,18 @@ public interface IInstanceClient
     }
 
     /// <summary>
+    /// Update data data values.
+    /// </summary>
+    /// <remarks>
+    /// The provided data value will be added with the existing collection of data values on the instance.
+    /// </remarks>
+    /// <param name="instance">The instance</param>
+    /// <param name="dataValues">The data value (null unsets the value)</param>
+    /// <returns>Returns the updated instance.</returns>
+    async Task<Instance> UpdateDataValues(Instance instance, Dictionary<string, string?> dataValues) =>
+        await UpdateDataValues(instance, dataValues, null, default);
+
+    /// <summary>
     /// Update single data value.
     /// </summary>
     /// <remarks>
@@ -227,6 +342,19 @@ public interface IInstanceClient
     }
 
     /// <summary>
+    /// Update single data value.
+    /// </summary>
+    /// <remarks>
+    /// The provided data value will be added with the existing collection of data values on the instance.
+    /// </remarks>
+    /// <param name="instance">The instance</param>
+    /// <param name="key">The key of the DataValues collection to be updated.</param>
+    /// <param name="value">The data value (null unsets the value)</param>
+    /// <returns>Returns the updated instance.</returns>
+    async Task<Instance> UpdateDataValue(Instance instance, string key, string? value) =>
+        await UpdateDataValue(instance, key, value, null, default);
+
+    /// <summary>
     /// Delete instance.
     /// </summary>
     /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
@@ -242,4 +370,14 @@ public interface IInstanceClient
         StorageAuthenticationMethod? authenticationMethod = null,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// Delete instance.
+    /// </summary>
+    /// <param name="instanceOwnerPartyId">The party id of the instance owner.</param>
+    /// <param name="instanceGuid">The id of the instance to delete.</param>
+    /// <param name="hard">Boolean to indicate if instance should be hard deleted.</param>
+    /// <returns>Returns the deleted instance.</returns>
+    Task<Instance> DeleteInstance(int instanceOwnerPartyId, Guid instanceGuid, bool hard) =>
+        DeleteInstance(instanceOwnerPartyId, instanceGuid, hard, null, default);
 }

--- a/src/Altinn.App.Core/Internal/Instances/IInstanceClient.cs
+++ b/src/Altinn.App.Core/Internal/Instances/IInstanceClient.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Altinn.App.Core.Internal.Instances;
 
-// [Obsolete] TODO: Remvoe default impememtations without authentication method and cancellation token when breaking binanry compatibility in next major version.
+// [Obsolete] TODO: Remove default implementations without authentication method and cancellation token when breaking binary compatibility in the next major version.
 
 /// <summary>
 /// Interface for handling form data related operations

--- a/src/Altinn.App.Core/Internal/Process/EventHandlers/EndEventEventHandler.cs
+++ b/src/Altinn.App.Core/Internal/Process/EventHandlers/EndEventEventHandler.cs
@@ -50,7 +50,13 @@ public class EndEventEventHandler : IEndEventEventHandler
         if (applicationMetadata.AutoDeleteOnProcessEnd && instance.Process?.Ended != null)
         {
             int instanceOwnerPartyId = int.Parse(instance.InstanceOwner.PartyId, CultureInfo.InvariantCulture);
-            await _instanceClient.DeleteInstance(instanceOwnerPartyId, instanceIdentifier.InstanceGuid, true);
+            await _instanceClient.DeleteInstance(
+                instanceOwnerPartyId,
+                instanceIdentifier.InstanceGuid,
+                true,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
         }
     }
 }

--- a/src/Altinn.App.Core/Internal/Process/ProcessEventDispatcher.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessEventDispatcher.cs
@@ -36,7 +36,12 @@ public class ProcessEventDispatcher : IProcessEventDispatcher
     /// <inheritdoc/>
     public async Task<Instance> DispatchToStorage(Instance instance, List<InstanceEvent>? events)
     {
-        Instance updatedInstance = await _instanceClient.UpdateProcessAndEvents(instance, events ?? []);
+        Instance updatedInstance = await _instanceClient.UpdateProcessAndEvents(
+            instance,
+            events ?? [],
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         return updatedInstance;
     }

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskCleaner.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskCleaner.cs
@@ -42,7 +42,9 @@ internal sealed class ProcessTaskCleaner : IProcessTaskCleaner
                 instanceIdentifier.InstanceOwnerPartyId,
                 instanceIdentifier.InstanceGuid,
                 Guid.Parse(dataElement.Id),
-                false
+                false,
+                authenticationMethod: null,
+                CancellationToken.None
             );
 
             instance.Data?.Remove(dataElement);

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskDataLocker.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskDataLocker.cs
@@ -33,7 +33,12 @@ public class ProcessTaskDataLocker : IProcessTaskDataLocker
             List<DataElement> dataElements = instance.Data.FindAll(de => de.DataType == dataType.Id);
             foreach (DataElement dataElement in dataElements)
             {
-                await _dataClient.UnlockDataElement(instanceIdentifier, Guid.Parse(dataElement.Id));
+                await _dataClient.UnlockDataElement(
+                    instanceIdentifier,
+                    Guid.Parse(dataElement.Id),
+                    authenticationMethod: null,
+                    CancellationToken.None
+                );
             }
         }
     }
@@ -49,7 +54,12 @@ public class ProcessTaskDataLocker : IProcessTaskDataLocker
             List<DataElement> dataElements = instance.Data.FindAll(de => de.DataType == dataType.Id);
             foreach (DataElement dataElement in dataElements)
             {
-                await _dataClient.LockDataElement(instanceIdentifier, Guid.Parse(dataElement.Id));
+                await _dataClient.LockDataElement(
+                    instanceIdentifier,
+                    Guid.Parse(dataElement.Id),
+                    authenticationMethod: null,
+                    CancellationToken.None
+                );
             }
         }
     }

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskInitializer.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/ProcessTaskInitializer.cs
@@ -90,7 +90,13 @@ public class ProcessTaskInitializer : IProcessTaskInitializer
             ObjectUtils.InitializeAltinnRowId(data);
             ObjectUtils.PrepareModelForXmlStorage(data);
 
-            DataElement createdDataElement = await _dataClient.InsertFormData(instance, dataType.Id, data);
+            DataElement createdDataElement = await _dataClient.InsertFormData(
+                instance,
+                dataType.Id,
+                data,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
             instance.Data ??= [];
             instance.Data.Add(createdDataElement);
 
@@ -116,7 +122,9 @@ public class ProcessTaskInitializer : IProcessTaskInitializer
             Instance updatedInstance = await _instanceClient.UpdatePresentationTexts(
                 int.Parse(instance.Id.Split("/")[0], CultureInfo.InvariantCulture),
                 Guid.Parse(instance.Id.Split("/")[1]),
-                new PresentationTexts { Texts = updatedValues }
+                new PresentationTexts { Texts = updatedValues },
+                authenticationMethod: null,
+                CancellationToken.None
             );
 
             instance.PresentationTexts = updatedInstance.PresentationTexts;
@@ -138,7 +146,9 @@ public class ProcessTaskInitializer : IProcessTaskInitializer
             Instance updatedInstance = await _instanceClient.UpdateDataValues(
                 int.Parse(instance.Id.Split("/")[0], CultureInfo.InvariantCulture),
                 Guid.Parse(instance.Id.Split("/")[1]),
-                new DataValues { Values = updatedValues }
+                new DataValues { Values = updatedValues },
+                authenticationMethod: null,
+                CancellationToken.None
             );
 
             instance.DataValues = updatedInstance.DataValues;

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/PaymentProcessTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/PaymentProcessTask.cs
@@ -87,7 +87,9 @@ internal sealed class PaymentProcessTask : IProcessTask
             PdfContentType,
             ReceiptFileName,
             pdfStream,
-            taskId
+            taskId,
+            authenticationMethod: null,
+            CancellationToken.None
         );
     }
 

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/ServiceTasks/Legacy/EformidlingServiceTaskLegacy.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/ServiceTasks/Legacy/EformidlingServiceTaskLegacy.cs
@@ -60,7 +60,11 @@ internal class EformidlingServiceTaskLegacy : IEFormidlingServiceTaskLegacy
         {
             if (_eFormidlingService != null)
             {
-                Instance updatedInstance = await _instanceClient.GetInstance(instance);
+                Instance updatedInstance = await _instanceClient.GetInstance(
+                    instance,
+                    authenticationMethod: null,
+                    CancellationToken.None
+                );
                 await _eFormidlingService.SendEFormidlingShipment(updatedInstance);
             }
             else

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/SigningProcessTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/SigningProcessTask.cs
@@ -101,7 +101,9 @@ internal sealed class SigningProcessTask : IProcessTask
                 PdfContentType,
                 signingPdfDataType + ".pdf",
                 pdfStream,
-                taskId
+                taskId,
+                authenticationMethod: null,
+                CancellationToken.None
             );
         }
     }

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.cs
@@ -565,7 +565,14 @@ public class ProcessControllerTests : ApiTestBase, IClassFixture<WebApplicationF
         if (saveToDataType is not null)
         {
             var instanceClient = Services.GetRequiredService<IInstanceClient>();
-            var instance = await instanceClient.GetInstance(App, Org, InstanceOwnerPartyId, _instanceGuid);
+            var instance = await instanceClient.GetInstance(
+                App,
+                Org,
+                InstanceOwnerPartyId,
+                _instanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
             var copyDataGuid = Guid.Parse(instance.Data.Single(de => de.DataType == saveToDataType).Id);
             dataPath = TestData.GetDataBlobPath(Org, App, InstanceOwnerPartyId, _instanceGuid, copyDataGuid);
         }

--- a/test/Altinn.App.Api.Tests/Mocks/PepWithPDPAuthorizationMockSI.cs
+++ b/test/Altinn.App.Api.Tests/Mocks/PepWithPDPAuthorizationMockSI.cs
@@ -110,7 +110,9 @@ public class PepWithPDPAuthorizationMockSI : Altinn.Common.PEP.Interfaces.IPDP
                 resourceAttributes.AppValue,
                 resourceAttributes.OrgValue,
                 Convert.ToInt32(resourceAttributes.InstanceValue.Split('/')[0]),
-                new Guid(resourceAttributes.InstanceValue.Split('/')[1])
+                new Guid(resourceAttributes.InstanceValue.Split('/')[1]),
+                authenticationMethod: null,
+                CancellationToken.None
             );
 
             if (instanceData != null)

--- a/test/Altinn.App.Core.Tests/Eformidling/Implementation/DefaultEFormidlingServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Eformidling/Implementation/DefaultEFormidlingServiceTests.cs
@@ -62,21 +62,21 @@ public class DefaultEFormidlingServiceTests
         services.AddAppImplementationFactory();
         services.AddLogging(logging => logging.AddProvider(NullLoggerProvider.Instance));
 
-        var userTokenProvider = new Mock<IUserTokenProvider>();
-        var appMetadata = new Mock<IAppMetadata>();
-        var dataClient = new Mock<IDataClient>();
-        var eFormidlingMetadata = new Mock<IEFormidlingMetadata>();
-        var eFormidlingReceivers = new Mock<IEFormidlingReceivers>();
-        var eventClient = new Mock<IEventsClient>();
+        var userTokenProvider = new Mock<IUserTokenProvider>(MockBehavior.Strict);
+        var appMetadata = new Mock<IAppMetadata>(MockBehavior.Strict);
+        var dataClient = new Mock<IDataClient>(MockBehavior.Strict);
+        var eFormidlingMetadata = new Mock<IEFormidlingMetadata>(MockBehavior.Strict);
+        var eFormidlingReceivers = new Mock<IEFormidlingReceivers>(MockBehavior.Strict);
+        var eventClient = new Mock<IEventsClient>(MockBehavior.Loose);
         var appSettings = Options.Create(
             new AppSettings { RuntimeCookieName = "AltinnStudioRuntime", EFormidlingSender = "980123456" }
         );
         var platformSettings = Options.Create(new PlatformSettings { SubscriptionKey = "subscription-key" });
         var eFormidlingClient = new Mock<IEFormidlingClient>();
-        var tokenGenerator = new Mock<IAccessTokenGenerator>();
-        var processReader = new Mock<IProcessReader>();
-        var hostEnvironment = new Mock<IHostEnvironment>();
-        var eFormidlingLegacyConfigProvider = new Mock<IEFormidlingLegacyConfigurationProvider>();
+        var tokenGenerator = new Mock<IAccessTokenGenerator>(MockBehavior.Strict);
+        var processReader = new Mock<IProcessReader>(MockBehavior.Strict);
+        var hostEnvironment = new Mock<IHostEnvironment>(MockBehavior.Strict);
+        var eFormidlingLegacyConfigProvider = new Mock<IEFormidlingLegacyConfigurationProvider>(MockBehavior.Strict);
 
         var instanceGuid = Guid.Parse("41C1099C-7EDD-47F5-AD1F-6267B497796F");
         var instance = new Instance

--- a/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Action/UniqueSignatureAuthorizerTests.cs
@@ -27,10 +27,10 @@ public sealed class UniqueSignatureAuthorizerTests : IDisposable
 
     public UniqueSignatureAuthorizerTests()
     {
-        _processReaderMock = new Mock<IProcessReader>();
-        _instanceClientMock = new Mock<IInstanceClient>();
-        _dataClientMock = new Mock<IDataClient>();
-        _appMetadataMock = new Mock<IAppMetadata>();
+        _processReaderMock = new Mock<IProcessReader>(MockBehavior.Strict);
+        _instanceClientMock = new Mock<IInstanceClient>(MockBehavior.Strict);
+        _dataClientMock = new Mock<IDataClient>(MockBehavior.Strict);
+        _appMetadataMock = new Mock<IAppMetadata>(MockBehavior.Strict);
     }
 
     [Fact]

--- a/test/Altinn.App.Core.Tests/Implementation/InstanceClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Implementation/InstanceClientTests.cs
@@ -467,14 +467,27 @@ public sealed class InstanceClientTests : IDisposable
                 await target.UpdateDataValues(
                     instanceOwnerId,
                     instanceGuid,
-                    new DataValues() { Values = new() { { "key", "value" } } }
+                    new DataValues() { Values = new() { { "key", "value" } } },
+                    authenticationMethod: null,
+                    CancellationToken.None
                 );
                 break;
             case 2:
-                await target.UpdateDataValue(instance, "key", "value");
+                await target.UpdateDataValue(
+                    instance,
+                    "key",
+                    "value",
+                    authenticationMethod: null,
+                    CancellationToken.None
+                );
                 break;
             case 3:
-                await target.UpdateDataValues(instance, new() { { "key", "value" } });
+                await target.UpdateDataValues(
+                    instance,
+                    new() { { "key", "value" } },
+                    authenticationMethod: null,
+                    CancellationToken.None
+                );
                 break;
         }
 

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTests.cs
@@ -243,7 +243,10 @@ public class DataClientTests
                 "catstories",
                 "application/pdf",
                 "a cats story.pdf",
-                stream
+                stream,
+                generatedFromTask: null,
+                authenticationMethod: null,
+                CancellationToken.None
             )
         );
 
@@ -329,7 +332,9 @@ public class DataClientTests
                 "application/json",
                 "test.json",
                 dataGuid,
-                new MemoryStream()
+                new MemoryStream(),
+                authenticationMethod: null,
+                CancellationToken.None
             )
         );
         invocations.Should().Be(1);
@@ -360,7 +365,9 @@ public class DataClientTests
                 "application/json",
                 "test.json",
                 dataGuid,
-                new MemoryStream()
+                new MemoryStream(),
+                authenticationMethod: null,
+                CancellationToken.None
             )
         );
         invocations.Should().Be(1);
@@ -462,7 +469,9 @@ public class DataClientTests
             await fixture.DataClient.GetBinaryData(
                 instanceIdentifier.InstanceOwnerPartyId,
                 instanceIdentifier.InstanceGuid,
-                dataGuid
+                dataGuid,
+                authenticationMethod: null,
+                CancellationToken.None
             )
         );
         invocations.Should().Be(1);
@@ -577,7 +586,10 @@ public class DataClientTests
             await fixture.DataClient.GetBinaryDataStream(
                 instanceIdentifier.InstanceOwnerPartyId,
                 instanceIdentifier.InstanceGuid,
-                dataGuid
+                dataGuid,
+                authenticationMethod: null,
+                timeout: null,
+                CancellationToken.None
             )
         );
         invocations.Should().Be(1);
@@ -618,7 +630,8 @@ public class DataClientTests
             "app",
             instanceIdentifier.InstanceOwnerPartyId,
             instanceIdentifier.InstanceGuid,
-            authenticationMethod: testCase?.AuthenticationMethod
+            authenticationMethod: testCase?.AuthenticationMethod,
+            CancellationToken.None
         );
         invocations.Should().Be(1);
         AssertHttpRequest(platformRequest, expectedUri, HttpMethod.Get, expectedAuth: testCase?.ExpectedToken);
@@ -674,7 +687,9 @@ public class DataClientTests
                 "ttd",
                 "app",
                 instanceIdentifier.InstanceOwnerPartyId,
-                instanceIdentifier.InstanceGuid
+                instanceIdentifier.InstanceGuid,
+                authenticationMethod: null,
+                CancellationToken.None
             )
         );
         invocations.Should().Be(1);
@@ -709,7 +724,9 @@ public class DataClientTests
             instanceIdentifier.InstanceOwnerPartyId,
             instanceIdentifier.InstanceGuid,
             dataGuid,
-            delay: false
+            delay: false,
+            authenticationMethod: null,
+            CancellationToken.None
         );
         invocations.Should().Be(1);
         AssertHttpRequest(platformRequest, expectedUri, HttpMethod.Delete);
@@ -744,7 +761,9 @@ public class DataClientTests
                 instanceIdentifier.InstanceOwnerPartyId,
                 instanceIdentifier.InstanceGuid,
                 dataGuid,
-                delay: false
+                delay: false,
+                authenticationMethod: null,
+                CancellationToken.None
             )
         );
         invocations.Should().Be(1);

--- a/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTestsXmlJson.cs
+++ b/test/Altinn.App.Core.Tests/Infrastructure/Clients/Storage/DataClientTestsXmlJson.cs
@@ -70,7 +70,13 @@ public class DataClientTestsXmlJson
         var dataClient = serviceProvider.GetRequiredService<IDataClient>();
 
         // New endpoint with instance
-        var elementNew = await dataClient.InsertFormData(_instance, dataType, data);
+        var elementNew = await dataClient.InsertFormData(
+            _instance,
+            dataType,
+            data,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
 
         Assert.Equal(dataType, elementNew.DataType);
         Assert.Equal(requestContentType, elementNew.ContentType);
@@ -209,7 +215,14 @@ public class DataClientTestsXmlJson
                 Guid.Parse(oldElement.Id)
             );
 
-        var actNew = async () => await dataClient.UpdateFormData(_instance, data, oldElement);
+        var actNew = async () =>
+            await dataClient.UpdateFormData(
+                _instance,
+                data,
+                oldElement,
+                authenticationMethod: null,
+                CancellationToken.None
+            );
 
         if (dataType == "xmlDataType")
         {
@@ -351,7 +364,12 @@ public class DataClientTestsXmlJson
         var dataClient = serviceProvider.GetRequiredService<IDataClient>();
 
         // Verify Most up-to-date method
-        var retrievedData = await dataClient.GetFormData(_instance, element);
+        var retrievedData = await dataClient.GetFormData(
+            _instance,
+            element,
+            authenticationMethod: null,
+            CancellationToken.None
+        );
         Assert.Equivalent(data, retrievedData);
 
         // Verify Obsolete method
@@ -400,7 +418,9 @@ public class DataClientTestsXmlJson
         await Assert.ThrowsAsync<PlatformHttpException>(() =>
             dataClient.GetFormData(_instanceId, typeof(TestDataXml), Org, App, InstanceOwnerPartyId, wrongElementId)
         );
-        await Assert.ThrowsAsync<PlatformHttpException>(() => dataClient.GetFormData(_instance, wrongDataElement));
+        await Assert.ThrowsAsync<PlatformHttpException>(() =>
+            dataClient.GetFormData(_instance, wrongDataElement, authenticationMethod: null, CancellationToken.None)
+        );
 
         await Assert.ThrowsAsync<PlatformHttpException>(() =>
             dataClient.GetFormData<TestData>(_instance, wrongDataElement)
@@ -446,7 +466,15 @@ public class DataClientTestsXmlJson
         );
 
         await Assert.ThrowsAsync<PlatformHttpException>(() =>
-            dataClient.GetDataBytes(Org, App, InstanceOwnerPartyId, _instanceId, wrongElementId)
+            dataClient.GetDataBytes(
+                Org,
+                App,
+                InstanceOwnerPartyId,
+                _instanceId,
+                wrongElementId,
+                authenticationMethod: null,
+                CancellationToken.None
+            )
         );
 
         _mockedServiceCollection.VerifyMocks();

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -3036,43 +3036,82 @@ namespace Altinn.App.Core.Internal.Data
     {
         [System.Obsolete("Use method DeleteData with delayed=false instead.", true)]
         System.Threading.Tasks.Task<bool> DeleteBinaryData(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataGuid);
+        System.Threading.Tasks.Task<bool> DeleteData(int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataGuid, bool delay);
         System.Threading.Tasks.Task<bool> DeleteData(int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataGuid, bool delay, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
         [System.Obsolete("Use the overload without org and app parameters")]
+        System.Threading.Tasks.Task<bool> DeleteData(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataGuid, bool delay);
+        [System.Obsolete("Use the overload without org and app parameters")]
         System.Threading.Tasks.Task<bool> DeleteData(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataGuid, bool delay, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<System.IO.Stream> GetBinaryData(int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId);
         System.Threading.Tasks.Task<System.IO.Stream> GetBinaryData(int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
         [System.Obsolete("Org and App parameters are not used, use the overload without these parameters")]
+        System.Threading.Tasks.Task<System.IO.Stream> GetBinaryData(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId);
+        [System.Obsolete("Org and App parameters are not used, use the overload without these parameters")]
         System.Threading.Tasks.Task<System.IO.Stream> GetBinaryData(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.List<Altinn.App.Core.Models.AttachmentList>> GetBinaryDataList(int instanceOwnerPartyId, System.Guid instanceGuid);
         System.Threading.Tasks.Task<System.Collections.Generic.List<Altinn.App.Core.Models.AttachmentList>> GetBinaryDataList(int instanceOwnerPartyId, System.Guid instanceGuid, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
         [System.Obsolete("Org and App parameters are not used, use the overload without these parameters")]
+        System.Threading.Tasks.Task<System.Collections.Generic.List<Altinn.App.Core.Models.AttachmentList>> GetBinaryDataList(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid);
+        [System.Obsolete("Org and App parameters are not used, use the overload without these parameters")]
         System.Threading.Tasks.Task<System.Collections.Generic.List<Altinn.App.Core.Models.AttachmentList>> GetBinaryDataList(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<System.IO.Stream> GetBinaryDataStream(int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId);
         System.Threading.Tasks.Task<System.IO.Stream> GetBinaryDataStream(int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.TimeSpan? timeout = default, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<byte[]> GetDataBytes(int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId);
         System.Threading.Tasks.Task<byte[]> GetDataBytes(int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
         [System.Obsolete("Org and App parameters are not used, use the overload without these parameters")]
+        System.Threading.Tasks.Task<byte[]> GetDataBytes(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId);
+        [System.Obsolete("Org and App parameters are not used, use the overload without these parameters")]
         System.Threading.Tasks.Task<byte[]> GetDataBytes(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataId, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<object> GetFormData(Altinn.Platform.Storage.Interface.Models.Instance instance, Altinn.Platform.Storage.Interface.Models.DataElement dataElement);
         System.Threading.Tasks.Task<object> GetFormData(Altinn.Platform.Storage.Interface.Models.Instance instance, Altinn.Platform.Storage.Interface.Models.DataElement dataElement, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
         [System.Obsolete("Use the overload with Instance parameter instead")]
+        System.Threading.Tasks.Task<object> GetFormData(System.Guid instanceGuid, System.Type type, string org, string app, int instanceOwnerPartyId, System.Guid dataId);
+        [System.Obsolete("Use the overload with Instance parameter instead")]
         System.Threading.Tasks.Task<object> GetFormData(System.Guid instanceGuid, System.Type type, string org, string app, int instanceOwnerPartyId, System.Guid dataId, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertBinaryData(string instanceId, string dataType, string contentType, string? filename, System.IO.Stream stream);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertBinaryData(string instanceId, string dataType, string contentType, string? filename, System.IO.Stream stream, string? generatedFromTask);
+        [System.Obsolete("The overload that takes a HttpRequest is deprecated, use the overload that takes " +
+            "a Stream instead")]
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertBinaryData(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, string dataType, Microsoft.AspNetCore.Http.HttpRequest request);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertBinaryData(string instanceId, string dataType, string contentType, string? filename, System.IO.Stream stream, string? generatedFromTask = null, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
         [System.Obsolete("The overload that takes a HttpRequest is deprecated, use the overload that takes " +
             "a Stream instead")]
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertBinaryData(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, string dataType, Microsoft.AspNetCore.Http.HttpRequest request, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertFormData(Altinn.Platform.Storage.Interface.Models.Instance instance, string dataTypeId, object dataToSerialize);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertFormData(Altinn.Platform.Storage.Interface.Models.Instance instance, string dataTypeId, object dataToSerialize, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        [System.Obsolete("Use the overload without Type parameter")]
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertFormData<T>(Altinn.Platform.Storage.Interface.Models.Instance instance, string dataTypeString, T dataToSerialize, System.Type type)
+            where T :  notnull;
         [System.Obsolete("Use the overload without Type parameter")]
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertFormData<T>(Altinn.Platform.Storage.Interface.Models.Instance instance, string dataTypeString, T dataToSerialize, System.Type type, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default)
             where T :  notnull;
         [System.Obsolete("Use InsertFormData with Instance parameter instead")]
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertFormData<T>(T dataToSerialize, System.Guid instanceGuid, System.Type type, string org, string app, int instanceOwnerPartyId, string dataType)
+            where T :  notnull;
+        [System.Obsolete("Use InsertFormData with Instance parameter instead")]
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> InsertFormData<T>(T dataToSerialize, System.Guid instanceGuid, System.Type type, string org, string app, int instanceOwnerPartyId, string dataType, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default)
             where T :  notnull;
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> LockDataElement(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Guid dataGuid);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> LockDataElement(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Guid dataGuid, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UnlockDataElement(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Guid dataGuid);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UnlockDataElement(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, System.Guid dataGuid, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> Update(Altinn.Platform.Storage.Interface.Models.Instance instance, Altinn.Platform.Storage.Interface.Models.DataElement dataElement);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> Update(Altinn.Platform.Storage.Interface.Models.Instance instance, Altinn.Platform.Storage.Interface.Models.DataElement dataElement, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UpdateBinaryData(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, string? contentType, string? filename, System.Guid dataGuid, System.IO.Stream stream);
+        [System.Obsolete("Deprecated please use UpdateBinaryData(InstanceIdentifier, string, string, Guid, " +
+            "Stream) instead", false)]
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UpdateBinaryData(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataGuid, Microsoft.AspNetCore.Http.HttpRequest request);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UpdateBinaryData(Altinn.App.Core.Models.InstanceIdentifier instanceIdentifier, string? contentType, string? filename, System.Guid dataGuid, System.IO.Stream stream, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
         [System.Obsolete("Deprecated please use UpdateBinaryData(InstanceIdentifier, string, string, Guid, " +
             "Stream) instead", false)]
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UpdateBinaryData(string org, string app, int instanceOwnerPartyId, System.Guid instanceGuid, System.Guid dataGuid, Microsoft.AspNetCore.Http.HttpRequest request, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
         [System.Obsolete("Use the UpdateFormData method with Instance parameter instead")]
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UpdateData<T>(T dataToSerialize, System.Guid instanceGuid, System.Type type, string org, string app, int instanceOwnerPartyId, System.Guid dataId)
+            where T :  notnull;
+        [System.Obsolete("Use the UpdateFormData method with Instance parameter instead")]
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UpdateData<T>(T dataToSerialize, System.Guid instanceGuid, System.Type type, string org, string app, int instanceOwnerPartyId, System.Guid dataId, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default)
             where T :  notnull;
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UpdateFormData(Altinn.Platform.Storage.Interface.Models.Instance instance, object dataToSerialize, Altinn.Platform.Storage.Interface.Models.DataElement dataElement);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.DataElement> UpdateFormData(Altinn.Platform.Storage.Interface.Models.Instance instance, object dataToSerialize, Altinn.Platform.Storage.Interface.Models.DataElement dataElement, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken cancellationToken = default);
     }
     public static class IDataClientExtensions
@@ -3239,19 +3278,33 @@ namespace Altinn.App.Core.Internal.Instances
 {
     public interface IInstanceClient
     {
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> AddCompleteConfirmation(int instanceOwnerPartyId, System.Guid instanceGuid);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> AddCompleteConfirmation(int instanceOwnerPartyId, System.Guid instanceGuid, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> CreateInstance(string org, string app, Altinn.Platform.Storage.Interface.Models.Instance instanceTemplate);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> CreateInstance(string org, string app, Altinn.Platform.Storage.Interface.Models.Instance instanceTemplate, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> DeleteInstance(int instanceOwnerPartyId, System.Guid instanceGuid, bool hard);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> DeleteInstance(int instanceOwnerPartyId, System.Guid instanceGuid, bool hard, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> GetInstance(Altinn.Platform.Storage.Interface.Models.Instance instance);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> GetInstance(Altinn.Platform.Storage.Interface.Models.Instance instance, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> GetInstance(string app, string org, int instanceOwnerPartyId, System.Guid instanceId);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> GetInstance(string app, string org, int instanceOwnerPartyId, System.Guid instanceId, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.List<Altinn.Platform.Storage.Interface.Models.Instance>> GetInstances(System.Collections.Generic.Dictionary<string, Microsoft.Extensions.Primitives.StringValues> queryParams);
         System.Threading.Tasks.Task<System.Collections.Generic.List<Altinn.Platform.Storage.Interface.Models.Instance>> GetInstances(System.Collections.Generic.Dictionary<string, Microsoft.Extensions.Primitives.StringValues> queryParams, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateDataValue(Altinn.Platform.Storage.Interface.Models.Instance instance, string key, string? value);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateDataValue(Altinn.Platform.Storage.Interface.Models.Instance instance, string key, string? value, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateDataValues(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Collections.Generic.Dictionary<string, string?> dataValues);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateDataValues(int instanceOwnerPartyId, System.Guid instanceGuid, Altinn.Platform.Storage.Interface.Models.DataValues dataValues);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateDataValues(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Collections.Generic.Dictionary<string, string?> dataValues, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateDataValues(int instanceOwnerPartyId, System.Guid instanceGuid, Altinn.Platform.Storage.Interface.Models.DataValues dataValues, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdatePresentationTexts(int instanceOwnerPartyId, System.Guid instanceGuid, Altinn.Platform.Storage.Interface.Models.PresentationTexts presentationTexts);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdatePresentationTexts(int instanceOwnerPartyId, System.Guid instanceGuid, Altinn.Platform.Storage.Interface.Models.PresentationTexts presentationTexts, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateProcess(Altinn.Platform.Storage.Interface.Models.Instance instance);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateProcess(Altinn.Platform.Storage.Interface.Models.Instance instance, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateProcessAndEvents(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Collections.Generic.List<Altinn.Platform.Storage.Interface.Models.InstanceEvent> events);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateProcessAndEvents(Altinn.Platform.Storage.Interface.Models.Instance instance, System.Collections.Generic.List<Altinn.Platform.Storage.Interface.Models.InstanceEvent> events, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateReadStatus(int instanceOwnerPartyId, System.Guid instanceGuid, string readStatus);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateReadStatus(int instanceOwnerPartyId, System.Guid instanceGuid, string readStatus, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
+        System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateSubstatus(int instanceOwnerPartyId, System.Guid instanceGuid, Altinn.Platform.Storage.Interface.Models.Substatus substatus);
         System.Threading.Tasks.Task<Altinn.Platform.Storage.Interface.Models.Instance> UpdateSubstatus(int instanceOwnerPartyId, System.Guid instanceGuid, Altinn.Platform.Storage.Interface.Models.Substatus substatus, Altinn.App.Core.Features.StorageAuthenticationMethod? authenticationMethod = null, System.Threading.CancellationToken ct = default);
     }
     public interface IInstanceEventClient


### PR DESCRIPTION
Adding optional parameters to an interface method causes other packages that depend on Altinn.App.Core to break when calling the method that was changed

The main changes are adding back methods without StorageAuthenticationMethod and CancellationToken to IDataClient  and IInstanceClient

Also updated AGENTS with some hints
- Normal interfaces in Altinn.App.Core must be binary compatible within a major version so that users can have local pacages that still work (never remove a method)
- Interfaces marked with the `ImplementableByApps` attribute must not change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

This release contains internal refactors and a documentation update; no functional user-facing changes.

* **Documentation**
  * Clarified versioning rules: added two contract constraints regarding interface compatibility and implementable interfaces.

* **Refactor**
  * Standardized internal client API signatures and added convenience overloads to simplify internal calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->