### PR TITLE
fix: version too long nuget

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -42,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sha=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefOid | jq -r '.headRefOid' | cut -c1-8)
-          branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName | jq -r '.headRefName' | sed 's/.*\///')
+          branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName | jq -r '.headRefName' | sed 's/.*\///' | cut -c1-30)
           version=$(git describe --abbrev=0 --tags 2>/dev/null)
           version=$(echo $version | cut -d '-' -f 1)
           version="$version-pr.${{ github.run_number }}.$branch.$sha"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Version too long, max limit 64 chars, so the branch name can be max 40. 30 is a conservative safe length that should be unique without coming close to too long

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request release version handling in automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->