### PR TITLE
chore: bump studioctl

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           STUDIOCTL_HOME: ${{ runner.temp }}/studioctl-home
           STUDIOCTL_INSTALL_DIR: ${{ runner.temp }}/studioctl-bin
-          STUDIOCTL_VERSION: v0.1.0-preview.6
+          STUDIOCTL_VERSION: v0.1.0-preview.8
         run: |
           mkdir -p "$STUDIOCTL_HOME" "$STUDIOCTL_INSTALL_DIR"
           curl -fsSL https://altinn.studio/designer/api/v1/studioctl/install.sh -o "$RUNNER_TEMP/studioctl-install.sh"
@@ -62,5 +62,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         env:
           STUDIOCTL_HOME: ${{ runner.temp }}/studioctl-home
+          TEST_STUDIOCTL_COMMAND: ${{ runner.temp }}/studioctl-bin/studioctl
         run: |
           dotnet test solutions/All.sln --no-restore --no-build --logger "console;verbosity=detailed" --filter "Category=Integration"

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.AppConnectivity_Localtest.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.AppConnectivity_Localtest.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   Success: true,
   StatusCode: 200,
-  Url: http://127.0.0.1:5101/health,
+  Url: http://local.altinn.cloud:8000/health,
   ResponseContent: Healthy,
   Message: Localtest health endpoint connectivity verified
 }

--- a/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.AppConnectivity_Pdf.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Basic/_snapshots/BasicAppTests.AppConnectivity_Pdf.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   Success: true,
   StatusCode: 200,
-  Url: http://127.0.0.1:<pdfPort>/health/startup,
+  Url: http://pdf.local.altinn.cloud:8000/health/startup,
   ResponseContent: OK,
   Message: PDF service connectivity verified
 }


### PR DESCRIPTION
## Description
Bumps studioctl used by Ubuntu integration tests to `v0.1.0-preview.8` and updates the localtest/pdf connectivity snapshots for the new preview 8 hostnames.

Supersedes #1749.

## Verification
- `dotnet build solutions/All.sln -v m`
- `dotnet test solutions/All.sln --no-restore --no-build --logger "console;verbosity=detailed" --filter "Category=Integration"` (54 passed, 1 skipped)

Note: local `dotnet test solutions/All.sln -v m --no-restore --no-build --filter "Category!=Integration"` completed the non-analyzer projects but the analyzer testhost hung locally; leaving CI to validate that runner.

cc @martinothamar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure with newer tooling version and revised test configuration endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/app-lib-dotnet/pull/1757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->