### PR TITLE
Feat/set data by expression suggestions

### DIFF
--- a/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
+++ b/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
@@ -69,8 +69,7 @@ internal sealed class DataModelFieldCalculator
             var resolvedFields = await dataAccessor
                 .GetLayoutEvaluatorState()
                 .GetResolvedKeys(
-                    new DataReference() { Field = baseField, DataElementIdentifier = dataElementIdentifier },
-                    true
+                    new DataReference() { Field = baseField, DataElementIdentifier = dataElementIdentifier }
                 );
             foreach (var resolvedField in resolvedFields)
             {

--- a/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
+++ b/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
@@ -66,26 +66,27 @@ internal sealed class DataModelFieldCalculator
 
         foreach (var (baseField, calculation) in dataModelFieldCalculations)
         {
-            var resolvedFields = await dataAccessor
-                .GetLayoutEvaluatorState()
-                .GetResolvedKeys(
-                    new DataReference() { Field = baseField, DataElementIdentifier = dataElementIdentifier }
-                );
+            var resolvedFields = formDataWrapper.GetResolvedKeys(baseField);
             foreach (var resolvedField in resolvedFields)
             {
+                var resolvedFieldReference = new DataReference()
+                {
+                    Field = resolvedField,
+                    DataElementIdentifier = dataElementIdentifier,
+                };
                 var context = new ComponentContext(
                     dataAccessor,
                     component: null,
-                    rowIndices: ExpressionHelper.GetRowIndices(resolvedField.Field),
-                    dataElementIdentifier: resolvedField.DataElementIdentifier
+                    rowIndices: ExpressionHelper.GetRowIndices(resolvedField),
+                    dataElementIdentifier: dataElementIdentifier
                 );
-                var positionalArguments = new ExpressionValue[] { resolvedField.Field };
+                var positionalArguments = new ExpressionValue[] { resolvedFieldReference.Field };
 
                 await RunCalculation(
                     dataAccessor,
                     context,
                     formDataWrapper,
-                    resolvedField,
+                    resolvedFieldReference,
                     positionalArguments,
                     calculation
                 );

--- a/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
+++ b/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
@@ -49,7 +49,7 @@ internal sealed class DataModelFieldCalculator
             var calculationConfig = _appResourceService.GetCalculationConfiguration(dataType.Id);
             if (!string.IsNullOrEmpty(calculationConfig))
             {
-                await CalculateFormData(dataAccessor, dataElement, taskId, calculationConfig);
+                await CalculateFormData(dataAccessor, dataElement, calculationConfig);
             }
         }
     }
@@ -57,14 +57,9 @@ internal sealed class DataModelFieldCalculator
     internal async Task CalculateFormData(
         IInstanceDataAccessor dataAccessor,
         DataElement dataElement,
-        string taskId,
         string rawCalculationConfig
     )
     {
-        var hiddenFields = await LayoutEvaluator.GetHiddenFieldsForRemoval(
-            dataAccessor.GetLayoutEvaluatorState(),
-            evaluateRemoveWhenHidden: false
-        );
         DataElementIdentifier dataElementIdentifier = dataElement;
         var dataModelFieldCalculations = ParseDataModelFieldCalculationConfig(rawCalculationConfig);
         var formDataWrapper = await dataAccessor.GetFormDataWrapper(dataElement);
@@ -79,16 +74,6 @@ internal sealed class DataModelFieldCalculator
                 );
             foreach (var resolvedField in resolvedFields)
             {
-                if (
-                    hiddenFields.Exists(d =>
-                        d.DataElementIdentifier == resolvedField.DataElementIdentifier
-                        && IsSameOrDescendantField(resolvedField.Field, d.Field)
-                    )
-                )
-                {
-                    continue;
-                }
-
                 var context = new ComponentContext(
                     dataAccessor,
                     component: null,
@@ -98,10 +83,10 @@ internal sealed class DataModelFieldCalculator
                 var positionalArguments = new ExpressionValue[] { resolvedField.Field };
 
                 await RunCalculation(
-                    formDataWrapper,
                     dataAccessor,
-                    resolvedField,
                     context,
+                    formDataWrapper,
+                    resolvedField,
                     positionalArguments,
                     calculation
                 );
@@ -110,10 +95,10 @@ internal sealed class DataModelFieldCalculator
     }
 
     private async Task RunCalculation(
-        IFormDataWrapper formDataWrapper,
         IInstanceDataAccessor dataAccessor,
-        DataReference resolvedField,
         ComponentContext context,
+        IFormDataWrapper formDataWrapper,
+        DataReference resolvedField,
         ExpressionValue[] positionalArguments,
         DataModelFieldCalculation calculation
     )

--- a/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
+++ b/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
@@ -20,13 +20,11 @@ internal sealed class DataModelFieldCalculator
 
     private readonly ILogger<DataModelFieldCalculator> _logger;
     private readonly IAppResources _appResourceService;
-    private readonly ILayoutEvaluatorStateInitializer _layoutEvaluatorStateInitializer;
     private readonly IDataElementAccessChecker _dataElementAccessChecker;
     private readonly Telemetry? _telemetry;
 
     public DataModelFieldCalculator(
         ILogger<DataModelFieldCalculator> logger,
-        ILayoutEvaluatorStateInitializer layoutEvaluatorStateInitializer,
         IAppResources appResourceService,
         IDataElementAccessChecker dataElementAccessChecker,
         Telemetry? telemetry = null
@@ -34,7 +32,6 @@ internal sealed class DataModelFieldCalculator
     {
         _logger = logger;
         _appResourceService = appResourceService;
-        _layoutEvaluatorStateInitializer = layoutEvaluatorStateInitializer;
         _dataElementAccessChecker = dataElementAccessChecker;
         _telemetry = telemetry;
     }
@@ -64,9 +61,8 @@ internal sealed class DataModelFieldCalculator
         string rawCalculationConfig
     )
     {
-        var evaluatorState = await _layoutEvaluatorStateInitializer.Init(dataAccessor, taskId);
         var hiddenFields = await LayoutEvaluator.GetHiddenFieldsForRemoval(
-            evaluatorState,
+            dataAccessor.GetLayoutEvaluatorState(),
             evaluateRemoveWhenHidden: false
         );
         DataElementIdentifier dataElementIdentifier = dataElement;
@@ -75,10 +71,12 @@ internal sealed class DataModelFieldCalculator
 
         foreach (var (baseField, calculation) in dataModelFieldCalculations)
         {
-            var resolvedFields = await evaluatorState.GetResolvedKeys(
-                new DataReference() { Field = baseField, DataElementIdentifier = dataElementIdentifier },
-                true
-            );
+            var resolvedFields = await dataAccessor
+                .GetLayoutEvaluatorState()
+                .GetResolvedKeys(
+                    new DataReference() { Field = baseField, DataElementIdentifier = dataElementIdentifier },
+                    true
+                );
             foreach (var resolvedField in resolvedFields)
             {
                 if (
@@ -92,16 +90,16 @@ internal sealed class DataModelFieldCalculator
                 }
 
                 var context = new ComponentContext(
-                    evaluatorState,
+                    dataAccessor,
                     component: null,
                     rowIndices: ExpressionHelper.GetRowIndices(resolvedField.Field),
                     dataElementIdentifier: resolvedField.DataElementIdentifier
                 );
-                var positionalArguments = new object[] { resolvedField.Field };
+                var positionalArguments = new ExpressionValue[] { resolvedField.Field };
 
                 await RunCalculation(
                     formDataWrapper,
-                    evaluatorState,
+                    dataAccessor,
                     resolvedField,
                     context,
                     positionalArguments,
@@ -113,17 +111,17 @@ internal sealed class DataModelFieldCalculator
 
     private async Task RunCalculation(
         IFormDataWrapper formDataWrapper,
-        LayoutEvaluatorState evaluatorState,
+        IInstanceDataAccessor dataAccessor,
         DataReference resolvedField,
         ComponentContext context,
-        object[] positionalArguments,
+        ExpressionValue[] positionalArguments,
         DataModelFieldCalculation calculation
     )
     {
         try
         {
             var calculationResult = await ExpressionEvaluator.EvaluateExpressionToExpressionValue(
-                evaluatorState,
+                dataAccessor,
                 calculation.Expression,
                 context,
                 positionalArguments

--- a/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
+++ b/src/Altinn.App.Core/Features/DataProcessing/DataModelFieldCalculator.cs
@@ -80,7 +80,7 @@ internal sealed class DataModelFieldCalculator
                     rowIndices: ExpressionHelper.GetRowIndices(resolvedField),
                     dataElementIdentifier: dataElementIdentifier
                 );
-                var positionalArguments = new ExpressionValue[] { resolvedFieldReference.Field };
+                var positionalArguments = new ExpressionValue[] { resolvedField };
 
                 await RunCalculation(
                     dataAccessor,
@@ -194,17 +194,5 @@ internal sealed class DataModelFieldCalculator
         };
 
         return dataModelFieldCalculation;
-    }
-
-    private static bool IsSameOrDescendantField(string candidate, string hiddenField)
-    {
-        if (candidate.Equals(hiddenField, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        return candidate.StartsWith(hiddenField, StringComparison.Ordinal)
-            && candidate.Length > hiddenField.Length
-            && (candidate[hiddenField.Length] == '.' || candidate[hiddenField.Length] == '[');
     }
 }

--- a/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
@@ -25,7 +25,6 @@ public class ExpressionValidator : IValidator
 
     private readonly ILogger<ExpressionValidator> _logger;
     private readonly IAppResources _appResourceService;
-    private readonly ILayoutEvaluatorStateInitializer _layoutEvaluatorStateInitializer;
     private readonly IAppMetadata _appMetadata;
     private readonly IDataElementAccessChecker _dataElementAccessChecker;
 
@@ -35,14 +34,12 @@ public class ExpressionValidator : IValidator
     public ExpressionValidator(
         ILogger<ExpressionValidator> logger,
         IAppResources appResourceService,
-        ILayoutEvaluatorStateInitializer layoutEvaluatorStateInitializer,
         IAppMetadata appMetadata,
         IServiceProvider serviceProvider
     )
     {
         _logger = logger;
         _appResourceService = appResourceService;
-        _layoutEvaluatorStateInitializer = layoutEvaluatorStateInitializer;
         _appMetadata = appMetadata;
         _dataElementAccessChecker = serviceProvider.GetRequiredService<IDataElementAccessChecker>();
     }
@@ -113,14 +110,8 @@ public class ExpressionValidator : IValidator
         string? language
     )
     {
-        var evaluatorState = await _layoutEvaluatorStateInitializer.Init(
-            dataAccessor,
-            taskId,
-            gatewayAction: null,
-            language
-        );
         var hiddenFields = await LayoutEvaluator.GetHiddenFieldsForRemoval(
-            evaluatorState,
+            dataAccessor.GetLayoutEvaluatorState(),
             evaluateRemoveWhenHidden: false
         );
 
@@ -130,9 +121,11 @@ public class ExpressionValidator : IValidator
 
         foreach (var (baseField, validations) in expressionValidations)
         {
-            var resolvedFields = await evaluatorState.GetResolvedKeys(
-                new DataReference() { Field = baseField, DataElementIdentifier = dataElementIdentifier }
-            );
+            var resolvedFields = await dataAccessor
+                .GetLayoutEvaluatorState()
+                .GetResolvedKeys(
+                    new DataReference() { Field = baseField, DataElementIdentifier = dataElementIdentifier }
+                );
             foreach (var resolvedField in resolvedFields)
             {
                 if (
@@ -150,11 +143,11 @@ public class ExpressionValidator : IValidator
                     rowIndices: ExpressionHelper.GetRowIndices(resolvedField.Field),
                     dataElementIdentifier: resolvedField.DataElementIdentifier
                 );
-                var positionalArguments = new object[] { resolvedField.Field };
+                var positionalArguments = new ExpressionValue[] { resolvedField.Field };
                 foreach (var validation in validations)
                 {
                     await RunValidation(
-                        evaluatorState,
+                        dataAccessor,
                         validationIssues,
                         resolvedField,
                         context,
@@ -169,27 +162,27 @@ public class ExpressionValidator : IValidator
     }
 
     private async Task RunValidation(
-        LayoutEvaluatorState evaluatorState,
+        IInstanceDataAccessor dataAccessor,
         List<ValidationIssue> validationIssues,
         DataReference resolvedField,
         ComponentContext context,
-        object[] positionalArguments,
+        ExpressionValue[] positionalArguments,
         ExpressionValidation validation
     )
     {
         try
         {
-            var validationResult = await ExpressionEvaluator.EvaluateExpression(
-                evaluatorState,
+            var validationResult = await ExpressionEvaluator.EvaluateExpressionToExpressionValue(
+                dataAccessor,
                 validation.Condition,
                 context,
                 positionalArguments
             );
-            switch (validationResult)
+            switch (validationResult.ValueKind)
             {
-                case true:
-                    var message = await ExpressionEvaluator.EvaluateExpression(
-                        evaluatorState,
+                case JsonValueKind.True:
+                    var message = await ExpressionEvaluator.EvaluateExpressionToExpressionValue(
+                        dataAccessor,
                         validation.Message,
                         context,
                         positionalArguments
@@ -200,13 +193,13 @@ public class ExpressionValidator : IValidator
                         Field = resolvedField.Field,
                         DataElementId = resolvedField.DataElementIdentifier.Id,
                         Severity = validation.Severity ?? ValidationIssueSeverity.Error,
-                        CustomTextKey = message as string ?? "",
-                        Code = message as string ?? "",
+                        Code = message.ToStringForText(),
+                        CustomTextKey = message.ToStringForText(),
                     };
                     validationIssues.Add(validationIssue);
 
                     break;
-                case false:
+                case JsonValueKind.False:
                     break;
                 default:
                     throw new ArgumentException(

--- a/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
@@ -93,7 +93,7 @@ public class ExpressionValidator : IValidator
             var validationConfig = _appResourceService.GetValidationConfiguration(dataType.Id);
             if (!string.IsNullOrEmpty(validationConfig))
             {
-                var issues = await ValidateFormData(dataElement, dataAccessor, validationConfig, taskId, language);
+                var issues = await ValidateFormData(dataElement, dataAccessor, validationConfig);
                 validationIssues.AddRange(issues);
             }
         }
@@ -105,11 +105,10 @@ public class ExpressionValidator : IValidator
     internal async Task<List<ValidationIssue>> ValidateFormData(
         DataElement dataElement,
         IInstanceDataAccessor dataAccessor,
-        string rawValidationConfig,
-        string taskId,
-        string? language
+        string rawValidationConfig
     )
     {
+        var formDataWrapper = await dataAccessor.GetFormDataWrapper(dataElement);
         var hiddenFields = await LayoutEvaluator.GetHiddenFieldsForRemoval(
             dataAccessor.GetLayoutEvaluatorState(),
             evaluateRemoveWhenHidden: false
@@ -150,6 +149,7 @@ public class ExpressionValidator : IValidator
                         dataAccessor,
                         validationIssues,
                         resolvedField,
+                        formDataWrapper,
                         context,
                         positionalArguments,
                         validation
@@ -165,6 +165,7 @@ public class ExpressionValidator : IValidator
         IInstanceDataAccessor dataAccessor,
         List<ValidationIssue> validationIssues,
         DataReference resolvedField,
+        IFormDataWrapper formDataWrapper,
         ComponentContext context,
         ExpressionValue[] positionalArguments,
         ExpressionValidation validation
@@ -172,8 +173,7 @@ public class ExpressionValidator : IValidator
     {
         try
         {
-            var wrapper = await dataAccessor.GetFormDataWrapper(resolvedField.DataElementIdentifier);
-            if (wrapper.Get(resolvedField.Field) == null)
+            if (formDataWrapper.Get(resolvedField.Field) == null)
             {
                 return; // Assume that the required validator will catch empty fields.
             }

--- a/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
+++ b/src/Altinn.App.Core/Features/Validation/Default/ExpressionValidator.cs
@@ -172,6 +172,11 @@ public class ExpressionValidator : IValidator
     {
         try
         {
+            var wrapper = await dataAccessor.GetFormDataWrapper(resolvedField.DataElementIdentifier);
+            if (wrapper.Get(resolvedField.Field) == null)
+            {
+                return; // Assume that the required validator will catch empty fields.
+            }
             var validationResult = await ExpressionEvaluator.EvaluateExpressionToExpressionValue(
                 dataAccessor,
                 validation.Condition,

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
@@ -123,29 +123,13 @@ public class DataModelWrapper
     /// </example>
     public string[] GetResolvedKeys(string field)
     {
-        return GetResolvedKeys(field, isCalculating: false);
-    }
-
-    /// <summary>
-    /// Get all valid indexed keys for the field, depending on the number of rows in repeating groups
-    /// </summary>
-    /// <example>
-    /// GetResolvedKeys("data.bedrifter.styre.medlemmer") =>
-    /// [
-    ///     "data.bedrifter[0].styre.medlemmer",
-    ///     "data.bedrifter[1].styre.medlemmer"
-    ///     ...
-    /// ]
-    /// </example>
-    public string[] GetResolvedKeys(string field, bool isCalculating)
-    {
         if (_dataModel is null)
         {
             return [];
         }
 
         var fieldParts = field.Split('.');
-        return GetResolvedKeysRecursive(fieldParts, _dataModel, _dataModel.GetType(), isCalculating: isCalculating);
+        return GetResolvedKeysRecursive(fieldParts, _dataModel, _dataModel.GetType());
     }
 
     private static string JoinFieldKeyParts(string? currentKey, string? key)
@@ -167,8 +151,7 @@ public class DataModelWrapper
         object? currentModel,
         Type currentType,
         int currentIndex = 0,
-        string currentKey = "",
-        bool isCalculating = false
+        string currentKey = ""
     )
     {
         if (currentIndex == keyParts.Length)
@@ -213,8 +196,7 @@ public class DataModelWrapper
                             child,
                             elementType,
                             currentIndex + 1,
-                            JoinFieldKeyParts(currentKey, $"{key}[{i}]"),
-                            isCalculating
+                            JoinFieldKeyParts(currentKey, $"{key}[{i}]")
                         );
                         resolvedKeys.AddRange(newResolvedKeys);
                         i++;
@@ -232,12 +214,11 @@ public class DataModelWrapper
                     elementAt,
                     elementType,
                     currentIndex + 1,
-                    JoinFieldKeyParts(currentKey, $"{key}[{groupIndex}]"),
-                    isCalculating
+                    JoinFieldKeyParts(currentKey, $"{key}[{groupIndex}]")
                 );
             }
 
-            if (isCalculating && currentIndex == keyParts.Length - 1)
+            if (currentIndex == keyParts.Length - 1)
             {
                 return [JoinFieldKeyParts(currentKey, key)];
             }
@@ -250,24 +231,17 @@ public class DataModelWrapper
         // If this is the last key part
         if (currentIndex == keyParts.Length - 1)
         {
-            // Return the key if value exists, or if calculating (to allow null fields during calculation)
-            return childValue is not null || isCalculating ? [JoinFieldKeyParts(currentKey, key)] : [];
+            // Return the key if value exists
+            return [JoinFieldKeyParts(currentKey, key)];
         }
 
-        // If child is null and we're not calculating, we can't continue
-        if (childValue is null && !isCalculating)
-        {
-            return [];
-        }
-
-        // Continue recursion using type information (childValue may be null if isCalculating=true)
+        // Continue recursion using type information
         return GetResolvedKeysRecursive(
             keyParts,
             childValue,
             childType,
             currentIndex + 1,
-            JoinFieldKeyParts(currentKey, key),
-            isCalculating
+            JoinFieldKeyParts(currentKey, key)
         );
     }
 

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
@@ -214,7 +214,7 @@ public class DataModelWrapper
                     elementAt,
                     elementType,
                     currentIndex + 1,
-                    JoinFieldKeyParts(currentKey, $"{key}[{groupIndex}]")
+                    JoinFieldKeyParts(currentKey, $"{key}[{groupIndex.Value}]")
                 );
             }
 
@@ -225,15 +225,16 @@ public class DataModelWrapper
             return [];
         }
 
-        // For non-collection properties, we can work with just the type
-        // Get the child object for further traversal
-        var childValue = currentModel is not null ? prop.GetValue(currentModel) : null;
         // If this is the last key part
         if (currentIndex == keyParts.Length - 1)
         {
             // Return the key (even if the value is null)
             return [JoinFieldKeyParts(currentKey, key)];
         }
+
+        // For non-collection properties, we can work with just the type
+        // Get the child object for further traversal
+        var childValue = currentModel is not null ? prop.GetValue(currentModel) : null;
 
         // Continue recursion using type information
         return GetResolvedKeysRecursive(

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
@@ -129,7 +129,8 @@ public class DataModelWrapper
         }
 
         var fieldParts = field.Split('.');
-        return GetResolvedKeysRecursive(fieldParts, _dataModel, _dataModel.GetType());
+        return GetResolvedKeysRecursive(fieldParts, _dataModel, _dataModel.GetType(), currentIndex: 0, currentKey: "")
+            .ToArray();
     }
 
     private static string JoinFieldKeyParts(string? currentKey, string? key)
@@ -146,12 +147,12 @@ public class DataModelWrapper
         return currentKey + "." + key;
     }
 
-    private static string[] GetResolvedKeysRecursive(
+    private static IEnumerable<string> GetResolvedKeysRecursive(
         string[] keyParts,
         object? currentModel,
         Type currentType,
-        int currentIndex = 0,
-        string currentKey = ""
+        int currentIndex,
+        string currentKey
     )
     {
         if (currentIndex == keyParts.Length)
@@ -213,7 +214,7 @@ public class DataModelWrapper
                 }
                 i++;
             }
-            return resolvedKeys.ToArray();
+            return resolvedKeys;
         }
 
         // Non-collection: resolve the key (even if the value is null) ...

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
@@ -67,7 +67,7 @@ public class DataModelWrapper
             return currentModel;
         }
 
-        var (key, groupIndex) = ParseKeyPart(keys[index]);
+        var (key, groupIndex, _) = ParseKeyPart(keys[index]);
         var prop = Array.Find(currentModel.GetType().GetProperties(), p => IsPropertyWithJsonName(p, key));
         var childModel = prop?.GetValue(currentModel);
         if (childModel is null)
@@ -111,13 +111,23 @@ public class DataModelWrapper
     }
 
     /// <summary>
-    /// Get all valid indexed keys for the field, depending on the number of rows in repeating groups
+    /// Get all valid indexed keys for the field, depending on the number of rows in repeating groups.
+    /// A collection in the middle of the path is always expanded over its rows. For a collection at
+    /// the end of the path, "group" refers to the collection itself, "group[]" enumerates every row,
+    /// and "group[n]" refers to a single row.
     /// </summary>
     /// <example>
     /// GetResolvedKeys("data.bedrifter.styre.medlemmer") =>
     /// [
     ///     "data.bedrifter[0].styre.medlemmer",
     ///     "data.bedrifter[1].styre.medlemmer"
+    ///     ...
+    /// ]
+    /// GetResolvedKeys("data.bedrifter[].styre.medlemmer[]") =>
+    /// [
+    ///     "data.bedrifter[0].styre.medlemmer[0]",
+    ///     "data.bedrifter[0].styre.medlemmer[1]",
+    ///     "data.bedrifter[1].styre.medlemmer[0]",
     ///     ...
     /// ]
     /// </example>
@@ -160,7 +170,7 @@ public class DataModelWrapper
             return [currentKey];
         }
 
-        var (key, groupIndex) = ParseKeyPart(keyParts[currentIndex]);
+        var (key, groupIndex, emptyIndex) = ParseKeyPart(keyParts[currentIndex]);
         var lookupType = currentModel?.GetType() ?? currentType;
         var prop = Array.Find(lookupType.GetProperties(), p => IsPropertyWithJsonName(p, key));
         if (prop is null)
@@ -171,15 +181,24 @@ public class DataModelWrapper
         var childType = prop.PropertyType;
         bool isLastPart = currentIndex == keyParts.Length - 1;
 
-        // Collection (but not string): we need the instance to enumerate the rows
+        // Collection (but not string)
         if (childType != typeof(string) && childType.IsAssignableTo(typeof(System.Collections.IEnumerable)))
         {
+            // A bare collection as the last part of the path (e.g. "group") refers to the
+            // collection itself, not its rows, so we return the key without enumerating (just
+            // like a non-collection leaf). Use "group[]" to enumerate every row, or "group[0]"
+            // to refer to a single row.
+            if (isLastPart && groupIndex is null && !emptyIndex)
+            {
+                return [JoinFieldKeyParts(currentKey, key)];
+            }
+
+            // Indexing into, or descending through, the collection requires the instance.
             var childModel = currentModel is not null ? prop.GetValue(currentModel) : null;
             if (childModel is not System.Collections.IEnumerable childModelList)
             {
-                // Collection is null: row count is unknown, so we can only resolve the
-                // bare key when it's the last part of the path.
-                return isLastPart ? [JoinFieldKeyParts(currentKey, key)] : [];
+                // Null collection: there are no rows to descend into, so nothing resolves.
+                return [];
             }
 
             if (groupIndex is not null)
@@ -196,6 +215,8 @@ public class DataModelWrapper
                 );
             }
 
+            // Enumerate every row: either an unindexed collection in the middle of the path
+            // (descending towards the rest of the path), or "group[]" at the end.
             var resolvedKeys = new List<string>();
             int i = 0;
             foreach (var child in childModelList)
@@ -253,18 +274,24 @@ public class DataModelWrapper
         TimeSpan.FromMilliseconds(2)
     );
 
-    private static (string key, int? index) ParseKeyPart(string keyPart)
+    private static (string key, int? index, bool emptyIndex) ParseKeyPart(string keyPart)
     {
         if (keyPart.Length == 0)
         {
             throw new DataModelException("Tried to parse empty part of dataModel key");
         }
-        if (keyPart.Last() != ']')
+        if (keyPart[^1] != ']')
         {
-            return (keyPart, null);
+            return (keyPart, null, false);
+        }
+        // "group[]" refers to every row of the collection (as opposed to "group", which refers
+        // to the collection itself, or "group[n]", which refers to a single row).
+        if (keyPart.EndsWith("[]", StringComparison.Ordinal))
+        {
+            return (keyPart[..^2], null, true);
         }
         var match = _keyPartRegex.Match(keyPart);
-        return (match.Groups[1].Value, int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture));
+        return (match.Groups[1].Value, int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture), false);
     }
 
     private static void AddIndexesRecursive(
@@ -278,7 +305,7 @@ public class DataModelWrapper
         {
             return;
         }
-        var (key, groupIndex) = ParseKeyPart(keys[0]);
+        var (key, groupIndex, _) = ParseKeyPart(keys[0]);
         var prop = Array.Find(currentModelType.GetProperties(), p => IsPropertyWithJsonName(p, key));
         if (prop is null)
         {
@@ -386,7 +413,7 @@ public class DataModelWrapper
     {
         var fieldSplit = field.Split('.');
         var keys = fieldSplit[0..^1];
-        var (lastKey, lastGroupIndex) = ParseKeyPart(fieldSplit[^1]);
+        var (lastKey, lastGroupIndex, _) = ParseKeyPart(fieldSplit[^1]);
 
         var containingObject = GetModelDataRecursive(keys, 0, _dataModel, default);
         if (containingObject is null)

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
@@ -168,75 +168,61 @@ public class DataModelWrapper
         }
 
         var childType = prop.PropertyType;
-        // Check if the property is a collection type (but not string)
+        bool isLastPart = currentIndex == keyParts.Length - 1;
+
+        // Collection (but not string): we need the instance to enumerate the rows
         if (childType != typeof(string) && childType.IsAssignableTo(typeof(System.Collections.IEnumerable)))
         {
-            // For collections, we need the actual object to enumerate
             var childModel = currentModel is not null ? prop.GetValue(currentModel) : null;
-            if (childModel is System.Collections.IEnumerable childModelList)
+            if (childModel is not System.Collections.IEnumerable childModelList)
             {
-                // Get the element type of the collection
-                var elementType = childType.IsArray
-                    ? childType.GetElementType() ?? typeof(object)
-                    : childType.GetGenericArguments().FirstOrDefault() ?? typeof(object);
-                // Index not specified, recurse on all elements
-                if (groupIndex is null)
-                {
-                    int i = 0;
-                    var resolvedKeys = new List<string>();
-                    foreach (var child in childModelList)
-                    {
-                        if (child is null)
-                        {
-                            i++;
-                            continue;
-                        }
-                        var newResolvedKeys = GetResolvedKeysRecursive(
-                            keyParts,
-                            child,
-                            elementType,
-                            currentIndex + 1,
-                            JoinFieldKeyParts(currentKey, $"{key}[{i}]")
-                        );
-                        resolvedKeys.AddRange(newResolvedKeys);
-                        i++;
-                    }
-                    return resolvedKeys.ToArray();
-                }
-                // Index specified, recurse on that element
+                // Collection is null: row count is unknown, so we can only resolve the
+                // bare key when it's the last part of the path.
+                return isLastPart ? [JoinFieldKeyParts(currentKey, key)] : [];
+            }
+
+            if (groupIndex is not null)
+            {
                 var elementAt = GetElementAt(childModelList, groupIndex.Value);
                 if (elementAt is null)
-                {
                     return [];
-                }
                 return GetResolvedKeysRecursive(
                     keyParts,
                     elementAt,
-                    elementType,
+                    elementAt.GetType(),
                     currentIndex + 1,
                     JoinFieldKeyParts(currentKey, $"{key}[{groupIndex.Value}]")
                 );
             }
 
-            if (currentIndex == keyParts.Length - 1)
+            var resolvedKeys = new List<string>();
+            int i = 0;
+            foreach (var child in childModelList)
             {
-                return [JoinFieldKeyParts(currentKey, key)];
+                if (child is not null) // null rows can't be set/resolved, skip them
+                {
+                    resolvedKeys.AddRange(
+                        GetResolvedKeysRecursive(
+                            keyParts,
+                            child,
+                            child.GetType(),
+                            currentIndex + 1,
+                            JoinFieldKeyParts(currentKey, $"{key}[{i}]")
+                        )
+                    );
+                }
+                i++;
             }
-            return [];
+            return resolvedKeys.ToArray();
         }
 
-        // If this is the last key part
-        if (currentIndex == keyParts.Length - 1)
+        // Non-collection: resolve the key (even if the value is null) ...
+        if (isLastPart)
         {
-            // Return the key (even if the value is null)
             return [JoinFieldKeyParts(currentKey, key)];
         }
-
-        // For non-collection properties, we can work with just the type
-        // Get the child object for further traversal
+        // ... otherwise traverse, falling back to the declared type when the value is null
         var childValue = currentModel is not null ? prop.GetValue(currentModel) : null;
-
-        // Continue recursion using type information
         return GetResolvedKeysRecursive(
             keyParts,
             childValue,

--- a/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
+++ b/src/Altinn.App.Core/Helpers/DataModel/DataModelWrapper.cs
@@ -231,7 +231,7 @@ public class DataModelWrapper
         // If this is the last key part
         if (currentIndex == keyParts.Length - 1)
         {
-            // Return the key if value exists
+            // Return the key (even if the value is null)
             return [JoinFieldKeyParts(currentKey, key)];
         }
 

--- a/src/Altinn.App.Core/Internal/Data/IFormDataWrapper.cs
+++ b/src/Altinn.App.Core/Internal/Data/IFormDataWrapper.cs
@@ -296,11 +296,7 @@ internal static class FormDataWrapperExtensions
     /// group[1].name
     /// group[1].age
     /// </example>
-    public static DataReference[] GetResolvedKeys(
-        this IFormDataWrapper formDataWrapper,
-        DataReference reference,
-        bool isCalculating = false
-    )
+    public static DataReference[] GetResolvedKeys(this IFormDataWrapper formDataWrapper, DataReference reference)
     {
         //TODO: write more efficient code that uses the formDataWrapper to resolve keys instead of reflection in DataModelWrapper
         var data = formDataWrapper.BackingData<object>();
@@ -308,7 +304,7 @@ internal static class FormDataWrapperExtensions
         var dataModelWrapper = new DataModelWrapper(data);
 #pragma warning restore CS0618 // Type or member is obsolete
         return dataModelWrapper
-            .GetResolvedKeys(reference.Field, isCalculating)
+            .GetResolvedKeys(reference.Field)
             .Select(resolvedField => reference with { Field = resolvedField })
             .ToArray();
     }

--- a/src/Altinn.App.Core/Internal/Data/IFormDataWrapper.cs
+++ b/src/Altinn.App.Core/Internal/Data/IFormDataWrapper.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using Altinn.App.Core.Helpers;
 using Altinn.App.Core.Helpers.DataModel;
 using Altinn.App.Core.Internal.Expressions;
-using Altinn.App.Core.Models.Layout;
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.App.Core.Internal.Data;
@@ -287,26 +286,22 @@ internal static class FormDataWrapperExtensions
     }
 
     /// <summary>
-    /// Get a list of all possible keys for the given data model
+    /// Get a list of all possible keys for the given data model at the path
     /// </summary>
     /// <example>
-    /// intro.fnr
-    /// group[0].name
-    /// group[0].age
-    /// group[1].name
-    /// group[1].age
+    /// group.name -> ["group[0].name", "group[1].name"]
+    /// group.age -> ["group[0].age", "group[1].age"]
     /// </example>
-    public static DataReference[] GetResolvedKeys(this IFormDataWrapper formDataWrapper, DataReference reference)
+    public static string[] GetResolvedKeys(this IFormDataWrapper formDataWrapper, string path)
     {
         //TODO: write more efficient code that uses the formDataWrapper to resolve keys instead of reflection in DataModelWrapper
+        // The current implementation also does not throw exceptions when the path ends in an enumerable.
+        // When resolving "group" it is not clear if the result should be "group[0]", "group[1]", or just "group"."
         var data = formDataWrapper.BackingData<object>();
 #pragma warning disable CS0618 // Type or member is obsolete
         var dataModelWrapper = new DataModelWrapper(data);
 #pragma warning restore CS0618 // Type or member is obsolete
-        return dataModelWrapper
-            .GetResolvedKeys(reference.Field)
-            .Select(resolvedField => reference with { Field = resolvedField })
-            .ToArray();
+        return dataModelWrapper.GetResolvedKeys(path);
     }
 
     private static int GetMaxBufferLength(ReadOnlySpan<char> path, ReadOnlySpan<int> rowIndexes)

--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Altinn.App.Core.Features;
 using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Expressions;
 using Altinn.App.Core.Models.Layout;
@@ -55,14 +56,13 @@ public static partial class ExpressionEvaluator
     /// Evaluate a <see cref="Expression" /> from a given <see cref="LayoutEvaluatorState" /> in a <see cref="ComponentContext" />
     /// </summary>
     public static async Task<ExpressionValue> EvaluateExpressionToExpressionValue(
-        LayoutEvaluatorState state,
+        IInstanceDataAccessor state,
         Expression expr,
         ComponentContext context,
-        object?[]? positionalArguments = null
+        ExpressionValue[]? positionalArguments = null
     )
     {
-        var positionalArgumentUnions = positionalArguments?.Select(ExpressionValue.FromObject).ToArray();
-        return await EvaluateExpression_internal(state, expr, context, positionalArgumentUnions);
+        return await EvaluateExpression_internal(state.GetLayoutEvaluatorState(), expr, context, positionalArguments);
     }
 
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/ExpressionEvaluator.cs
@@ -53,7 +53,7 @@ public static partial class ExpressionEvaluator
     }
 
     /// <summary>
-    /// Evaluate a <see cref="Expression" /> from a given <see cref="LayoutEvaluatorState" /> in a <see cref="ComponentContext" />
+    /// Evaluate a <see cref="Expression" /> from a given <see cref="IInstanceDataAccessor" /> in a <see cref="ComponentContext" />
     /// </summary>
     public static async Task<ExpressionValue> EvaluateExpressionToExpressionValue(
         IInstanceDataAccessor state,

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -239,15 +239,6 @@ public class LayoutEvaluatorState
     }
 
     /// <summary>
-    /// Get all the resolved keys (including all possible indexes) from a data model key
-    /// </summary>
-    public async Task<DataReference[]> GetResolvedKeys(DataReference reference, bool isCalculating)
-    {
-        var data = await DataAccessor.GetFormDataWrapper(reference.DataElementIdentifier);
-        return data.GetResolvedKeys(reference, isCalculating);
-    }
-
-    /// <summary>
     /// Set the value of a field to null.
     /// </summary>
     public async Task RemoveDataField(DataReference key, RowRemovalOption rowRemovalOption)

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -235,7 +235,9 @@ public class LayoutEvaluatorState
     public async Task<DataReference[]> GetResolvedKeys(DataReference reference)
     {
         var data = await DataAccessor.GetFormDataWrapper(reference.DataElementIdentifier);
-        return data.GetResolvedKeys(reference);
+        return data.GetResolvedKeys(reference.Field)
+            .Select(resolvedField => reference with { Field = resolvedField })
+            .ToArray();
     }
 
     /// <summary>

--- a/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
+++ b/src/Altinn.App.Core/Internal/Expressions/LayoutEvaluatorState.cs
@@ -243,7 +243,7 @@ public class LayoutEvaluatorState
     /// </summary>
     public async Task<DataReference[]> GetResolvedKeys(DataReference reference, bool isCalculating)
     {
-        var data = await _dataAccessor.GetFormDataWrapper(reference.DataElementIdentifier);
+        var data = await DataAccessor.GetFormDataWrapper(reference.DataElementIdentifier);
         return data.GetResolvedKeys(reference, isCalculating);
     }
 

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_FailingValidator_ReturnsValidationErrors.verified.txt
@@ -6,11 +6,6 @@
       HasParent: true
     },
     {
-      Name: ApplicationMetadata.Service.GetLayoutModel,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
       Name: ApplicationMetadata.Service.GetLayoutSet,
       IdFormat: W3C,
       HasParent: true
@@ -22,26 +17,6 @@
     },
     {
       Name: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSets,
       IdFormat: W3C,
       HasParent: true
     },
@@ -62,16 +37,6 @@
     },
     {
       Name: ApplicationMetadata.Service.GetLayoutSetsForTask,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSetsForTask,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSettingsForSet,
       IdFormat: W3C,
       HasParent: true
     },

--- a/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProcessControllerTests.RunProcessNext_PdfFails_DataIsUnlocked.verified.txt
@@ -6,11 +6,6 @@
       HasParent: true
     },
     {
-      Name: ApplicationMetadata.Service.GetLayoutModel,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
       Name: ApplicationMetadata.Service.GetLayoutSet,
       IdFormat: W3C,
       HasParent: true
@@ -22,26 +17,6 @@
     },
     {
       Name: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSet,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSets,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSets,
       IdFormat: W3C,
       HasParent: true
     },
@@ -62,16 +37,6 @@
     },
     {
       Name: ApplicationMetadata.Service.GetLayoutSetsForTask,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSetsForTask,
-      IdFormat: W3C,
-      HasParent: true
-    },
-    {
-      Name: ApplicationMetadata.Service.GetLayoutSettingsForSet,
       IdFormat: W3C,
       HasParent: true
     },

--- a/test/Altinn.App.Core.Tests/Features/DataProcessing/DataModelFieldCalculatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/DataProcessing/DataModelFieldCalculatorTests.cs
@@ -11,6 +11,7 @@ using Altinn.App.Core.Models.Layout;
 using Altinn.App.Core.Tests.LayoutExpressions.TestUtilities;
 using Altinn.App.Core.Tests.TestUtils;
 using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -133,6 +134,7 @@ public sealed class DataModelFieldCalculatorTests
             if (expected.Result.HasValue)
             {
                 Assert.Equal(expected.Result.Value.ToObject(), result.Get(expected.Field));
+                Assert.Empty(_logger.Collector.GetSnapshot());
             }
             else
             {
@@ -183,13 +185,6 @@ public sealed class DataModelFieldCalculatorTests
             gatewayAction: null,
             language: null,
             _dataElement
-        );
-
-        var evaluatorState = new LayoutEvaluatorState(
-            _instanceDataAccessor,
-            componentModel,
-            translationService,
-            _frontendSettings.Value
         );
 
         _appResources

--- a/test/Altinn.App.Core.Tests/Features/DataProcessing/DataModelFieldCalculatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/DataProcessing/DataModelFieldCalculatorTests.cs
@@ -99,7 +99,6 @@ public sealed class DataModelFieldCalculatorTests
             _dataModelFieldCalculator.CalculateFormData(
                 _instanceDataAccessor,
                 _dataElement,
-                "Task_1",
                 JsonSerializer.Serialize(testCase.CalculationConfig)
             )
         );
@@ -154,7 +153,6 @@ public sealed class DataModelFieldCalculatorTests
         await _dataModelFieldCalculator.CalculateFormData(
             _instanceDataAccessor,
             _dataElement,
-            "Task_1",
             JsonSerializer.Serialize(testCase.CalculationConfig)
         );
 

--- a/test/Altinn.App.Core.Tests/Features/DataProcessing/DataModelFieldCalculatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/DataProcessing/DataModelFieldCalculatorTests.cs
@@ -25,7 +25,6 @@ public sealed class DataModelFieldCalculatorTests
     private readonly DataModelFieldCalculator _dataModelFieldCalculator;
     private readonly FakeLogger<DataModelFieldCalculator> _logger = new();
     private readonly Mock<IAppResources> _appResources = new(MockBehavior.Strict);
-    private readonly Mock<ILayoutEvaluatorStateInitializer> _layoutInitializer = new(MockBehavior.Strict);
     private readonly IOptions<FrontEndSettings> _frontendSettings = Microsoft.Extensions.Options.Options.Create(
         new FrontEndSettings()
     );
@@ -48,7 +47,6 @@ public sealed class DataModelFieldCalculatorTests
         _output = output;
         _dataModelFieldCalculator = new DataModelFieldCalculator(
             _logger,
-            _layoutInitializer.Object,
             _appResources.Object,
             dataElementAccessChecker.Object,
             telemetry.Object
@@ -171,12 +169,6 @@ public sealed class DataModelFieldCalculatorTests
         var dataType = new DataType() { Id = "default" };
 
         _dataElement = new DataElement { Id = "30844cc0-81af-4429-9f9e-035d78f1f9da", DataType = "default" };
-        _instanceDataAccessor = DynamicClassBuilder.DataAccessorFromJsonDocument(
-            instance,
-            testCase.FormData,
-            _dataElement
-        );
-
         var layout = new LayoutSetComponent(testCase.Layouts, "layout", dataType);
         var componentModel = new LayoutModel([layout], null);
         var translationService = new TranslationService(
@@ -184,17 +176,23 @@ public sealed class DataModelFieldCalculatorTests
             _appResources.Object,
             FakeLoggerXunit.Get<TranslationService>(_output)
         );
+        _instanceDataAccessor = DynamicClassBuilder.DataAccessorFromJsonDocument(
+            instance,
+            translationService,
+            componentModel,
+            new FrontEndSettings(),
+            testCase.FormData,
+            gatewayAction: null,
+            language: null,
+            _dataElement
+        );
+
         var evaluatorState = new LayoutEvaluatorState(
             _instanceDataAccessor,
             componentModel,
             translationService,
             _frontendSettings.Value
         );
-        _layoutInitializer
-            .Setup(init =>
-                init.Init(It.IsAny<IInstanceDataAccessor>(), "Task_1", It.IsAny<string?>(), It.IsAny<string?>())
-            )
-            .ReturnsAsync(evaluatorState);
 
         _appResources
             .Setup(ar => ar.GetTexts("org", "app", "nb"))

--- a/test/Altinn.App.Core.Tests/Features/DataProcessing/data-field-value-calculator-tests/calculate-in-group.json
+++ b/test/Altinn.App.Core.Tests/Features/DataProcessing/data-field-value-calculator-tests/calculate-in-group.json
@@ -1,5 +1,5 @@
 {
-    "name": "Should set multiple values when in a group",
+    "name": "Should set multiple values when resolving keys in a datamodel array",
     "expects": [
         {
             "field": "form.children[0].total",

--- a/test/Altinn.App.Core.Tests/Features/DataProcessing/data-field-value-calculator-tests/calculate-in-group.json
+++ b/test/Altinn.App.Core.Tests/Features/DataProcessing/data-field-value-calculator-tests/calculate-in-group.json
@@ -1,22 +1,37 @@
 {
-    "name": "Should set field when looking up hidden component",
+    "name": "Should set multiple values when in a group",
     "expects": [
         {
-            "field": "form.name",
-            "result": "nyVerdi"
+            "field": "form.children[0].total",
+            "result": 200
+        },
+        {
+            "field": "form.children[1].total",
+            "result": 220
         }
     ],
     "calculationConfig": {
         "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/calculation/calculation.schema.v1.json",
         "calculations": {
-            "form.name": {
-                "expression": "nyVerdi"
+            "form.children.total": {
+                "expression": ["multiply", ["dataModel", "form.children.price"], ["dataModel", "form.children.quantity"]]
             }
         }
     },
     "formData": {
         "form": {
-            "name": "feil"
+            "children": [
+                {
+                    "price": 100,
+                    "quantity": 2,
+                    "total": 0
+                },
+                {
+                    "price": 5,
+                    "quantity": 44,
+                    "total": 0
+                }
+            ]
         }
     },
     "layouts": {

--- a/test/Altinn.App.Core.Tests/Features/DataProcessing/data-field-value-calculator-tests/hidden-field.json
+++ b/test/Altinn.App.Core.Tests/Features/DataProcessing/data-field-value-calculator-tests/hidden-field.json
@@ -1,16 +1,16 @@
 {
-    "name": "Should not set field when component is hidden",
+    "name": "Should set field when component is hidden",
     "expects": [
         {
             "field": "form.name",
-            "result": "feil"
+            "result": "nyVerdi"
         }
     ],
     "calculationConfig": {
         "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/calculation/calculation.schema.v1.json",
         "calculations": {
             "form.name": {
-                "expression": ["equals", ["dataModel", ["argv", 0]], "feil"]
+                "expression": "nyVerdi"
             }
         }
     },

--- a/test/Altinn.App.Core.Tests/Features/DataProcessing/data-field-value-calculator-tests/hidden-page.json
+++ b/test/Altinn.App.Core.Tests/Features/DataProcessing/data-field-value-calculator-tests/hidden-page.json
@@ -1,16 +1,16 @@
 {
-    "name": "Should not set field if field is on hidden page",
+    "name": "Should set field if field is on hidden page",
     "expects": [
         {
             "field": "form.name",
-            "result": "none"
+            "result": "newValue"
         }
     ],
     "calculationConfig": {
         "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/calculation/calculation.schema.v1.json",
         "calculations": {
             "form.name": {
-                "expression": ["equals", ["dataModel", ["argv", 0]], "none"]
+                "expression": "newValue"
             }
         }
     },

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -120,9 +120,7 @@ public class ExpressionValidatorTests
         var validationIssues = await _validator.ValidateFormData(
             dataElement,
             dataAccessor,
-            JsonSerializer.Serialize(testCase.ValidationConfig),
-            "Task_1",
-            null
+            JsonSerializer.Serialize(testCase.ValidationConfig)
         );
 
         var result = validationIssues.Select(i => new

--- a/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Validators/Default/ExpressionValidatorTests.cs
@@ -1,11 +1,9 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Altinn.App.Core.Configuration;
-using Altinn.App.Core.Features;
 using Altinn.App.Core.Features.Validation.Default;
 using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Data;
-using Altinn.App.Core.Internal.Expressions;
 using Altinn.App.Core.Internal.Texts;
 using Altinn.App.Core.Models;
 using Altinn.App.Core.Models.Layout;
@@ -31,7 +29,6 @@ public class ExpressionValidatorTests
     private readonly IOptions<FrontEndSettings> _frontendSettings = Microsoft.Extensions.Options.Options.Create(
         new FrontEndSettings()
     );
-    private readonly Mock<ILayoutEvaluatorStateInitializer> _layoutInitializer = new(MockBehavior.Strict);
     private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         WriteIndented = true,
@@ -52,7 +49,6 @@ public class ExpressionValidatorTests
         _validator = new ExpressionValidator(
             _logger.Object,
             _appResources.Object,
-            _layoutInitializer.Object,
             _appMetadata.Object,
             serviceProviderMock.Object
         );
@@ -112,12 +108,6 @@ public class ExpressionValidatorTests
         };
         var evaluatorState = dataAccessor.GetLayoutEvaluatorState();
         Assert.NotNull(evaluatorState);
-
-        _layoutInitializer
-            .Setup(init =>
-                init.Init(It.IsAny<IInstanceDataAccessor>(), "Task_1", It.IsAny<string?>(), It.IsAny<string?>())
-            )
-            .ReturnsAsync(evaluatorState);
 
         _appResources
             .Setup(ar => ar.GetTexts("org", "app", "nb"))

--- a/test/Altinn.App.Core.Tests/Features/Validators/expression-validation-tests/shared/ignore-value-null.json
+++ b/test/Altinn.App.Core.Tests/Features/Validators/expression-validation-tests/shared/ignore-value-null.json
@@ -1,0 +1,74 @@
+{
+  "name": "Should ignore validation when value is null",
+  "expects": [],
+  "validationConfig": {
+    "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/validation/validation.schema.v1.json",
+    "validations": {
+      "personer.navn": [
+        {
+          "message": "Always ivalid rule",
+          "severity": "error",
+          "condition": true
+        }
+      ]
+    }
+  },
+  "formData": {
+    "personer": [
+      {
+        "altinnRowId": "person0",
+        "navn": null,
+        "utenNavn": false
+      },
+      {
+        "altinnRowId": "person1",
+        "navn": null,
+        "utenNavn": true
+      },
+      {
+        "altinnRowId": "person2",
+        "navn": null,
+        "utenNavn": false
+      }
+    ]
+  },
+  "layouts": {
+    "Page": {
+      "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
+      "data": {
+        "layout": [
+          {
+            "id": "personer",
+            "type": "RepeatingGroup",
+            "dataModelBindings": {
+              "group": "personer"
+            },
+            "children": [
+              "person-navn",
+              "uten-navn"
+            ]
+          },
+          {
+            "id": "person-navn",
+            "type": "Input",
+            "dataModelBindings": {
+              "simpleBinding": "personer.navn"
+            },
+            "hidden": ["equals", ["component", "uten-navn"], true]
+          },
+          {
+            "id": "uten-navn",
+            "type": "Checkboxes",
+            "dataModelBindings": {
+              "simpleBinding": "personer.utenNavn"
+            },
+            "options": [
+              { "label": "Ja", "value": true },
+              { "label": "Nei", "value": false }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/Altinn.App.Core.Tests/Features/Validators/expression-validation-tests/shared/ignore-value-null.json
+++ b/test/Altinn.App.Core.Tests/Features/Validators/expression-validation-tests/shared/ignore-value-null.json
@@ -6,7 +6,7 @@
     "validations": {
       "personer.navn": [
         {
-          "message": "Always ivalid rule",
+          "message": "Always invalid rule",
           "severity": "error",
           "condition": true
         }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2374,7 +2374,6 @@ namespace Altinn.App.Core.Helpers.DataModel
         public object? GetModelData(string field, System.ReadOnlySpan<int> rowIndexes = default) { }
         public int? GetModelDataCount(string field, System.ReadOnlySpan<int> rowIndexes = default) { }
         public string[] GetResolvedKeys(string field) { }
-        public string[] GetResolvedKeys(string field, bool isCalculating) { }
         public void RemoveField(string field, Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption) { }
     }
 }
@@ -3315,7 +3314,6 @@ namespace Altinn.App.Core.Internal.Expressions
         public string GetLanguage() { }
         public System.Threading.Tasks.Task<object?> GetModelData(Altinn.App.Core.Models.Layout.ModelBinding key, Altinn.App.Core.Models.DataElementIdentifier? defaultDataElementIdentifier, int[]? indexes) { }
         public System.Threading.Tasks.Task<Altinn.App.Core.Models.Layout.DataReference[]> GetResolvedKeys(Altinn.App.Core.Models.Layout.DataReference reference) { }
-        public System.Threading.Tasks.Task<Altinn.App.Core.Models.Layout.DataReference[]> GetResolvedKeys(Altinn.App.Core.Models.Layout.DataReference reference, bool isCalculating) { }
         public System.TimeZoneInfo? GetTimeZone() { }
         public System.Threading.Tasks.Task RemoveDataField(Altinn.App.Core.Models.Layout.DataReference key, Altinn.App.Core.Helpers.RowRemovalOption rowRemovalOption) { }
         public System.Threading.Tasks.Task<string> TranslateText(string textKey, Altinn.App.Core.Models.Expressions.ComponentContext context) { }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -2156,7 +2156,7 @@ namespace Altinn.App.Core.Features.Validation.Default
     }
     public class ExpressionValidator : Altinn.App.Core.Features.IValidator
     {
-        public ExpressionValidator(Microsoft.Extensions.Logging.ILogger<Altinn.App.Core.Features.Validation.Default.ExpressionValidator> logger, Altinn.App.Core.Internal.App.IAppResources appResourceService, Altinn.App.Core.Internal.Expressions.ILayoutEvaluatorStateInitializer layoutEvaluatorStateInitializer, Altinn.App.Core.Internal.App.IAppMetadata appMetadata, System.IServiceProvider serviceProvider) { }
+        public ExpressionValidator(Microsoft.Extensions.Logging.ILogger<Altinn.App.Core.Features.Validation.Default.ExpressionValidator> logger, Altinn.App.Core.Internal.App.IAppResources appResourceService, Altinn.App.Core.Internal.App.IAppMetadata appMetadata, System.IServiceProvider serviceProvider) { }
         public string TaskId { get; }
         public string ValidationSource { get; }
         public System.Threading.Tasks.Task<bool> HasRelevantChanges(Altinn.App.Core.Features.IInstanceDataAccessor dataAccessor, string taskId, Altinn.App.Core.Models.DataElementChanges changes) { }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -3237,7 +3237,7 @@ namespace Altinn.App.Core.Internal.Expressions
         [System.Obsolete("Use ComponentContext.IsHidden or ComponentContext.EvaluateExpression instead")]
         public static System.Threading.Tasks.Task<bool> EvaluateBooleanExpression(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.Expressions.ComponentContext context, string property, bool defaultReturn) { }
         public static System.Threading.Tasks.Task<object?> EvaluateExpression(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.Expressions.Expression expr, Altinn.App.Core.Models.Expressions.ComponentContext context, object?[]? positionalArguments = null) { }
-        public static System.Threading.Tasks.Task<Altinn.App.Core.Internal.Expressions.ExpressionValue> EvaluateExpressionToExpressionValue(Altinn.App.Core.Internal.Expressions.LayoutEvaluatorState state, Altinn.App.Core.Models.Expressions.Expression expr, Altinn.App.Core.Models.Expressions.ComponentContext context, object?[]? positionalArguments = null) { }
+        public static System.Threading.Tasks.Task<Altinn.App.Core.Internal.Expressions.ExpressionValue> EvaluateExpressionToExpressionValue(Altinn.App.Core.Features.IInstanceDataAccessor state, Altinn.App.Core.Models.Expressions.Expression expr, Altinn.App.Core.Models.Expressions.ComponentContext context, Altinn.App.Core.Internal.Expressions.ExpressionValue[]? positionalArguments = null) { }
     }
     public class ExpressionEvaluatorTypeErrorException : Altinn.App.Core.Exceptions.AltinnException
     {

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGetResolvedKeys.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGetResolvedKeys.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Altinn.App.Core.Helpers.DataModel;
+using Altinn.App.Core.Internal.Data;
+using Altinn.App.Core.Models.Layout;
+using Altinn.App.SourceGenerator.Integration.Tests.Models;
+using Altinn.Platform.Storage.Interface.Models;
+using Xunit;
+
+namespace Altinn.App.SourceGenerator.Integration.Tests.UnitTest;
+
+public class TestGetResolvedKeys()
+{
+    private readonly DataElement _dataElement = new()
+    {
+        Id = "00000000-0000-0000-0000-000000000000",
+        DataType = "model",
+    };
+    private readonly DataType _dataType = new() { Id = "model" };
+
+    /// <summary>
+    /// Create a shared instance of Skjema for testing.
+    /// </summary>
+    private readonly Skjema _skjema = new Skjema()
+    {
+        Skjemanummer = "1243",
+        Skjemaversjon = "x4",
+        Skjemainnhold =
+        [
+            new SkjemaInnhold()
+            {
+                Navn = "navn",
+                Alder = 42,
+                Deltar = true,
+            },
+            new SkjemaInnhold()
+            {
+                Navn = "navn2",
+                Alder = 43,
+                Deltar = false,
+                Adresse = new() { Gate = "gate", Postnummer = 1234 },
+                TidligereAdresse =
+                [
+                    new() { Gate = "gate1", Postnummer = 1235 },
+                    new()
+                    {
+                        Gate = "gate2",
+                        Postnummer = 1236,
+                        Tags = ["tag1", "tag2"],
+                    },
+                ],
+            },
+        ],
+        EierAdresse = null,
+    };
+
+    [Theory]
+    [InlineData("skjemanummer", new[] { "skjemanummer" })]
+    [InlineData("skjemainnhold.navn", new[] { "skjemainnhold[0].navn", "skjemainnhold[1].navn" })]
+    [InlineData("skjemainnhold.alder", new[] { "skjemainnhold[0].alder", "skjemainnhold[1].alder" })]
+    [InlineData("skjemainnhold[0].alder", new[] { "skjemainnhold[0].alder" })]
+    [InlineData("skjemainnhold[1].alder", new[] { "skjemainnhold[1].alder" })]
+    [InlineData("skjemainnhold.deltar", new[] { "skjemainnhold[0].deltar", "skjemainnhold[1].deltar" })]
+    [InlineData("skjemainnhold.adresse", new[] { "skjemainnhold[0].adresse", "skjemainnhold[1].adresse" })]
+    [InlineData(
+        "skjemainnhold.adresse.gate",
+        new[] { "skjemainnhold[0].adresse.gate", "skjemainnhold[1].adresse.gate" }
+    )]
+    [InlineData(
+        "skjemainnhold.adresse.postnummer",
+        new[] { "skjemainnhold[0].adresse.postnummer", "skjemainnhold[1].adresse.postnummer" }
+    )]
+    [InlineData(
+        "skjemainnhold.tidligere-adresse.gate",
+        new[] { "skjemainnhold[1].tidligere-adresse[0].gate", "skjemainnhold[1].tidligere-adresse[1].gate" }
+    )]
+    [InlineData("skjemainnhold[0].tidligere-adresse.gate", new string[] { })]
+    [InlineData(
+        "skjemainnhold.tidligere-adresse.postnummer",
+        new[] { "skjemainnhold[1].tidligere-adresse[0].postnummer", "skjemainnhold[1].tidligere-adresse[1].postnummer" }
+    )]
+    [InlineData("eierAdresse", new[] { "eierAdresse" })]
+    [InlineData("eierAdresse.gate", new[] { "eierAdresse.gate" })]
+    [InlineData("doesnotexist", new string[] { })]
+    [InlineData("skjemainnhold.doesnotexist", new string[] { })]
+    // These cases ends in enumerables does not make sense to resolve keys for, and should throw exceptions.
+    // Currently added as test here to verify current behaviour, but should be removed when the implementation is updated to throw exceptions for these cases.
+    [InlineData("skjemainnhold", new string[] { "skjemainnhold[0]", "skjemainnhold[1]" })]
+    [InlineData(
+        "skjemainnhold.tidligere-adresse",
+        new string[]
+        {
+            "skjemainnhold[0].tidligere-adresse",
+            "skjemainnhold[1].tidligere-adresse[0]",
+            "skjemainnhold[1].tidligere-adresse[1]",
+        }
+    )]
+    [InlineData(
+        "skjemainnhold.tidligere-adresse.tags",
+        new string[]
+        {
+            "skjemainnhold[1].tidligere-adresse[0].tags",
+            "skjemainnhold[1].tidligere-adresse[1].tags[0]",
+            "skjemainnhold[1].tidligere-adresse[1].tags[1]",
+        }
+    )]
+    [InlineData(
+        "skjemainnhold.tidligere-adresse[1]",
+        new string[] { "skjemainnhold[0].tidligere-adresse", "skjemainnhold[1].tidligere-adresse[1]" }
+    )]
+    [InlineData("skjemainnhold[0]", new string[] { "skjemainnhold[0]" })]
+    public void TestResolvedKeys(string field, string[] expectedKeys)
+    {
+        // Test old reflection based implementation
+        var modelWrapper = new DataModelWrapper(_skjema);
+        var resolvedKeysReflection = modelWrapper.GetResolvedKeys(field);
+        Assert.Equal(expectedKeys, resolvedKeysReflection);
+
+        // Test formDataWrapper
+        var dataWrapper = FormDataWrapperFactory.Create(_skjema, _dataType, _dataElement);
+        var resolvedKeys = dataWrapper
+            .GetResolvedKeys(new DataReference() { Field = field, DataElementIdentifier = _dataElement })
+            .Select(k => k.Field)
+            .ToArray();
+        Assert.Equal(expectedKeys, resolvedKeys);
+    }
+
+    // [Theory]
+    // TODO: move test cases here when implementation is updated to throw exceptions for cases that resolves to enumerables, as these cases does not make sense to resolve keys for.
+    private void TestResolvedKeys_ErrorConditions(string field)
+    {
+        // Test old reflection based implementation
+        var modelWrapper = new DataModelWrapper(_skjema);
+        var exception = Assert.Throws<Exception>(() => modelWrapper.GetResolvedKeys(field).ToArray());
+        Assert.Contains("ResolveKeys", exception.Message);
+
+        var dataWrapper = FormDataWrapperFactory.Create(_skjema, _dataType, _dataElement);
+        var dataException = Assert.Throws<ArgumentException>(() =>
+            dataWrapper
+                .GetResolvedKeys(new DataReference() { Field = field, DataElementIdentifier = _dataElement })
+                .ToArray()
+        );
+        Assert.Contains("ResolveKeys", dataException.Message);
+    }
+}

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGetResolvedKeys.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGetResolvedKeys.cs
@@ -119,10 +119,7 @@ public class TestGetResolvedKeys()
 
         // Test formDataWrapper
         var dataWrapper = FormDataWrapperFactory.Create(_skjema, _dataType, _dataElement);
-        var resolvedKeys = dataWrapper
-            .GetResolvedKeys(new DataReference() { Field = field, DataElementIdentifier = _dataElement })
-            .Select(k => k.Field)
-            .ToArray();
+        var resolvedKeys = dataWrapper.GetResolvedKeys(field);
         Assert.Equal(expectedKeys, resolvedKeys);
     }
 
@@ -136,11 +133,7 @@ public class TestGetResolvedKeys()
         Assert.Contains("ResolveKeys", exception.Message);
 
         var dataWrapper = FormDataWrapperFactory.Create(_skjema, _dataType, _dataElement);
-        var dataException = Assert.Throws<ArgumentException>(() =>
-            dataWrapper
-                .GetResolvedKeys(new DataReference() { Field = field, DataElementIdentifier = _dataElement })
-                .ToArray()
-        );
+        var dataException = Assert.Throws<ArgumentException>(() => dataWrapper.GetResolvedKeys(field));
         Assert.Contains("ResolveKeys", dataException.Message);
     }
 }

--- a/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGetResolvedKeys.cs
+++ b/test/Altinn.App.SourceGenerator.Integration.Tests/UnitTest/TestGetResolvedKeys.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using Altinn.App.Core.Helpers.DataModel;
 using Altinn.App.Core.Internal.Data;
 using Altinn.App.Core.Models.Layout;
@@ -84,32 +82,43 @@ public class TestGetResolvedKeys()
     [InlineData("eierAdresse.gate", new[] { "eierAdresse.gate" })]
     [InlineData("doesnotexist", new string[] { })]
     [InlineData("skjemainnhold.doesnotexist", new string[] { })]
-    // These cases ends in enumerables does not make sense to resolve keys for, and should throw exceptions.
-    // Currently added as test here to verify current behaviour, but should be removed when the implementation is updated to throw exceptions for these cases.
-    [InlineData("skjemainnhold", new string[] { "skjemainnhold[0]", "skjemainnhold[1]" })]
+    // An unindexed collection as the last part of the path refers to the collection itself,
+    // so it resolves to the (indexed) collection key without enumerating its rows. The
+    // collection reference is returned even when the collection is null (cf. skjemainnhold[0]).
+    [InlineData("skjemainnhold", new string[] { "skjemainnhold" })]
     [InlineData(
         "skjemainnhold.tidligere-adresse",
-        new string[]
-        {
-            "skjemainnhold[0].tidligere-adresse",
-            "skjemainnhold[1].tidligere-adresse[0]",
-            "skjemainnhold[1].tidligere-adresse[1]",
-        }
+        new string[] { "skjemainnhold[0].tidligere-adresse", "skjemainnhold[1].tidligere-adresse" }
     )]
     [InlineData(
         "skjemainnhold.tidligere-adresse.tags",
-        new string[]
-        {
-            "skjemainnhold[1].tidligere-adresse[0].tags",
-            "skjemainnhold[1].tidligere-adresse[1].tags[0]",
-            "skjemainnhold[1].tidligere-adresse[1].tags[1]",
-        }
+        new string[] { "skjemainnhold[1].tidligere-adresse[0].tags", "skjemainnhold[1].tidligere-adresse[1].tags" }
     )]
+    // An explicit index refers to a single row, which is resolved as usual.
     [InlineData(
+        // skjemainnhold[0].tidligere-adresse is null, so the index does not resolve
         "skjemainnhold.tidligere-adresse[1]",
-        new string[] { "skjemainnhold[0].tidligere-adresse", "skjemainnhold[1].tidligere-adresse[1]" }
+        new string[] { "skjemainnhold[1].tidligere-adresse[1]" }
     )]
     [InlineData("skjemainnhold[0]", new string[] { "skjemainnhold[0]" })]
+    // "group[]" enumerates every row of the collection at the end of the path.
+    [InlineData("skjemainnhold[]", new[] { "skjemainnhold[0]", "skjemainnhold[1]" })]
+    // "[]" in the middle of the path is equivalent to a bare collection (both expand over rows).
+    [InlineData("skjemainnhold[].navn", new[] { "skjemainnhold[0].navn", "skjemainnhold[1].navn" })]
+    [InlineData(
+        // skjemainnhold[0].tidligere-adresse is null, so it contributes no rows
+        "skjemainnhold.tidligere-adresse[]",
+        new[] { "skjemainnhold[1].tidligere-adresse[0]", "skjemainnhold[1].tidligere-adresse[1]" }
+    )]
+    [InlineData(
+        "skjemainnhold[1].tidligere-adresse[]",
+        new[] { "skjemainnhold[1].tidligere-adresse[0]", "skjemainnhold[1].tidligere-adresse[1]" }
+    )]
+    [InlineData(
+        // tidligere-adresse[0].tags is null, so only tidligere-adresse[1].tags contributes rows
+        "skjemainnhold[].tidligere-adresse[].tags[]",
+        new[] { "skjemainnhold[1].tidligere-adresse[1].tags[0]", "skjemainnhold[1].tidligere-adresse[1].tags[1]" }
+    )]
     public void TestResolvedKeys(string field, string[] expectedKeys)
     {
         // Test old reflection based implementation
@@ -123,17 +132,52 @@ public class TestGetResolvedKeys()
         Assert.Equal(expectedKeys, resolvedKeys);
     }
 
-    // [Theory]
-    // TODO: move test cases here when implementation is updated to throw exceptions for cases that resolves to enumerables, as these cases does not make sense to resolve keys for.
-    private void TestResolvedKeys_ErrorConditions(string field)
+    /// <summary>
+    /// A null collection and an empty collection must resolve identically - the result must
+    /// depend only on the path, not on whether the (empty) collection was instantiated.
+    ///
+    /// A bare collection at the end of the path resolves to the collection itself (so the key
+    /// is returned regardless of contents), while descending through or indexing into an
+    /// empty/null collection finds no rows and resolves to nothing.
+    /// </summary>
+    [Theory]
+    // Top level collection (Skjemainnhold)
+    [InlineData("skjemainnhold", new[] { "skjemainnhold" })]
+    [InlineData("skjemainnhold[]", new string[] { })]
+    [InlineData("skjemainnhold.navn", new string[] { })]
+    [InlineData("skjemainnhold[0].navn", new string[] { })]
+    public void NullAndEmptyTopLevelCollection_ResolveTheSame(string field, string[] expectedKeys)
+    {
+        AssertResolvedKeys(new Skjema() { Skjemainnhold = null }, field, expectedKeys);
+        AssertResolvedKeys(new Skjema() { Skjemainnhold = [] }, field, expectedKeys);
+    }
+
+    /// <summary>
+    /// Same as <see cref="NullAndEmptyTopLevelCollection_ResolveTheSame"/>, but for a nested
+    /// collection (TidligereAdresse) inside a populated parent row.
+    /// </summary>
+    [Theory]
+    [InlineData("skjemainnhold[0].tidligere-adresse", new[] { "skjemainnhold[0].tidligere-adresse" })]
+    [InlineData("skjemainnhold[0].tidligere-adresse[]", new string[] { })]
+    [InlineData("skjemainnhold[0].tidligere-adresse.gate", new string[] { })]
+    [InlineData("skjemainnhold[0].tidligere-adresse[1].gate", new string[] { })]
+    public void NullAndEmptyNestedCollection_ResolveTheSame(string field, string[] expectedKeys)
+    {
+        AssertResolvedKeys(BuildNested(null), field, expectedKeys);
+        AssertResolvedKeys(BuildNested([]), field, expectedKeys);
+
+        static Skjema BuildNested(List<Adresse>? tidligereAdresse) =>
+            new() { Skjemainnhold = [new SkjemaInnhold() { Navn = "navn", TidligereAdresse = tidligereAdresse }] };
+    }
+
+    private void AssertResolvedKeys(Skjema skjema, string field, string[] expectedKeys)
     {
         // Test old reflection based implementation
-        var modelWrapper = new DataModelWrapper(_skjema);
-        var exception = Assert.Throws<Exception>(() => modelWrapper.GetResolvedKeys(field).ToArray());
-        Assert.Contains("ResolveKeys", exception.Message);
+        var modelWrapper = new DataModelWrapper(skjema);
+        Assert.Equal(expectedKeys, modelWrapper.GetResolvedKeys(field));
 
-        var dataWrapper = FormDataWrapperFactory.Create(_skjema, _dataType, _dataElement);
-        var dataException = Assert.Throws<ArgumentException>(() => dataWrapper.GetResolvedKeys(field));
-        Assert.Contains("ResolveKeys", dataException.Message);
+        // Test formDataWrapper
+        var dataWrapper = FormDataWrapperFactory.Create(skjema, _dataType, _dataElement);
+        Assert.Equal(expectedKeys, dataWrapper.GetResolvedKeys(field));
     }
 }


### PR DESCRIPTION
Suggested changes to #1683

commit 9b1e757f8c9d471343b4c3bbf84cb20a6b940d50
Date:   Mon Jun 8 23:21:16 2026 +0200

    Unify GetResolvedKeys to always return all resolved keys
    
    ExpressionValidation now checks for null by it self, not relying on isCalculating = false. (added a shared test for this)

commit be58d5d856375911225a49708c635e252a0b7dba
Date:   Mon Jun 8 23:07:20 2026 +0200

    Get rid of LayoutEvaluatorStateInitializer in ExpressionValidator

commit b8f15ac5d559cc7ca4264e574fee1cc5a1e39349
Date:   Mon Jun 8 15:47:43 2026 +0200

    Don't filter calcluations to only run when the display of the value is not hidden

commit 89840fa77e712ffc8f21e65800f7ffd6ff5f19ce
Date:   Mon Jun 8 15:42:09 2026 +0200

    Fix merge conflict and don't use object[] for positional arguments