### PR TITLE
chore: avoid analyzer test Buildalyzer hang

### DIFF
--- a/test/Altinn.App.Analyzers.Tests/Fixtures/BaseFixture.cs
+++ b/test/Altinn.App.Analyzers.Tests/Fixtures/BaseFixture.cs
@@ -31,7 +31,7 @@ public abstract class BaseFixture : IDisposable
 
     private static readonly SemaphoreSlim _lck = new SemaphoreSlim(1, 1);
 
-    protected async Task Init(string projectFilePath, string? preBuildTarget = null)
+    protected async Task Init(string projectFilePath)
     {
         if (IsInitialized)
             return;
@@ -54,12 +54,7 @@ public abstract class BaseFixture : IDisposable
             Workspace.WorkspaceFailed += (sender, args) => Output.WriteLine("Workspace failed: {0}", args.Diagnostic);
 
             var analyzer = manager.GetProject(projectFilePath);
-            var options = new EnvironmentOptions() { DesignTime = false };
-            options.TargetsToBuild.Clear();
-            var targets = new List<string> { "Clean", "Build" };
-            if (preBuildTarget != null)
-                targets.Insert(1, preBuildTarget);
-            options.TargetsToBuild.AddRange(targets);
+            var options = new EnvironmentOptions();
             var results = analyzer.Build(options);
             var result =
                 results
@@ -67,7 +62,12 @@ public abstract class BaseFixture : IDisposable
                     .FirstOrDefault(r => r.Succeeded)
                 ?? results.First();
             Assert.True(result.Succeeded, log.ToString());
-            Project = result.AddToWorkspace(Workspace);
+            Project = result.AddToWorkspace(Workspace, addProjectReferences: true);
+            Project = RemoveMetadataReferencesDuplicatedByProjectReferences(Project);
+            var projectId = Project.Id;
+            Assert.True(Workspace.TryApplyChanges(Project.Solution));
+            Project = Workspace.CurrentSolution.GetProject(projectId);
+            Assert.NotNull(Project);
 
             Assert.True(Workspace.CanApplyChange(ApplyChangesKind.AddDocument));
             Assert.True(Workspace.CanApplyChange(ApplyChangesKind.RemoveDocument));
@@ -89,6 +89,27 @@ public abstract class BaseFixture : IDisposable
         {
             _lck.Release();
         }
+    }
+
+    private static Project RemoveMetadataReferencesDuplicatedByProjectReferences(Project project)
+    {
+        var referencedAssemblyNames = project
+            .ProjectReferences.Select(reference => project.Solution.GetProject(reference.ProjectId)?.AssemblyName)
+            .Where(assemblyName => !string.IsNullOrWhiteSpace(assemblyName))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var metadataReference in project.MetadataReferences)
+        {
+            if (
+                metadataReference is PortableExecutableReference { FilePath: { } filePath }
+                && referencedAssemblyNames.Contains(Path.GetFileNameWithoutExtension(filePath))
+            )
+            {
+                project = project.RemoveMetadataReference(metadataReference);
+            }
+        }
+
+        return project;
     }
 
     protected async Task<(


### PR DESCRIPTION
## Summary
- switch analyzer test fixture initialization to Buildalyzer's design-time project analysis path
- add referenced projects to the Roslyn workspace so injected test code resolves app-lib project types
- remove duplicate metadata references for assemblies that are represented by workspace project references

## Why
The local analyzer test harness could hang inside Buildalyzer/MSBuild pipe logger disposal when the fixture forced a non-design-time `Clean;Build`. The analyzer tests only need Roslyn compilation inputs, not build outputs, so design-time analysis is a better fit.

## Testing
- `dotnet build test/Altinn.App.Analyzers.Tests/Altinn.App.Analyzers.Tests.csproj -v minimal`
- `timeout 120s dotnet test test/Altinn.App.Analyzers.Tests/Altinn.App.Analyzers.Tests.csproj --no-build -v normal --filter "FullyQualifiedName~HttpContextAccessorUsageAnalyzerTests.Emits_Diagnostic" --blame-hang --blame-hang-timeout 2m --blame-hang-dump-type mini`
- `dotnet test test/Altinn.App.Analyzers.Tests/Altinn.App.Analyzers.Tests.csproj --no-build -v minimal --filter "Category!=Integration"`

Build emits existing NU1903 package vulnerability warnings for Microsoft.Build/System.Security.Cryptography.Xml packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains internal testing infrastructure improvements with no user-facing changes. Updates include:

* **Tests**
  * Simplified test fixture initialization process
  * Enhanced workspace project handling to eliminate metadata reference duplication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->