### PR TITLE
Remove RequiredService from service lookup of INetsWebhookSecretProvi…

### DIFF
--- a/src/Altinn.App.Api/Controllers/PaymentController.cs
+++ b/src/Altinn.App.Api/Controllers/PaymentController.cs
@@ -29,7 +29,7 @@ public class PaymentController : ControllerBase
     private readonly IPaymentService _paymentService;
     private readonly AppImplementationFactory _appImplementationFactory;
     private readonly ILogger<PaymentController> _logger;
-    private readonly INetsWebhookSecretProvider _netsWebhookSecretProvider;
+    private readonly INetsWebhookSecretProvider? _netsWebhookSecretProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PaymentController"/> class.
@@ -44,7 +44,7 @@ public class PaymentController : ControllerBase
         _instanceClient = instanceClient;
         _processReader = processReader;
         _logger = logger;
-        _netsWebhookSecretProvider = serviceProvider.GetRequiredService<INetsWebhookSecretProvider>();
+        _netsWebhookSecretProvider = serviceProvider.GetService<INetsWebhookSecretProvider>();
         _paymentService = serviceProvider.GetRequiredService<IPaymentService>();
         _appImplementationFactory = serviceProvider.GetRequiredService<AppImplementationFactory>();
     }
@@ -232,6 +232,13 @@ public class PaymentController : ControllerBase
         [FromHeader(Name = "Authorization")] string authorizationHeader
     )
     {
+        if (_netsWebhookSecretProvider is null)
+        {
+            throw new PaymentException(
+                "No INetsWebhookSecretProvider is registered. Ensure the Nets payment provider is correctly configured."
+            );
+        }
+
         if (!_netsWebhookSecretProvider.IsValidIncomingSecret(authorizationHeader))
         {
             _logger.LogWarning(

--- a/test/Altinn.App.Api.Tests/Controllers/PaymentControllerTests.cs
+++ b/test/Altinn.App.Api.Tests/Controllers/PaymentControllerTests.cs
@@ -578,6 +578,56 @@ public class PaymentControllerTests
         _services.VerifyMocks();
     }
 
+    [Fact]
+    public void Constructor_NetsWebhookSecretProviderNotRegistered_DoesNotThrow()
+    {
+        var services = new MockedServiceCollection();
+        services.Mock<IProcessReader>();
+        services.Services.AddSingleton<IPaymentService, PaymentService>();
+        services.Services.AddSingleton<PaymentController>();
+        // Deliberately not registering INetsWebhookSecretProvider
+        services.Storage.AddInstance(_instance);
+
+        using var sp = services.BuildServiceProvider();
+
+        // Must not throw — the controller should be constructable without Nets configured
+        var controller = sp.GetRequiredService<PaymentController>();
+        Assert.NotNull(controller);
+    }
+
+    [Fact]
+    public async Task PaymentWebhookListener_NetsNotConfigured_ThrowsPaymentException()
+    {
+        var services = new MockedServiceCollection();
+        services.Mock<IProcessReader>();
+        services.Services.AddSingleton<IPaymentService, PaymentService>();
+        services.Services.AddSingleton<PaymentController>();
+        // Deliberately not registering INetsWebhookSecretProvider
+        services.Storage.AddInstance(_instance);
+
+        await using var sp = services.BuildServiceProvider();
+        var controller = sp.GetRequiredService<PaymentController>();
+
+        var exception = await Assert.ThrowsAsync<PaymentException>(async () =>
+            await controller.PaymentWebhookListener(
+                "org",
+                "app",
+                PartyId,
+                _instanceGuid,
+                new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Data = new() { PaymentId = Guid.NewGuid().ToString() },
+                    EventName = "PaymentCreated",
+                    Timestamp = DateTime.UtcNow,
+                    MerchantId = 222,
+                },
+                "somekey"
+            )
+        );
+        Assert.Contains("INetsWebhookSecretProvider", exception.Message);
+    }
+
     private void SetupAltinnTaskExtensionMock(string taskId, AltinnTaskExtension? taskExtension, Times times)
     {
         _services


### PR DESCRIPTION
Remove RequiredService from service lookup of INetsWebhookSecretProvider. It will only be registered in the service provider if NetsPaymentSettings exist in config.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Payment webhook configuration is now optional; applications start successfully even without Nets provider registration.
  * Enhanced error handling with clear failure messages when payment webhooks are invoked without proper configuration.

* **Tests**
  * Added test coverage for payment webhook scenarios with missing provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->