### PR TITLE
fix: support non-list collections in form wrapper generator

### DIFF
--- a/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
+++ b/src/Altinn.App.Analyzers/FormDataWrapper/FormDataWrapperUtils.cs
@@ -126,18 +126,23 @@ public static class FormDataWrapperUtils
             return null;
         }
 
-        var propertyTypeInfo = SourceReaderUtils.GetTypeFromProperty(rootSymbol);
+        var collectionTypeSymbols = SourceReaderUtils.GetCollectionTypeSymbols(compilation);
+        var propertyTypeInfo = SourceReaderUtils.GetTypeFromProperty(rootSymbol, collectionTypeSymbols);
 
         return new ModelPathNode(
             "",
             "",
             propertyTypeInfo.PropertyTypeString,
             propertyTypeInfo.IsNullable,
-            GetNodeProperties(rootSymbol, diagnostics)
+            GetNodeProperties(rootSymbol, diagnostics, collectionTypeSymbols)
         );
     }
 
-    private static ModelPathNode[]? GetNodeProperties(ITypeSymbol typeSymbol, List<Diagnostic> diagnostics)
+    private static ModelPathNode[]? GetNodeProperties(
+        ITypeSymbol typeSymbol,
+        List<Diagnostic> diagnostics,
+        SourceReaderUtils.CollectionTypeSymbols? collectionTypeSymbols
+    )
     {
         if (typeSymbol is not INamedTypeSymbol namedTypeSymbol)
         {
@@ -158,12 +163,12 @@ public static class FormDataWrapperUtils
                 // Skip static, readonly, writeonly, implicitly declared, private and indexer properties
                 continue;
             }
-            var propertyTypeInfo = SourceReaderUtils.GetTypeFromProperty(property.Type);
+            var propertyTypeInfo = SourceReaderUtils.GetTypeFromProperty(property.Type, collectionTypeSymbols);
 
             var cSharpName = property.Name;
             var jsonName = SourceReaderUtils.GetJsonName(property) ?? cSharpName;
 
-            var subProperties = GetNodeProperties(propertyTypeInfo.PropertyType, diagnostics);
+            var subProperties = GetNodeProperties(propertyTypeInfo.PropertyType, diagnostics, collectionTypeSymbols);
 
             nodeProperties.Add(
                 new ModelPathNode(
@@ -173,7 +178,8 @@ public static class FormDataWrapperUtils
                     propertyTypeInfo.IsNullable,
                     subProperties,
                     propertyTypeInfo.PropertyCollectionTypeString,
-                    propertyTypeInfo.IsNullableCollection
+                    propertyTypeInfo.IsNullableCollection,
+                    propertyTypeInfo.IsIndexableCollection
                 )
             );
         }

--- a/src/Altinn.App.Analyzers/ModelPathNode.cs
+++ b/src/Altinn.App.Analyzers/ModelPathNode.cs
@@ -20,13 +20,15 @@ public record ModelPathNode
         bool isNullable,
         ModelPathNode[]? properties = null,
         string? listType = null,
-        bool isNullableList = false
+        bool isNullableList = false,
+        bool isIndexableList = true
     )
     {
         CSharpName = cSharpName;
         JsonName = jsonName;
         ListType = listType;
         IsNullableList = isNullableList;
+        IsIndexableList = isIndexableList;
         TypeName = typeName;
         IsNullable = isNullable;
         IsJsonValueType = properties is null;
@@ -77,6 +79,7 @@ public record ModelPathNode
     /// </remarks>
     public string? ListType { get; }
     public bool IsNullableList { get; }
+    public bool IsIndexableList { get; }
 
     public string? ListTypeWithNullable => IsNullableList ? $"{ListType}?" : ListType;
 

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/CollectionAccessorGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/CollectionAccessorGenerator.cs
@@ -1,0 +1,9 @@
+namespace Altinn.App.Analyzers.SourceTextGenerator;
+
+internal static class CollectionAccessorGenerator
+{
+    internal static string GenerateAccessor(ModelPathNode node, string collectionName, string indexName) =>
+        node.IsIndexableList
+            ? $"{collectionName}[{indexName}]"
+            : $"global::System.Linq.Enumerable.ElementAt({collectionName}, {indexName})";
+}

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/GetterGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/GetterGenerator.cs
@@ -46,6 +46,15 @@ internal static class GetterGenerator
     {
         if (modelPathNode.ListType != null && generatedTypes.Add(modelPathNode.ListType))
         {
+            var itemAccessor = CollectionAccessorGenerator.GenerateAccessor(modelPathNode, "model", "literalIndex");
+            var returnStatement =
+                modelPathNode.Properties.Count == 0
+                    ? $"return {itemAccessor};"
+                    : $$"""
+                        var item = {{itemAccessor}};
+                                return GetRecursive(item, path, offset);
+                        """;
+
             builder.Append(
                 $$"""
 
@@ -66,11 +75,7 @@ internal static class GetterGenerator
                             return null;
                         }
 
-                        {{(
-                    modelPathNode.Properties.Count == 0
-                        ? "return model[literalIndex];"
-                        : "return GetRecursive(model[literalIndex], path, offset);"
-                )}}
+                        {{returnStatement}}
                     }
 
                 """

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/RemoveGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/RemoveGenerator.cs
@@ -73,27 +73,46 @@ internal static class RemoveGenerator
                         }
                         if (offset == -1)
                         {
-                            switch (rowRemovalOption)
-                            {
-                                case global::Altinn.App.Core.Helpers.RowRemovalOption.DeleteRow:
-                                    model.RemoveAt(index);
-                                    break;
-                                case global::Altinn.App.Core.Helpers.RowRemovalOption.SetToNull:
-                                    model[index] = default!;
-                                    break;
-                            }
-                        }
                 """
             );
+            builder.Append("\r\n");
+            if (modelPathNode.IsIndexableList)
+            {
+                builder.Append(
+                    """
+                                switch (rowRemovalOption)
+                                {
+                                    case global::Altinn.App.Core.Helpers.RowRemovalOption.DeleteRow:
+                                        model.RemoveAt(index);
+                                        break;
+                                    case global::Altinn.App.Core.Helpers.RowRemovalOption.SetToNull:
+                                        model[index] = default!;
+                                        break;
+                                }
+                            }
+                    """
+                );
+            }
+            else
+            {
+                builder.Append(
+                    """
+                                return;
+                            }
+                    """
+                );
+            }
             if (modelPathNode.Properties.Count > 0)
             {
                 // Don't recurs into primitives (classes with no properties)
+                var itemAccessor = CollectionAccessorGenerator.GenerateAccessor(modelPathNode, "model", "index");
                 builder.Append(
-                    """
+                    $$"""
 
                             else
                             {
-                                RemoveRecursive(model[index], path, offset, rowRemovalOption);
+                                var item = {{itemAccessor}};
+                                RemoveRecursive(item, path, offset, rowRemovalOption);
                             }
                     """
                 );

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/SetterGenerator.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/SetterGenerator.cs
@@ -90,7 +90,16 @@ internal static class SetterGenerator
             if (modelPathNode.Properties.Count == 0)
             {
                 // Simple list element - direct set
-                if (modelPathNode.IsNullable || modelPathNode.IsCSharpValueType())
+                if (!modelPathNode.IsIndexableList)
+                {
+                    builder.Append(
+                        """
+                                return false;
+
+                        """
+                    );
+                }
+                else if (modelPathNode.IsNullable || modelPathNode.IsCSharpValueType())
                 {
                     builder.Append(
                         $$"""
@@ -121,9 +130,11 @@ internal static class SetterGenerator
             }
             else
             {
+                var itemAccessor = CollectionAccessorGenerator.GenerateAccessor(modelPathNode, "model", "literalIndex");
                 builder.Append(
-                    """
-                            return SetRecursive(model[literalIndex], path, offset, value);
+                    $$"""
+                            var item = {{itemAccessor}};
+                            return SetRecursive(item, path, offset, value);
 
                     """
                 );
@@ -232,6 +243,16 @@ internal static class SetterGenerator
             if (child.ListType != null)
             {
                 // Generate list creation helper
+                var ensureCollection = child.IsIndexableList
+                    ? $"model.{child.CSharpName} ??= new();"
+                    : $$"""
+                        if (model.{{child.CSharpName}} is null)
+                                {
+                                    return false;
+                                }
+
+                        """;
+
                 builder.Append(
                     $$"""
 
@@ -243,7 +264,7 @@ internal static class SetterGenerator
                             global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
                         )
                         {
-                            model.{{child.CSharpName}} ??= new();
+                            {{ensureCollection}}
                             return SetRecursive(model.{{child.CSharpName}}, path, literalIndex, nextOffset, value);
                         }
 

--- a/src/Altinn.App.Analyzers/SourceTextGenerator/SourceReaderUtils.cs
+++ b/src/Altinn.App.Analyzers/SourceTextGenerator/SourceReaderUtils.cs
@@ -1,3 +1,5 @@
+using Altinn.App.Analyzers.Utils;
+
 namespace Altinn.App.Analyzers.SourceTextGenerator;
 
 public static class SourceReaderUtils
@@ -52,11 +54,12 @@ public static class SourceReaderUtils
         return typeSymbol.ToDisplayString(_format);
     }
 
-    public record PropertyTypeInfo(
+    internal record PropertyTypeInfo(
         ITypeSymbol PropertyType,
         bool IsNullable,
         ITypeSymbol? PropertyCollectionType,
-        bool IsNullableCollection
+        bool IsNullableCollection,
+        bool IsIndexableCollection
     )
     {
         public string PropertyTypeString => TypeSymbolToString(PropertyType);
@@ -64,24 +67,32 @@ public static class SourceReaderUtils
             PropertyCollectionType is null ? null : TypeSymbolToString(PropertyCollectionType);
     };
 
-    public static PropertyTypeInfo GetTypeFromProperty(ITypeSymbol propertyTypeSymbol)
+    internal record CollectionTypeSymbols(INamedTypeSymbol ICollectionOfT, INamedTypeSymbol IListOfT);
+
+    internal static CollectionTypeSymbols? GetCollectionTypeSymbols(Compilation compilation)
+    {
+        var iCollectionOfT = compilation.GetBestTypeByMetadataName(typeof(ICollection<>));
+        var iListOfT = compilation.GetBestTypeByMetadataName(typeof(IList<>));
+
+        return iCollectionOfT is null || iListOfT is null ? null : new CollectionTypeSymbols(iCollectionOfT, iListOfT);
+    }
+
+    internal static PropertyTypeInfo GetTypeFromProperty(
+        ITypeSymbol propertyTypeSymbol,
+        CollectionTypeSymbols? collectionTypeSymbols
+    )
     {
         var (unwrappedTypeSymbol, isNullable) = UnwrapNullable(propertyTypeSymbol);
 
         switch (unwrappedTypeSymbol)
         {
             case INamedTypeSymbol { Arity: 1 } namedTypeSymbol:
-                var collectionTypeSymbol = namedTypeSymbol.AllInterfaces.FirstOrDefault(i =>
-                    i.MetadataName == "ICollection`1"
-                    && i.ContainingNamespace.Name == "Generic"
-                    && i.ContainingNamespace.ContainingNamespace.Name == "Collections"
-                    && i.ContainingNamespace.ContainingNamespace.ContainingNamespace.Name == "System"
-                    && i.ContainingNamespace
-                        .ContainingNamespace
-                        .ContainingNamespace
-                        .ContainingNamespace
-                        .IsGlobalNamespace
-                );
+                if (collectionTypeSymbols is not { } symbols)
+                {
+                    break;
+                }
+
+                var collectionTypeSymbol = GetGenericTypeOrInterface(namedTypeSymbol, symbols.ICollectionOfT);
 
                 if (collectionTypeSymbol is not null)
                 {
@@ -92,7 +103,8 @@ public static class SourceReaderUtils
                         PropertyType: collectionValueProperty,
                         IsNullable: isValueNullable,
                         PropertyCollectionType: unwrappedTypeSymbol,
-                        IsNullableCollection: isNullable
+                        IsNullableCollection: isNullable,
+                        IsIndexableCollection: GetGenericTypeOrInterface(namedTypeSymbol, symbols.IListOfT) is not null
                     );
                 }
 
@@ -106,7 +118,22 @@ public static class SourceReaderUtils
                 );
         }
 
-        return new PropertyTypeInfo(unwrappedTypeSymbol, isNullable, null, false);
+        return new PropertyTypeInfo(unwrappedTypeSymbol, isNullable, null, false, false);
+    }
+
+    private static INamedTypeSymbol? GetGenericTypeOrInterface(
+        INamedTypeSymbol symbol,
+        INamedTypeSymbol genericTypeDefinition
+    )
+    {
+        if (SymbolEqualityComparer.Default.Equals(symbol.OriginalDefinition, genericTypeDefinition.OriginalDefinition))
+        {
+            return symbol;
+        }
+
+        return symbol.AllInterfaces.FirstOrDefault(i =>
+            SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, genericTypeDefinition.OriginalDefinition)
+        );
     }
 
     public static bool HasJsonIgnoreAttribute(IPropertySymbol property)

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/gen/Altinn.App.Analyzers/Altinn.App.Analyzers.FormDataWrapperGenerator/SkjemaFormDataWrapper.g.cs
@@ -80,7 +80,8 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             return null;
         }
 
-        return GetRecursive(model[literalIndex], path, offset);
+        var item = model[literalIndex];
+        return GetRecursive(item, path, offset);
     }
 
     private static object? GetRecursive(
@@ -171,7 +172,8 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
             return null;
         }
 
-        return GetRecursive(model[literalIndex], path, offset);
+        var item = model[literalIndex];
+        return GetRecursive(item, path, offset);
     }
 
     private static object? GetRecursive(
@@ -337,7 +339,8 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         {
             return false;
         }
-        return SetRecursive(model[literalIndex], path, offset, value);
+        var item = model[literalIndex];
+        return SetRecursive(item, path, offset, value);
     }
 
     private static bool SetRecursive(
@@ -610,7 +613,8 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         {
             return false;
         }
-        return SetRecursive(model[literalIndex], path, offset, value);
+        var item = model[literalIndex];
+        return SetRecursive(item, path, offset, value);
     }
 
     private static bool SetRecursive(
@@ -1465,7 +1469,8 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         }
         else
         {
-            RemoveRecursive(model[index], path, offset, rowRemovalOption);
+            var item = model[index];
+            RemoveRecursive(item, path, offset, rowRemovalOption);
         }
     }
 
@@ -1627,7 +1632,8 @@ public sealed class Altinn_App_SourceGenerator_Integration_Tests_Models_SkjemaFo
         }
         else
         {
-            RemoveRecursive(model[index], path, offset, rowRemovalOption);
+            var item = model[index];
+            RemoveRecursive(item, path, offset, rowRemovalOption);
         }
     }
 

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.Run#SkjemaFormDataWrapper.g.verified.cs
@@ -81,7 +81,8 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             return null;
         }
 
-        return GetRecursive(model[literalIndex], path, offset);
+        var item = model[literalIndex];
+        return GetRecursive(item, path, offset);
     }
 
     private static object? GetRecursive(
@@ -108,6 +109,9 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             "withListOfString" => GetRecursive(model.WithListOfString, path, literalIndex, nextOffset),
             "withListOfInt" => GetRecursive(model.WithListOfInt, path, literalIndex, nextOffset),
             "withListOfNullableInt" => GetRecursive(model.ListNullableInt, path, literalIndex, nextOffset),
+            "withHashSetOfString" => GetRecursive(model.WithHashSetOfString, path, literalIndex, nextOffset),
+            "withHashSetOfInt" => GetRecursive(model.WithHashSetOfInt, path, literalIndex, nextOffset),
+            "hashSetAdresse" => GetRecursive(model.HashSetAdresse, path, literalIndex, nextOffset),
             // _ => throw new global::Altinn.App.Core.Helpers.DataModel.DataModelException($"{path} is not a valid path."),
             _ => null,
         };
@@ -173,7 +177,8 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             return null;
         }
 
-        return GetRecursive(model[literalIndex], path, offset);
+        var item = model[literalIndex];
+        return GetRecursive(item, path, offset);
     }
 
     private static object? GetRecursive(
@@ -233,6 +238,67 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         }
 
         return model[literalIndex];
+    }
+
+    private static object? GetRecursive(
+        global::System.Collections.Generic.HashSet<string>? model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset
+    )
+    {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
+        if (model is null || literalIndex < 0 || literalIndex >= model.Count)
+        {
+            return null;
+        }
+
+        return global::System.Linq.Enumerable.ElementAt(model, literalIndex);
+    }
+
+    private static object? GetRecursive(
+        global::System.Collections.Generic.HashSet<int>? model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset
+    )
+    {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
+        if (model is null || literalIndex < 0 || literalIndex >= model.Count)
+        {
+            return null;
+        }
+
+        return global::System.Linq.Enumerable.ElementAt(model, literalIndex);
+    }
+
+    private static object? GetRecursive(
+        global::System.Collections.Generic.HashSet<global::Altinn.App.SourceGenerator.Tests.Adresse>? model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset
+    )
+    {
+        if (literalIndex == -1)
+        {
+            return model;
+        }
+
+        if (model is null || literalIndex < 0 || literalIndex >= model.Count)
+        {
+            return null;
+        }
+
+        var item = global::System.Linq.Enumerable.ElementAt(model, literalIndex);
+        return GetRecursive(item, path, offset);
     }
 
     #endregion Getters
@@ -339,7 +405,8 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         {
             return false;
         }
-        return SetRecursive(model[literalIndex], path, offset, value);
+        var item = model[literalIndex];
+        return SetRecursive(item, path, offset, value);
     }
 
     private static bool SetRecursive(
@@ -437,6 +504,30 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     nextOffset,
                     value
                 );
+            case "withHashSetOfString":
+                return SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_WithHashSetOfString(
+                    model,
+                    path,
+                    literalIndex,
+                    nextOffset,
+                    value
+                );
+            case "withHashSetOfInt":
+                return SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_WithHashSetOfInt(
+                    model,
+                    path,
+                    literalIndex,
+                    nextOffset,
+                    value
+                );
+            case "hashSetAdresse":
+                return SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_HashSetAdresse(
+                    model,
+                    path,
+                    literalIndex,
+                    nextOffset,
+                    value
+                );
             default:
                 return false;
         }
@@ -510,6 +601,54 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
     {
         model.ListNullableInt ??= new();
         return SetRecursive(model.ListNullableInt, path, literalIndex, nextOffset, value);
+    }
+
+    private static bool SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_WithHashSetOfString(
+        global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int nextOffset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model.WithHashSetOfString is null)
+        {
+            return false;
+        }
+
+        return SetRecursive(model.WithHashSetOfString, path, literalIndex, nextOffset, value);
+    }
+
+    private static bool SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_WithHashSetOfInt(
+        global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int nextOffset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model.WithHashSetOfInt is null)
+        {
+            return false;
+        }
+
+        return SetRecursive(model.WithHashSetOfInt, path, literalIndex, nextOffset, value);
+    }
+
+    private static bool SetRecursive_WithListCreation_Altinn_App_SourceGenerator_Tests_SkjemaInnhold_HashSetAdresse(
+        global::Altinn.App.SourceGenerator.Tests.SkjemaInnhold model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int nextOffset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model.HashSetAdresse is null)
+        {
+            return false;
+        }
+
+        return SetRecursive(model.HashSetAdresse, path, literalIndex, nextOffset, value);
     }
 
     private static bool SetRecursive(
@@ -619,7 +758,8 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         {
             return false;
         }
-        return SetRecursive(model[literalIndex], path, offset, value);
+        var item = model[literalIndex];
+        return SetRecursive(item, path, offset, value);
     }
 
     private static bool SetRecursive(
@@ -694,6 +834,64 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             return true;
         }
         return false;
+    }
+
+    private static bool SetRecursive(
+        global::System.Collections.Generic.HashSet<string>? model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model is null || literalIndex < 0)
+        {
+            return false;
+        }
+        if (model.Count <= literalIndex)
+        {
+            return false;
+        }
+        return false;
+    }
+
+    private static bool SetRecursive(
+        global::System.Collections.Generic.HashSet<int>? model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model is null || literalIndex < 0)
+        {
+            return false;
+        }
+        if (model.Count <= literalIndex)
+        {
+            return false;
+        }
+        return false;
+    }
+
+    private static bool SetRecursive(
+        global::System.Collections.Generic.HashSet<global::Altinn.App.SourceGenerator.Tests.Adresse>? model,
+        global::System.ReadOnlySpan<char> path,
+        int literalIndex,
+        int offset,
+        global::Altinn.App.Core.Internal.Expressions.ExpressionValue value
+    )
+    {
+        if (model is null || literalIndex < 0)
+        {
+            return false;
+        }
+        if (model.Count <= literalIndex)
+        {
+            return false;
+        }
+        var item = global::System.Linq.Enumerable.ElementAt(model, literalIndex);
+        return SetRecursive(item, path, offset, value);
     }
 
     #endregion Setters
@@ -1086,6 +1284,157 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                     return;
                 }
                 return;
+            case "withHashSetOfString":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 19;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
+                return;
+            case "withHashSetOfInt":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 16;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
+                return;
+            case "hashSetAdresse":
+                segment.CopyTo(buffer.Slice(bufferOffset));
+                bufferOffset += 14;
+
+                if (literalIndex != -1)
+                {
+                    // Copy index from path to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!literalIndex.TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = default;
+                }
+                else if (rowIndexes.Length >= 1)
+                {
+                    // Write index from rowIndexes to buffer
+                    buffer[bufferOffset++] = '[';
+                    if (!rowIndexes[0].TryFormat(buffer[bufferOffset..], out int charsWritten))
+                    {
+                        throw new global::System.ArgumentException(
+                            $"Buffer too small to write index for {path}."
+                        );
+                    }
+                    bufferOffset += charsWritten;
+                    buffer[bufferOffset++] = ']';
+                    rowIndexes = rowIndexes.Slice(1);
+                }
+                else if (pathOffset == -1)
+                {
+                    // No more segments in the path, and the last part is valid in a list
+                    // without index (e.g. "model.listProperty" is valid, but "model.listProperty.val" needs an index)
+                    return;
+                }
+                else
+                {
+                    // No index to write, but there are more segments in the path
+                    // thus the path is not valid
+                    bufferOffset = 0;
+                    return;
+                }
+                if (pathOffset != -1)
+                {
+                    AddIndexToPathRecursive_Altinn_App_SourceGenerator_Tests_Adresse(
+                        path,
+                        pathOffset,
+                        rowIndexes,
+                        buffer,
+                        ref bufferOffset
+                    );
+                }
+                return;
             default:
                 bufferOffset = 0;
                 return;
@@ -1274,6 +1623,9 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             WithListOfString = CopyRecursive(data.WithListOfString),
             WithListOfInt = CopyRecursive(data.WithListOfInt),
             ListNullableInt = CopyRecursive(data.ListNullableInt),
+            WithHashSetOfString = CopyRecursive(data.WithHashSetOfString),
+            WithHashSetOfInt = CopyRecursive(data.WithHashSetOfInt),
+            HashSetAdresse = CopyRecursive(data.HashSetAdresse),
         };
     }
 
@@ -1395,6 +1747,66 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         return result;
     }
 
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
+    private static global::System.Collections.Generic.HashSet<string>? CopyRecursive(
+        global::System.Collections.Generic.HashSet<string>? list
+    )
+    {
+        if (list is null)
+        {
+            return null!;
+        }
+        // csharpier-ignore
+        global::System.Collections.Generic.HashSet<string> result = new (list.Count);
+
+        foreach (var item in list)
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
+    private static global::System.Collections.Generic.HashSet<int>? CopyRecursive(
+        global::System.Collections.Generic.HashSet<int>? list
+    )
+    {
+        if (list is null)
+        {
+            return null!;
+        }
+        // csharpier-ignore
+        global::System.Collections.Generic.HashSet<int> result = new (list.Count);
+
+        foreach (var item in list)
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+    [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("list")]
+    private static global::System.Collections.Generic.HashSet<global::Altinn.App.SourceGenerator.Tests.Adresse>? CopyRecursive(
+        global::System.Collections.Generic.HashSet<global::Altinn.App.SourceGenerator.Tests.Adresse>? list
+    )
+    {
+        if (list is null)
+        {
+            return null!;
+        }
+        // csharpier-ignore
+        global::System.Collections.Generic.HashSet<global::Altinn.App.SourceGenerator.Tests.Adresse> result = new (list.Count);
+
+        foreach (var item in list)
+        {
+            result.Add(CopyRecursive(item));
+        }
+
+        return result;
+    }
+
     #endregion Copy
     #region Remove
 
@@ -1479,7 +1891,8 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         }
         else
         {
-            RemoveRecursive(model[index], path, offset, rowRemovalOption);
+            var item = model[index];
+            RemoveRecursive(item, path, offset, rowRemovalOption);
         }
     }
 
@@ -1543,6 +1956,24 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
                 break;
             case "withListOfNullableInt":
                 RemoveRecursive(model.ListNullableInt, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
+            case "withHashSetOfString" when (nextOffset is -1) && (literalIndex is -1):
+                model.WithHashSetOfString = default;
+                break;
+            case "withHashSetOfString":
+                RemoveRecursive(model.WithHashSetOfString, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
+            case "withHashSetOfInt" when (nextOffset is -1) && (literalIndex is -1):
+                model.WithHashSetOfInt = default;
+                break;
+            case "withHashSetOfInt":
+                RemoveRecursive(model.WithHashSetOfInt, path, nextOffset, literalIndex, rowRemovalOption);
+                break;
+            case "hashSetAdresse" when (nextOffset is -1) && (literalIndex is -1):
+                model.HashSetAdresse = default;
+                break;
+            case "hashSetAdresse":
+                RemoveRecursive(model.HashSetAdresse, path, nextOffset, literalIndex, rowRemovalOption);
                 break;
             default:
                 // throw new ArgumentException("{path} is not a valid path.");
@@ -1644,7 +2075,8 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         }
         else
         {
-            RemoveRecursive(model[index], path, offset, rowRemovalOption);
+            var item = model[index];
+            RemoveRecursive(item, path, offset, rowRemovalOption);
         }
     }
 
@@ -1730,6 +2162,77 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         }
     }
 
+    private static void RemoveRecursive(
+        global::System.Collections.Generic.HashSet<string>? model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        int index,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        if (index < 0 || index >= model.Count)
+        {
+            return;
+        }
+        if (offset == -1)
+        {
+            return;
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::System.Collections.Generic.HashSet<int>? model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        int index,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        if (index < 0 || index >= model.Count)
+        {
+            return;
+        }
+        if (offset == -1)
+        {
+            return;
+        }
+    }
+
+    private static void RemoveRecursive(
+        global::System.Collections.Generic.HashSet<global::Altinn.App.SourceGenerator.Tests.Adresse>? model,
+        global::System.ReadOnlySpan<char> path,
+        int offset,
+        int index,
+        global::Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption
+    )
+    {
+        if (model is null)
+        {
+            return;
+        }
+        if (index < 0 || index >= model.Count)
+        {
+            return;
+        }
+        if (offset == -1)
+        {
+            return;
+        }
+        else
+        {
+            var item = global::System.Linq.Enumerable.ElementAt(model, index);
+            RemoveRecursive(item, path, offset, rowRemovalOption);
+        }
+    }
+
     #endregion Remove
     #region AltinnRowIds
 
@@ -1786,6 +2289,16 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         if (dataModel.TidligereAdresse is not null)
         {
             foreach (var item in dataModel.TidligereAdresse)
+            {
+                if (item is not null)
+                {
+                    SetAltinnRowIds(item, initialize);
+                }
+            }
+        }
+        if (dataModel.HashSetAdresse is not null)
+        {
+            foreach (var item in dataModel.HashSetAdresse)
             {
                 if (item is not null)
                 {
@@ -2101,6 +2614,68 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
 //           "TypeName": "int",
 //           "IsJsonValueType": true,
 //           "ListType": "global::System.Collections.Generic.List<int?>",
+//         },
+//         {
+//           "JsonName": "withHashSetOfString",
+//           "CSharpName": "WithHashSetOfString",
+//           "IsNullable": false,
+//           "TypeName": "string",
+//           "IsJsonValueType": true,
+//           "ListType": "global::System.Collections.Generic.HashSet<string>",
+//         },
+//         {
+//           "JsonName": "withHashSetOfInt",
+//           "CSharpName": "WithHashSetOfInt",
+//           "IsNullable": false,
+//           "TypeName": "int",
+//           "IsJsonValueType": true,
+//           "ListType": "global::System.Collections.Generic.HashSet<int>",
+//         },
+//         {
+//           "JsonName": "hashSetAdresse",
+//           "CSharpName": "HashSetAdresse",
+//           "IsNullable": false,
+//           "TypeName": "global::Altinn.App.SourceGenerator.Tests.Adresse",
+//           "IsJsonValueType": false,
+//           "ListType": "global::System.Collections.Generic.HashSet<global::Altinn.App.SourceGenerator.Tests.Adresse>",
+//           "Properties": [
+//             {
+//               "JsonName": "altinnRowId",
+//               "CSharpName": "AltinnRowId",
+//               "IsNullable": false,
+//               "TypeName": "global::System.Guid",
+//               "IsJsonValueType": true,
+//             },
+//             {
+//               "JsonName": "gate",
+//               "CSharpName": "Gate",
+//               "IsNullable": true,
+//               "TypeName": "string",
+//               "IsJsonValueType": true,
+//             },
+//             {
+//               "JsonName": "postnummer",
+//               "CSharpName": "Postnummer",
+//               "IsNullable": true,
+//               "TypeName": "int",
+//               "IsJsonValueType": true,
+//             },
+//             {
+//               "JsonName": "poststed",
+//               "CSharpName": "Poststed",
+//               "IsNullable": true,
+//               "TypeName": "string",
+//               "IsJsonValueType": true,
+//             },
+//             {
+//               "JsonName": "tags",
+//               "CSharpName": "Tags",
+//               "IsNullable": false,
+//               "TypeName": "string",
+//               "IsJsonValueType": true,
+//               "ListType": "global::System.Collections.Generic.List<string>",
+//             }
+//           ]
 //         }
 //       ]
 //     },

--- a/test/Altinn.App.SourceGenerator.Tests/FullTests.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/FullTests.cs
@@ -125,6 +125,15 @@ public class FullTests(ITestOutputHelper output)
                 public List<int?> ListNullableInt { get; set; }
 
                 #nullable enable
+
+                [JsonPropertyName("withHashSetOfString")]
+                public HashSet<string>? WithHashSetOfString { get; set; }
+
+                [JsonPropertyName("withHashSetOfInt")]
+                public HashSet<int>? WithHashSetOfInt { get; set; }
+
+                [JsonPropertyName("hashSetAdresse")]
+                public HashSet<Adresse>? HashSetAdresse { get; set; }
             }
 
             public class Adresse

--- a/test/Altinn.App.SourceGenerator.Tests/SourceReaderTests/CollectionTypeTests.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceReaderTests/CollectionTypeTests.cs
@@ -1,0 +1,57 @@
+using Altinn.App.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Altinn.App.SourceGenerator.Tests.SourceReaderTests;
+
+public class CollectionTypeTests
+{
+    [Theory]
+    [InlineData("ListValue", true)]
+    [InlineData("CustomListValue", true)]
+    [InlineData("HashSetValue", false)]
+    [InlineData("CustomHashSetValue", false)]
+    public void CreateRootSymbolNode_DetectsIndexableCollections(string propertyName, bool expectedIndexable)
+    {
+        var source = """
+            using System.Collections.Generic;
+
+            public class CustomList<T> : List<T>;
+
+            public class CustomHashSet<T> : HashSet<T>;
+
+            public class TestClass
+            {
+                public List<string>? ListValue { get; set; }
+                public CustomList<string>? CustomListValue { get; set; }
+                public HashSet<string>? HashSetValue { get; set; }
+                public CustomHashSet<string>? CustomHashSetValue { get; set; }
+            }
+            """;
+
+        var compilation = CreateCompilation(source);
+        var rootNode = FormDataWrapperUtils.CreateRootSymbolNode("TestClass", compilation, []);
+
+        var property = Assert.Single(rootNode?.Properties ?? [], p => p.CSharpName == propertyName);
+
+        Assert.NotNull(property.ListType);
+        Assert.Equal(expectedIndexable, property.IsIndexableList);
+    }
+
+    private static Compilation CreateCompilation(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = AppDomain
+            .CurrentDomain.GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))
+            .Select(assembly => MetadataReference.CreateFromFile(assembly.Location));
+
+        return CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+    }
+}

--- a/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
+++ b/test/Altinn.App.SourceGenerator.Tests/SourceTextGeneratorTests.Generate.verified.cs
@@ -80,7 +80,8 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
             return null;
         }
 
-        return GetRecursive(model[literalIndex], path, offset);
+        var item = model[literalIndex];
+        return GetRecursive(item, path, offset);
     }
 
     private static object? GetRecursive(
@@ -255,7 +256,8 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         {
             return false;
         }
-        return SetRecursive(model[literalIndex], path, offset, value);
+        var item = model[literalIndex];
+        return SetRecursive(item, path, offset, value);
     }
 
     private static bool SetRecursive(
@@ -943,7 +945,8 @@ public sealed class Altinn_App_SourceGenerator_Tests_SkjemaFormDataWrapper
         }
         else
         {
-            RemoveRecursive(model[index], path, offset, rowRemovalOption);
+            var item = model[index];
+            RemoveRecursive(item, path, offset, rowRemovalOption);
         }
     }
 


### PR DESCRIPTION
## What
- Updated the form data wrapper source generator to avoid indexing arbitrary `ICollection<T>` implementations.
- Reads now enumerate to the requested item, while set/remove-by-index only runs for collections that implement `IList<T>`.
- Added regression coverage for `HashSet<string>`, `HashSet<int>`, and `HashSet<Adresse>` model properties.

## Why
A production app upgrade failed when the generated wrapper tried to compile `HashSet<string>[index]`, which is invalid because `HashSet<T>` implements `ICollection<T>` but has no indexer.

I could not query the BRG app directly from this shell because the prod Gitea API returned `403` without a signed-in API session, so the reproduction is encoded in source-generator tests with equivalent model shapes.

## Testing
```text
dotnet test test/Altinn.App.SourceGenerator.Tests/Altinn.App.SourceGenerator.Tests.csproj -v m
Passed!  - Failed:     0, Passed:    44, Skipped:     0, Total:    44

dotnet test test/Altinn.App.SourceGenerator.Integration.Tests/Altinn.App.SourceGenerator.Integration.Tests.csproj -v m --no-restore --no-build
Passed!  - Failed:     0, Passed:    94, Skipped:     0, Total:    94

dotnet build solutions/All.sln -v m
Build succeeded.
20 Warning(s)
0 Error(s)
```

Build warnings are existing NU1903 package vulnerability warnings for analyzer/benchmark dependencies.

cc @martinothamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended form data model support for additional collection types including HashSet

* **Improvements**
  * Improved collection type detection and code generation to properly handle both indexed and non-indexed collection implementations

* **Tests**
  * Added collection type detection tests to validate proper handling of various collection types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/app-lib-dotnet/pull/1758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->