### PR TITLE
fix: ignore non-route endpoints in scope auth

### DIFF
--- a/src/Altinn.App.Api/Infrastructure/Middleware/ScopeAuthorizationMiddleware.cs
+++ b/src/Altinn.App.Api/Infrastructure/Middleware/ScopeAuthorizationMiddleware.cs
@@ -250,6 +250,7 @@ internal sealed class ScopeAuthorizationService(
                 || !string.IsNullOrWhiteSpace(appMetadata.ApiScopes?.Users?.Write)
                 || !string.IsNullOrWhiteSpace(appMetadata.ApiScopes?.ServiceOwners?.Read)
                 || !string.IsNullOrWhiteSpace(appMetadata.ApiScopes?.ServiceOwners?.Write);
+
             ProcessEndpoints(appMetadata);
 
             _initialization.TrySetResult();
@@ -272,10 +273,23 @@ internal sealed class ScopeAuthorizationService(
     {
         var metadataLookup = new Dictionary<ApiEndpoint, ScopeRequirementMetadata>();
         var endpoints = _endpointDataSources.SelectMany(ed => ed.Endpoints).ToArray();
+        var routeEndpoints = endpoints.OfType<RouteEndpoint>().ToArray();
+
         foreach (var endpointObj in endpoints)
         {
             if (endpointObj is not RouteEndpoint endpoint)
+            {
+                if (IsMvcInertEndpoint(endpointObj))
+                {
+                    _logger.LogDebug(
+                        "Skipping non-routable MVC inert endpoint {DisplayName} during scope authorization initialization",
+                        endpointObj.DisplayName
+                    );
+                    continue;
+                }
+
                 throw new Exception("Unexpected endpoint type: " + endpointObj.GetType().FullName);
+            }
 
             var httpMethods = GetEndpointHttpMethods(endpoint);
             foreach (var httpMethod in httpMethods)
@@ -310,18 +324,13 @@ internal sealed class ScopeAuthorizationService(
 
         if (_logger.IsEnabled(LogLevel.Debug) && HasDefinedCustomScopes)
         {
-            endpoints = _endpointDataSources.SelectMany(ed => ed.Endpoints).ToArray();
-
             var message = new StringBuilder("Endpoint API scope authorization summary:\n");
-            foreach (var endpoint in endpoints)
+            foreach (var endpoint in routeEndpoints)
             {
                 var httpMethods = GetEndpointHttpMethods(endpoint);
                 foreach (var httpMethod in httpMethods)
                 {
-                    var apiEndpoint = new ApiEndpoint(
-                        endpoint as RouteEndpoint ?? throw new Exception("Not a route endpoint"),
-                        httpMethod
-                    );
+                    var apiEndpoint = new ApiEndpoint(endpoint, httpMethod);
                     var metadata = _metadataLookup.GetValueOrDefault(apiEndpoint);
                     if (metadata is not null)
                     {
@@ -373,6 +382,16 @@ internal sealed class ScopeAuthorizationService(
 
             _logger.LogDebug(message.ToString());
         }
+    }
+
+    private static bool IsMvcInertEndpoint(Endpoint endpoint)
+    {
+        if (endpoint.GetType() != typeof(Endpoint))
+            return false;
+
+        // MapFallbackToController creates non-routable MVC "inert" endpoints for dynamic selection.
+        // They are represented by base Endpoint instances with MVC action metadata, not RouteEndpoint instances.
+        return endpoint.Metadata.GetMetadata<ControllerActionDescriptor>() is not null;
     }
 
     private void ProcessEndpoint(

--- a/test/Altinn.App.Api.Tests/Middleware/ScopeAuthorizationServiceTests.cs
+++ b/test/Altinn.App.Api.Tests/Middleware/ScopeAuthorizationServiceTests.cs
@@ -1,0 +1,145 @@
+using System.Reflection;
+using Altinn.App.Api.Infrastructure.Middleware;
+using Altinn.App.Core.Configuration;
+using Altinn.App.Core.Features.Cache;
+using Altinn.App.Core.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Moq;
+
+namespace Altinn.App.Api.Tests.Middleware;
+
+public class ScopeAuthorizationServiceTests
+{
+    [Fact]
+    public async Task EnsureInitialized_WhenNoCustomScopesAndMvcInertEndpoint_DoesNotThrow()
+    {
+        var routeActionDescriptor = CreateControllerActionDescriptor();
+        var inertActionDescriptor = CreateControllerActionDescriptor();
+        var routeEndpoint = CreateRouteEndpoint(
+            "/instances/{instanceOwnerPartyId}/{instanceGuid}",
+            routeActionDescriptor,
+            "GET"
+        );
+        var inertEndpoint = CreateMvcInertEndpoint(inertActionDescriptor, "GET");
+        var service = CreateService(new ApplicationMetadata("ttd/app"), inertEndpoint, routeEndpoint);
+
+        await service.EnsureInitialized();
+
+        Assert.False(service.HasDefinedCustomScopes);
+        Assert.Single(service.Metadata);
+    }
+
+    [Fact]
+    public async Task EnsureInitialized_WhenCustomScopesAndMvcInertEndpoint_SkipsInertEndpoint()
+    {
+        var appMetadata = new ApplicationMetadata("ttd/app")
+        {
+            ApiScopes = new ApiScopesConfiguration
+            {
+                Users = new ApiScopes { Read = "ttd:[app]/instances.read", Write = "ttd:[app]/instances.write" },
+            },
+        };
+        var routeActionDescriptor = CreateControllerActionDescriptor();
+        var inertActionDescriptor = CreateControllerActionDescriptor();
+        var routeEndpoint = CreateRouteEndpoint(
+            "/instances/{instanceOwnerPartyId}/{instanceGuid}",
+            routeActionDescriptor,
+            "GET"
+        );
+        var inertEndpoint = CreateMvcInertEndpoint(inertActionDescriptor, "GET");
+        var service = CreateService(appMetadata, inertEndpoint, routeEndpoint);
+
+        await service.EnsureInitialized();
+
+        Assert.True(service.HasDefinedCustomScopes);
+        var endpointInfo = Assert.Single(service.Metadata);
+        Assert.Equal("GET /instances/{instanceOwnerPartyId}/{instanceGuid}", endpointInfo.Endpoint);
+        Assert.NotNull(endpointInfo.Metadata.RequiredScopesUsers);
+        Assert.Contains("ttd:app/instances.read", endpointInfo.Metadata.RequiredScopesUsers.AsEnumerable());
+    }
+
+    [Fact]
+    public async Task EnsureInitialized_WhenUnexpectedNonRouteEndpoint_Throws()
+    {
+        var service = CreateService(new ApplicationMetadata("ttd/app"), CreateNonRouteEndpoint());
+
+        var exception = await Assert.ThrowsAsync<Exception>(() => service.EnsureInitialized());
+
+        Assert.Contains("Unexpected endpoint type: Microsoft.AspNetCore.Http.Endpoint", exception.Message);
+    }
+
+    private static ScopeAuthorizationService CreateService(ApplicationMetadata appMetadata, params Endpoint[] endpoints)
+    {
+        return new ScopeAuthorizationService(
+            new TestAppConfigurationCache(appMetadata),
+            [new TestEndpointDataSource(endpoints)],
+            Mock.Of<IHostApplicationLifetime>(),
+            Options.Create(new GeneralSettings()),
+            NullLogger<ScopeAuthorizationService>.Instance
+        );
+    }
+
+    private static Endpoint CreateNonRouteEndpoint() =>
+        new(_ => Task.CompletedTask, EndpointMetadataCollection.Empty, "Non-route endpoint");
+
+    private static Endpoint CreateMvcInertEndpoint(
+        ControllerActionDescriptor actionDescriptor,
+        params string[] methods
+    ) =>
+        new(
+            _ => Task.CompletedTask,
+            new EndpointMetadataCollection(new HttpMethodMetadata(methods), actionDescriptor),
+            actionDescriptor.DisplayName
+        );
+
+    private static RouteEndpoint CreateRouteEndpoint(
+        string route,
+        ControllerActionDescriptor actionDescriptor,
+        params string[] methods
+    )
+    {
+        var builder = new RouteEndpointBuilder(_ => Task.CompletedTask, RoutePatternFactory.Parse(route), order: 0);
+        builder.Metadata.Add(new HttpMethodMetadata(methods));
+        builder.Metadata.Add(actionDescriptor);
+        return (RouteEndpoint)builder.Build();
+    }
+
+    private static ControllerActionDescriptor CreateControllerActionDescriptor()
+    {
+        var httpMethodMetadata = new HttpMethodMetadata(["GET"]);
+        return new ControllerActionDescriptor
+        {
+            DisplayName = "TestController.Get (Test)",
+            ActionName = "Get",
+            ControllerName = "Test",
+            ControllerTypeInfo = typeof(ScopeAuthorizationServiceTests).GetTypeInfo(),
+            MethodInfo = typeof(ScopeAuthorizationServiceTests).GetMethod(
+                nameof(TestControllerAction),
+                BindingFlags.NonPublic | BindingFlags.Static
+            )!,
+            EndpointMetadata = [httpMethodMetadata],
+        };
+    }
+
+    private static void TestControllerAction() { }
+
+    private sealed class TestAppConfigurationCache(ApplicationMetadata appMetadata) : IAppConfigurationCache
+    {
+        public ApplicationMetadata ApplicationMetadata { get; } = appMetadata;
+    }
+
+    private sealed class TestEndpointDataSource(IReadOnlyList<Endpoint> endpoints) : EndpointDataSource
+    {
+        public override IReadOnlyList<Endpoint> Endpoints { get; } = endpoints;
+
+        public override IChangeToken GetChangeToken() => new CancellationChangeToken(CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Summary
- skip scope endpoint processing entirely when the app has no custom `apiScopes` configured
- ignore non-route ASP.NET endpoints when building scope metadata for apps that do use custom scopes
- add regression coverage for a plain `Microsoft.AspNetCore.Http.Endpoint` in the endpoint table

## Why
A BRG app branch upgraded to app-lib `8.12.0` failed during startup with `Unexpected endpoint type: Microsoft.AspNetCore.Http.Endpoint`. The app has no `apiScopes`, so scope authorization would no-op at request time, but initialization still scanned all endpoints and assumed every endpoint from `EndpointDataSource` was a `RouteEndpoint`. ASP.NET can expose non-route endpoints; those do not have route pattern or HTTP method metadata that this scope mapping can represent.

## Testing
- `dotnet csharpier format src/Altinn.App.Api/Infrastructure/Middleware/ScopeAuthorizationMiddleware.cs test/Altinn.App.Api.Tests/Middleware/ScopeAuthorizationServiceTests.cs`
- `dotnet test test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj --filter ScopeAuthorizationServiceTests --no-restore`
- `dotnet test test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj --no-restore`

cc @martinothamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced scope-based authorization middleware to handle endpoint processing more robustly, reducing false authorization failures in edge cases.

* **Tests**
  * Added comprehensive test coverage for authorization service initialization across multiple endpoint scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/app-lib-dotnet/pull/1759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->