### PR TITLE
Update correspondence integration

### DIFF
--- a/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
@@ -18,7 +18,6 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     private CorrespondenceNotificationChannel? _notificationChannel;
     private CorrespondenceNotificationChannel? _reminderNotificationChannel;
     private string? _sendersReference;
-    private DateTimeOffset? _requestedSendTime;
     private CorrespondenceNotificationRecipient? _recipientOverride;
 
     [Obsolete]
@@ -119,7 +118,7 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     [Obsolete("RequestedSendTime is no longer supported by the Correspondence API.")]
     public ICorrespondenceNotificationBuilder WithRequestedSendTime(DateTimeOffset? requestedSendTime)
     {
-        _requestedSendTime = requestedSendTime;
+        // Intentional no-op: RequestedSendTime is no longer accepted by the Correspondence API.
         return this;
     }
 

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
@@ -18,7 +18,6 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     private CorrespondenceNotificationChannel? _notificationChannel;
     private CorrespondenceNotificationChannel? _reminderNotificationChannel;
     private string? _sendersReference;
-    private DateTimeOffset? _requestedSendTime;
     private CorrespondenceNotificationRecipient? _recipientOverride;
 
     [Obsolete]
@@ -116,13 +115,6 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     }
 
     /// <inheritdoc/>
-    public ICorrespondenceNotificationBuilder WithRequestedSendTime(DateTimeOffset? requestedSendTime)
-    {
-        _requestedSendTime = requestedSendTime;
-        return this;
-    }
-
-    /// <inheritdoc/>
     public ICorrespondenceNotificationBuilder WithRecipientOverride(
         ICorrespondenceNotificationOverrideBuilder recipientOverrideBuilder
     )
@@ -181,7 +173,6 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
             NotificationChannel = _notificationChannel,
             ReminderNotificationChannel = _reminderNotificationChannel,
             SendersReference = _sendersReference,
-            RequestedSendTime = _requestedSendTime,
             CustomRecipient = _recipientOverride,
         };
     }

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
@@ -18,6 +18,7 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     private CorrespondenceNotificationChannel? _notificationChannel;
     private CorrespondenceNotificationChannel? _reminderNotificationChannel;
     private string? _sendersReference;
+    private DateTimeOffset? _requestedSendTime;
     private CorrespondenceNotificationRecipient? _recipientOverride;
 
     [Obsolete]
@@ -111,6 +112,14 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     public ICorrespondenceNotificationBuilder WithSendersReference(string? sendersReference)
     {
         _sendersReference = sendersReference;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    [Obsolete("RequestedSendTime is no longer supported by the Correspondence API.")]
+    public ICorrespondenceNotificationBuilder WithRequestedSendTime(DateTimeOffset? requestedSendTime)
+    {
+        _requestedSendTime = requestedSendTime;
         return this;
     }
 

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceRequestBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceRequestBuilder.cs
@@ -14,7 +14,6 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
     private CorrespondenceContent? _content;
     private List<CorrespondenceAttachment>? _contentAttachments;
     private DateTimeOffset? _dueDateTime;
-    private DateTimeOffset? _allowSystemDeleteAfter;
     private List<OrganisationOrPersonIdentifier>? _recipients;
     private DateTimeOffset? _requestedPublishTime;
     private string? _messageSender;
@@ -167,7 +166,7 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
     [Obsolete("AllowSystemDeleteAfter is no longer supported by the Correspondence API.")]
     public ICorrespondenceRequestBuilder WithAllowSystemDeleteAfter(DateTimeOffset allowSystemDeleteAfter)
     {
-        _allowSystemDeleteAfter = allowSystemDeleteAfter;
+        // Intentional no-op: AllowSystemDeleteAfter is no longer accepted by the Correspondence API.
         return this;
     }
 

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceRequestBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceRequestBuilder.cs
@@ -14,6 +14,7 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
     private CorrespondenceContent? _content;
     private List<CorrespondenceAttachment>? _contentAttachments;
     private DateTimeOffset? _dueDateTime;
+    private DateTimeOffset? _allowSystemDeleteAfter;
     private List<OrganisationOrPersonIdentifier>? _recipients;
     private DateTimeOffset? _requestedPublishTime;
     private string? _messageSender;
@@ -159,6 +160,14 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
     {
         BuilderUtils.NotNullOrEmpty(dueDateTime, "DueDateTime cannot be empty");
         _dueDateTime = dueDateTime;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    [Obsolete("AllowSystemDeleteAfter is no longer supported by the Correspondence API.")]
+    public ICorrespondenceRequestBuilder WithAllowSystemDeleteAfter(DateTimeOffset allowSystemDeleteAfter)
+    {
+        _allowSystemDeleteAfter = allowSystemDeleteAfter;
         return this;
     }
 

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceRequestBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceRequestBuilder.cs
@@ -13,7 +13,6 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
     private string? _sendersReference;
     private CorrespondenceContent? _content;
     private List<CorrespondenceAttachment>? _contentAttachments;
-    private DateTimeOffset? _allowSystemDeleteAfter;
     private DateTimeOffset? _dueDateTime;
     private List<OrganisationOrPersonIdentifier>? _recipients;
     private DateTimeOffset? _requestedPublishTime;
@@ -24,6 +23,7 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
     private CorrespondenceNotification? _notification;
     private bool? _ignoreReservation;
     private bool? _isConfirmationNeeded;
+    private bool? _isConfidential;
     private List<Guid>? _existingAttachments;
 
     private CorrespondenceRequestBuilder() { }
@@ -106,14 +106,6 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
         BuilderUtils.NotNullOrEmpty(recipients, "Recipients cannot be empty");
         _recipients ??= [];
         _recipients.AddRange(recipients);
-        return this;
-    }
-
-    /// <inheritdoc/>
-    public ICorrespondenceRequestBuilder WithAllowSystemDeleteAfter(DateTimeOffset allowSystemDeleteAfter)
-    {
-        BuilderUtils.NotNullOrEmpty(allowSystemDeleteAfter, "AllowSystemDeleteAfter cannot be empty");
-        _allowSystemDeleteAfter = allowSystemDeleteAfter;
         return this;
     }
 
@@ -308,6 +300,13 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
     }
 
     /// <inheritdoc/>
+    public ICorrespondenceRequestBuilder WithIsConfidential(bool isConfidential)
+    {
+        _isConfidential = isConfidential;
+        return this;
+    }
+
+    /// <inheritdoc/>
     public CorrespondenceRequest Build()
     {
         BuilderUtils.NotNullOrEmpty(_resourceId);
@@ -322,7 +321,6 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
             Sender = _sender.Value,
             SendersReference = _sendersReference,
             Content = _content with { Attachments = _contentAttachments },
-            AllowSystemDeleteAfter = _allowSystemDeleteAfter,
             DueDateTime = _dueDateTime,
             Recipients = _recipients,
             RequestedPublishTime = _requestedPublishTime,
@@ -334,6 +332,7 @@ public class CorrespondenceRequestBuilder : ICorrespondenceRequestBuilder
             IgnoreReservation = _ignoreReservation,
             ExistingAttachments = _existingAttachments,
             IsConfirmationNeeded = _isConfirmationNeeded,
+            IsConfidential = _isConfidential,
         };
     }
 }

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationBuilder.cs
@@ -91,12 +91,6 @@ public interface ICorrespondenceNotificationBuilder : ICorrespondenceNotificatio
     ICorrespondenceNotificationBuilder WithSendersReference(string? sendersReference);
 
     /// <summary>
-    /// Sets the requested send time for the correspondence notification.
-    /// </summary>
-    /// <param name="requestedSendTime">The requested send time</param>
-    ICorrespondenceNotificationBuilder WithRequestedSendTime(DateTimeOffset? requestedSendTime);
-
-    /// <summary>
     /// Sets the recipient override for the correspondence notification.
     /// </summary>
     /// <param name="recipientOverride">The recipient override</param>

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationBuilder.cs
@@ -91,6 +91,13 @@ public interface ICorrespondenceNotificationBuilder : ICorrespondenceNotificatio
     ICorrespondenceNotificationBuilder WithSendersReference(string? sendersReference);
 
     /// <summary>
+    /// Sets the requested send time for the correspondence notification.
+    /// </summary>
+    /// <param name="requestedSendTime">The requested send time</param>
+    [Obsolete("RequestedSendTime is no longer supported by the Correspondence API.")]
+    ICorrespondenceNotificationBuilder WithRequestedSendTime(DateTimeOffset? requestedSendTime);
+
+    /// <summary>
     /// Sets the recipient override for the correspondence notification.
     /// </summary>
     /// <param name="recipientOverride">The recipient override</param>

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceRequestBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceRequestBuilder.cs
@@ -152,6 +152,13 @@ public interface ICorrespondenceRequestBuilder
     ICorrespondenceRequestBuilder WithDueDateTime(DateTimeOffset dueDateTime);
 
     /// <summary>
+    /// Sets when Altinn can remove the correspondence from its database.
+    /// </summary>
+    /// <param name="allowSystemDeleteAfter">The point in time when the correspondence can be deleted</param>
+    [Obsolete("AllowSystemDeleteAfter is no longer supported by the Correspondence API.")]
+    ICorrespondenceRequestBuilder WithAllowSystemDeleteAfter(DateTimeOffset allowSystemDeleteAfter);
+
+    /// <summary>
     /// Sets the requested publish time for the correspondence.
     /// </summary>
     /// <param name="requestedPublishTime">The point in time when the correspondence should be published</param>

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceRequestBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceRequestBuilder.cs
@@ -146,12 +146,6 @@ public interface ICorrespondenceRequestBuilder
         ICorrespondenceRequestBuilderContent
 {
     /// <summary>
-    /// Sets the date and time when the correspondence can be deleted from the system.
-    /// </summary>
-    /// <param name="allowSystemDeleteAfter">The point in time when the correspondence may be safely deleted</param>
-    ICorrespondenceRequestBuilder WithAllowSystemDeleteAfter(DateTimeOffset allowSystemDeleteAfter);
-
-    /// <summary>
     /// Sets due date and time for the correspondence.
     /// </summary>
     /// <param name="dueDateTime">The point in time when the correspondence is due</param>
@@ -251,6 +245,12 @@ public interface ICorrespondenceRequestBuilder
     /// </summary>
     /// <param name="isConfirmationNeeded">A boolean value indicating if confirmation is needed or not</param>
     ICorrespondenceRequestBuilder WithIsConfirmationNeeded(bool isConfirmationNeeded);
+
+    /// <summary>
+    /// Sets whether the correspondence is confidential.
+    /// </summary>
+    /// <param name="isConfidential">A boolean value indicating if the correspondence is confidential or not</param>
+    ICorrespondenceRequestBuilder WithIsConfidential(bool isConfidential);
 
     /// <summary>
     /// <p>Adds an existing attachment reference to the correspondence.</p>

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotification.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotification.cs
@@ -81,11 +81,6 @@ public sealed record CorrespondenceNotification : MultipartCorrespondenceItem
     public string? SendersReference { get; init; }
 
     /// <summary>
-    /// The date and time for when the notification should be sent.
-    /// </summary>
-    public DateTimeOffset? RequestedSendTime { get; init; }
-
-    /// <summary>
     /// A list of recipients for the notification. If not set, the notification will be sent to the recipient of the Correspondence
     /// </summary>
     public CorrespondenceNotificationRecipient? CustomRecipient { get; init; }
@@ -111,7 +106,6 @@ public sealed record CorrespondenceNotification : MultipartCorrespondenceItem
         AddIfNotNull(content, ReminderSmsBody, "Correspondence.Notification.ReminderSmsBody");
         AddIfNotNull(content, NotificationChannel.ToString(), "Correspondence.Notification.NotificationChannel");
         AddIfNotNull(content, SendersReference, "Correspondence.Notification.SendersReference");
-        AddIfNotNull(content, RequestedSendTime, "Correspondence.Notification.RequestedSendTime");
         CustomRecipient?.Serialise(content);
         if (CustomRecipient is null)
         {

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotification.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotification.cs
@@ -81,6 +81,12 @@ public sealed record CorrespondenceNotification : MultipartCorrespondenceItem
     public string? SendersReference { get; init; }
 
     /// <summary>
+    /// The date and time for when the notification should be sent.
+    /// </summary>
+    [Obsolete("RequestedSendTime is no longer supported by the Correspondence API.")]
+    public DateTimeOffset? RequestedSendTime { get; init; }
+
+    /// <summary>
     /// A list of recipients for the notification. If not set, the notification will be sent to the recipient of the Correspondence
     /// </summary>
     public CorrespondenceNotificationRecipient? CustomRecipient { get; init; }

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceRequest.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceRequest.cs
@@ -249,11 +249,6 @@ public sealed record CorrespondenceRequest : MultipartCorrespondenceItem
     public DateTimeOffset? RequestedPublishTime { get; init; }
 
     /// <summary>
-    /// When can Altinn remove the correspondence from its database?
-    /// </summary>
-    public required DateTimeOffset? AllowSystemDeleteAfter { get; init; }
-
-    /// <summary>
     /// When must the recipient respond by?
     /// </summary>
     public DateTimeOffset? DueDateTime { get; init; }
@@ -299,6 +294,11 @@ public sealed record CorrespondenceRequest : MultipartCorrespondenceItem
     public bool? IsConfirmationNeeded { get; init; }
 
     /// <summary>
+    /// Specifies whether the correspondence is confidential.
+    /// </summary>
+    public bool? IsConfidential { get; init; }
+
+    /// <summary>
     /// Existing attachments that should be added to the correspondence.
     /// </summary>
     public IReadOnlyList<Guid>? ExistingAttachments { get; init; }
@@ -314,12 +314,12 @@ public sealed record CorrespondenceRequest : MultipartCorrespondenceItem
         AddRequired(content, ResourceId, "Correspondence.ResourceId");
         AddRequired(content, Sender.ToUrnFormattedString(), "Correspondence.Sender");
         AddRequired(content, SendersReference, "Correspondence.SendersReference");
-        AddIfNotNull(content, AllowSystemDeleteAfter, "Correspondence.AllowSystemDeleteAfter");
         AddIfNotNull(content, MessageSender, "Correspondence.MessageSender");
         AddIfNotNull(content, RequestedPublishTime, "Correspondence.RequestedPublishTime");
         AddIfNotNull(content, DueDateTime, "Correspondence.DueDateTime");
         AddIfNotNull(content, IgnoreReservation?.ToString(), "Correspondence.IgnoreReservation");
         AddIfNotNull(content, IsConfirmationNeeded?.ToString(), "Correspondence.IsConfirmationNeeded");
+        AddIfNotNull(content, IsConfidential?.ToString(), "Correspondence.IsConfidential");
         AddDictionaryItems(content, PropertyList, x => x, key => $"Correspondence.PropertyList.{key}");
         AddListItems(content, ExistingAttachments, x => x.ToString(), i => $"Correspondence.ExistingAttachments[{i}]");
         AddListItems(content, Recipients, x => x.ToUrnFormattedString(), i => $"Recipients[{i}]");
@@ -351,18 +351,6 @@ public sealed record CorrespondenceRequest : MultipartCorrespondenceItem
         if (IsConfirmationNeeded is true && DueDateTime is null)
             ValidationError($"When {nameof(IsConfirmationNeeded)} is set, {nameof(DueDateTime)} is also required");
 
-        DateTimeOffset? normalisedAllowSystemDeleteAfter = AllowSystemDeleteAfter is not null
-            ? NormaliseDateTime(AllowSystemDeleteAfter.Value)
-            : null;
-
-        if (normalisedAllowSystemDeleteAfter is not null)
-        {
-            if (normalisedAllowSystemDeleteAfter.Value < DateTimeOffset.UtcNow)
-                ValidationError($"{nameof(AllowSystemDeleteAfter)} cannot be a time in the past");
-            if (normalisedAllowSystemDeleteAfter.Value < RequestedPublishTime)
-                ValidationError($"{nameof(AllowSystemDeleteAfter)} cannot be prior to {nameof(RequestedPublishTime)}");
-        }
-
         if (DueDateTime is not null)
         {
             var normalisedDueDate = NormaliseDateTime(DueDateTime.Value);
@@ -370,11 +358,6 @@ public sealed record CorrespondenceRequest : MultipartCorrespondenceItem
                 ValidationError($"{nameof(DueDateTime)} cannot be a time in the past");
             if (normalisedDueDate < RequestedPublishTime)
                 ValidationError($"{nameof(DueDateTime)} cannot be prior to {nameof(RequestedPublishTime)}");
-            if (
-                normalisedAllowSystemDeleteAfter is not null
-                && normalisedAllowSystemDeleteAfter.Value < normalisedDueDate
-            )
-                ValidationError($"{nameof(AllowSystemDeleteAfter)} cannot be prior to {nameof(DueDateTime)}");
         }
     }
 

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceRequest.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceRequest.cs
@@ -249,6 +249,12 @@ public sealed record CorrespondenceRequest : MultipartCorrespondenceItem
     public DateTimeOffset? RequestedPublishTime { get; init; }
 
     /// <summary>
+    /// When can Altinn remove the correspondence from its database?
+    /// </summary>
+    [Obsolete("AllowSystemDeleteAfter is no longer supported by the Correspondence API.")]
+    public DateTimeOffset? AllowSystemDeleteAfter { get; init; }
+
+    /// <summary>
     /// When must the recipient respond by?
     /// </summary>
     public DateTimeOffset? DueDateTime { get; init; }

--- a/src/Altinn.App.Core/Features/Correspondence/Models/Response/CorrespondenceNotificationOrderResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/Response/CorrespondenceNotificationOrderResponse.cs
@@ -20,12 +20,6 @@ public sealed record CorrespondenceNotificationOrderResponse
     public string? SendersReference { get; set; }
 
     /// <summary>
-    /// The requested send time of the notification.
-    /// </summary>
-    [JsonPropertyName("requestedSendTime")]
-    public DateTimeOffset RequestedSendTime { get; set; }
-
-    /// <summary>
     /// The short name of the creator of the notification order.
     /// </summary>
     [JsonPropertyName("creator")]

--- a/src/Altinn.App.Core/Features/Correspondence/Models/Response/CorrespondenceNotificationOrderResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/Response/CorrespondenceNotificationOrderResponse.cs
@@ -20,6 +20,15 @@ public sealed record CorrespondenceNotificationOrderResponse
     public string? SendersReference { get; set; }
 
     /// <summary>
+    /// The requested send time of the notification.
+    /// </summary>
+    [Obsolete(
+        "RequestedSendTime is no longer returned by the Correspondence API and will be removed in a future version."
+    )]
+    [JsonPropertyName("requestedSendTime")]
+    public DateTimeOffset? RequestedSendTime { get; set; }
+
+    /// <summary>
     /// The short name of the creator of the notification order.
     /// </summary>
     [JsonPropertyName("creator")]

--- a/src/Altinn.App.Core/Features/Correspondence/Models/Response/CorrespondenceNotificationOrderResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/Response/CorrespondenceNotificationOrderResponse.cs
@@ -22,9 +22,7 @@ public sealed record CorrespondenceNotificationOrderResponse
     /// <summary>
     /// The requested send time of the notification.
     /// </summary>
-    [Obsolete(
-        "RequestedSendTime is no longer returned by the Correspondence API and will be removed in a future version."
-    )]
+    [Obsolete("RequestedSendTime is no longer returned by the Correspondence API.")]
     [JsonPropertyName("requestedSendTime")]
     public DateTimeOffset? RequestedSendTime { get; set; }
 

--- a/src/Altinn.App.Core/Features/Correspondence/Models/Response/GetCorrespondenceStatusResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/Response/GetCorrespondenceStatusResponse.cs
@@ -100,12 +100,6 @@ public sealed record GetCorrespondenceStatusResponse
     public DateTimeOffset? RequestedPublishTime { get; init; }
 
     /// <summary>
-    /// The date for when Altinn can remove the correspondence from its database.
-    /// </summary>
-    [JsonPropertyName("allowSystemDeleteAfter")]
-    public DateTimeOffset? AllowSystemDeleteAfter { get; init; }
-
-    /// <summary>
     /// A date and time for when the recipient must reply.
     /// </summary>
     [JsonPropertyName("dueDateTime")]
@@ -147,4 +141,10 @@ public sealed record GetCorrespondenceStatusResponse
     /// </summary>
     [JsonPropertyName("isConfirmationNeeded")]
     public bool IsConfirmationNeeded { get; init; }
+
+    /// <summary>
+    /// Specifies whether the correspondence is confidential.
+    /// </summary>
+    [JsonPropertyName("isConfidential")]
+    public bool IsConfidential { get; init; }
 }

--- a/src/Altinn.App.Core/Features/Correspondence/Models/Response/GetCorrespondenceStatusResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/Response/GetCorrespondenceStatusResponse.cs
@@ -102,9 +102,7 @@ public sealed record GetCorrespondenceStatusResponse
     /// <summary>
     /// The date for when Altinn can remove the correspondence from its database.
     /// </summary>
-    [Obsolete(
-        "AllowSystemDeleteAfter is no longer returned by the Correspondence API and will be removed in a future version."
-    )]
+    [Obsolete("AllowSystemDeleteAfter is no longer returned by the Correspondence API.")]
     [JsonPropertyName("allowSystemDeleteAfter")]
     public DateTimeOffset? AllowSystemDeleteAfter { get; init; }
 

--- a/src/Altinn.App.Core/Features/Correspondence/Models/Response/GetCorrespondenceStatusResponse.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/Response/GetCorrespondenceStatusResponse.cs
@@ -100,6 +100,15 @@ public sealed record GetCorrespondenceStatusResponse
     public DateTimeOffset? RequestedPublishTime { get; init; }
 
     /// <summary>
+    /// The date for when Altinn can remove the correspondence from its database.
+    /// </summary>
+    [Obsolete(
+        "AllowSystemDeleteAfter is no longer returned by the Correspondence API and will be removed in a future version."
+    )]
+    [JsonPropertyName("allowSystemDeleteAfter")]
+    public DateTimeOffset? AllowSystemDeleteAfter { get; init; }
+
+    /// <summary>
     /// A date and time for when the recipient must reply.
     /// </summary>
     [JsonPropertyName("dueDateTime")]

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/Builder/CorrespondenceBuilderTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/Builder/CorrespondenceBuilderTests.cs
@@ -84,7 +84,6 @@ public class CorrespondenceBuilderTests
                 reminderEmailSubject = "reminder-email-subject-1",
                 reminderEmailBody = "reminder-email-body-1",
                 reminderSmsBody = "reminder-sms-body-1",
-                requestedSendTime = DateTimeOffset.Now.AddDays(1),
                 sendersReference = "notification-senders-ref-1",
                 sendReminder = true,
                 notificationChannel = CorrespondenceNotificationChannel.EmailPreferred,
@@ -166,7 +165,6 @@ public class CorrespondenceBuilderTests
                     .WithReminderEmailSubject(data.notification.reminderEmailSubject)
                     .WithReminderEmailBody(data.notification.reminderEmailBody)
                     .WithReminderSmsBody(data.notification.reminderSmsBody)
-                    .WithRequestedSendTime(data.notification.requestedSendTime)
                     .WithSendersReference(data.notification.sendersReference)
                     .WithSendReminder(data.notification.sendReminder)
                     .WithNotificationChannel(data.notification.notificationChannel)
@@ -179,7 +177,6 @@ public class CorrespondenceBuilderTests
                     )
             )
             .WithDueDateTime(data.dueDateTime)
-            .WithAllowSystemDeleteAfter(data.allowDeleteAfter)
             .WithMessageSender(data.messageSender)
             .WithIgnoreReservation(data.ignoreReservation)
             .WithIsConfirmationNeeded(data.isConfirmationNeeded)
@@ -251,7 +248,6 @@ public class CorrespondenceBuilderTests
         correspondence.SendersReference.Should().Be(data.sendersReference);
         correspondence.Recipients.Should().BeEquivalentTo([data.recipient]);
         correspondence.DueDateTime.Should().Be(data.dueDateTime);
-        correspondence.AllowSystemDeleteAfter.Should().Be(data.allowDeleteAfter);
         correspondence.IgnoreReservation.Should().Be(data.ignoreReservation);
         correspondence.IsConfirmationNeeded.Should().Be(data.isConfirmationNeeded);
         correspondence.RequestedPublishTime.Should().Be(data.requestedPublishTime);
@@ -282,7 +278,6 @@ public class CorrespondenceBuilderTests
         correspondence.Notification.ReminderEmailSubject.Should().Be(data.notification.reminderEmailSubject);
         correspondence.Notification.ReminderEmailBody.Should().Be(data.notification.reminderEmailBody);
         correspondence.Notification.ReminderSmsBody.Should().Be(data.notification.reminderSmsBody);
-        correspondence.Notification.RequestedSendTime.Should().Be(data.notification.requestedSendTime);
         correspondence.Notification.SendersReference.Should().Be(data.notification.sendersReference);
         correspondence.Notification.SendReminder.Should().Be(data.notification.sendReminder);
         correspondence.Notification.NotificationChannel.Should().Be(data.notification.notificationChannel);
@@ -340,7 +335,6 @@ public class CorrespondenceBuilderTests
                     .WithEmailBody("email-body-1")
             )
             .WithReplyOption("url1", "text1")
-            .WithAllowSystemDeleteAfter(DateTimeOffset.UtcNow.AddDays(1))
             .WithExternalReference(CorrespondenceReferenceType.Generic, "aaa")
             .WithPropertyList(new Dictionary<string, string> { ["prop1"] = "value1", ["prop2"] = "value2" })
             .WithExistingAttachment(Guid.Parse("a3ac4826-5873-4ecb-9fe7-dc4cfccd0afa"))
@@ -362,7 +356,6 @@ public class CorrespondenceBuilderTests
             TestHelpers.GetNationalIdentityNumber(7).Value,
         ]);
         builder.WithDueDateTime(DateTimeOffset.UtcNow.AddDays(2));
-        builder.WithAllowSystemDeleteAfter(DateTimeOffset.UtcNow.AddDays(2));
         builder.WithContent("en", "content-title-2", "content-summary-2", "content-body-2");
         builder.WithNotification(
             CorrespondenceNotificationBuilder
@@ -405,7 +398,6 @@ public class CorrespondenceBuilderTests
         correspondence.ResourceId.Should().Be("resourceId-2");
         correspondence.Sender.Should().Be(TestHelpers.GetOrganisationNumber(2));
         correspondence.SendersReference.Should().Be("sender-reference-2");
-        correspondence.AllowSystemDeleteAfter.Should().BeSameDateAs(DateTimeOffset.UtcNow.AddDays(2));
         correspondence.DueDateTime.Should().BeSameDateAs(DateTimeOffset.UtcNow.AddDays(2));
         correspondence.Recipients.Should().HaveCount(7);
         correspondence

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/Models/CorrespondenceRequestTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/Models/CorrespondenceRequestTests.cs
@@ -20,7 +20,6 @@ public class CorrespondenceRequestTests
             Sender = TestHelpers.GetOrganisationNumber(0),
             SendersReference = "senders-reference",
             RequestedPublishTime = DateTimeOffset.UtcNow.AddDays(1),
-            AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddDays(2),
             DueDateTime = DateTimeOffset.UtcNow.AddDays(2),
             IgnoreReservation = true,
             IsConfirmationNeeded = true,
@@ -101,7 +100,6 @@ public class CorrespondenceRequestTests
                 NotificationChannel = CorrespondenceNotificationChannel.EmailPreferred,
                 ReminderNotificationChannel = CorrespondenceNotificationChannel.SmsPreferred,
                 SendersReference = "senders-reference",
-                RequestedSendTime = DateTimeOffset.UtcNow,
                 CustomRecipient = new CorrespondenceNotificationRecipient
                 {
                     EmailAddress = "email-address-1",
@@ -124,7 +122,6 @@ public class CorrespondenceRequestTests
             ["Correspondence.Sender"] = correspondence.Sender.ToUrnFormattedString(),
             ["Correspondence.SendersReference"] = correspondence.SendersReference,
             ["Correspondence.RequestedPublishTime"] = correspondence.RequestedPublishTime,
-            ["Correspondence.AllowSystemDeleteAfter"] = correspondence.AllowSystemDeleteAfter,
             ["Correspondence.DueDateTime"] = correspondence.DueDateTime,
             ["Correspondence.MessageSender"] = correspondence.MessageSender,
             ["Correspondence.IgnoreReservation"] = correspondence.IgnoreReservation,
@@ -167,7 +164,6 @@ public class CorrespondenceRequestTests
             ["Correspondence.Notification.NotificationChannel"] = correspondence.Notification.NotificationChannel,
             ["Correspondence.Notification.ReminderNotificationChannel"] = correspondence.Notification.ReminderNotificationChannel,
             ["Correspondence.Notification.SendersReference"] = correspondence.Notification.SendersReference,
-            ["Correspondence.Notification.RequestedSendTime"] = correspondence.Notification.RequestedSendTime,
             ["Correspondence.Notification.CustomRecipient.EmailAddress"] = correspondence.Notification.CustomRecipient.EmailAddress,
             ["Correspondence.Notification.CustomRecipient.OrganizationNumber"] = correspondence.Notification.CustomRecipient.OrganizationNumber,
         };
@@ -189,7 +185,6 @@ public class CorrespondenceRequestTests
             Sender = TestHelpers.GetOrganisationNumber(0),
             SendersReference = "senders-reference",
             RequestedPublishTime = DateTimeOffset.UtcNow.AddDays(1),
-            AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddDays(2),
             DueDateTime = DateTimeOffset.UtcNow.AddDays(2),
             // Setting IgnoreReservation to false, but IsReserved will override this
             IgnoreReservation = false,
@@ -271,7 +266,6 @@ public class CorrespondenceRequestTests
                 NotificationChannel = CorrespondenceNotificationChannel.EmailPreferred,
                 ReminderNotificationChannel = CorrespondenceNotificationChannel.SmsPreferred,
                 SendersReference = "senders-reference",
-                RequestedSendTime = DateTimeOffset.UtcNow,
                 CustomRecipient = new CorrespondenceNotificationRecipient
                 {
                     EmailAddress = "email-address-1",
@@ -296,7 +290,6 @@ public class CorrespondenceRequestTests
             ["Correspondence.Sender"] = correspondence.Sender.ToUrnFormattedString(),
             ["Correspondence.SendersReference"] = correspondence.SendersReference,
             ["Correspondence.RequestedPublishTime"] = correspondence.RequestedPublishTime,
-            ["Correspondence.AllowSystemDeleteAfter"] = correspondence.AllowSystemDeleteAfter,
             ["Correspondence.DueDateTime"] = correspondence.DueDateTime,
             ["Correspondence.MessageSender"] = correspondence.MessageSender,
             ["Correspondence.IsConfirmationNeeded"] = correspondence.IsConfirmationNeeded,
@@ -338,7 +331,6 @@ public class CorrespondenceRequestTests
             ["Correspondence.Notification.NotificationChannel"] = correspondence.Notification.NotificationChannel,
             ["Correspondence.Notification.ReminderNotificationChannel"] = correspondence.Notification.ReminderNotificationChannel,
             ["Correspondence.Notification.SendersReference"] = correspondence.Notification.SendersReference,
-            ["Correspondence.Notification.RequestedSendTime"] = correspondence.Notification.RequestedSendTime,
             ["Correspondence.Notification.CustomRecipient.EmailAddress"] = correspondence.Notification.CustomRecipient.EmailAddress,
             ["Correspondence.Notification.CustomRecipient.OrganizationNumber"] = correspondence.Notification.CustomRecipient.OrganizationNumber,
             ["Correspondence.IgnoreReservation"] = correspondence.Notification.CustomRecipient.IsReserved,
@@ -361,7 +353,6 @@ public class CorrespondenceRequestTests
             ResourceId = "resource-id",
             Sender = TestHelpers.GetOrganisationNumber(0),
             SendersReference = "senders-reference",
-            AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddDays(2),
             DueDateTime = DateTimeOffset.UtcNow.AddDays(2),
             Recipients = [OrganisationOrPersonIdentifier.Create(TestHelpers.GetOrganisationNumber(1))],
             Content = new CorrespondenceContent
@@ -444,7 +435,6 @@ public class CorrespondenceRequestTests
             ResourceId = "resource-id",
             Sender = TestHelpers.GetOrganisationNumber(0),
             SendersReference = "senders-reference",
-            AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddYears(1),
             Recipients =
             [
                 OrganisationOrPersonIdentifier.Create(TestHelpers.GetOrganisationNumber(1)),
@@ -475,7 +465,6 @@ public class CorrespondenceRequestTests
             ResourceId = "resource-id",
             Sender = TestHelpers.GetOrganisationNumber(0),
             SendersReference = "senders-reference",
-            AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddYears(1),
             IsConfirmationNeeded = true,
             Recipients = [OrganisationOrPersonIdentifier.Create(TestHelpers.GetOrganisationNumber(1))],
             Content = new CorrespondenceContent
@@ -503,7 +492,6 @@ public class CorrespondenceRequestTests
             ResourceId = "resource-id",
             Sender = TestHelpers.GetOrganisationNumber(0),
             SendersReference = "senders-reference",
-            AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddYears(1),
             Recipients = [OrganisationOrPersonIdentifier.Create(TestHelpers.GetOrganisationNumber(1))],
             Content = new CorrespondenceContent
             {
@@ -520,15 +508,9 @@ public class CorrespondenceRequestTests
             var correspondence = baseCorrespondence with { DueDateTime = DateTimeOffset.Now.AddSeconds(-1) };
             correspondence.Serialise();
         };
-        var act2 = () =>
-        {
-            var correspondence = baseCorrespondence with { AllowSystemDeleteAfter = DateTimeOffset.Now.AddSeconds(-1) };
-            correspondence.Serialise();
-        };
 
         // Assert
         act1.Should().Throw<CorrespondenceArgumentException>().WithMessage("*not be*in the past");
-        act2.Should().Throw<CorrespondenceArgumentException>().WithMessage("*not be*in the past");
     }
 
     [Fact]
@@ -541,7 +523,6 @@ public class CorrespondenceRequestTests
             Sender = TestHelpers.GetOrganisationNumber(0),
             SendersReference = "senders-reference",
             RequestedPublishTime = DateTimeOffset.Now.AddDays(2),
-            AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddYears(1),
             Recipients = [OrganisationOrPersonIdentifier.Create(TestHelpers.GetOrganisationNumber(1))],
             Content = new CorrespondenceContent
             {
@@ -558,43 +539,8 @@ public class CorrespondenceRequestTests
             var correspondence = baseCorrespondence with { DueDateTime = DateTimeOffset.Now.AddDays(1) };
             correspondence.Serialise();
         };
-        var act2 = () =>
-        {
-            var correspondence = baseCorrespondence with { AllowSystemDeleteAfter = DateTimeOffset.Now.AddDays(1) };
-            correspondence.Serialise();
-        };
-
         // Assert
         act1.Should().Throw<CorrespondenceArgumentException>().WithMessage("*not be prior to*");
-        act2.Should().Throw<CorrespondenceArgumentException>().WithMessage("*not be prior to*");
-    }
-
-    [Fact]
-    public void Serialise_ValidatesDeleteDateAfterDueDate()
-    {
-        // Arrange
-        var correspondence = new CorrespondenceRequest
-        {
-            ResourceId = "resource-id",
-            Sender = TestHelpers.GetOrganisationNumber(0),
-            SendersReference = "senders-reference",
-            AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddDays(2),
-            DueDateTime = DateTimeOffset.UtcNow.AddDays(3),
-            Recipients = [OrganisationOrPersonIdentifier.Create(TestHelpers.GetOrganisationNumber(1))],
-            Content = new CorrespondenceContent
-            {
-                Title = "title",
-                Body = "body",
-                Summary = "summary",
-                Language = LanguageCode<Iso6391>.Parse("no"),
-            },
-        };
-
-        // Act
-        var act = () => correspondence.Serialise();
-
-        // Assert
-        act.Should().Throw<CorrespondenceArgumentException>().WithMessage("*not be prior to*");
     }
 
     private static async Task AssertContent(MultipartFormDataContent content, string dispositionName, object? value)

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/Models/CorrespondenceRequestTests_Obsolete.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/Models/CorrespondenceRequestTests_Obsolete.cs
@@ -21,7 +21,6 @@ public class CorrespondenceRequestTests_Obsolete
             Sender = TestHelpers.GetOrganisationNumber(0),
             SendersReference = "senders-reference",
             RequestedPublishTime = DateTimeOffset.UtcNow.AddDays(1),
-            AllowSystemDeleteAfter = DateTimeOffset.UtcNow.AddDays(2),
             DueDateTime = DateTimeOffset.UtcNow.AddDays(2),
             IgnoreReservation = true,
             IsConfirmationNeeded = true,
@@ -102,7 +101,6 @@ public class CorrespondenceRequestTests_Obsolete
                 NotificationChannel = CorrespondenceNotificationChannel.EmailPreferred,
                 ReminderNotificationChannel = CorrespondenceNotificationChannel.SmsPreferred,
                 SendersReference = "senders-reference",
-                RequestedSendTime = DateTimeOffset.UtcNow,
                 CustomNotificationRecipients =
                 [
                     new CorrespondenceNotificationRecipientWrapper()
@@ -155,7 +153,6 @@ public class CorrespondenceRequestTests_Obsolete
             ["Correspondence.Sender"] = correspondence.Sender.ToUrnFormattedString(),
             ["Correspondence.SendersReference"] = correspondence.SendersReference,
             ["Correspondence.RequestedPublishTime"] = correspondence.RequestedPublishTime,
-            ["Correspondence.AllowSystemDeleteAfter"] = correspondence.AllowSystemDeleteAfter,
             ["Correspondence.DueDateTime"] = correspondence.DueDateTime,
             ["Correspondence.MessageSender"] = correspondence.MessageSender,
             ["Correspondence.IgnoreReservation"] = correspondence.IgnoreReservation,
@@ -198,7 +195,6 @@ public class CorrespondenceRequestTests_Obsolete
             ["Correspondence.Notification.NotificationChannel"] = correspondence.Notification.NotificationChannel,
             ["Correspondence.Notification.ReminderNotificationChannel"] = correspondence.Notification.ReminderNotificationChannel,
             ["Correspondence.Notification.SendersReference"] = correspondence.Notification.SendersReference,
-            ["Correspondence.Notification.RequestedSendTime"] = correspondence.Notification.RequestedSendTime,
             ["Correspondence.Notification.CustomRecipient.EmailAddress"] = correspondence.Notification.CustomNotificationRecipients[0].CorrespondenceNotificationRecipients[0].EmailAddress,
             ["Correspondence.Notification.CustomRecipient.OrganizationNumber"] = correspondence.Notification.CustomNotificationRecipients[0].CorrespondenceNotificationRecipients[0].OrganizationNumber,
         };

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/Models/CorrespondenceResponseTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/Models/CorrespondenceResponseTests.cs
@@ -144,7 +144,6 @@ public class CorrespondenceResponseTests
                     {
                         "id": "598e8044-5ec4-43f9-8ce2-6a37c24cc7df",
                         "sendersReference": "1234",
-                        "requestedSendTime": "2024-11-14T12:10:57.031351Z",
                         "creator": "digdir",
                         "created": "2024-11-14T11:05:57.237047Z",
                         "isReminder": true,
@@ -164,7 +163,6 @@ public class CorrespondenceResponseTests
                     {
                         "id": "7ab0ff62-8c5d-4a2e-8ad2-7e7236e847a4",
                         "sendersReference": "1234",
-                        "requestedSendTime": "2024-11-14T11:10:57.031351Z",
                         "creator": "digdir",
                         "created": "2024-11-14T11:05:57.054356Z",
                         "isReminder": false,
@@ -232,7 +230,6 @@ public class CorrespondenceResponseTests
                 "sendersReference": "1234",
                 "messageSender": "Test Testesen",
                 "requestedPublishTime": "2024-05-29T13:31:28.290518+00:00",
-                "allowSystemDeleteAfter": "2025-05-29T13:31:28.290518+00:00",
                 "dueDateTime": "2025-05-29T13:31:28.290518+00:00",
                 "externalReferences": [
                     {
@@ -258,7 +255,8 @@ public class CorrespondenceResponseTests
                 "notification": null,
                 "ignoreReservation": true,
                 "published": "2024-11-14T11:06:56.208705+00:00",
-                "isConfirmationNeeded": false
+                "isConfirmationNeeded": false,
+                "isConfidential": false
             }
             """;
 
@@ -288,7 +286,6 @@ public class CorrespondenceResponseTests
                 {
                     Id = "7ab0ff62-8c5d-4a2e-8ad2-7e7236e847a4",
                     SendersReference = "1234",
-                    RequestedSendTime = DateTimeOffset.Parse("2024-11-14T11:10:57.031351Z"),
                     Creator = "digdir",
                     Created = DateTimeOffset.Parse("2024-11-14T11:05:57.054356Z"),
                     NotificationChannel = CorrespondenceNotificationChannel.EmailPreferred,
@@ -359,7 +356,6 @@ public class CorrespondenceResponseTests
         parsedResponse.SendersReference.Should().Be("1234");
         parsedResponse.MessageSender.Should().Be("Test Testesen");
         parsedResponse.RequestedPublishTime.Should().Be(DateTimeOffset.Parse("2024-05-29T13:31:28.290518+00:00"));
-        parsedResponse.AllowSystemDeleteAfter.Should().Be(DateTimeOffset.Parse("2025-05-29T13:31:28.290518+00:00"));
         parsedResponse.DueDateTime.Should().Be(DateTimeOffset.Parse("2025-05-29T13:31:28.290518+00:00"));
         parsedResponse.ExternalReferences.Should().HaveCount(2);
         parsedResponse

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/Models/CorrespondenceResponseTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/Models/CorrespondenceResponseTests.cs
@@ -386,5 +386,6 @@ public class CorrespondenceResponseTests
         parsedResponse.IgnoreReservation.Should().BeTrue();
         parsedResponse.Published.Should().Be(DateTimeOffset.Parse("2024-11-14T11:06:56.208705+00:00"));
         parsedResponse.IsConfirmationNeeded.Should().BeFalse();
+        parsedResponse.IsConfidential.Should().BeFalse();
     }
 }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -477,6 +477,8 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailSubject(string? reminderEmailSubject) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? reminderNotificationChannel) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderSmsBody(string? reminderSmsBody) { }
+        [System.Obsolete("RequestedSendTime is no longer supported by the Correspondence API.")]
+        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRequestedSendTime(System.DateTimeOffset? requestedSendTime) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSendReminder(bool? sendReminder) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSendersReference(string? sendersReference) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSmsBody(string? smsBody) { }
@@ -515,6 +517,8 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
     public class CorrespondenceRequestBuilder : Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderContent, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderRecipients, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderResourceId, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderSender, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderSendersReference
     {
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceRequest Build() { }
+        [System.Obsolete("AllowSystemDeleteAfter is no longer supported by the Correspondence API.")]
+        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAllowSystemDeleteAfter(System.DateTimeOffset allowSystemDeleteAfter) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachment(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceAttachmentBuilder builder) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachment(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAttachment attachment) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachments(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAttachment> attachments) { }
@@ -606,6 +610,8 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailSubject(string? reminderEmailSubject);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? reminderNotificationChannel);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderSmsBody(string? reminderSmsBody);
+        [System.Obsolete("RequestedSendTime is no longer supported by the Correspondence API.")]
+        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRequestedSendTime(System.DateTimeOffset? requestedSendTime);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSendReminder(bool? sendReminder);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSendersReference(string? sendersReference);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSmsBody(string? smsBody);
@@ -646,6 +652,8 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
     public interface ICorrespondenceRequestBuilder : Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderContent, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderRecipients, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderResourceId, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderSender, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderSendersReference
     {
         Altinn.App.Core.Features.Correspondence.Models.CorrespondenceRequest Build();
+        [System.Obsolete("AllowSystemDeleteAfter is no longer supported by the Correspondence API.")]
+        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAllowSystemDeleteAfter(System.DateTimeOffset allowSystemDeleteAfter);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachment(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceAttachmentBuilder builder);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachment(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAttachment attachment);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachments(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAttachment> attachments);
@@ -862,6 +870,8 @@ namespace Altinn.App.Core.Features.Correspondence.Models
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? ReminderNotificationChannel { get; init; }
         [System.ComponentModel.DataAnnotations.StringLength(2144, MinimumLength=0)]
         public string? ReminderSmsBody { get; init; }
+        [System.Obsolete("RequestedSendTime is no longer supported by the Correspondence API.")]
+        public System.DateTimeOffset? RequestedSendTime { get; init; }
         public bool? SendReminder { get; init; }
         public string? SendersReference { get; init; }
         [System.ComponentModel.DataAnnotations.StringLength(2144, MinimumLength=0)]
@@ -904,6 +914,10 @@ namespace Altinn.App.Core.Features.Correspondence.Models
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationSummaryResponse? NotificationStatusDetails { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("processingStatus")]
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationStatusSummaryResponse? ProcessingStatus { get; init; }
+        [System.Obsolete("RequestedSendTime is no longer returned by the Correspondence API and will be rem" +
+            "oved in a future version.")]
+        [System.Text.Json.Serialization.JsonPropertyName("requestedSendTime")]
+        public System.DateTimeOffset? RequestedSendTime { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("resourceId")]
         public string? ResourceId { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("sendersReference")]
@@ -1009,6 +1023,8 @@ namespace Altinn.App.Core.Features.Correspondence.Models
     public sealed class CorrespondenceRequest : Altinn.App.Core.Features.Correspondence.Models.MultipartCorrespondenceItem, System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceRequest>
     {
         public CorrespondenceRequest() { }
+        [System.Obsolete("AllowSystemDeleteAfter is no longer supported by the Correspondence API.")]
+        public System.DateTimeOffset? AllowSystemDeleteAfter { get; init; }
         public required Altinn.App.Core.Features.Correspondence.Models.CorrespondenceContent Content { get; init; }
         public System.DateTimeOffset? DueDateTime { get; init; }
         public System.Collections.Generic.IReadOnlyList<System.Guid>? ExistingAttachments { get; init; }
@@ -1065,6 +1081,10 @@ namespace Altinn.App.Core.Features.Correspondence.Models
     public sealed class GetCorrespondenceStatusResponse : System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.GetCorrespondenceStatusResponse>
     {
         public GetCorrespondenceStatusResponse() { }
+        [System.Obsolete("AllowSystemDeleteAfter is no longer returned by the Correspondence API and will b" +
+            "e removed in a future version.")]
+        [System.Text.Json.Serialization.JsonPropertyName("allowSystemDeleteAfter")]
+        public System.DateTimeOffset? AllowSystemDeleteAfter { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("content")]
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceContentResponse? Content { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("correspondenceId")]

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -914,8 +914,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationSummaryResponse? NotificationStatusDetails { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("processingStatus")]
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationStatusSummaryResponse? ProcessingStatus { get; init; }
-        [System.Obsolete("RequestedSendTime is no longer returned by the Correspondence API and will be rem" +
-            "oved in a future version.")]
+        [System.Obsolete("RequestedSendTime is no longer returned by the Correspondence API.")]
         [System.Text.Json.Serialization.JsonPropertyName("requestedSendTime")]
         public System.DateTimeOffset? RequestedSendTime { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("resourceId")]
@@ -1081,8 +1080,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models
     public sealed class GetCorrespondenceStatusResponse : System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.GetCorrespondenceStatusResponse>
     {
         public GetCorrespondenceStatusResponse() { }
-        [System.Obsolete("AllowSystemDeleteAfter is no longer returned by the Correspondence API and will b" +
-            "e removed in a future version.")]
+        [System.Obsolete("AllowSystemDeleteAfter is no longer returned by the Correspondence API.")]
         [System.Text.Json.Serialization.JsonPropertyName("allowSystemDeleteAfter")]
         public System.DateTimeOffset? AllowSystemDeleteAfter { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("content")]

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -477,7 +477,6 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailSubject(string? reminderEmailSubject) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? reminderNotificationChannel) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderSmsBody(string? reminderSmsBody) { }
-        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRequestedSendTime(System.DateTimeOffset? requestedSendTime) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSendReminder(bool? sendReminder) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSendersReference(string? sendersReference) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSmsBody(string? smsBody) { }
@@ -516,7 +515,6 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
     public class CorrespondenceRequestBuilder : Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderContent, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderRecipients, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderResourceId, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderSender, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderSendersReference
     {
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceRequest Build() { }
-        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAllowSystemDeleteAfter(System.DateTimeOffset allowSystemDeleteAfter) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachment(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceAttachmentBuilder builder) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachment(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAttachment attachment) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachments(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAttachment> attachments) { }
@@ -531,6 +529,7 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithExternalReference(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceReferenceType type, string value) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithExternalReferences(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceExternalReference> externalReferences) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithIgnoreReservation(bool ignoreReservation) { }
+        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithIsConfidential(bool isConfidential) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithIsConfirmationNeeded(bool isConfirmationNeeded) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithMessageSender(string messageSender) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithNotification(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder builder) { }
@@ -607,7 +606,6 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailSubject(string? reminderEmailSubject);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? reminderNotificationChannel);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderSmsBody(string? reminderSmsBody);
-        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRequestedSendTime(System.DateTimeOffset? requestedSendTime);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSendReminder(bool? sendReminder);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSendersReference(string? sendersReference);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithSmsBody(string? smsBody);
@@ -648,7 +646,6 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
     public interface ICorrespondenceRequestBuilder : Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderContent, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderRecipients, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderResourceId, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderSender, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilderSendersReference
     {
         Altinn.App.Core.Features.Correspondence.Models.CorrespondenceRequest Build();
-        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAllowSystemDeleteAfter(System.DateTimeOffset allowSystemDeleteAfter);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachment(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceAttachmentBuilder builder);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachment(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAttachment attachment);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithAttachments(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceAttachment> attachments);
@@ -659,6 +656,7 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithExternalReference(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceReferenceType type, string value);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithExternalReferences(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceExternalReference> externalReferences);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithIgnoreReservation(bool ignoreReservation);
+        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithIsConfidential(bool isConfidential);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithIsConfirmationNeeded(bool isConfirmationNeeded);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithMessageSender(string messageSender);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceRequestBuilder WithNotification(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder builder);
@@ -864,7 +862,6 @@ namespace Altinn.App.Core.Features.Correspondence.Models
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? ReminderNotificationChannel { get; init; }
         [System.ComponentModel.DataAnnotations.StringLength(2144, MinimumLength=0)]
         public string? ReminderSmsBody { get; init; }
-        public System.DateTimeOffset? RequestedSendTime { get; init; }
         public bool? SendReminder { get; init; }
         public string? SendersReference { get; init; }
         [System.ComponentModel.DataAnnotations.StringLength(2144, MinimumLength=0)]
@@ -907,8 +904,6 @@ namespace Altinn.App.Core.Features.Correspondence.Models
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationSummaryResponse? NotificationStatusDetails { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("processingStatus")]
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationStatusSummaryResponse? ProcessingStatus { get; init; }
-        [System.Text.Json.Serialization.JsonPropertyName("requestedSendTime")]
-        public System.DateTimeOffset RequestedSendTime { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("resourceId")]
         public string? ResourceId { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("sendersReference")]
@@ -1014,12 +1009,12 @@ namespace Altinn.App.Core.Features.Correspondence.Models
     public sealed class CorrespondenceRequest : Altinn.App.Core.Features.Correspondence.Models.MultipartCorrespondenceItem, System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceRequest>
     {
         public CorrespondenceRequest() { }
-        public required System.DateTimeOffset? AllowSystemDeleteAfter { get; init; }
         public required Altinn.App.Core.Features.Correspondence.Models.CorrespondenceContent Content { get; init; }
         public System.DateTimeOffset? DueDateTime { get; init; }
         public System.Collections.Generic.IReadOnlyList<System.Guid>? ExistingAttachments { get; init; }
         public System.Collections.Generic.IReadOnlyList<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceExternalReference>? ExternalReferences { get; init; }
         public bool? IgnoreReservation { get; init; }
+        public bool? IsConfidential { get; init; }
         public bool? IsConfirmationNeeded { get; init; }
         public string? MessageSender { get; init; }
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotification? Notification { get; init; }
@@ -1070,8 +1065,6 @@ namespace Altinn.App.Core.Features.Correspondence.Models
     public sealed class GetCorrespondenceStatusResponse : System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.GetCorrespondenceStatusResponse>
     {
         public GetCorrespondenceStatusResponse() { }
-        [System.Text.Json.Serialization.JsonPropertyName("allowSystemDeleteAfter")]
-        public System.DateTimeOffset? AllowSystemDeleteAfter { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("content")]
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceContentResponse? Content { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("correspondenceId")]
@@ -1084,6 +1077,8 @@ namespace Altinn.App.Core.Features.Correspondence.Models
         public System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceExternalReference>? ExternalReferences { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("ignoreReservation")]
         public bool? IgnoreReservation { get; init; }
+        [System.Text.Json.Serialization.JsonPropertyName("isConfidential")]
+        public bool IsConfidential { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("isConfirmationNeeded")]
         public bool IsConfirmationNeeded { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("markedUnread")]


### PR DESCRIPTION
## Description
The correspondence API has been updated with new functionality regarding the IsConfidential flag. If a correspondence is sent with a resource which uses the access package: "taushetsbelagt-post-til-virksomheten" the IsConfidential flag must be set.
Added the possibility to send IsConfidential, and removed unused api fields by making the With-methods no-ops.

## Related Issue(s)
- https://github.com/Altinn/altinn-correspondence/issues/1843

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Correspondence requests can be marked as confidential.

* **Refactor**
  * Requested send-time and automatic-delete fields are deprecated and no longer applied or serialized.
  * Date validation around the deprecated delete-time was removed; response shapes adjusted to accept absent values.

* **Tests**
  * Tests and fixtures updated to match the revised correspondence contract and deprecated fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->