### PR TITLE
feat: revoke signee rights on signing task end

### DIFF
--- a/src/Altinn.App.Core/Features/Signing/Services/ISigningService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/ISigningService.cs
@@ -44,4 +44,14 @@ internal interface ISigningService
         AltinnSignatureConfiguration signatureConfiguration,
         CancellationToken ct = default
     );
+
+    /// <summary>
+    /// Revokes any delegated signee access rights for the current task without touching signing data,
+    /// so that the rights don't outlive the task that granted them.
+    /// </summary>
+    Task RevokeSigneeRightsOnTaskEnd(
+        IInstanceDataMutator instanceDataMutator,
+        AltinnSignatureConfiguration signatureConfiguration,
+        CancellationToken ct = default
+    );
 }

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
@@ -226,11 +226,12 @@ internal sealed class SigningService(
 
         using var activity = telemetry?.StartAbortRuntimeDelegatedSigningActivity(taskId);
 
+        // Revoke must run before cleanup, since it reads signee state that cleanup removes.
+        await RevokeDelegatedSigneeRights(instanceDataMutator, signatureConfiguration, taskId, ct);
+
         // cleanup
         RemoveSigneeState(instanceDataMutator, signatureConfiguration.SigneeStatesDataTypeId);
         RemoveAllSignatures(instanceDataMutator, signatureConfiguration.SignatureDataType);
-
-        await RevokeDelegatedSigneeRights(instanceDataMutator, signatureConfiguration, taskId, ct);
     }
 
     /// <inheritdoc />

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
@@ -230,6 +230,30 @@ internal sealed class SigningService(
         RemoveSigneeState(instanceDataMutator, signatureConfiguration.SigneeStatesDataTypeId);
         RemoveAllSignatures(instanceDataMutator, signatureConfiguration.SignatureDataType);
 
+        await RevokeDelegatedSigneeRights(instanceDataMutator, signatureConfiguration, taskId, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task RevokeSigneeRightsOnTaskEnd(
+        IInstanceDataMutator instanceDataMutator,
+        AltinnSignatureConfiguration signatureConfiguration,
+        CancellationToken ct = default
+    )
+    {
+        string taskId = instanceDataMutator.Instance.Process.CurrentTask.ElementId;
+
+        using var activity = telemetry?.StartRevokeSigneeRightsOnTaskEndActivity(taskId);
+
+        await RevokeDelegatedSigneeRights(instanceDataMutator, signatureConfiguration, taskId, ct);
+    }
+
+    private async Task RevokeDelegatedSigneeRights(
+        IInstanceDataMutator instanceDataMutator,
+        AltinnSignatureConfiguration signatureConfiguration,
+        string taskId,
+        CancellationToken ct
+    )
+    {
         List<SigneeContext> signeeContexts = await GetSigneeContexts(
             instanceDataMutator,
             signatureConfiguration,

--- a/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigningService.cs
@@ -222,7 +222,7 @@ internal sealed class SigningService(
         CancellationToken ct = default
     )
     {
-        string taskId = instanceDataMutator.Instance.Process.CurrentTask.ElementId;
+        string taskId = GetTaskId(instanceDataMutator);
 
         using var activity = telemetry?.StartAbortRuntimeDelegatedSigningActivity(taskId);
 
@@ -240,12 +240,25 @@ internal sealed class SigningService(
         CancellationToken ct = default
     )
     {
-        string taskId = instanceDataMutator.Instance.Process.CurrentTask.ElementId;
+        string taskId = GetTaskId(instanceDataMutator);
 
         using var activity = telemetry?.StartRevokeSigneeRightsOnTaskEndActivity(taskId);
 
         await RevokeDelegatedSigneeRights(instanceDataMutator, signatureConfiguration, taskId, ct);
     }
+
+    /// <summary>
+    /// Gets the id of the task currently being processed.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IInstanceDataAccessor.TaskId"/> is used instead of <c>Instance.Process.CurrentTask</c>,
+    /// because the latter may already have been moved to the next task (or cleared if the process ended)
+    /// by the time task end/abandon handlers run.
+    /// </remarks>
+    private static string GetTaskId(IInstanceDataAccessor instanceDataAccessor) =>
+        instanceDataAccessor.TaskId
+        ?? instanceDataAccessor.Instance.Process.CurrentTask?.ElementId
+        ?? throw new SigningException("Unable to determine the task ID for signee rights revocation.");
 
     private async Task RevokeDelegatedSigneeRights(
         IInstanceDataMutator instanceDataMutator,

--- a/src/Altinn.App.Core/Features/Telemetry/Signing/Telemetry.SigningService.cs
+++ b/src/Altinn.App.Core/Features/Telemetry/Signing/Telemetry.SigningService.cs
@@ -75,6 +75,13 @@ partial class Telemetry
         return activity;
     }
 
+    internal Activity? StartRevokeSigneeRightsOnTaskEndActivity(string taskId)
+    {
+        Activity? activity = ActivitySource.StartActivity("SigningService.RevokeSigneeRightsOnTaskEnd");
+        activity?.SetTag(Labels.TaskId, taskId);
+        return activity;
+    }
+
     internal Activity? StartGetServiceOwnerPartyActivity() =>
         ActivitySource.StartActivity("SigningService.GetServiceOwnerParty");
 

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/SigningProcessTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/SigningProcessTask.cs
@@ -110,6 +110,7 @@ internal sealed class SigningProcessTask : IProcessTask
             );
         }
 
+        // Revoke delegated signing if configured
         if (
             signatureConfiguration?.SigneeProviderId is not null
             && signatureConfiguration.SigneeStatesDataTypeId is not null

--- a/src/Altinn.App.Core/Internal/Process/ProcessTasks/SigningProcessTask.cs
+++ b/src/Altinn.App.Core/Internal/Process/ProcessTasks/SigningProcessTask.cs
@@ -82,7 +82,10 @@ internal sealed class SigningProcessTask : IProcessTask
     }
 
     /// <inheritdoc/>
-    /// <remarks> Generates a PDF if the signature configuration specifies a signature data type. </remarks>
+    /// <remarks>
+    /// Generates a PDF if the signature configuration specifies a signature data type, and revokes any
+    /// signee access rights that were delegated for runtime delegated signing, so they don't outlive the task.
+    /// </remarks>
     public async Task End(string taskId, Instance instance)
     {
         AltinnSignatureConfiguration? signatureConfiguration = _processReader
@@ -105,6 +108,26 @@ internal sealed class SigningProcessTask : IProcessTask
                 authenticationMethod: null,
                 CancellationToken.None
             );
+        }
+
+        if (
+            signatureConfiguration?.SigneeProviderId is not null
+            && signatureConfiguration.SigneeStatesDataTypeId is not null
+        )
+        {
+            using var cts = new CancellationTokenSource();
+
+            InstanceDataUnitOfWork cachedDataMutator = await _instanceDataUnitOfWorkInitializer.Init(
+                instance,
+                taskId,
+                null
+            );
+
+            await _signingService.RevokeSigneeRightsOnTaskEnd(cachedDataMutator, signatureConfiguration, cts.Token);
+
+            DataElementChanges changes = cachedDataMutator.GetDataElementChanges(false);
+            await cachedDataMutator.UpdateInstanceData(changes);
+            await cachedDataMutator.SaveChanges(changes);
         }
     }
 

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
@@ -741,6 +741,11 @@ public sealed class SigningServiceTests : IDisposable
         );
 
         // Assert
+        cachedInstanceMutator.Verify(x => x.Instance);
+        cachedInstanceMutator.Verify(x => x.TaskId);
+
+        // The signing data (signee state and signatures) must be left untouched - only the delegated rights are revoked
+        cachedInstanceMutator.VerifyNoOtherCalls();
         _signingDelegationService.Verify(
             x =>
                 x.RevokeSigneeRights(
@@ -753,6 +758,7 @@ public sealed class SigningServiceTests : IDisposable
                 ),
             Times.Once
         );
+        _signingDelegationService.VerifyNoOtherCalls();
     }
 
     [Fact]

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
@@ -467,6 +467,156 @@ public sealed class SigningServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task AbortRuntimeDelegatedSigning_Revokes_Delegation_Before_Removing_SigningData()
+    {
+        // Arrange
+        var signatureConfiguration = new AltinnSignatureConfiguration
+        {
+            SigneeStatesDataTypeId = "signeeStates",
+            SignatureDataType = "signature",
+        };
+
+        var signeeStateDataElement = new DataElement
+        {
+            Id = Guid.NewGuid().ToString(),
+            DataType = signatureConfiguration.SigneeStatesDataTypeId,
+        };
+
+        var signatureDataElement = new DataElement
+        {
+            Id = Guid.NewGuid().ToString(),
+            DataType = signatureConfiguration.SignatureDataType,
+        };
+
+        const string taskId = "task1";
+        var instance = new Instance
+        {
+            Id = new InstanceIdentifier(123, Guid.NewGuid()).ToString(),
+            AppId = "ttd/app1",
+            InstanceOwner = new InstanceOwner { PartyId = Guid.NewGuid().ToString(), OrganisationNumber = "ttd" },
+            Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = taskId } },
+            Data = [signeeStateDataElement, signatureDataElement],
+        };
+
+        // Strict, so that a call made out of turn relative to the `MockSequence` below
+        // (i.e. cleanup running before revocation reads signee state) throws instead of silently no-oping.
+        var cachedInstanceMutator = new Mock<IInstanceDataMutator>(MockBehavior.Strict);
+
+        cachedInstanceMutator.Setup(x => x.Instance).Returns(instance);
+        cachedInstanceMutator.Setup(x => x.TaskId).Returns(instance.Process.CurrentTask.ElementId);
+
+        var signeeContexts = new List<SigneeContext>()
+        {
+            new()
+            {
+                TaskId = taskId,
+                Signee = new PersonSignee
+                {
+                    SocialSecurityNumber = "12345678910",
+                    FullName = "Name",
+                    Party = new Party(),
+                },
+                SigneeState = new SigneeState { IsAccessDelegated = true },
+            },
+        };
+
+        List<SignDocument> signDocuments =
+        [
+            new SignDocument { SigneeInfo = new StorageSignee { PersonNumber = "12345678910" } },
+        ];
+
+        var signeeContextsWithDocuments = new List<SigneeContext>()
+        {
+            new()
+            {
+                TaskId = taskId,
+                Signee = new PersonSignee
+                {
+                    SocialSecurityNumber = "12345678910",
+                    FullName = "Name",
+                    Party = new Party(),
+                },
+                SigneeState = new SigneeState { IsAccessDelegated = true },
+                SignDocument = signDocuments[0],
+            },
+        };
+
+        _signeeContextsManager
+            .Setup(x =>
+                x.GetSigneeContexts(cachedInstanceMutator.Object, signatureConfiguration, CancellationToken.None)
+            )
+            .ReturnsAsync(signeeContexts);
+
+        _signDocumentManager
+            .Setup(x =>
+                x.GetSignDocuments(cachedInstanceMutator.Object, signatureConfiguration, CancellationToken.None)
+            )
+            .ReturnsAsync(signDocuments);
+
+        _signDocumentManager
+            .Setup(x =>
+                x.SynchronizeSigneeContextsWithSignDocuments(
+                    taskId,
+                    signeeContexts,
+                    signDocuments,
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(signeeContextsWithDocuments);
+
+        _altinnPartyClient
+            .Setup(x => x.LookupParty(It.IsAny<PartyLookup>()))
+            .ReturnsAsync(new Party { PartyUuid = Guid.NewGuid() });
+
+        // Asserts call order across mocks: revocation must read signee state (position 0)
+        // before the signee state / signature data elements are removed (positions 1 and 2).
+        // Since `cachedInstanceMutator` is Strict, a call made before its turn has no matching
+        // setup and throws, failing the test.
+        var sequence = new MockSequence();
+
+        _signingDelegationService
+            .InSequence(sequence)
+            .Setup(x =>
+                x.RevokeSigneeRights(
+                    taskId,
+                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<List<SigneeContext>>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync((signeeContexts, true));
+
+        cachedInstanceMutator.InSequence(sequence).Setup(x => x.RemoveDataElement(signeeStateDataElement));
+        cachedInstanceMutator.InSequence(sequence).Setup(x => x.RemoveDataElement(signatureDataElement));
+
+        // Act
+        await _signingService.AbortRuntimeDelegatedSigning(
+            cachedInstanceMutator.Object,
+            signatureConfiguration,
+            CancellationToken.None
+        );
+
+        // Assert
+        _signingDelegationService.Verify(
+            x =>
+                x.RevokeSigneeRights(
+                    taskId,
+                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<AppIdentifier>(),
+                    It.IsAny<List<SigneeContext>>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+
+        cachedInstanceMutator.Verify(x => x.RemoveDataElement(signeeStateDataElement), Times.Once);
+        cachedInstanceMutator.Verify(x => x.RemoveDataElement(signatureDataElement), Times.Once);
+    }
+
+    [Fact]
     public async Task RevokeSigneeRightsOnTaskEnd_Revokes_Delegation_Without_Removing_SigningData()
     {
         // Arrange

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
@@ -467,6 +467,206 @@ public sealed class SigningServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RevokeSigneeRightsOnTaskEnd_Revokes_Delegation_Without_Removing_SigningData()
+    {
+        // Arrange
+        var signatureConfiguration = new AltinnSignatureConfiguration
+        {
+            SigneeStatesDataTypeId = "signeeStates",
+            SignatureDataType = "signature",
+        };
+
+        var signeeStateDataElement = new DataElement
+        {
+            Id = Guid.NewGuid().ToString(),
+            DataType = signatureConfiguration.SigneeStatesDataTypeId,
+        };
+
+        var signatureDataElement = new DataElement
+        {
+            Id = Guid.NewGuid().ToString(),
+            DataType = signatureConfiguration.SignatureDataType,
+        };
+
+        const string taskId = "task1";
+        var instance = new Instance
+        {
+            Id = new InstanceIdentifier(123, Guid.NewGuid()).ToString(),
+            AppId = "ttd/app1",
+            InstanceOwner = new InstanceOwner { PartyId = Guid.NewGuid().ToString(), OrganisationNumber = "ttd" },
+            Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = taskId } },
+            Data = [signeeStateDataElement, signatureDataElement],
+        };
+
+        var cachedInstanceMutator = new Mock<IInstanceDataMutator>();
+
+        cachedInstanceMutator.Setup(x => x.Instance).Returns(instance);
+        cachedInstanceMutator.Setup(x => x.TaskId).Returns(instance.Process.CurrentTask.ElementId);
+
+        var signeeContexts = new List<SigneeContext>()
+        {
+            new()
+            {
+                TaskId = taskId,
+                Signee = new PersonSignee
+                {
+                    SocialSecurityNumber = "12345678910",
+                    FullName = "Name",
+                    Party = new Party(),
+                },
+                SigneeState = new SigneeState { IsAccessDelegated = true },
+            },
+        };
+
+        List<SignDocument> signDocuments =
+        [
+            new SignDocument { SigneeInfo = new StorageSignee { PersonNumber = "12345678910" } },
+        ];
+
+        var signeeContextsWithDocuments = new List<SigneeContext>()
+        {
+            new()
+            {
+                TaskId = taskId,
+                Signee = new PersonSignee
+                {
+                    SocialSecurityNumber = "12345678910",
+                    FullName = "Name",
+                    Party = new Party(),
+                },
+                SigneeState = new SigneeState { IsAccessDelegated = true },
+                SignDocument = signDocuments[0],
+            },
+        };
+
+        _signeeContextsManager
+            .Setup(x =>
+                x.GetSigneeContexts(cachedInstanceMutator.Object, signatureConfiguration, CancellationToken.None)
+            )
+            .ReturnsAsync(signeeContexts);
+
+        _signDocumentManager
+            .Setup(x =>
+                x.GetSignDocuments(cachedInstanceMutator.Object, signatureConfiguration, CancellationToken.None)
+            )
+            .ReturnsAsync(signDocuments);
+
+        _signDocumentManager
+            .Setup(x =>
+                x.SynchronizeSigneeContextsWithSignDocuments(
+                    taskId,
+                    signeeContexts,
+                    signDocuments,
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(signeeContextsWithDocuments);
+
+        Guid instanceOwnerPartyUuid = Guid.NewGuid();
+
+        _signingDelegationService
+            .Setup(x =>
+                x.RevokeSigneeRights(
+                    taskId,
+                    instance.Id,
+                    instanceOwnerPartyUuid,
+                    It.Is<AppIdentifier>(a => a.Org == "ttd" && a.App == "app1"),
+                    signeeContextsWithDocuments,
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync((signeeContextsWithDocuments, true));
+
+        _altinnPartyClient
+            .Setup(x => x.LookupParty(It.IsAny<PartyLookup>()))
+            .ReturnsAsync(new Party { PartyUuid = instanceOwnerPartyUuid });
+
+        // Act
+        await _signingService.RevokeSigneeRightsOnTaskEnd(
+            cachedInstanceMutator.Object,
+            signatureConfiguration,
+            CancellationToken.None
+        );
+
+        // Assert
+        cachedInstanceMutator.Verify(x => x.Instance);
+        cachedInstanceMutator.Verify(x => x.TaskId);
+
+        // The signing data (signee state and signatures) must be left untouched - only the delegated rights are revoked
+        cachedInstanceMutator.VerifyNoOtherCalls();
+
+        _signingDelegationService.Verify(
+            x =>
+                x.RevokeSigneeRights(
+                    taskId,
+                    instance.Id,
+                    instanceOwnerPartyUuid,
+                    It.IsAny<AppIdentifier>(),
+                    signeeContextsWithDocuments,
+                    CancellationToken.None
+                ),
+            Times.Once
+        );
+        _signingDelegationService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task RevokeSigneeRightsOnTaskEnd_Does_Nothing_If_No_Delegated_Access()
+    {
+        // Arrange
+        var signatureConfiguration = new AltinnSignatureConfiguration
+        {
+            SigneeStatesDataTypeId = "signeeStates",
+            SignatureDataType = "signature",
+        };
+
+        var cachedInstanceMutator = new Mock<IInstanceDataMutator>();
+        var instance = new Instance
+        {
+            Process = new ProcessState { CurrentTask = new ProcessElementInfo { ElementId = "task1" } },
+            Data = [],
+        };
+        cachedInstanceMutator.Setup(x => x.Instance).Returns(instance);
+        cachedInstanceMutator.Setup(x => x.TaskId).Returns(instance.Process.CurrentTask.ElementId);
+
+        _signDocumentManager
+            .Setup(x =>
+                x.GetSignDocuments(cachedInstanceMutator.Object, signatureConfiguration, CancellationToken.None)
+            )
+            .ReturnsAsync([]);
+        _signDocumentManager
+            .Setup(x =>
+                x.SynchronizeSigneeContextsWithSignDocuments(
+                    instance.Process.CurrentTask.ElementId,
+                    It.IsAny<List<SigneeContext>>(),
+                    It.IsAny<List<SignDocument>>(),
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync([]);
+
+        _signeeContextsManager
+            .Setup(x =>
+                x.GetSigneeContexts(cachedInstanceMutator.Object, signatureConfiguration, CancellationToken.None)
+            )
+            .ReturnsAsync([]);
+
+        // Act
+        await _signingService.RevokeSigneeRightsOnTaskEnd(
+            cachedInstanceMutator.Object,
+            signatureConfiguration,
+            CancellationToken.None
+        );
+
+        // Assert
+        cachedInstanceMutator.Verify(x => x.Instance);
+        cachedInstanceMutator.Verify(x => x.TaskId);
+        cachedInstanceMutator.VerifyNoOtherCalls();
+
+        _signingDelegationService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
     public async Task AbortRuntimeDelegatedSigning_Does_Nothing_If_No_Existing_Data()
     {
         var signatureConfiguration = new AltinnSignatureConfiguration

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningServiceTests.cs
@@ -611,6 +611,151 @@ public sealed class SigningServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RevokeSigneeRightsOnTaskEnd_Revokes_Delegation_When_ProcessHasMovedPastTheTask()
+    {
+        // Arrange
+        // Simulates the state of `instance` when SigningProcessTask.End runs as the last task in the process:
+        // by the time the end-task event is handled, instance.Process.CurrentTask has already been
+        // cleared (process moved to the end event), so the task ID can only be read from TaskId.
+        var signatureConfiguration = new AltinnSignatureConfiguration
+        {
+            SigneeStatesDataTypeId = "signeeStates",
+            SignatureDataType = "signature",
+        };
+
+        var signeeStateDataElement = new DataElement
+        {
+            Id = Guid.NewGuid().ToString(),
+            DataType = signatureConfiguration.SigneeStatesDataTypeId,
+        };
+
+        var signatureDataElement = new DataElement
+        {
+            Id = Guid.NewGuid().ToString(),
+            DataType = signatureConfiguration.SignatureDataType,
+        };
+
+        const string taskId = "task1";
+        var instance = new Instance
+        {
+            Id = new InstanceIdentifier(123, Guid.NewGuid()).ToString(),
+            AppId = "ttd/app1",
+            InstanceOwner = new InstanceOwner { PartyId = Guid.NewGuid().ToString(), OrganisationNumber = "ttd" },
+            Process = new ProcessState
+            {
+                CurrentTask = null,
+                EndEvent = "EndEvent",
+                Ended = DateTime.UtcNow,
+            },
+            Data = [signeeStateDataElement, signatureDataElement],
+        };
+
+        var cachedInstanceMutator = new Mock<IInstanceDataMutator>();
+
+        cachedInstanceMutator.Setup(x => x.Instance).Returns(instance);
+        cachedInstanceMutator.Setup(x => x.TaskId).Returns(taskId);
+
+        var signeeContexts = new List<SigneeContext>()
+        {
+            new()
+            {
+                TaskId = taskId,
+                Signee = new PersonSignee
+                {
+                    SocialSecurityNumber = "12345678910",
+                    FullName = "Name",
+                    Party = new Party(),
+                },
+                SigneeState = new SigneeState { IsAccessDelegated = true },
+            },
+        };
+
+        List<SignDocument> signDocuments =
+        [
+            new SignDocument { SigneeInfo = new StorageSignee { PersonNumber = "12345678910" } },
+        ];
+
+        var signeeContextsWithDocuments = new List<SigneeContext>()
+        {
+            new()
+            {
+                TaskId = taskId,
+                Signee = new PersonSignee
+                {
+                    SocialSecurityNumber = "12345678910",
+                    FullName = "Name",
+                    Party = new Party(),
+                },
+                SigneeState = new SigneeState { IsAccessDelegated = true },
+                SignDocument = signDocuments[0],
+            },
+        };
+
+        _signeeContextsManager
+            .Setup(x =>
+                x.GetSigneeContexts(cachedInstanceMutator.Object, signatureConfiguration, CancellationToken.None)
+            )
+            .ReturnsAsync(signeeContexts);
+
+        _signDocumentManager
+            .Setup(x =>
+                x.GetSignDocuments(cachedInstanceMutator.Object, signatureConfiguration, CancellationToken.None)
+            )
+            .ReturnsAsync(signDocuments);
+
+        _signDocumentManager
+            .Setup(x =>
+                x.SynchronizeSigneeContextsWithSignDocuments(
+                    taskId,
+                    signeeContexts,
+                    signDocuments,
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(signeeContextsWithDocuments);
+
+        Guid instanceOwnerPartyUuid = Guid.NewGuid();
+
+        _signingDelegationService
+            .Setup(x =>
+                x.RevokeSigneeRights(
+                    taskId,
+                    instance.Id,
+                    instanceOwnerPartyUuid,
+                    It.Is<AppIdentifier>(a => a.Org == "ttd" && a.App == "app1"),
+                    signeeContextsWithDocuments,
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync((signeeContextsWithDocuments, true));
+
+        _altinnPartyClient
+            .Setup(x => x.LookupParty(It.IsAny<PartyLookup>()))
+            .ReturnsAsync(new Party { PartyUuid = instanceOwnerPartyUuid });
+
+        // Act
+        await _signingService.RevokeSigneeRightsOnTaskEnd(
+            cachedInstanceMutator.Object,
+            signatureConfiguration,
+            CancellationToken.None
+        );
+
+        // Assert
+        _signingDelegationService.Verify(
+            x =>
+                x.RevokeSigneeRights(
+                    taskId,
+                    instance.Id,
+                    instanceOwnerPartyUuid,
+                    It.IsAny<AppIdentifier>(),
+                    signeeContextsWithDocuments,
+                    CancellationToken.None
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
     public async Task RevokeSigneeRightsOnTaskEnd_Does_Nothing_If_No_Delegated_Access()
     {
         // Arrange
@@ -659,8 +804,8 @@ public sealed class SigningServiceTests : IDisposable
         );
 
         // Assert
-        cachedInstanceMutator.Verify(x => x.Instance);
-        cachedInstanceMutator.Verify(x => x.TaskId);
+        // TaskId alone is enough to determine the task ID, so Instance is never accessed.
+        cachedInstanceMutator.Verify(x => x.TaskId, Times.AtLeastOnce);
         cachedInstanceMutator.VerifyNoOtherCalls();
 
         _signingDelegationService.VerifyNoOtherCalls();

--- a/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/SigningProcessTaskTests.cs
+++ b/test/Altinn.App.Core.Tests/Internal/Process/ProcessTasks/SigningProcessTaskTests.cs
@@ -123,6 +123,60 @@ public class SigningProcessTaskTests
     }
 
     [Fact]
+    public async Task End_RevokesDelegatedSigneeRights_WhenRuntimeDelegatedSigningConfigured()
+    {
+        // Arrange
+        Instance instance = CreateInstance();
+        string taskId = instance.Process.CurrentTask.ElementId;
+        var altinnTaskExtension = new AltinnTaskExtension { SignatureConfiguration = CreateSigningConfiguration() };
+
+        await using var sp = _serviceCollection.BuildStrictServiceProvider();
+        var signingProcessTask = sp.GetRequiredService<SigningProcessTask>();
+
+        _processReaderMock.Setup(x => x.GetAltinnTaskExtension(It.IsAny<string>())).Returns(altinnTaskExtension);
+        _signingServiceMock
+            .Setup(x =>
+                x.RevokeSigneeRightsOnTaskEnd(
+                    It.IsAny<IInstanceDataMutator>(),
+                    altinnTaskExtension.SignatureConfiguration,
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask)
+            .Verifiable(Times.Once);
+
+        // Act
+        await signingProcessTask.End(taskId, instance);
+
+        // Assert
+        _signingServiceMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task End_DoesNotRevokeSigneeRights_WhenRuntimeDelegatedSigningNotConfigured()
+    {
+        // Arrange
+        Instance instance = CreateInstance();
+        string taskId = instance.Process.CurrentTask.ElementId;
+        var altinnTaskExtension = new AltinnTaskExtension
+        {
+            SignatureConfiguration = new AltinnSignatureConfiguration { SignatureDataType = "SignatureDataType" },
+        };
+
+        await using var sp = _serviceCollection.BuildStrictServiceProvider();
+        var signingProcessTask = sp.GetRequiredService<SigningProcessTask>();
+
+        _processReaderMock.Setup(x => x.GetAltinnTaskExtension(It.IsAny<string>())).Returns(altinnTaskExtension);
+
+        // Act
+        // The strict ISigningService mock has no setup for RevokeSigneeRightsOnTaskEnd, so this throws if it's called.
+        await signingProcessTask.End(taskId, instance);
+
+        // Assert
+        _signingServiceMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
     public async Task Abandon_ShouldDeleteExistingSigningData()
     {
         // Arrange


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Revoke signee rights after signing task.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Delegated signing access is now automatically revoked when signing tasks complete, improving security by removing temporary delegated rights after the task ends.
  * Revocation is performed without changing stored signing data.
  * Task-end revocation is only triggered when runtime delegated signing is configured.
* **Bug Fixes**
  * Abort and task-end delegation revocation now consistently use the correct task identifier for telemetry.
* **Tests**
  * Added coverage for task-end revocation and “no delegated access” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->