### PR TITLE
Move env disabled check before eformidling service null check.

### DIFF
--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/ServiceTasks/EFormidlingServiceTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/ServiceTasks/EFormidlingServiceTask.cs
@@ -43,13 +43,6 @@ internal sealed class EFormidlingServiceTask : IEFormidlingServiceTask
     /// <inheritdoc/>
     public async Task<ServiceTaskResult> Execute(ServiceTaskContext context)
     {
-        if (_eFormidlingService is null)
-        {
-            throw new ProcessException(
-                $"No implementation of {nameof(IEFormidlingService)} has been added to the DI container. Remember to add eFormidling services. Use AddEFormidlingServices2<TM,TR> to register eFormidling services."
-            );
-        }
-
         string taskId = context.InstanceDataMutator.Instance.Process.CurrentTask.ElementId;
         Instance instance = context.InstanceDataMutator.Instance;
         ValidAltinnEFormidlingConfiguration configuration = await GetValidAltinnEFormidlingConfiguration(taskId);
@@ -61,6 +54,13 @@ internal sealed class EFormidlingServiceTask : IEFormidlingServiceTask
                 LogSanitizer.Sanitize(taskId)
             );
             return ServiceTaskResult.Success();
+        }
+
+        if (_eFormidlingService is null)
+        {
+            throw new ProcessException(
+                $"No implementation of {nameof(IEFormidlingService)} has been added to the DI container. Remember to add eFormidling services. Use AddEFormidlingServices2<TM,TR> to register eFormidling services."
+            );
         }
 
         _logger.LogDebug(

--- a/test/Altinn.App.Core.Tests/Internal/Process/ServiceTasks/EFormidlingServiceTaskTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ServiceTasks/EFormidlingServiceTaskTests.cs
@@ -57,6 +57,9 @@ public class EFormidlingServiceTaskTests
             null
         );
 
+        var taskExtension = new AltinnTaskExtension { EFormidlingConfiguration = GetConfig() };
+        _processReaderMock.Setup(x => x.GetAltinnTaskExtension("taskId")).Returns(taskExtension);
+
         var instanceMutatorMock = new Mock<IInstanceDataMutator>();
         instanceMutatorMock.Setup(x => x.Instance).Returns(instance);
 
@@ -64,6 +67,34 @@ public class EFormidlingServiceTaskTests
 
         // Act & Assert
         await Assert.ThrowsAsync<ProcessException>(() => serviceTask.Execute(parameters));
+    }
+
+    [Fact]
+    public async Task Execute_Should_SkipExecution_When_BpmnConfigDisabled_AndServiceIsNull()
+    {
+        // Arrange
+        Instance instance = GetInstance();
+
+        var serviceTask = new EFormidlingServiceTask(
+            _loggerMock.Object,
+            _processReaderMock.Object,
+            _hostEnvironmentMock.Object,
+            null
+        );
+
+        var taskExtension = new AltinnTaskExtension { EFormidlingConfiguration = GetConfig(disabled: true) };
+        _processReaderMock.Setup(x => x.GetAltinnTaskExtension("taskId")).Returns(taskExtension);
+
+        var instanceMutatorMock = new Mock<IInstanceDataMutator>();
+        instanceMutatorMock.Setup(x => x.Instance).Returns(instance);
+
+        var parameters = new ServiceTaskContext { InstanceDataMutator = instanceMutatorMock.Object };
+
+        // Act
+        var result = await serviceTask.Execute(parameters);
+
+        // Assert
+        Assert.IsType<ServiceTaskSuccessResult>(result);
     }
 
     [Fact]


### PR DESCRIPTION
Move env disabled check before eformidling service null check. That way one can skip adding eformidling event sub client when IsDevelopment.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the eFormidling service task to verify proper handling of disabled configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/app-lib-dotnet/pull/1760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->