### PR TITLE
Workflow tweaking

### DIFF
--- a/.github/workflows/check-label-added.yml
+++ b/.github/workflows/check-label-added.yml
@@ -1,6 +1,9 @@
 name: "Label Check"
 on:
   pull_request:
+    branches:
+      - "main"
+      - "release/**"
     types: [opened, edited, labeled, unlabeled, synchronize]
 
 jobs:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -6,9 +6,6 @@ on:
       - "main"
       - "release/**"
   pull_request:
-    branches:
-      - "main"
-      - "release/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -6,10 +6,17 @@ on:
       - "main"
       - "release/**"
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
   workflow_dispatch:
 
 jobs:
   analyze:
+    # Only run on pull_request edit if the base branch was changed, to avoid running when only description or title was edited.
+    if: github.event.action != 'edited' || github.event.changes.base.ref != null
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]


### PR DESCRIPTION
Run tests on all PRs, but only check labels on main and release.

Tested by opening the PR against another branch to see that label check did not run, but tests did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request workflow configurations to restrict checks to specific branches and event types, optimizing continuous integration pipeline efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->