### PR TITLE
fix: root app request traces from service registration

### DIFF
--- a/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/ServiceCollectionExtensions.cs
@@ -226,13 +226,7 @@ public static class ServiceCollectionExtensions
         services.AddHostedService<TelemetryInitialization>();
         services.AddSingleton<Telemetry>();
 
-        // This bit of code makes ASP.NET Core spans always root.
-        // Depending on infrastructure used and how the application is exposed/called,
-        // it might be a good idea to be in control of the root span (and therefore the size, baggage etch)
-        // Taken from: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1773
-        _ = Sdk.SuppressInstrumentation; // Just to trigger static constructor. The static constructor in Sdk initializes Propagators.DefaultTextMapPropagator which we depend on below
-        Sdk.SetDefaultTextMapPropagator(new OtelPropagator(Propagators.DefaultTextMapPropagator));
-        DistributedContextPropagator.Current = new AspNetCorePropagator();
+        ConfigureRootRequestPropagation(services);
 
         var appInsightsConnectionString = GetAppInsightsConnectionStringForOtel(config, env);
         var useOpenTelemetryCollector = config.GetValue<bool?>("AppSettings:UseOpenTelemetryCollector");
@@ -377,6 +371,65 @@ public static class ServiceCollectionExtensions
     /// <returns></returns>
     private static bool IsPdfGeneratorRequest(IHeaderDictionary headers) => headers.ContainsKey("X-Altinn-IsPdf");
 
+    // This makes ASP.NET Core request spans start as root spans so callers cannot control app trace size.
+    // ASP.NET Core copies DistributedContextPropagator.Current into DI during WebApplication.CreateBuilder,
+    // so update both the static default and the already-registered service descriptor.
+    // Based on the workaround discussed in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1773.
+    private static void ConfigureRootRequestPropagation(IServiceCollection services)
+    {
+        _ = Sdk.SuppressInstrumentation; // Triggers Sdk static initialization before reading the default propagator.
+
+        if (Propagators.DefaultTextMapPropagator is not OtelPropagator)
+        {
+            Sdk.SetDefaultTextMapPropagator(new OtelPropagator(Propagators.DefaultTextMapPropagator));
+        }
+
+        if (DistributedContextPropagator.Current is not AspNetCorePropagator)
+        {
+            DistributedContextPropagator.Current = new AspNetCorePropagator(
+                DistributedContextPropagator.Current,
+                ownsInner: false
+            );
+        }
+
+        var existingDescriptor = services.LastOrDefault(service =>
+            service.ServiceType == typeof(DistributedContextPropagator)
+        );
+
+        services.RemoveAll<DistributedContextPropagator>();
+        services.AddSingleton(serviceProvider =>
+        {
+            var (inner, ownsInner) = ResolveDistributedContextPropagator(serviceProvider, existingDescriptor);
+            return inner is AspNetCorePropagator ? inner : new AspNetCorePropagator(inner, ownsInner);
+        });
+    }
+
+    private static (DistributedContextPropagator Propagator, bool OwnsInstance) ResolveDistributedContextPropagator(
+        IServiceProvider serviceProvider,
+        ServiceDescriptor? descriptor
+    )
+    {
+        if (descriptor is null)
+            return (DistributedContextPropagator.Current, false);
+
+        if (descriptor.ImplementationInstance is DistributedContextPropagator instance)
+            return (instance, false);
+
+        if (descriptor.ImplementationFactory is not null)
+            return ((DistributedContextPropagator)descriptor.ImplementationFactory(serviceProvider), true);
+
+        if (descriptor.ImplementationType is not null)
+        {
+            return (
+                (DistributedContextPropagator)
+                    ActivatorUtilities.CreateInstance(serviceProvider, descriptor.ImplementationType),
+                true
+            );
+        }
+
+        return (DistributedContextPropagator.Current, false);
+    }
+
     internal sealed class OtelPropagator : TextMapPropagator
     {
         private readonly TextMapPropagator _inner;
@@ -401,11 +454,17 @@ public static class ServiceCollectionExtensions
             _inner.Inject(context, carrier, setter);
     }
 
-    internal sealed class AspNetCorePropagator : DistributedContextPropagator
+    internal sealed class AspNetCorePropagator : DistributedContextPropagator, IDisposable, IAsyncDisposable
     {
         private readonly DistributedContextPropagator _inner;
+        private readonly bool _ownsInner;
+        private bool _disposed;
 
-        public AspNetCorePropagator() => _inner = CreateDefaultPropagator();
+        public AspNetCorePropagator(DistributedContextPropagator inner, bool ownsInner)
+        {
+            _inner = inner;
+            _ownsInner = ownsInner;
+        }
 
         public override IReadOnlyCollection<string> Fields => _inner.Fields;
 
@@ -439,6 +498,28 @@ public static class ServiceCollectionExtensions
 
         public override void Inject(Activity? activity, object? carrier, PropagatorSetterCallback? setter) =>
             _inner.Inject(activity, carrier, setter);
+
+        public void Dispose()
+        {
+            if (!_ownsInner || _disposed)
+                return;
+
+            _disposed = true;
+            if (_inner is IDisposable disposable)
+                disposable.Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (!_ownsInner || _disposed)
+                return;
+
+            _disposed = true;
+            if (_inner is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+            else if (_inner is IDisposable disposable)
+                disposable.Dispose();
+        }
     }
 
     private static void AddAuthorizationPolicies(IServiceCollection services)

--- a/test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj
+++ b/test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj
@@ -24,6 +24,7 @@
     <!-- TODO: cleaner sharing -->
     <Compile Include="_testapps/_shared/FixtureConfiguration.cs" />
     <Compile Include="_testapps/_shared/ConnectivityResult.cs" />
+    <Compile Include="_testapps/_shared/CurrentActivityResult.cs" />
     <Compile Remove="_localtest/**" />
   </ItemGroup>
 

--- a/test/Altinn.App.Integration.Tests/Telemetry/OpenTelemetryRootingTests.cs
+++ b/test/Altinn.App.Integration.Tests/Telemetry/OpenTelemetryRootingTests.cs
@@ -1,0 +1,52 @@
+using System.Net.Http.Json;
+using TestApp.Shared;
+using Xunit.Abstractions;
+
+namespace Altinn.App.Integration.Tests.Telemetry;
+
+[Trait("Category", "Integration")]
+public sealed class OpenTelemetryRootingTests(ITestOutputHelper _output)
+{
+    private const string IncomingTraceId = "ac256066b49c4cb79dc4b83b9616f73c";
+    private const string IncomingParentSpanId = "cca043edb2398eb2";
+
+    [Theory]
+    [InlineData("01")]
+    [InlineData("00")]
+    public async Task AppRequests_Are_Root_Traces_When_Incoming_TraceContext_Is_Present(string traceFlags)
+    {
+        await using var fixture = await AppFixture.Create(
+            _output,
+            TestApps.Basic,
+            scenario: "open-telemetry-parent-based-sampler",
+            environmentVariables: new Dictionary<string, string>
+            {
+                ["AppSettings__UseOpenTelemetry"] = "true",
+                ["GeneralSettings__IsTest"] = "true",
+            }
+        );
+
+        var endpoint = $"/ttd/{fixture.EffectiveApp}/api/testing/telemetry/current-activity";
+        using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+        request.Headers.TryAddWithoutValidation(
+            "traceparent",
+            $"00-{IncomingTraceId}-{IncomingParentSpanId}-{traceFlags}"
+        );
+
+        using var response = await fixture.GetDirectAppClient().SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        var activity = await response.Content.ReadFromJsonAsync<CurrentActivityResult>();
+
+        var snapshot = new
+        {
+            TraceId = activity?.TraceId == IncomingTraceId ? activity.TraceId : "<new trace id>",
+            SpanId = activity?.SpanId is null ? null : "<span id>",
+            activity?.ParentSpanId,
+            ParentId = activity?.ParentId ?? "<null>",
+            activity?.Recorded,
+            activity?.IsAllDataRequested,
+        };
+        await fixture.ScopedVerifier.Verify(snapshot, parameters: new { traceFlags });
+    }
+}

--- a/test/Altinn.App.Integration.Tests/Telemetry/_snapshots/OpenTelemetryRootingTests.AppRequests_Are_Root_Traces_When_Incoming_TraceContext_Is_Present_0_traceFlags=00.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Telemetry/_snapshots/OpenTelemetryRootingTests.AppRequests_Are_Root_Traces_When_Incoming_TraceContext_Is_Present_0_traceFlags=00.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  TraceId: <new trace id>,
+  SpanId: <span id>,
+  ParentSpanId: 0000000000000000,
+  ParentId: <null>,
+  Recorded: true,
+  IsAllDataRequested: true
+}

--- a/test/Altinn.App.Integration.Tests/Telemetry/_snapshots/OpenTelemetryRootingTests.AppRequests_Are_Root_Traces_When_Incoming_TraceContext_Is_Present_0_traceFlags=01.verified.txt
+++ b/test/Altinn.App.Integration.Tests/Telemetry/_snapshots/OpenTelemetryRootingTests.AppRequests_Are_Root_Traces_When_Incoming_TraceContext_Is_Present_0_traceFlags=01.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  TraceId: <new trace id>,
+  SpanId: <span id>,
+  ParentSpanId: 0000000000000000,
+  ParentId: <null>,
+  Recorded: true,
+  IsAllDataRequested: true
+}

--- a/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/AppFixture.cs
@@ -105,7 +105,8 @@ public sealed partial class AppFixture : IAsyncDisposable
         ITestOutputHelper output,
         string app = TestApps.Basic,
         string scenario = "default",
-        bool isClassFixture = false
+        bool isClassFixture = false,
+        IReadOnlyDictionary<string, string>? environmentVariables = null
     )
     {
         var timer = Stopwatch.StartNew();
@@ -154,6 +155,7 @@ public sealed partial class AppFixture : IAsyncDisposable
                 generatedAppDirectory,
                 fixtureConfigurationPath,
                 _nugetPackagesDirectory,
+                environmentVariables,
                 logger,
                 cancellationToken
             );

--- a/test/Altinn.App.Integration.Tests/_fixture/StudioctlEnvironment.cs
+++ b/test/Altinn.App.Integration.Tests/_fixture/StudioctlEnvironment.cs
@@ -202,6 +202,11 @@ internal sealed class StudioctlEnvironmentLease : IAsyncDisposable
 internal sealed class StudioctlAppProcess : IAsyncDisposable
 {
     private static readonly TimeSpan _stopTimeout = TimeSpan.FromSeconds(10);
+    private static readonly HashSet<string> _reservedEnvironmentVariables = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "AppFixture__ConfigurationPath",
+        "NUGET_PACKAGES",
+    };
 
     private readonly ILogger _logger;
 
@@ -236,6 +241,7 @@ internal sealed class StudioctlAppProcess : IAsyncDisposable
         string appDirectory,
         string fixtureConfigurationPath,
         string nugetPackagesDirectory,
+        IReadOnlyDictionary<string, string>? environmentVariables,
         ILogger logger,
         CancellationToken cancellationToken
     )
@@ -244,6 +250,7 @@ internal sealed class StudioctlAppProcess : IAsyncDisposable
             appDirectory,
             fixtureConfigurationPath,
             nugetPackagesDirectory,
+            environmentVariables,
             logger,
             cancellationToken,
             "run",
@@ -280,6 +287,7 @@ internal sealed class StudioctlAppProcess : IAsyncDisposable
             appDirectory,
             fixtureConfigurationPath: null,
             nugetPackagesDirectory: null,
+            environmentVariables: null,
             logger,
             CancellationToken.None,
             "app",
@@ -402,6 +410,7 @@ internal sealed class StudioctlAppProcess : IAsyncDisposable
         string workingDirectory,
         string? fixtureConfigurationPath,
         string? nugetPackagesDirectory,
+        IReadOnlyDictionary<string, string>? environmentVariables,
         ILogger logger,
         CancellationToken cancellationToken,
         params string[] arguments
@@ -418,6 +427,16 @@ internal sealed class StudioctlAppProcess : IAsyncDisposable
             process.StartInfo.Environment["AppFixture__ConfigurationPath"] = fixtureConfigurationPath;
         if (nugetPackagesDirectory is not null)
             process.StartInfo.Environment["NUGET_PACKAGES"] = nugetPackagesDirectory;
+        if (environmentVariables is not null)
+        {
+            foreach (var (key, value) in environmentVariables)
+            {
+                if (_reservedEnvironmentVariables.Contains(key))
+                    throw new InvalidOperationException($"Environment variable '{key}' is reserved by the fixture.");
+
+                process.StartInfo.Environment[key] = value;
+            }
+        }
         foreach (var argument in arguments)
             process.StartInfo.ArgumentList.Add(argument);
 

--- a/test/Altinn.App.Integration.Tests/_testapps/_shared/CurrentActivityResult.cs
+++ b/test/Altinn.App.Integration.Tests/_testapps/_shared/CurrentActivityResult.cs
@@ -1,0 +1,11 @@
+namespace TestApp.Shared;
+
+internal sealed class CurrentActivityResult
+{
+    public string? TraceId { get; set; }
+    public string? SpanId { get; set; }
+    public string? ParentSpanId { get; set; }
+    public string? ParentId { get; set; }
+    public bool? Recorded { get; set; }
+    public bool? IsAllDataRequested { get; set; }
+}

--- a/test/Altinn.App.Integration.Tests/_testapps/_shared/TestingApis.cs
+++ b/test/Altinn.App.Integration.Tests/_testapps/_shared/TestingApis.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Serialization;
@@ -192,7 +193,11 @@ public static class TestingApis
                     var service =
                         serviceProvider.GetRequiredService<Altinn.App.Api.Infrastructure.Middleware.ScopeAuthorizationService>();
                     var metadata = service
-                        .Metadata.Where(endpoint => endpoint.Endpoint != "POST /test/fixture-configuration/reload")
+                        .Metadata.Where(endpoint =>
+                            endpoint.Endpoint
+                                is not "POST /test/fixture-configuration/reload"
+                                    and not "GET /{org}/{app}/api/testing/telemetry/current-activity"
+                        )
                         .ToArray();
 
                     return Results.Ok(new { hasDefinedCustomScopes = service.HasDefinedCustomScopes, metadata });
@@ -235,6 +240,27 @@ public static class TestingApis
             )
             .AllowAnonymous()
             .WithName("API testing - GET - public");
+
+        app.MapGet(
+                "/{org}/{app}/api/testing/telemetry/current-activity",
+                () =>
+                {
+                    var activity = Activity.Current;
+                    return Results.Json(
+                        new CurrentActivityResult
+                        {
+                            TraceId = activity?.TraceId.ToString(),
+                            SpanId = activity?.SpanId.ToString(),
+                            ParentSpanId = activity?.ParentSpanId.ToString(),
+                            ParentId = activity?.ParentId,
+                            Recorded = activity?.ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded),
+                            IsAllDataRequested = activity?.IsAllDataRequested,
+                        }
+                    );
+                }
+            )
+            .AllowAnonymous()
+            .WithName("API testing - GET - current activity");
 
         return app;
     }

--- a/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/open-telemetry-parent-based-sampler/services/OpenTelemetrySamplerConfiguration.cs
+++ b/test/Altinn.App.Integration.Tests/_testapps/basic/_scenarios/open-telemetry-parent-based-sampler/services/OpenTelemetrySamplerConfiguration.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+
+internal static class OpenTelemetrySamplerConfiguration
+{
+    public static void RegisterServices(IServiceCollection services)
+    {
+        services.ConfigureOpenTelemetryTracerProvider(builder =>
+        {
+            builder.SetSampler(new ParentBasedSampler(new AlwaysOnSampler()));
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- supersedes #1761 with the simpler service-registration approach
- adds integration coverage proving incoming `traceparent` does not become the app request parent
- replaces ASP.NET Core's already-registered `DistributedContextPropagator` service in addition to wrapping OpenTelemetry's default text-map propagator

## Why

Some apps call `WebApplication.CreateBuilder` before `AddAltinnAppServices`. ASP.NET Core copies `DistributedContextPropagator.Current` into DI during `CreateBuilder`, so changing only the static propagator later can be too late. `dibk/nabovarsel-v5` has that shape and also configures a parent-based OpenTelemetry sampler.

This keeps the fix on app-lib's side while avoiding the generated module initializer/build target approach from #1761.

## Testing

Old implementation, with only the new integration test ported:

```text
dotnet test test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj -v m --filter FullyQualifiedName~OpenTelemetryRootingTests

Failed: AppRequests_Are_Root_Traces_When_Incoming_TraceContext_Is_Present(traceFlags: "01")
Assert.NotEqual() Failure: Strings are equal
Expected: Not "ac256066b49c4cb79dc4b83b9616f73c"
Actual:       "ac256066b49c4cb79dc4b83b9616f73c"
```

New implementation:

```text
git diff --check HEAD~2..HEAD
# passed

dotnet build src/Altinn.App.Api/Altinn.App.Api.csproj -v m
# Build succeeded. 0 Warning(s), 0 Error(s)

dotnet test test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj --no-build -v m --filter FullyQualifiedName~OpenTelemetryRootingTests
# Passed: 2/2
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests validating OpenTelemetry trace-rooting and snapshots; introduced a test endpoint returning current activity identifiers and related test DTOs.

* **Chores**
  * Refactored OpenTelemetry propagation/setup to synchronize propagators and rooting behavior.
  * Enhanced test infrastructure and fixtures to allow passing environment variables (with reserved-name protection).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/app-lib-dotnet/pull/1782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->