### PR TITLE
fix(correspondence): Signing notifications failing with 'multiple identifiers' and double-sending to signees

### DIFF
--- a/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
@@ -1,5 +1,7 @@
 using Altinn.App.Core.Features.Correspondence.Models;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Altinn.App.Core.Features.Correspondence.Builder;
 
 /// <summary>
@@ -19,6 +21,7 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     private CorrespondenceNotificationChannel? _reminderNotificationChannel;
     private string? _sendersReference;
     private CorrespondenceNotificationRecipient? _recipientOverride;
+    private List<CorrespondenceNotificationRecipient>? _recipientOverrides;
 
     [Obsolete]
     private List<CorrespondenceNotificationRecipientWrapper>? _recipientToOverrideWrapper;
@@ -123,6 +126,9 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     }
 
     /// <inheritdoc/>
+    [Obsolete(
+        "Use WithRecipientOverrides instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+    )]
     public ICorrespondenceNotificationBuilder WithRecipientOverride(
         ICorrespondenceNotificationOverrideBuilder recipientOverrideBuilder
     )
@@ -131,6 +137,9 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     }
 
     /// <inheritdoc/>
+    [Obsolete(
+        "Use WithRecipientOverrides instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+    )]
     public ICorrespondenceNotificationBuilder WithRecipientOverride(
         CorrespondenceNotificationRecipient recipientOverride
     )
@@ -140,6 +149,9 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     }
 
     /// <inheritdoc/>
+    [Obsolete(
+        "Use WithRecipientOverridesIfConfigured instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+    )]
     public ICorrespondenceNotificationBuilder WithRecipientOverrideIfConfigured(
         CorrespondenceNotificationRecipient? recipientOverride
     )
@@ -150,6 +162,30 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
         }
 
         return this;
+    }
+
+    /// <inheritdoc/>
+    public ICorrespondenceNotificationBuilder WithRecipientOverrides(
+        IEnumerable<CorrespondenceNotificationRecipient> recipientOverrides
+    )
+    {
+        ArgumentNullException.ThrowIfNull(recipientOverrides);
+        _recipientOverrides = recipientOverrides.ToList();
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ICorrespondenceNotificationBuilder WithRecipientOverridesIfConfigured(
+        IEnumerable<CorrespondenceNotificationRecipient>? recipientOverrides
+    )
+    {
+        if (recipientOverrides is null)
+        {
+            return this;
+        }
+
+        List<CorrespondenceNotificationRecipient> list = recipientOverrides.ToList();
+        return list.Count == 0 ? this : WithRecipientOverrides(list);
     }
 
     /// <inheritdoc/>
@@ -182,6 +218,7 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
             ReminderNotificationChannel = _reminderNotificationChannel,
             SendersReference = _sendersReference,
             CustomRecipient = _recipientOverride,
+            CustomRecipients = _recipientOverrides,
         };
     }
 }

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/CorrespondenceNotificationBuilder.cs
@@ -21,7 +21,7 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     private CorrespondenceNotificationChannel? _reminderNotificationChannel;
     private string? _sendersReference;
     private CorrespondenceNotificationRecipient? _recipientOverride;
-    private List<CorrespondenceNotificationRecipient>? _recipientOverrides;
+    private List<CorrespondenceNotificationRecipient>? _customRecipients;
 
     [Obsolete]
     private List<CorrespondenceNotificationRecipientWrapper>? _recipientToOverrideWrapper;
@@ -127,7 +127,7 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
 
     /// <inheritdoc/>
     [Obsolete(
-        "Use WithRecipientOverrides instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+        "Use WithCustomRecipients instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
     )]
     public ICorrespondenceNotificationBuilder WithRecipientOverride(
         ICorrespondenceNotificationOverrideBuilder recipientOverrideBuilder
@@ -138,7 +138,7 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
 
     /// <inheritdoc/>
     [Obsolete(
-        "Use WithRecipientOverrides instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+        "Use WithCustomRecipients instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
     )]
     public ICorrespondenceNotificationBuilder WithRecipientOverride(
         CorrespondenceNotificationRecipient recipientOverride
@@ -150,7 +150,7 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
 
     /// <inheritdoc/>
     [Obsolete(
-        "Use WithRecipientOverridesIfConfigured instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+        "Use WithCustomRecipientsIfConfigured instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
     )]
     public ICorrespondenceNotificationBuilder WithRecipientOverrideIfConfigured(
         CorrespondenceNotificationRecipient? recipientOverride
@@ -165,27 +165,27 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
     }
 
     /// <inheritdoc/>
-    public ICorrespondenceNotificationBuilder WithRecipientOverrides(
-        IEnumerable<CorrespondenceNotificationRecipient> recipientOverrides
+    public ICorrespondenceNotificationBuilder WithCustomRecipients(
+        IEnumerable<CorrespondenceNotificationRecipient> customRecipients
     )
     {
-        ArgumentNullException.ThrowIfNull(recipientOverrides);
-        _recipientOverrides = recipientOverrides.ToList();
+        ArgumentNullException.ThrowIfNull(customRecipients);
+        _customRecipients = customRecipients.ToList();
         return this;
     }
 
     /// <inheritdoc/>
-    public ICorrespondenceNotificationBuilder WithRecipientOverridesIfConfigured(
-        IEnumerable<CorrespondenceNotificationRecipient>? recipientOverrides
+    public ICorrespondenceNotificationBuilder WithCustomRecipientsIfConfigured(
+        IEnumerable<CorrespondenceNotificationRecipient>? customRecipients
     )
     {
-        if (recipientOverrides is null)
+        if (customRecipients is null)
         {
             return this;
         }
 
-        List<CorrespondenceNotificationRecipient> list = recipientOverrides.ToList();
-        return list.Count == 0 ? this : WithRecipientOverrides(list);
+        List<CorrespondenceNotificationRecipient> list = customRecipients.ToList();
+        return list.Count == 0 ? this : WithCustomRecipients(list);
     }
 
     /// <inheritdoc/>
@@ -218,7 +218,7 @@ public class CorrespondenceNotificationBuilder : ICorrespondenceNotificationBuil
             ReminderNotificationChannel = _reminderNotificationChannel,
             SendersReference = _sendersReference,
             CustomRecipient = _recipientOverride,
-            CustomRecipients = _recipientOverrides,
+            CustomRecipients = _customRecipients,
         };
     }
 }

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationBuilder.cs
@@ -102,18 +102,18 @@ public interface ICorrespondenceNotificationBuilder : ICorrespondenceNotificatio
     /// default correspondence recipient and must carry exactly one identifier (email, mobile, organisation number or
     /// national identity number).
     /// </summary>
-    /// <param name="recipientOverrides">The custom recipients.</param>
-    public ICorrespondenceNotificationBuilder WithRecipientOverrides(
-        IEnumerable<CorrespondenceNotificationRecipient> recipientOverrides
+    /// <param name="customRecipients">The custom recipients.</param>
+    public ICorrespondenceNotificationBuilder WithCustomRecipients(
+        IEnumerable<CorrespondenceNotificationRecipient> customRecipients
     );
 
     /// <summary>
     /// Sets the custom recipients for the correspondence notification, if any are provided. A <c>null</c> or empty
     /// collection is a no-op.
     /// </summary>
-    /// <param name="recipientOverrides">The custom recipients.</param>
-    public ICorrespondenceNotificationBuilder WithRecipientOverridesIfConfigured(
-        IEnumerable<CorrespondenceNotificationRecipient>? recipientOverrides
+    /// <param name="customRecipients">The custom recipients.</param>
+    public ICorrespondenceNotificationBuilder WithCustomRecipientsIfConfigured(
+        IEnumerable<CorrespondenceNotificationRecipient>? customRecipients
     );
 
     /// <summary>
@@ -121,7 +121,7 @@ public interface ICorrespondenceNotificationBuilder : ICorrespondenceNotificatio
     /// </summary>
     /// <param name="recipientOverride">The recipient override</param>
     [Obsolete(
-        "Use WithRecipientOverrides instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+        "Use WithCustomRecipients instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
     )]
     public ICorrespondenceNotificationBuilder WithRecipientOverride(
         CorrespondenceNotificationRecipient recipientOverride
@@ -132,7 +132,7 @@ public interface ICorrespondenceNotificationBuilder : ICorrespondenceNotificatio
     /// </summary>
     /// <param name="recipientOverrideBuilder">The recipient override builder.</param>
     [Obsolete(
-        "Use WithRecipientOverrides instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+        "Use WithCustomRecipients instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
     )]
     public ICorrespondenceNotificationBuilder WithRecipientOverride(
         ICorrespondenceNotificationOverrideBuilder recipientOverrideBuilder

--- a/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationBuilder.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationBuilder.cs
@@ -98,9 +98,31 @@ public interface ICorrespondenceNotificationBuilder : ICorrespondenceNotificatio
     ICorrespondenceNotificationBuilder WithRequestedSendTime(DateTimeOffset? requestedSendTime);
 
     /// <summary>
+    /// Sets the custom recipients for the correspondence notification. Each recipient is notified in addition to the
+    /// default correspondence recipient and must carry exactly one identifier (email, mobile, organisation number or
+    /// national identity number).
+    /// </summary>
+    /// <param name="recipientOverrides">The custom recipients.</param>
+    public ICorrespondenceNotificationBuilder WithRecipientOverrides(
+        IEnumerable<CorrespondenceNotificationRecipient> recipientOverrides
+    );
+
+    /// <summary>
+    /// Sets the custom recipients for the correspondence notification, if any are provided. A <c>null</c> or empty
+    /// collection is a no-op.
+    /// </summary>
+    /// <param name="recipientOverrides">The custom recipients.</param>
+    public ICorrespondenceNotificationBuilder WithRecipientOverridesIfConfigured(
+        IEnumerable<CorrespondenceNotificationRecipient>? recipientOverrides
+    );
+
+    /// <summary>
     /// Sets the recipient override for the correspondence notification.
     /// </summary>
     /// <param name="recipientOverride">The recipient override</param>
+    [Obsolete(
+        "Use WithRecipientOverrides instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+    )]
     public ICorrespondenceNotificationBuilder WithRecipientOverride(
         CorrespondenceNotificationRecipient recipientOverride
     );
@@ -109,6 +131,9 @@ public interface ICorrespondenceNotificationBuilder : ICorrespondenceNotificatio
     /// Sets the recipient override for the correspondence notification.
     /// </summary>
     /// <param name="recipientOverrideBuilder">The recipient override builder.</param>
+    [Obsolete(
+        "Use WithRecipientOverrides instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API."
+    )]
     public ICorrespondenceNotificationBuilder WithRecipientOverride(
         ICorrespondenceNotificationOverrideBuilder recipientOverrideBuilder
     );

--- a/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/CorrespondenceClient.cs
@@ -357,9 +357,10 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
             NotificationChannel = notification.NotificationChannel,
             ReminderNotificationChannel = notification.ReminderNotificationChannel,
             SendersReference = notification.SendersReference,
-            CustomRecipient = notification.CustomRecipient is null
-                ? null
-                : BuildNotificationRecipient(notification.CustomRecipient),
+            // The Correspondence API no longer accepts the singular customRecipient, nor a recipient carrying more
+            // than one identifier. Both the new CustomRecipients and the legacy singular CustomRecipient are folded
+            // into the plural customRecipients, exploded into one entry per identifier.
+            CustomRecipients = BuildCustomRecipients(notification),
             CustomNotificationRecipients = notification
                 .CustomNotificationRecipients?.Select(x => new CorrespondenceCustomNotificationRecipientRequest
                 {
@@ -381,6 +382,62 @@ internal sealed class CorrespondenceClient : ICorrespondenceClient
             OrganizationNumber = recipient.OrganizationNumber?.ToUrnFormattedString(),
             NationalIdentityNumber = recipient.NationalIdentityNumber?.ToUrnFormattedString(),
         };
+    }
+
+    private static List<CorrespondenceNotificationRecipientRequest>? BuildCustomRecipients(
+        CorrespondenceNotification notification
+    )
+    {
+        List<CorrespondenceNotificationRecipientRequest>? recipients = null;
+
+        if (notification.CustomRecipients is not null)
+        {
+            foreach (CorrespondenceNotificationRecipient recipient in notification.CustomRecipients)
+            {
+                (recipients ??= []).AddRange(ExplodeNotificationRecipient(recipient));
+            }
+        }
+
+        if (notification.CustomRecipient is not null)
+        {
+            (recipients ??= []).AddRange(ExplodeNotificationRecipient(notification.CustomRecipient));
+        }
+
+        return recipients;
+    }
+
+    /// <summary>
+    /// Splits a recipient into one request per populated identifier. The Correspondence API requires each custom
+    /// recipient to carry exactly one of email, mobile, organisation number or national identity number.
+    /// </summary>
+    private static IEnumerable<CorrespondenceNotificationRecipientRequest> ExplodeNotificationRecipient(
+        CorrespondenceNotificationRecipient recipient
+    )
+    {
+        if (recipient.EmailAddress is not null)
+        {
+            yield return new CorrespondenceNotificationRecipientRequest { EmailAddress = recipient.EmailAddress };
+        }
+
+        if (recipient.MobileNumber is not null)
+        {
+            yield return new CorrespondenceNotificationRecipientRequest { MobileNumber = recipient.MobileNumber };
+        }
+
+        string? organizationNumber = recipient.OrganizationNumber?.ToUrnFormattedString();
+        if (organizationNumber is not null)
+        {
+            yield return new CorrespondenceNotificationRecipientRequest { OrganizationNumber = organizationNumber };
+        }
+
+        string? nationalIdentityNumber = recipient.NationalIdentityNumber?.ToUrnFormattedString();
+        if (nationalIdentityNumber is not null)
+        {
+            yield return new CorrespondenceNotificationRecipientRequest
+            {
+                NationalIdentityNumber = nationalIdentityNumber,
+            };
+        }
     }
 
     private async Task<HttpRequestMessage> AuthenticatedHttpRequestFactory(

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotification.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotification.cs
@@ -87,14 +87,27 @@ public sealed record CorrespondenceNotification
     public DateTimeOffset? RequestedSendTime { get; init; }
 
     /// <summary>
-    /// A list of recipients for the notification. If not set, the notification will be sent to the recipient of the Correspondence
+    /// Custom recipients for the notification. These are notified <em>in addition to</em> the recipient of the Correspondence.
     /// </summary>
+    /// <remarks>
+    /// Each recipient must be identified by exactly one of email address, mobile number, organisation number or
+    /// national identity number. A recipient carrying more than one of these is automatically split into one
+    /// notification recipient per identifier when the request is sent.
+    /// </remarks>
+    public IReadOnlyList<CorrespondenceNotificationRecipient>? CustomRecipients { get; init; }
+
+    /// <summary>
+    /// A custom recipient for the notification. If not set, the notification will be sent to the recipient of the Correspondence
+    /// </summary>
+    [Obsolete(
+        "This property is deprecated and will be removed in a future version. Use CustomRecipients instead. A single recipient with multiple identifiers is no longer accepted by the Correspondence API and will be split into one recipient per identifier."
+    )]
     public CorrespondenceNotificationRecipient? CustomRecipient { get; init; }
 
     /// <summary>
     /// A list of recipients for the notification. If not set, the notification will be sent to the recipient of the Correspondence
     /// </summary>
     /// <remarks> Only the first recipient in the list will be used for sending the notification. </remarks>
-    [Obsolete("This property is deprecated and will be removed in a future version. Use CustomRecipient instead.")]
+    [Obsolete("This property is deprecated and will be removed in a future version. Use CustomRecipients instead.")]
     public IReadOnlyList<CorrespondenceNotificationRecipientWrapper>? CustomNotificationRecipients { get; init; }
 }

--- a/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotificationChannel.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/CorrespondenceNotificationChannel.cs
@@ -27,4 +27,9 @@ public enum CorrespondenceNotificationChannel
     /// The selected channel for the notification is SMS preferred.
     /// </summary>
     SmsPreferred,
+
+    /// <summary>
+    /// The notification is sent on both email and SMS.
+    /// </summary>
+    EmailAndSms,
 }

--- a/src/Altinn.App.Core/Features/Correspondence/Models/Request/InitializeCorrespondencesRequest.cs
+++ b/src/Altinn.App.Core/Features/Correspondence/Models/Request/InitializeCorrespondencesRequest.cs
@@ -281,8 +281,18 @@ internal sealed record CorrespondenceNotificationRequest
     public string? SendersReference { get; init; }
 
     /// <summary>
+    /// Custom recipients for the notification. These are notified in addition to the default correspondence recipient.
+    /// </summary>
+    /// <remarks>Each entry must carry exactly one identifier (email, mobile, organisation number or national identity number).</remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("customRecipients")]
+    public IReadOnlyList<CorrespondenceNotificationRecipientRequest>? CustomRecipients { get; init; }
+
+    /// <summary>
     /// A custom recipient for the notification. When set, overrides the default correspondence recipient.
     /// </summary>
+    [Obsolete("This property is deprecated by the Correspondence API. Use CustomRecipients instead.")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("customRecipient")]
     public CorrespondenceNotificationRecipientRequest? CustomRecipient { get; init; }
 
@@ -290,7 +300,7 @@ internal sealed record CorrespondenceNotificationRequest
     /// Per-recipient notification overrides.
     /// </summary>
     /// <remarks>Only the first entry is used by the API.</remarks>
-    [Obsolete("This property is deprecated. Use CustomRecipient instead.")]
+    [Obsolete("This property is deprecated. Use CustomRecipients instead.")]
     [JsonPropertyName("customNotificationRecipients")]
     public IReadOnlyList<CorrespondenceCustomNotificationRecipientRequest>? CustomNotificationRecipients { get; init; }
 }
@@ -303,24 +313,28 @@ internal sealed record CorrespondenceNotificationRecipientRequest
     /// <summary>
     /// Email address of the recipient.
     /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("emailAddress")]
     public string? EmailAddress { get; init; }
 
     /// <summary>
     /// Mobile number of the recipient.
     /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("mobileNumber")]
     public string? MobileNumber { get; init; }
 
     /// <summary>
     /// Organisation number of the recipient in URN format.
     /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("organizationNumber")]
     public string? OrganizationNumber { get; init; }
 
     /// <summary>
     /// National identity number of the recipient in URN format.
     /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("nationalIdentityNumber")]
     public string? NationalIdentityNumber { get; init; }
 }

--- a/src/Altinn.App.Core/Features/Signing/Helpers/SigningNotificationHelper.cs
+++ b/src/Altinn.App.Core/Features/Signing/Helpers/SigningNotificationHelper.cs
@@ -24,26 +24,30 @@ internal sealed class SigningNotificationHelper
     /// Determines the notification choice based on the provided notification object.
     /// This is to keep backwards compatibility.
     /// </summary>
+    /// <remarks>
+    /// The choice is inferred from which notification blocks the app declared (<see cref="Notification.Email"/> /
+    /// <see cref="Notification.Sms"/>), not from whether explicit contact addresses are populated. Declaring a block
+    /// expresses intent to notify on that channel; the contact itself is resolved from the registry for the default
+    /// correspondence recipient when no explicit override is provided.
+    /// </remarks>
     /// <param name="notification"></param>
     /// <returns></returns>
     internal static NotificationChoice GetNotificationChoiceIfNotSet(Notification? notification)
     {
-        if (
-            notification?.Email is not null
-            && notification.Email.EmailAddress is not null
-            && notification.Sms is not null
-            && notification.Sms.MobileNumber is not null
-        )
+        bool hasEmail = notification?.Email is not null;
+        bool hasSms = notification?.Sms is not null;
+
+        if (hasEmail && hasSms)
         {
             return NotificationChoice.SmsAndEmail;
         }
 
-        if (notification?.Email is not null && notification.Email.EmailAddress is not null)
+        if (hasEmail)
         {
             return NotificationChoice.Email;
         }
 
-        if (notification?.Sms is not null && notification.Sms.MobileNumber is not null)
+        if (hasSms)
         {
             return NotificationChoice.Sms;
         }
@@ -65,14 +69,7 @@ internal sealed class SigningNotificationHelper
                 .WithEmailSubject(cw.EmailSubject)
                 .WithEmailBody(cw.EmailBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverride(
-                    CorrespondenceNotificationOverrideBuilder
-                        .Create()
-                        .WithEmailAddress(emailAddress)
-                        .WithMobileNumber(mobileNumber)
-                        .WithOrganisationOrPersonIdentifier(cw.Recipient)
-                        .Build()
-                )
+                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress, mobileNumber: null))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -84,13 +81,7 @@ internal sealed class SigningNotificationHelper
                 .WithNotificationChannel(CorrespondenceNotificationChannel.Sms)
                 .WithSmsBody(cw.SmsBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverride(
-                    CorrespondenceNotificationOverrideBuilder
-                        .Create()
-                        .WithMobileNumber(mobileNumber)
-                        .WithOrganisationOrPersonIdentifier(cw.Recipient)
-                        .Build()
-                )
+                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress: null, mobileNumber))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -99,19 +90,12 @@ internal sealed class SigningNotificationHelper
             NotificationChoice.SmsAndEmail => CorrespondenceNotificationBuilder
                 .Create()
                 .WithNotificationTemplate(CorrespondenceNotificationTemplate.CustomMessage)
-                .WithNotificationChannel(CorrespondenceNotificationChannel.EmailPreferred)
+                .WithNotificationChannel(CorrespondenceNotificationChannel.EmailAndSms)
                 .WithSmsBody(cw.SmsBody)
                 .WithEmailSubject(cw.EmailSubject)
                 .WithEmailBody(cw.EmailBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverride(
-                    CorrespondenceNotificationOverrideBuilder
-                        .Create()
-                        .WithEmailAddress(emailAddress)
-                        .WithMobileNumber(mobileNumber)
-                        .WithOrganisationOrPersonIdentifier(cw.Recipient)
-                        .Build()
-                )
+                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress, mobileNumber))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -125,13 +109,7 @@ internal sealed class SigningNotificationHelper
                 .WithEmailSubject(cw.EmailSubject)
                 .WithEmailBody(cw.EmailBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverride(
-                    CorrespondenceNotificationOverrideBuilder
-                        .Create()
-                        .WithMobileNumber(mobileNumber)
-                        .WithOrganisationOrPersonIdentifier(cw.Recipient)
-                        .Build()
-                )
+                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress: null, mobileNumber))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -145,13 +123,7 @@ internal sealed class SigningNotificationHelper
                 .WithEmailSubject(cw.EmailSubject)
                 .WithEmailBody(cw.EmailBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverride(
-                    CorrespondenceNotificationOverrideBuilder
-                        .Create()
-                        .WithEmailAddress(emailAddress)
-                        .WithOrganisationOrPersonIdentifier(cw.Recipient)
-                        .Build()
-                )
+                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress, mobileNumber: null))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -167,5 +139,31 @@ internal sealed class SigningNotificationHelper
                 .Build(),
             _ => null,
         };
+    }
+
+    /// <summary>
+    /// Builds one custom notification recipient per explicitly provided contact method. The Correspondence API
+    /// requires each custom recipient to carry exactly one identifier, so email and mobile overrides become separate
+    /// recipients. When no contact override is provided, the notification falls back to the correspondence recipient
+    /// (resolved via the contact and reservation registry) and the notification channel governs delivery.
+    /// </summary>
+    private static List<CorrespondenceNotificationRecipient> BuildRecipientOverrides(
+        string? emailAddress,
+        string? mobileNumber
+    )
+    {
+        var recipients = new List<CorrespondenceNotificationRecipient>();
+
+        if (emailAddress is not null)
+        {
+            recipients.Add(new CorrespondenceNotificationRecipient { EmailAddress = emailAddress });
+        }
+
+        if (mobileNumber is not null)
+        {
+            recipients.Add(new CorrespondenceNotificationRecipient { MobileNumber = mobileNumber });
+        }
+
+        return recipients;
     }
 }

--- a/src/Altinn.App.Core/Features/Signing/Helpers/SigningNotificationHelper.cs
+++ b/src/Altinn.App.Core/Features/Signing/Helpers/SigningNotificationHelper.cs
@@ -69,7 +69,7 @@ internal sealed class SigningNotificationHelper
                 .WithEmailSubject(cw.EmailSubject)
                 .WithEmailBody(cw.EmailBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress, mobileNumber: null))
+                .WithCustomRecipientsIfConfigured(BuildCustomRecipients(emailAddress, mobileNumber: null))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -81,7 +81,7 @@ internal sealed class SigningNotificationHelper
                 .WithNotificationChannel(CorrespondenceNotificationChannel.Sms)
                 .WithSmsBody(cw.SmsBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress: null, mobileNumber))
+                .WithCustomRecipientsIfConfigured(BuildCustomRecipients(emailAddress: null, mobileNumber))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -95,7 +95,7 @@ internal sealed class SigningNotificationHelper
                 .WithEmailSubject(cw.EmailSubject)
                 .WithEmailBody(cw.EmailBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress, mobileNumber))
+                .WithCustomRecipientsIfConfigured(BuildCustomRecipients(emailAddress, mobileNumber))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -109,7 +109,7 @@ internal sealed class SigningNotificationHelper
                 .WithEmailSubject(cw.EmailSubject)
                 .WithEmailBody(cw.EmailBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress: null, mobileNumber))
+                .WithCustomRecipientsIfConfigured(BuildCustomRecipients(emailAddress: null, mobileNumber))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -123,7 +123,7 @@ internal sealed class SigningNotificationHelper
                 .WithEmailSubject(cw.EmailSubject)
                 .WithEmailBody(cw.EmailBody)
                 .WithSendersReference(cw.SendersReference)
-                .WithRecipientOverridesIfConfigured(BuildRecipientOverrides(emailAddress, mobileNumber: null))
+                .WithCustomRecipientsIfConfigured(BuildCustomRecipients(emailAddress, mobileNumber: null))
                 .WithSendReminder(cw.ReminderNotification is not null)
                 .WithReminderEmailBody(cw.ReminderEmailBody)
                 .WithReminderEmailSubject(cw.ReminderEmailSubject)
@@ -143,11 +143,11 @@ internal sealed class SigningNotificationHelper
 
     /// <summary>
     /// Builds one custom notification recipient per explicitly provided contact method. The Correspondence API
-    /// requires each custom recipient to carry exactly one identifier, so email and mobile overrides become separate
-    /// recipients. When no contact override is provided, the notification falls back to the correspondence recipient
+    /// requires each custom recipient to carry exactly one identifier, so email and mobile contacts become separate
+    /// recipients. When no explicit contact is provided, the notification falls back to the correspondence recipient
     /// (resolved via the contact and reservation registry) and the notification channel governs delivery.
     /// </summary>
-    private static List<CorrespondenceNotificationRecipient> BuildRecipientOverrides(
+    private static List<CorrespondenceNotificationRecipient> BuildCustomRecipients(
         string? emailAddress,
         string? mobileNumber
     )

--- a/src/Altinn.App.Core/Features/Signing/Services/SigneeContextsManager.cs
+++ b/src/Altinn.App.Core/Features/Signing/Services/SigneeContextsManager.cs
@@ -9,7 +9,6 @@ using Altinn.App.Core.Internal.App;
 using Altinn.App.Core.Internal.Process.Elements.AltinnExtensionProperties;
 using Altinn.App.Core.Internal.Registers;
 using Altinn.App.Core.Models;
-using Altinn.Platform.Register.Models;
 using Altinn.Platform.Storage.Interface.Models;
 using Microsoft.Extensions.Logging;
 using static Altinn.App.Core.Features.Signing.Models.Signee;
@@ -141,22 +140,12 @@ internal sealed class SigneeContextsManager(
     )
     {
         Signee signee = await From(providedSignee, altinnPartyClient.LookupParty);
-        Party party = signee.GetParty();
 
-        Notification? notification = providedSignee.CommunicationConfig?.Notification;
-
-        Email? emailNotification = notification?.Email;
-        if (emailNotification is not null && string.IsNullOrEmpty(emailNotification.EmailAddress))
-        {
-            emailNotification.EmailAddress = party.Organization?.EMailAddress;
-        }
-
-        Sms? smsNotification = notification?.Sms;
-        if (smsNotification is not null && string.IsNullOrEmpty(smsNotification.MobileNumber))
-        {
-            smsNotification.MobileNumber = party.Organization?.MobileNumber ?? party.Person?.MobileNumber;
-        }
-
+        // Contact info is intentionally not enriched from the registry here. A correspondence notification is always
+        // sent to the default correspondence recipient (the signee), resolved via the contact and reservation
+        // registry. Custom notification recipients are notified *in addition* to that default recipient, so injecting
+        // the signee's own registry contact here would notify the signee twice. Explicit contact overrides provided
+        // by the app flow through CommunicationConfig unchanged.
         return new SigneeContext
         {
             TaskId = taskId,

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/Builder/CorrespondenceBuilderTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/Builder/CorrespondenceBuilderTests.cs
@@ -169,12 +169,12 @@ public class CorrespondenceBuilderTests
                     .WithSendReminder(data.notification.sendReminder)
                     .WithNotificationChannel(data.notification.notificationChannel)
                     .WithReminderNotificationChannel(data.notification.reminderNotificationChannel)
-                    .WithRecipientOverride(
+                    .WithRecipientOverrides([
                         CorrespondenceNotificationOverrideBuilder
                             .Create()
                             .WithOrganizationNumber(data.recipient.Value)
-                            .Build()
-                    )
+                            .Build(),
+                    ])
             )
             .WithDueDateTime(data.dueDateTime)
             .WithMessageSender(data.messageSender)
@@ -283,10 +283,10 @@ public class CorrespondenceBuilderTests
         correspondence
             .Notification.ReminderNotificationChannel.Should()
             .Be(data.notification.reminderNotificationChannel);
-        correspondence.Notification.CustomRecipient.Should().NotBeNull();
-        correspondence.Notification.CustomRecipient!.OrganizationNumber.Should().NotBeNull();
-
-        correspondence.Notification.CustomRecipient.OrganizationNumber.Should().Be(data.recipient.Value);
+        correspondence.Notification.CustomRecipients.Should().NotBeNull();
+        correspondence.Notification.CustomRecipients!.Should().ContainSingle();
+        correspondence.Notification.CustomRecipients![0].OrganizationNumber.Should().NotBeNull();
+        correspondence.Notification.CustomRecipients[0].OrganizationNumber.Should().Be(data.recipient.Value);
 
         correspondence.ExistingAttachments.Should().BeEquivalentTo(data.existingAttachments);
 

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/Builder/CorrespondenceBuilderTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/Builder/CorrespondenceBuilderTests.cs
@@ -169,7 +169,7 @@ public class CorrespondenceBuilderTests
                     .WithSendReminder(data.notification.sendReminder)
                     .WithNotificationChannel(data.notification.notificationChannel)
                     .WithReminderNotificationChannel(data.notification.reminderNotificationChannel)
-                    .WithRecipientOverrides([
+                    .WithCustomRecipients([
                         CorrespondenceNotificationOverrideBuilder
                             .Create()
                             .WithOrganizationNumber(data.recipient.Value)

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/CorrespondenceClientMappingTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/CorrespondenceClientMappingTests.cs
@@ -93,7 +93,7 @@ public class CorrespondenceClientMappingTests
                     .WithNotificationChannel(CorrespondenceNotificationChannel.EmailPreferred)
                     .WithReminderNotificationChannel(CorrespondenceNotificationChannel.SmsPreferred)
                     .WithSendersReference("notification-senders-ref")
-                    .WithRecipientOverrides([
+                    .WithCustomRecipients([
                         new CorrespondenceNotificationRecipient { EmailAddress = "override@example.com" },
                         new CorrespondenceNotificationRecipient { MobileNumber = "+4799999999" },
                     ])

--- a/test/Altinn.App.Core.Tests/Features/Correspondence/CorrespondenceClientMappingTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Correspondence/CorrespondenceClientMappingTests.cs
@@ -93,13 +93,10 @@ public class CorrespondenceClientMappingTests
                     .WithNotificationChannel(CorrespondenceNotificationChannel.EmailPreferred)
                     .WithReminderNotificationChannel(CorrespondenceNotificationChannel.SmsPreferred)
                     .WithSendersReference("notification-senders-ref")
-                    .WithRecipientOverride(
-                        CorrespondenceNotificationOverrideBuilder
-                            .Create()
-                            .WithEmailAddress("override@example.com")
-                            .WithMobileNumber("+4799999999")
-                            .Build()
-                    )
+                    .WithRecipientOverrides([
+                        new CorrespondenceNotificationRecipient { EmailAddress = "override@example.com" },
+                        new CorrespondenceNotificationRecipient { MobileNumber = "+4799999999" },
+                    ])
             )
             .WithExistingAttachment(existingAttachmentId)
             .Build();
@@ -187,9 +184,15 @@ public class CorrespondenceClientMappingTests
         notification.GetProperty("reminderNotificationChannel").GetString().Should().Be("SmsPreferred");
         notification.GetProperty("sendersReference").GetString().Should().Be("notification-senders-ref");
 
-        var customRecipient = notification.GetProperty("customRecipient");
-        customRecipient.GetProperty("emailAddress").GetString().Should().Be("override@example.com");
-        customRecipient.GetProperty("mobileNumber").GetString().Should().Be("+4799999999");
+        // The deprecated singular customRecipient is no longer emitted; recipients are sent as the plural
+        // customRecipients array with exactly one identifier per entry.
+        notification.TryGetProperty("customRecipient", out _).Should().BeFalse();
+        var customRecipients = notification.GetProperty("customRecipients");
+        customRecipients.GetArrayLength().Should().Be(2);
+        customRecipients[0].GetProperty("emailAddress").GetString().Should().Be("override@example.com");
+        customRecipients[0].TryGetProperty("mobileNumber", out _).Should().BeFalse();
+        customRecipients[1].GetProperty("mobileNumber").GetString().Should().Be("+4799999999");
+        customRecipients[1].TryGetProperty("emailAddress", out _).Should().BeFalse();
     }
 
     [Fact]

--- a/test/Altinn.App.Core.Tests/Features/Signing/Helpers/SigningNotificationHelpers.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/Helpers/SigningNotificationHelpers.cs
@@ -1,5 +1,8 @@
+using Altinn.App.Core.Features.Correspondence.Models;
 using Altinn.App.Core.Features.Signing;
 using Altinn.App.Core.Features.Signing.Helpers;
+using Altinn.App.Core.Features.Signing.Models;
+using Altinn.App.Core.Models;
 
 namespace Altinn.App.Core.Tests.Features.Signing.Helpers;
 
@@ -65,5 +68,122 @@ public class SigningNotificationHelpers
             NotificationChoice.None,
             SigningNotificationHelper.GetNotificationChoiceIfNotSet(notificationWithNone)
         );
+    }
+
+    [Fact]
+    public void GetNotificationChoiceIfNotSet_InfersFromBlockPresence_NotPopulatedAddresses()
+    {
+        // Declaring a block (even without an explicit address) expresses intent to notify on that channel; the
+        // contact is resolved from the registry for the default correspondence recipient.
+        Notification emailAndSmsBlocks = new() { Email = new Email(), Sms = new Sms() };
+        Notification emailBlockOnly = new() { Email = new Email() };
+        Notification smsBlockOnly = new() { Sms = new Sms() };
+
+        Assert.Equal(
+            NotificationChoice.SmsAndEmail,
+            SigningNotificationHelper.GetNotificationChoiceIfNotSet(emailAndSmsBlocks)
+        );
+        Assert.Equal(NotificationChoice.Email, SigningNotificationHelper.GetNotificationChoiceIfNotSet(emailBlockOnly));
+        Assert.Equal(NotificationChoice.Sms, SigningNotificationHelper.GetNotificationChoiceIfNotSet(smsBlockOnly));
+    }
+
+    [Fact]
+    public void CreateNotification_SmsAndEmail_WithBothOverrides_CreatesOneRecipientPerMethod()
+    {
+        // Arrange
+        ContentWrapper cw = BuildContentWrapper(
+            NotificationChoice.SmsAndEmail,
+            new Notification
+            {
+                Email = new Email { EmailAddress = "test@test.no" },
+                Sms = new Sms { MobileNumber = "12345678" },
+            }
+        );
+
+        // Act
+        CorrespondenceNotification? notification = SigningNotificationHelper.CreateNotification(cw);
+
+        // Assert
+        Assert.NotNull(notification);
+        Assert.Equal(CorrespondenceNotificationChannel.EmailAndSms, notification.NotificationChannel);
+        Assert.NotNull(notification.CustomRecipients);
+        Assert.Equal(2, notification.CustomRecipients!.Count);
+
+        Assert.Equal("test@test.no", notification.CustomRecipients[0].EmailAddress);
+        Assert.Null(notification.CustomRecipients[0].MobileNumber);
+
+        Assert.Equal("12345678", notification.CustomRecipients[1].MobileNumber);
+        Assert.Null(notification.CustomRecipients[1].EmailAddress);
+    }
+
+    [Fact]
+    public void CreateNotification_Email_WithOverrides_DoesNotLeakMobileIntoEmailNotification()
+    {
+        // Arrange - both contact methods are provided, but the choice is email only
+        ContentWrapper cw = BuildContentWrapper(
+            NotificationChoice.Email,
+            new Notification
+            {
+                Email = new Email { EmailAddress = "test@test.no" },
+                Sms = new Sms { MobileNumber = "12345678" },
+            }
+        );
+
+        // Act
+        CorrespondenceNotification? notification = SigningNotificationHelper.CreateNotification(cw);
+
+        // Assert
+        Assert.NotNull(notification);
+        Assert.Equal(CorrespondenceNotificationChannel.Email, notification.NotificationChannel);
+        Assert.NotNull(notification.CustomRecipients);
+        CorrespondenceNotificationRecipient recipient = Assert.Single(notification.CustomRecipients!);
+        Assert.Equal("test@test.no", recipient.EmailAddress);
+        Assert.Null(recipient.MobileNumber);
+    }
+
+    [Fact]
+    public void CreateNotification_WithoutContactOverride_DoesNotSetCustomRecipients()
+    {
+        // Arrange - no explicit contact overrides; delivery falls back to the correspondence recipient
+        ContentWrapper cw = BuildContentWrapper(NotificationChoice.SmsAndEmail, notification: null);
+
+        // Act
+        CorrespondenceNotification? notification = SigningNotificationHelper.CreateNotification(cw);
+
+        // Assert
+        Assert.NotNull(notification);
+        Assert.Equal(CorrespondenceNotificationChannel.EmailAndSms, notification.NotificationChannel);
+        Assert.Null(notification.CustomRecipients);
+    }
+
+    [Fact]
+    public void CreateNotification_None_DoesNotSetCustomRecipients()
+    {
+        // Arrange
+        ContentWrapper cw = BuildContentWrapper(NotificationChoice.None, notification: null);
+
+        // Act
+        CorrespondenceNotification? notification = SigningNotificationHelper.CreateNotification(cw);
+
+        // Assert
+        Assert.NotNull(notification);
+        Assert.Null(notification.CustomRecipients);
+    }
+
+    private static ContentWrapper BuildContentWrapper(NotificationChoice choice, Notification? notification)
+    {
+        return new ContentWrapper
+        {
+            CorrespondenceContent = new CorrespondenceContent
+            {
+                Title = "title",
+                Language = LanguageCode<Iso6391>.Parse("nb"),
+                Summary = "summary",
+                Body = "body",
+            },
+            SendersReference = "senders-ref",
+            NotificationChoice = choice,
+            Notification = notification,
+        };
     }
 }

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigneeContextsManagerTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigneeContextsManagerTests.cs
@@ -241,8 +241,11 @@ public sealed class SigneeContextsManagerTests : IDisposable
             {
                 Notification = new Notification
                 {
-                    Email = new EmailModel { }, // Empty to test auto-fill from Party
-                    Sms = new SmsModel { }, // Empty to test auto-fill from Party
+                    // Empty blocks: contact info is NOT auto-filled from the registry anymore. The notification is
+                    // sent to the default correspondence recipient (the signee), resolved via the registry by
+                    // Correspondence itself, so the addresses remain empty here.
+                    Email = new EmailModel { },
+                    Sms = new SmsModel { },
                 },
             },
         };
@@ -276,10 +279,12 @@ public sealed class SigneeContextsManagerTests : IDisposable
 
         Assert.NotNull(context.CommunicationConfig);
         Assert.NotNull(context.CommunicationConfig.Notification);
+        // The declared blocks are preserved (expressing intent to notify on those channels), but the contact info is
+        // left unset - it is no longer enriched from the registry.
         Assert.NotNull(context.CommunicationConfig.Notification.Email);
-        Assert.Equal("test@org.com", context.CommunicationConfig.Notification.Email.EmailAddress);
+        Assert.True(string.IsNullOrEmpty(context.CommunicationConfig.Notification.Email.EmailAddress));
         Assert.NotNull(context.CommunicationConfig.Notification.Sms);
-        Assert.Equal("87654321", context.CommunicationConfig.Notification.Sms.MobileNumber);
+        Assert.True(string.IsNullOrEmpty(context.CommunicationConfig.Notification.Sms.MobileNumber));
     }
 
     [Fact]

--- a/test/Altinn.App.Core.Tests/Features/Signing/SigningCallToActionServiceTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Signing/SigningCallToActionServiceTests.cs
@@ -659,4 +659,152 @@ public class SigningCallToActionServiceTests(ITestOutputHelper output)
         Assert.NotNull(result.EmailSubject);
         Assert.Contains(expectedBodyContains, result.Body);
     }
+
+    /// <summary>
+    /// Regression test for the double-notification bug: when the app declares notification channels but provides no
+    /// explicit contact info, no custom recipients are sent. The signee is then notified exactly once — via the
+    /// default correspondence recipient (resolved through the registry by Correspondence).
+    /// </summary>
+    [Fact]
+    public async Task SendSignCallToAction_NoExplicitContact_DoesNotAddCustomRecipients()
+    {
+        // Arrange
+        SendCorrespondencePayload? capturedPayload = null;
+        Mock<ICorrespondenceClient> correspondenceClientMock = new();
+        correspondenceClientMock
+            .Setup(m => m.Send(It.IsAny<SendCorrespondencePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<SendCorrespondencePayload, CancellationToken>((payload, _) => capturedPayload = payload);
+
+        Mock<IHostEnvironment> hostEnvironmentMock = new();
+        hostEnvironmentMock.Setup(m => m.EnvironmentName).Returns("tt02");
+        Mock<IAppMetadata> appMetadataMock = new();
+        appMetadataMock
+            .Setup(m => m.GetApplicationMetadata())
+            .ReturnsAsync(new ApplicationMetadata("org/app") { Title = new() { { LanguageConst.Nb, "TestAppName" } } });
+
+        SigningCallToActionService service = SetupService(
+            correspondenceClientMockOverride: correspondenceClientMock,
+            appMetadataMockOverride: appMetadataMock,
+            hostEnvironmentMockOverride: hostEnvironmentMock
+        );
+
+        // Both channels requested, but no explicit address/number (these would previously be registry-enriched).
+        CommunicationConfig communicationConfig = new()
+        {
+            Notification = new Notification { Email = new Email(), Sms = new Sms() },
+        };
+
+        var ssn = GetSsn(2);
+        Party signingParty = new() { Name = "Signee", SSN = ssn };
+        Party serviceOwnerParty = new() { Name = "Service owner", OrgNumber = GetOrgNumber(2) };
+        List<AltinnEnvironmentConfig> correspondenceResources =
+        [
+            new() { Environment = "tt02", Value = "app_ttd_appname" },
+        ];
+
+        // Act
+        await service.SendSignCallToAction(
+            communicationConfig,
+            new AppIdentifier("org", "app"),
+            new InstanceIdentifier(123, Guid.Parse("ab0cdeb5-dc5e-4faa-966b-d18bb932ca07")),
+            signingParty,
+            serviceOwnerParty,
+            correspondenceResources,
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.NotNull(capturedPayload);
+        // The signee is the single (default) correspondence recipient...
+        Assert.Single(capturedPayload.CorrespondenceRequest.Recipients);
+        Assert.True(ssn == capturedPayload.CorrespondenceRequest.Recipients[0]);
+        // ...and is NOT additionally added as a custom recipient (which would double-notify the signee).
+        Assert.Null(capturedPayload.CorrespondenceRequest.Notification!.CustomRecipients);
+        // Channel is inferred from the declared notification blocks.
+        Assert.Equal(
+            CorrespondenceNotificationChannel.EmailAndSms,
+            capturedPayload.CorrespondenceRequest.Notification.NotificationChannel
+        );
+    }
+
+    /// <summary>
+    /// When the app provides explicit contact info for multiple channels, each becomes its own custom recipient with
+    /// exactly one identifier — never a single recipient carrying multiple identifiers (which the Correspondence API
+    /// rejects with "Custom recipient with multiple identifiers is not allowed").
+    /// </summary>
+    [Fact]
+    public async Task SendSignCallToAction_ExplicitEmailAndMobile_AddsOneSingleIdentifierRecipientPerMethod()
+    {
+        // Arrange
+        SendCorrespondencePayload? capturedPayload = null;
+        Mock<ICorrespondenceClient> correspondenceClientMock = new();
+        correspondenceClientMock
+            .Setup(m => m.Send(It.IsAny<SendCorrespondencePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<SendCorrespondencePayload, CancellationToken>((payload, _) => capturedPayload = payload);
+
+        Mock<IHostEnvironment> hostEnvironmentMock = new();
+        hostEnvironmentMock.Setup(m => m.EnvironmentName).Returns("tt02");
+        Mock<IAppMetadata> appMetadataMock = new();
+        appMetadataMock
+            .Setup(m => m.GetApplicationMetadata())
+            .ReturnsAsync(new ApplicationMetadata("org/app") { Title = new() { { LanguageConst.Nb, "TestAppName" } } });
+
+        SigningCallToActionService service = SetupService(
+            correspondenceClientMockOverride: correspondenceClientMock,
+            appMetadataMockOverride: appMetadataMock,
+            hostEnvironmentMockOverride: hostEnvironmentMock
+        );
+
+        CommunicationConfig communicationConfig = new()
+        {
+            Notification = new Notification
+            {
+                Email = new Email { EmailAddress = "explicit@test.no" },
+                Sms = new Sms { MobileNumber = "99887766" },
+            },
+            NotificationChoice = NotificationChoice.SmsAndEmail,
+        };
+
+        Party signingParty = new() { Name = "Signee", SSN = GetSsn(3) };
+        Party serviceOwnerParty = new() { Name = "Service owner", OrgNumber = GetOrgNumber(3) };
+        List<AltinnEnvironmentConfig> correspondenceResources =
+        [
+            new() { Environment = "tt02", Value = "app_ttd_appname" },
+        ];
+
+        // Act
+        await service.SendSignCallToAction(
+            communicationConfig,
+            new AppIdentifier("org", "app"),
+            new InstanceIdentifier(123, Guid.Parse("ab0cdeb5-dc5e-4faa-966b-d18bb932ca07")),
+            signingParty,
+            serviceOwnerParty,
+            correspondenceResources,
+            CancellationToken.None
+        );
+
+        // Assert
+        Assert.NotNull(capturedPayload);
+        IReadOnlyList<CorrespondenceNotificationRecipient>? customRecipients = capturedPayload
+            .CorrespondenceRequest
+            .Notification!
+            .CustomRecipients;
+        Assert.NotNull(customRecipients);
+        Assert.Equal(2, customRecipients!.Count);
+        // Each entry carries exactly one identifier.
+        Assert.All(
+            customRecipients,
+            r =>
+            {
+                int identifierCount =
+                    (r.EmailAddress is not null ? 1 : 0)
+                    + (r.MobileNumber is not null ? 1 : 0)
+                    + (r.OrganizationNumber is not null ? 1 : 0)
+                    + (r.NationalIdentityNumber is not null ? 1 : 0);
+                Assert.Equal(1, identifierCount);
+            }
+        );
+        Assert.Contains(customRecipients, r => r.EmailAddress == "explicit@test.no");
+        Assert.Contains(customRecipients, r => r.MobileNumber == "99887766");
+    }
 }

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -471,12 +471,20 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithEmailSubject(string? emailSubject) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? notificationChannel) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithNotificationTemplate(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationTemplate notificationTemplate) { }
+        [System.Obsolete("Use WithRecipientOverrides instead. A single recipient with multiple identifiers " +
+            "is no longer accepted by the Correspondence API.")]
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationOverrideBuilder recipientOverrideBuilder) { }
+        [System.Obsolete("Use WithRecipientOverrides instead. A single recipient with multiple identifiers " +
+            "is no longer accepted by the Correspondence API.")]
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient recipientOverride) { }
         [System.Obsolete("Use WithRecipientOverride(CorrespondenceNotificationRecipient recipientOverride) " +
             "instead.")]
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipientWrapper recipientToOverrideWrapper) { }
+        [System.Obsolete("Use WithRecipientOverridesIfConfigured instead. A single recipient with multiple " +
+            "identifiers is no longer accepted by the Correspondence API.")]
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverrideIfConfigured(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient? recipientOverride) { }
+        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverrides(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient> recipientOverrides) { }
+        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverridesIfConfigured(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient>? recipientOverrides) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailBody(string? reminderEmailBody) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailSubject(string? reminderEmailSubject) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? reminderNotificationChannel) { }
@@ -612,11 +620,17 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithEmailBody(string? emailBody);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithEmailSubject(string? emailSubject);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? notificationChannel);
+        [System.Obsolete("Use WithRecipientOverrides instead. A single recipient with multiple identifiers " +
+            "is no longer accepted by the Correspondence API.")]
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationOverrideBuilder recipientOverrideBuilder);
+        [System.Obsolete("Use WithRecipientOverrides instead. A single recipient with multiple identifiers " +
+            "is no longer accepted by the Correspondence API.")]
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient recipientOverride);
         [System.Obsolete("Use WithRecipientOverride(CorrespondenceNotificationRecipient recipientOverride) " +
             "instead.")]
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipientWrapper recipientToOverrideWrapper);
+        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverrides(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient> recipientOverrides);
+        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverridesIfConfigured(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient>? recipientOverrides);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailBody(string? reminderEmailBody);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailSubject(string? reminderEmailSubject);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? reminderNotificationChannel);
@@ -869,9 +883,14 @@ namespace Altinn.App.Core.Features.Correspondence.Models
     {
         public CorrespondenceNotification() { }
         [System.Obsolete("This property is deprecated and will be removed in a future version. Use CustomRe" +
-            "cipient instead.")]
+            "cipients instead.")]
         public System.Collections.Generic.IReadOnlyList<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipientWrapper>? CustomNotificationRecipients { get; init; }
+        [System.Obsolete("This property is deprecated and will be removed in a future version. Use CustomRe" +
+            "cipients instead. A single recipient with multiple identifiers is no longer acce" +
+            "pted by the Correspondence API and will be split into one recipient per identifi" +
+            "er.")]
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient? CustomRecipient { get; init; }
+        public System.Collections.Generic.IReadOnlyList<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient>? CustomRecipients { get; init; }
         [System.ComponentModel.DataAnnotations.StringLength(10000, MinimumLength=0)]
         public string? EmailBody { get; init; }
         [System.ComponentModel.DataAnnotations.StringLength(128, MinimumLength=0)]
@@ -899,6 +918,7 @@ namespace Altinn.App.Core.Features.Correspondence.Models
         Sms = 1,
         EmailPreferred = 2,
         SmsPreferred = 3,
+        EmailAndSms = 4,
     }
     public sealed class CorrespondenceNotificationDetailsResponse : System.IEquatable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationDetailsResponse>
     {

--- a/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
+++ b/test/Altinn.App.Core.Tests/PublicApiTests.PublicApi_ShouldNotChange_Unintentionally.verified.txt
@@ -467,24 +467,24 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
     public class CorrespondenceNotificationBuilder : Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder, Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilderTemplate
     {
         public Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotification Build() { }
+        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithCustomRecipients(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient> customRecipients) { }
+        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithCustomRecipientsIfConfigured(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient>? customRecipients) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithEmailBody(string? emailBody) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithEmailSubject(string? emailSubject) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? notificationChannel) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithNotificationTemplate(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationTemplate notificationTemplate) { }
-        [System.Obsolete("Use WithRecipientOverrides instead. A single recipient with multiple identifiers " +
-            "is no longer accepted by the Correspondence API.")]
+        [System.Obsolete("Use WithCustomRecipients instead. A single recipient with multiple identifiers is" +
+            " no longer accepted by the Correspondence API.")]
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationOverrideBuilder recipientOverrideBuilder) { }
-        [System.Obsolete("Use WithRecipientOverrides instead. A single recipient with multiple identifiers " +
-            "is no longer accepted by the Correspondence API.")]
+        [System.Obsolete("Use WithCustomRecipients instead. A single recipient with multiple identifiers is" +
+            " no longer accepted by the Correspondence API.")]
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient recipientOverride) { }
         [System.Obsolete("Use WithRecipientOverride(CorrespondenceNotificationRecipient recipientOverride) " +
             "instead.")]
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipientWrapper recipientToOverrideWrapper) { }
-        [System.Obsolete("Use WithRecipientOverridesIfConfigured instead. A single recipient with multiple " +
-            "identifiers is no longer accepted by the Correspondence API.")]
+        [System.Obsolete("Use WithCustomRecipientsIfConfigured instead. A single recipient with multiple id" +
+            "entifiers is no longer accepted by the Correspondence API.")]
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverrideIfConfigured(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient? recipientOverride) { }
-        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverrides(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient> recipientOverrides) { }
-        public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverridesIfConfigured(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient>? recipientOverrides) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailBody(string? reminderEmailBody) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailSubject(string? reminderEmailSubject) { }
         public Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? reminderNotificationChannel) { }
@@ -617,20 +617,20 @@ namespace Altinn.App.Core.Features.Correspondence.Builder
     public interface ICorrespondenceNotificationBuilder : Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilderTemplate
     {
         Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotification Build();
+        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithCustomRecipients(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient> customRecipients);
+        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithCustomRecipientsIfConfigured(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient>? customRecipients);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithEmailBody(string? emailBody);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithEmailSubject(string? emailSubject);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? notificationChannel);
-        [System.Obsolete("Use WithRecipientOverrides instead. A single recipient with multiple identifiers " +
-            "is no longer accepted by the Correspondence API.")]
+        [System.Obsolete("Use WithCustomRecipients instead. A single recipient with multiple identifiers is" +
+            " no longer accepted by the Correspondence API.")]
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationOverrideBuilder recipientOverrideBuilder);
-        [System.Obsolete("Use WithRecipientOverrides instead. A single recipient with multiple identifiers " +
-            "is no longer accepted by the Correspondence API.")]
+        [System.Obsolete("Use WithCustomRecipients instead. A single recipient with multiple identifiers is" +
+            " no longer accepted by the Correspondence API.")]
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient recipientOverride);
         [System.Obsolete("Use WithRecipientOverride(CorrespondenceNotificationRecipient recipientOverride) " +
             "instead.")]
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverride(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipientWrapper recipientToOverrideWrapper);
-        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverrides(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient> recipientOverrides);
-        Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithRecipientOverridesIfConfigured(System.Collections.Generic.IEnumerable<Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationRecipient>? recipientOverrides);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailBody(string? reminderEmailBody);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderEmailSubject(string? reminderEmailSubject);
         Altinn.App.Core.Features.Correspondence.Builder.ICorrespondenceNotificationBuilder WithReminderNotificationChannel(Altinn.App.Core.Features.Correspondence.Models.CorrespondenceNotificationChannel? reminderNotificationChannel);


### PR DESCRIPTION
## Why

Runtime-delegated signing notifications started failing in TT02 with `Correspondence request failed with status BadRequest: Custom recipient with multiple identifiers is not allowed` ("Varsling mislyktes" next to the signee).

The Correspondence API now:
- rejects a custom notification recipient that carries **more than one** identifier, and
- deprecates the singular `customRecipient` in favour of the plural **`customRecipients`** array, where each entry must carry **exactly one** of email / mobile / org number / national id.

Two problems in our code:
1. `SigningNotificationHelper` packed `email + mobile` into a single recipient → 400.
2. `customRecipients` are notified **in addition to** the default correspondence recipient (the signee, resolved via KRR). We were enriching the override with the signee's *own* registry contact info, so the signee would be **notified twice**.

Fixes #1807 (Altinn/altinn-studio#19153). Under the umbrella Altinn/altinn-studio#17410; complements Altinn/altinn-studio#17407.

## What changed

**Correspondence client / builder / model**
- Added `EmailAndSms` to `CorrespondenceNotificationChannel` (matches the API enum).
- Added plural `CustomRecipients` to the public model, builder (`WithRecipientOverrides` / `WithRecipientOverridesIfConfigured`) and wire DTO.
- Marked the singular `CustomRecipient` / `WithRecipientOverride` API `[Obsolete]` — kept binary-compatible.
- `CorrespondenceClient` now sends `customRecipients`, **exploding** any recipient (new plural or legacy singular) into one single-identifier entry per populated field. The deprecated singular wire field is no longer emitted.

**Signing**
- `SigningNotificationHelper.CreateNotification` builds one recipient per app-provided contact method, maps `SmsAndEmail` → `EmailAndSms`, and omits the override entirely when no explicit contact is given.
- Removed registry contact-info enrichment in `SigneeContextsManager` (the source of the double-notification) — the default recipient is already notified via KRR.
- Notification channel is now inferred from the **presence of the `Email`/`Sms` config blocks** rather than from populated addresses.

## Behavioral note

Explicit app-supplied contact addresses are now **additional** notifications, not replacements of the signee's KRR contact (inherent to the additive Correspondence API; aligns with #17407). Worth a heads-up for service owners.

## Tests
- Updated mapping/builder/manager tests; added `CreateNotification` + block-presence coverage; regenerated the public-API snapshot.
- Added `SigningCallToActionService` regression tests: signee notified exactly once (no `customRecipients` when no explicit contact), and one single-identifier recipient per method when explicit email+mobile are given.
- All Core tests pass (2572), clean build.

## Follow-ups
- [ ] **Docs**: update the [runtime-delegated-signing guide](https://docs.altinn.studio/en/altinn-studio/v8/guides/development/signing/runtime-delegated-signing/) (step 6 "customize who to notify") and the Correspondence notifications guide — additive custom recipients, no registry enrichment in app-lib, `EmailAndSms`, and the obsolete singular API. (altinn-studio docs repo)
- [ ] **End-to-end coverage** (optional): the regression above is asserted at the service layer because the integration-test localtest environment does not stub the Correspondence API and there is no signing test app. A true integration test would require adding a correspondence stub endpoint + signing app first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)