### PR TITLE
chore: add studioctl local configuration

### DIFF
--- a/src/Altinn.App.Api/Extensions/StudioctlLocalConfiguration.cs
+++ b/src/Altinn.App.Api/Extensions/StudioctlLocalConfiguration.cs
@@ -1,0 +1,211 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Altinn.App.Api.Extensions;
+
+internal static class StudioctlLocalConfiguration
+{
+    private const string StudioctlAppRunEnvironmentVariable = "STUDIOCTL_APP_RUN";
+    private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(3);
+    private static readonly IReadOnlyDictionary<string, string?> _emptyConfiguration =
+        new Dictionary<string, string?>();
+
+    internal static void AddIfAvailable(IConfigurationBuilder configBuilder, IHostEnvironment hostEnvironment)
+    {
+        try
+        {
+            AddIfAvailableCore(configBuilder, hostEnvironment);
+        }
+        catch (Exception ex)
+        {
+            WriteWarning("Failed to import local studioctl app configuration.", ex);
+        }
+    }
+
+    private static void AddIfAvailableCore(IConfigurationBuilder configBuilder, IHostEnvironment hostEnvironment)
+    {
+        if (configBuilder is null || !ShouldAdd(hostEnvironment))
+        {
+            return;
+        }
+
+        string contentRootPath = hostEnvironment.ContentRootPath;
+        IReadOnlyDictionary<string, string?> env = TryReadStudioctlEnvironment(
+            FindProjectPath(contentRootPath) ?? contentRootPath,
+            _defaultTimeout
+        );
+        if (env.Count == 0)
+        {
+            return;
+        }
+
+        configBuilder.AddInMemoryCollection(NormalizeConfigurationKeys(env));
+    }
+
+    internal static bool ShouldAdd(IHostEnvironment? hostEnvironment)
+    {
+        if (hostEnvironment is null)
+        {
+            return false;
+        }
+
+        if (!hostEnvironment.IsDevelopment())
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(StudioctlAppRunEnvironmentVariable)))
+        {
+            return false;
+        }
+
+        string contentRootPath = hostEnvironment.ContentRootPath;
+        return !string.IsNullOrWhiteSpace(contentRootPath) && Directory.Exists(contentRootPath);
+    }
+
+    internal static IReadOnlyDictionary<string, string?> TryReadStudioctlEnvironment(
+        string projectOrRootPath,
+        TimeSpan timeout
+    )
+    {
+        // Contract with studioctl: `studioctl app env --json` returns a flat JSON object
+        // where keys are environment variable names and values are environment variable values.
+        return
+            TryRunStudioctlEnvironmentCommand(projectOrRootPath, timeout, out string json)
+            && TryParseEnvironmentJson(json, out Dictionary<string, string?> values)
+            ? values
+            : _emptyConfiguration;
+    }
+
+    internal static bool TryParseEnvironmentJson(string json, out Dictionary<string, string?> values)
+    {
+        values = [];
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(json);
+        }
+        catch (Exception ex)
+        {
+            WriteWarning("studioctl app env returned invalid JSON.", ex);
+            return false;
+        }
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            values = new(StringComparer.OrdinalIgnoreCase);
+            foreach (JsonProperty property in document.RootElement.EnumerateObject())
+            {
+                if (property.Value.ValueKind == JsonValueKind.String)
+                {
+                    values[property.Name] = property.Value.GetString();
+                }
+            }
+        }
+
+        return true;
+    }
+
+    internal static Dictionary<string, string?> NormalizeConfigurationKeys(IReadOnlyDictionary<string, string?> values)
+    {
+        Dictionary<string, string?> normalized = new(StringComparer.OrdinalIgnoreCase);
+        foreach ((string key, string? value) in values)
+        {
+            normalized[key.Replace("__", ":", StringComparison.Ordinal)] = value;
+        }
+
+        return normalized;
+    }
+
+    internal static ProcessStartInfo CreateStartInfo(string projectOrRootPath)
+    {
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = "studioctl",
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        startInfo.ArgumentList.Add("app");
+        startInfo.ArgumentList.Add("env");
+        startInfo.ArgumentList.Add("--json");
+        startInfo.ArgumentList.Add("--project");
+        startInfo.ArgumentList.Add(projectOrRootPath);
+
+        return startInfo;
+    }
+
+    private static bool TryRunStudioctlEnvironmentCommand(string projectOrRootPath, TimeSpan timeout, out string output)
+    {
+        output = string.Empty;
+        using Process process = new() { StartInfo = CreateStartInfo(projectOrRootPath) };
+
+        if (!process.Start())
+        {
+            WriteWarning("studioctl app env did not start.");
+            return false;
+        }
+
+        if (!process.WaitForExit(timeout))
+        {
+            TryKill(process);
+            WriteWarning($"studioctl app env timed out after {timeout.TotalSeconds} seconds.");
+            return false;
+        }
+
+        output = process.StandardOutput.ReadToEnd();
+        string errorOutput = process.StandardError.ReadToEnd().Trim();
+
+        if (process.ExitCode == 0)
+        {
+            return true;
+        }
+
+        string details = string.IsNullOrWhiteSpace(errorOutput) ? "." : $": {errorOutput}";
+        WriteWarning($"studioctl app env exited with code {process.ExitCode}{details}");
+        return false;
+    }
+
+    private static string? FindProjectPath(string contentRootPath)
+    {
+        return Directory
+            .EnumerateFiles(contentRootPath, "*.csproj", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (Exception ex)
+        {
+            WriteWarning("Failed to stop timed out studioctl app env process.", ex);
+        }
+    }
+
+    private static void WriteWarning(string message, Exception? exception = null)
+    {
+        if (exception is null)
+        {
+            Console.Error.WriteLine($"Warning: {message}");
+            return;
+        }
+
+        Console.Error.WriteLine($"Warning: {message}{Environment.NewLine}{exception}");
+    }
+}

--- a/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
@@ -31,6 +31,7 @@ public static class WebHostBuilderExtensions
                 }
 
                 configBuilder.AddInMemoryCollection(config);
+                StudioctlLocalConfiguration.AddIfAvailable(configBuilder, context.HostingEnvironment);
 
                 var runtimeSecretsDirectory = context.Configuration["AppSettings:RuntimeSecretsDirectory"];
                 if (string.IsNullOrWhiteSpace(runtimeSecretsDirectory))

--- a/test/Altinn.App.Api.Tests/Extensions/WebHostBuilderExtensionsTests.cs
+++ b/test/Altinn.App.Api.Tests/Extensions/WebHostBuilderExtensionsTests.cs
@@ -97,6 +97,94 @@ public sealed class WebHostBuilderExtensionsTests
         );
     }
 
+    [Fact]
+    public void TryParseEnvironmentJson_ParsesFlatStudioctlEnvironment()
+    {
+        bool parsed = StudioctlLocalConfiguration.TryParseEnvironmentJson(
+            """
+            {
+              "ASPNETCORE_ENVIRONMENT": "Development",
+              "PlatformSettings__ApiStorageEndpoint": "http://local.altinn.cloud:8000/storage/api/v1/",
+              "STUDIOCTL_APP_RUN": "1",
+              "Ignored": 123
+            }
+            """,
+            out Dictionary<string, string?> values
+        );
+
+        Assert.True(parsed);
+        Assert.Equal("Development", values["ASPNETCORE_ENVIRONMENT"]);
+        Assert.Equal("http://local.altinn.cloud:8000/storage/api/v1/", values["PlatformSettings__ApiStorageEndpoint"]);
+        Assert.Equal("1", values["STUDIOCTL_APP_RUN"]);
+        Assert.DoesNotContain("Ignored", values.Keys);
+    }
+
+    [Fact]
+    public void TryParseEnvironmentJson_InvalidJson_ReturnsFalse()
+    {
+        bool parsed = StudioctlLocalConfiguration.TryParseEnvironmentJson("{", out Dictionary<string, string?> values);
+
+        Assert.False(parsed);
+        Assert.Empty(values);
+    }
+
+    [Fact]
+    public void NormalizeConfigurationKeys_MapsEnvironmentVariableSeparatorsToConfigurationSeparators()
+    {
+        Dictionary<string, string?> values = new()
+        {
+            ["PlatformSettings__ApiStorageEndpoint"] = "http://local.altinn.cloud:8000/storage/api/v1/",
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://otel.local.altinn.cloud:4317",
+        };
+
+        Dictionary<string, string?> normalized = StudioctlLocalConfiguration.NormalizeConfigurationKeys(values);
+
+        Assert.Equal(
+            "http://local.altinn.cloud:8000/storage/api/v1/",
+            normalized["PlatformSettings:ApiStorageEndpoint"]
+        );
+        Assert.Equal("http://otel.local.altinn.cloud:4317", normalized["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+    }
+
+    [Fact]
+    public void CreateStartInfo_UsesStudioctlAppEnvWithDefaultRandomHostPort()
+    {
+        var startInfo = StudioctlLocalConfiguration.CreateStartInfo("/apps/test/App/App.csproj");
+
+        Assert.Equal("studioctl", startInfo.FileName);
+        Assert.Equal(
+            new[] { "app", "env", "--json", "--project", "/apps/test/App/App.csproj" },
+            startInfo.ArgumentList
+        );
+        Assert.DoesNotContain("--random-host-port=false", startInfo.ArgumentList);
+    }
+
+    [Fact]
+    public void ShouldAdd_StudioctlAppRunSet_ReturnsFalse()
+    {
+        using var tempDirectory = new TempDirectory(_outputHelper);
+        using var environmentVariable = new EnvironmentVariableScope("STUDIOCTL_APP_RUN", "1");
+
+        bool shouldAdd = StudioctlLocalConfiguration.ShouldAdd(
+            new TestHostEnvironment(Environments.Development) { ContentRootPath = tempDirectory.Path }
+        );
+
+        Assert.False(shouldAdd);
+    }
+
+    [Fact]
+    public void ShouldAdd_NonDevelopment_ReturnsFalse()
+    {
+        using var tempDirectory = new TempDirectory(_outputHelper);
+        using var environmentVariable = new EnvironmentVariableScope("STUDIOCTL_APP_RUN", null);
+
+        bool shouldAdd = StudioctlLocalConfiguration.ShouldAdd(
+            new TestHostEnvironment(Environments.Production) { ContentRootPath = tempDirectory.Path }
+        );
+
+        Assert.False(shouldAdd);
+    }
+
     private sealed class TestHostEnvironment(string environmentName) : IHostEnvironment
     {
         public string EnvironmentName { get; set; } = environmentName;
@@ -136,5 +224,20 @@ public sealed class WebHostBuilderExtensionsTests
                 );
             }
         }
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _originalValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            _name = name;
+            _originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose() => Environment.SetEnvironmentVariable(_name, _originalValue);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a Development-only app startup hook that imports local harness configuration from `studioctl app env --json --project <app>`.
- Skips the hook when the app was already launched by studioctl via `STUDIOCTL_APP_RUN`.
- Keeps app-lib coupled only to studioctl's flat JSON env-var contract and logs warnings instead of failing app startup if studioctl is missing or returns bad output.

## Why

This lets IDE/debugger launches get the same local platform configuration as `studioctl run`, while still keeping `studioctl run` as the source of truth for local harness values.

## Testing

- Installed/verified `studioctl v0.1.0-preview.13`.
- `dotnet csharpier check src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs src/Altinn.App.Api/Extensions/StudioctlLocalConfiguration.cs test/Altinn.App.Api.Tests/Extensions/WebHostBuilderExtensionsTests.cs`
- `dotnet test test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj --filter "FullyQualifiedName~WebHostBuilderExtensionsTests" -v minimal`
  - Passed: 9/9.
- `dotnet build solutions/All.sln -v minimal`
  - Passed with existing NU1903 warnings in analyzer/benchmark projects.
- Manual martinotest project-reference smoke test:
  - `studioctl run -p /data/home/code/apps/martinotest-app-lib-pr` started the app on a random host port and routed through `http://local.altinn.cloud:8000/ttd/martinotest/`.
  - `dotnet run --project App/App.csproj --launch-profile AppRef --no-build` imported studioctl config, bound a random host port, and was discoverable through `studioctl app ps`.

## Integration test note

I also reproduced a PDF integration failure locally, but it reproduces the same way on clean `upstream/main` at `3c666448`.

Command:

```sh
dotnet test test/Altinn.App.Integration.Tests/Altinn.App.Integration.Tests.csproj --filter "FullyQualifiedName~InstanceLocking.InstanceLockTests.ProcessNext_ConcurrentRequests_OneRequestGetsConflict" -v minimal
```

Result on both this branch and clean upstream main: the app receives a 500 from `localtest-pdf3` after about 30 seconds. PDF container logs show Chromium failing to load frontend CDN assets with `ERR_CERT_AUTHORITY_INVALID`, then timing out waiting for `#readyForPrint`:

```text
Failed to load resource: net::ERR_CERT_AUTHORITY_INVALID url:https://altinncdn.no/toolkits/altinn-app-frontend/4/altinn-app-frontend.css
Failed to load resource: net::ERR_CERT_AUTHORITY_INVALID url:https://altinncdn.no/toolkits/altinn-app-frontend/4/altinn-app-frontend.js
Wait condition not satisfied within timeout waitFor="#readyForPrint"
status_code=500 detail="waitFor element not ready within timeout: failed waiting for condition: timeout"
```
