### PR TITLE
fix: poll app secret config files

### DIFF
--- a/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
+++ b/src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs
@@ -114,7 +114,7 @@ public static class WebHostBuilderExtensions
             }
 
             configBuilder.AddJsonFile(
-                provider: secretsFileProvider ??= new PhysicalFileProvider(secretsDirectory),
+                provider: secretsFileProvider ??= CreateRuntimeSecretsFileProvider(secretsDirectory),
                 path: jsonFileName,
                 optional: true,
                 reloadOnChange: true
@@ -136,11 +136,20 @@ public static class WebHostBuilderExtensions
             }
 
             configBuilder.AddJsonFile(
-                provider: secretsFileProvider ??= new PhysicalFileProvider(secretsDirectory),
+                provider: secretsFileProvider ??= CreateRuntimeSecretsFileProvider(secretsDirectory),
                 path: jsonFileName,
                 optional: true,
                 reloadOnChange: true
             );
         }
     }
+
+    private static PhysicalFileProvider CreateRuntimeSecretsFileProvider(string secretsDirectory) =>
+        new(secretsDirectory)
+        {
+            // This path is normally a Kubernetes Secret/projected volume. Kubernetes updates it by swapping
+            // the ..data symlink target, so polling is required to detect credential changes reliably.
+            UsePollingFileWatcher = true,
+            UseActivePolling = true,
+        };
 }

--- a/src/Altinn.App.Core/Features/Maskinporten/Extensions/WebHostBuilderExtensions.cs
+++ b/src/Altinn.App.Core/Features/Maskinporten/Extensions/WebHostBuilderExtensions.cs
@@ -16,19 +16,36 @@ internal static class WebHostBuilderExtensions
         string jsonProvidedPath = context.Configuration.GetValue<string>(configurationKey) ?? defaultFileLocation;
         string jsonAbsolutePath = Path.GetFullPath(jsonProvidedPath);
 
-        if (File.Exists(jsonAbsolutePath))
-        {
-            string jsonDir = Path.GetDirectoryName(jsonAbsolutePath) ?? string.Empty;
-            string jsonFile = Path.GetFileName(jsonAbsolutePath);
-
-            configurationBuilder.AddJsonFile(
-                provider: new PhysicalFileProvider(jsonDir),
-                path: jsonFile,
-                optional: true,
-                reloadOnChange: true
-            );
-        }
+        string jsonDir = Path.GetDirectoryName(jsonAbsolutePath) ?? string.Empty;
+        string providerRoot = GetExistingProviderRoot(jsonDir);
+        string jsonFile = Path.GetRelativePath(providerRoot, jsonAbsolutePath);
+        configurationBuilder.AddJsonFile(
+            provider: CreateAppSecretsFileProvider(providerRoot),
+            path: jsonFile,
+            optional: true,
+            reloadOnChange: true
+        );
 
         return configurationBuilder;
     }
+
+    internal static string GetExistingProviderRoot(string path)
+    {
+        string? currentPath = path;
+        while (!string.IsNullOrWhiteSpace(currentPath) && !Directory.Exists(currentPath))
+        {
+            currentPath = Path.GetDirectoryName(currentPath);
+        }
+
+        return currentPath ?? Path.GetPathRoot(path) ?? Directory.GetCurrentDirectory();
+    }
+
+    private static PhysicalFileProvider CreateAppSecretsFileProvider(string providerRoot) =>
+        new(providerRoot)
+        {
+            // This path is normally a Kubernetes Secret/projected volume. Kubernetes updates it by swapping
+            // the ..data symlink target, so polling is required to detect credential changes reliably.
+            UsePollingFileWatcher = true,
+            UseActivePolling = true,
+        };
 }

--- a/test/Altinn.App.Api.Tests/Extensions/WebHostBuilderExtensionsTests.cs
+++ b/test/Altinn.App.Api.Tests/Extensions/WebHostBuilderExtensionsTests.cs
@@ -55,6 +55,7 @@ public sealed class WebHostBuilderExtensionsTests
             new[] { "10-settings.json", "30-config.json", "20-OVERRIDE.json", "40-settings.override.json" },
             jsonSourcePaths
         );
+        Assert.All(configBuilder.Sources.OfType<JsonConfigurationSource>(), AssertUsesPollingFileProvider);
     }
 
     [Fact]
@@ -66,7 +67,7 @@ public sealed class WebHostBuilderExtensionsTests
         File.WriteAllText(Path.Join(tempDirectory.Path, "appsettings.override.json"), "{}");
 
         IConfigurationBuilder configBuilder = new ConfigurationBuilder();
-        var fileProvider = new PhysicalFileProvider(tempDirectory.Path);
+        using var fileProvider = new PhysicalFileProvider(tempDirectory.Path);
         configBuilder.AddJsonFile(
             provider: fileProvider,
             path: "maskinporten-settings.json",
@@ -95,6 +96,40 @@ public sealed class WebHostBuilderExtensionsTests
             Array.IndexOf(jsonSourcePaths, "appsettings.override.json")
                 > Array.IndexOf(jsonSourcePaths, "appsettings.json")
         );
+    }
+
+    [LinuxOnlyFact]
+    public async Task AddRuntimeConfigFiles_Production_ReloadsWhenKubernetesDataSymlinkChanges()
+    {
+        using var tempDirectory = new TempDirectory(_outputHelper);
+        const string fileName = "runtime-settings.json";
+        var projectedVolume = new KubernetesProjectedVolume(tempDirectory.Path);
+        projectedVolume.WriteVersion(
+            KubernetesProjectedVolume.InitialVersionDirectoryName,
+            fileName,
+            CreateRuntimeSettingsJson("before")
+        );
+        projectedVolume.CreateSymlinks(KubernetesProjectedVolume.InitialVersionDirectoryName, fileName);
+
+        IConfigurationBuilder configBuilder = new ConfigurationBuilder();
+        WebHostBuilderExtensions.AddRuntimeConfigFiles(
+            configBuilder,
+            new TestHostEnvironment(Environments.Production),
+            tempDirectory.Path
+        );
+
+        var configuration = configBuilder.Build();
+        using var configurationDisposable = configuration as IDisposable;
+        Assert.Equal("before", configuration["RuntimeSettings:Value"]);
+
+        projectedVolume.WriteVersion(
+            KubernetesProjectedVolume.UpdatedVersionDirectoryName,
+            fileName,
+            CreateRuntimeSettingsJson("after")
+        );
+        projectedVolume.SwapDataSymlink(KubernetesProjectedVolume.UpdatedVersionDirectoryName);
+
+        await Wait.Until(() => configuration["RuntimeSettings:Value"] == "after", TimeSpan.FromSeconds(15));
     }
 
     [Fact]
@@ -195,6 +230,24 @@ public sealed class WebHostBuilderExtensionsTests
 
         public IFileProvider ContentRootFileProvider { get; set; } = new PhysicalFileProvider(AppContext.BaseDirectory);
     }
+
+    private static void AssertUsesPollingFileProvider(JsonConfigurationSource source)
+    {
+        var fileProvider = Assert.IsType<PhysicalFileProvider>(source.FileProvider);
+        Assert.True(source.Optional);
+        Assert.True(source.ReloadOnChange);
+        Assert.True(fileProvider.UsePollingFileWatcher);
+        Assert.True(fileProvider.UseActivePolling);
+    }
+
+    private static string CreateRuntimeSettingsJson(string value) =>
+        $$"""
+            {
+              "RuntimeSettings": {
+                "Value": "{{value}}"
+              }
+            }
+            """;
 
     private readonly struct TempDirectory : IDisposable
     {

--- a/test/Altinn.App.Core.Tests/Features/Maskinporten/Extensions/WebHostBuilderExtensionsTests.cs
+++ b/test/Altinn.App.Core.Tests/Features/Maskinporten/Extensions/WebHostBuilderExtensionsTests.cs
@@ -1,0 +1,164 @@
+using Altinn.App.Core.Features.Maskinporten.Extensions;
+using Altinn.App.Core.Features.Maskinporten.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using MaskinportenWebHostBuilderExtensions = Altinn.App.Core.Features.Maskinporten.Extensions.WebHostBuilderExtensions;
+
+namespace Altinn.App.Core.Tests.Features.Maskinporten.Extensions;
+
+public sealed class WebHostBuilderExtensionsTests
+{
+    private const string ConfigurationKey = "MaskinportenSettingsFilepath";
+    private const string SettingsFileName = "maskinporten-settings.json";
+
+    [Fact]
+    public void AddMaskinportenSettingsFile_RegistersOptionalPollingSource_WhenFileDoesNotExist()
+    {
+        using var tempDirectory = new TempDirectory();
+        string settingsPath = Path.Join(tempDirectory.Path, SettingsFileName);
+        var configBuilder = new ConfigurationBuilder();
+
+        configBuilder.AddMaskinportenSettingsFile(CreateContext(settingsPath), ConfigurationKey, settingsPath);
+
+        var source = Assert.Single(configBuilder.Sources.OfType<JsonConfigurationSource>());
+        var fileProvider = Assert.IsType<PhysicalFileProvider>(source.FileProvider);
+        Assert.Equal(SettingsFileName, source.Path);
+        Assert.True(source.Optional);
+        Assert.True(source.ReloadOnChange);
+        Assert.True(fileProvider.UsePollingFileWatcher);
+        Assert.True(fileProvider.UseActivePolling);
+    }
+
+    [Fact]
+    public void GetExistingProviderRoot_ReturnsPath_WhenDirectoryExists()
+    {
+        using var tempDirectory = new TempDirectory();
+
+        string providerRoot = MaskinportenWebHostBuilderExtensions.GetExistingProviderRoot(tempDirectory.Path);
+
+        Assert.Equal(tempDirectory.Path, providerRoot);
+    }
+
+    [Fact]
+    public void GetExistingProviderRoot_ReturnsNearestExistingParent_WhenDirectoryDoesNotExist()
+    {
+        using var tempDirectory = new TempDirectory();
+        string missingDirectory = Path.Join(tempDirectory.Path, "missing", "app-secrets");
+
+        string providerRoot = MaskinportenWebHostBuilderExtensions.GetExistingProviderRoot(missingDirectory);
+
+        Assert.Equal(tempDirectory.Path, providerRoot);
+    }
+
+    [Fact]
+    public void AddMaskinportenSettingsFile_RegistersOptionalPollingSource_WhenDirectoryDoesNotExist()
+    {
+        using var tempDirectory = new TempDirectory();
+        string settingsPath = Path.Join(tempDirectory.Path, "missing", SettingsFileName);
+        var configBuilder = new ConfigurationBuilder();
+
+        configBuilder.AddMaskinportenSettingsFile(CreateContext(settingsPath), ConfigurationKey, settingsPath);
+
+        var source = Assert.Single(configBuilder.Sources.OfType<JsonConfigurationSource>());
+        var fileProvider = Assert.IsType<PhysicalFileProvider>(source.FileProvider);
+        Assert.Equal(Path.Join("missing", SettingsFileName), source.Path);
+        Assert.True(source.Optional);
+        Assert.True(source.ReloadOnChange);
+        Assert.True(fileProvider.UsePollingFileWatcher);
+        Assert.True(fileProvider.UseActivePolling);
+    }
+
+    [LinuxOnlyFact]
+    public async Task AddMaskinportenSettingsFile_LoadsFile_WhenDirectoryAppearsLater()
+    {
+        using var tempDirectory = new TempDirectory();
+        string settingsDirectory = Path.Join(tempDirectory.Path, "missing");
+        string settingsPath = Path.Join(settingsDirectory, SettingsFileName);
+        var configBuilder = new ConfigurationBuilder();
+        configBuilder.AddMaskinportenSettingsFile(CreateContext(settingsPath), ConfigurationKey, settingsPath);
+
+        var configuration = configBuilder.Build();
+        using var configurationDisposable = configuration as IDisposable;
+
+        Directory.CreateDirectory(settingsDirectory);
+        await File.WriteAllTextAsync(settingsPath, CreateSettingsJson("client-after"));
+
+        await Wait.Until(
+            () => configuration["MaskinportenSettings:clientId"] == "client-after",
+            TimeSpan.FromSeconds(15)
+        );
+    }
+
+    [LinuxOnlyFact]
+    public async Task AddMaskinportenSettingsFile_ReloadsOptions_WhenKubernetesDataSymlinkChanges()
+    {
+        using var tempDirectory = new TempDirectory();
+        var projectedVolume = new KubernetesProjectedVolume(tempDirectory.Path);
+        projectedVolume.WriteVersion(
+            KubernetesProjectedVolume.InitialVersionDirectoryName,
+            SettingsFileName,
+            CreateSettingsJson("client-before")
+        );
+        projectedVolume.CreateSymlinks(KubernetesProjectedVolume.InitialVersionDirectoryName, SettingsFileName);
+
+        string settingsPath = Path.Join(tempDirectory.Path, SettingsFileName);
+        var configBuilder = new ConfigurationBuilder();
+        configBuilder.AddMaskinportenSettingsFile(CreateContext(settingsPath), ConfigurationKey, settingsPath);
+
+        var configuration = configBuilder.Build();
+        using var configurationDisposable = configuration as IDisposable;
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.ConfigureMaskinportenClient("MaskinportenSettings");
+
+        await using var serviceProvider = services.BuildStrictServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptionsMonitor<MaskinportenSettings>>();
+        Assert.Equal("client-before", options.CurrentValue.ClientId);
+
+        projectedVolume.WriteVersion(
+            KubernetesProjectedVolume.UpdatedVersionDirectoryName,
+            SettingsFileName,
+            CreateSettingsJson("client-after")
+        );
+        projectedVolume.SwapDataSymlink(KubernetesProjectedVolume.UpdatedVersionDirectoryName);
+
+        await Wait.Until(() => options.CurrentValue.ClientId == "client-after", TimeSpan.FromSeconds(15));
+    }
+
+    private static WebHostBuilderContext CreateContext(string settingsPath) =>
+        new()
+        {
+            Configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection([new KeyValuePair<string, string?>(ConfigurationKey, settingsPath)])
+                .Build(),
+        };
+
+    private static string CreateSettingsJson(string clientId) =>
+        $$"""
+            {
+              "MaskinportenSettings": {
+                "authority": "https://test.maskinporten.no/",
+                "clientId": "{{clientId}}"
+              }
+            }
+            """;
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory() => Path = Directory.CreateTempSubdirectory().FullName;
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/test/Altinn.App.Tests.Common/KubernetesProjectedVolume.cs
+++ b/test/Altinn.App.Tests.Common/KubernetesProjectedVolume.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace Altinn.App.Tests.Common;
+
+internal sealed class KubernetesProjectedVolume
+{
+    // Kubernetes writes Secret/projected volume payloads into timestamped hidden directories and keeps the
+    // visible files pointing through ..data. Updates are published by renaming the ..data_tmp symlink over ..data.
+    // The exact timestamp-like directory names below are representative fixtures; the symlink swap is the behavior under test.
+    public const string InitialVersionDirectoryName = "..2026_06_15_10_00_00.000000001";
+    public const string UpdatedVersionDirectoryName = "..2026_06_15_10_00_10.000000002";
+
+    private const string DataSymlinkName = "..data";
+
+    public KubernetesProjectedVolume(string path)
+    {
+        Assert.True(OperatingSystem.IsLinux(), $"{nameof(KubernetesProjectedVolume)} can only be used on Linux.");
+        Path = path;
+    }
+
+    public string Path { get; }
+
+    public void WriteVersion(string versionDirectoryName, string fileName, string content)
+    {
+        string versionDirectory = System.IO.Path.Join(Path, versionDirectoryName);
+        Directory.CreateDirectory(versionDirectory);
+        File.WriteAllText(System.IO.Path.Join(versionDirectory, fileName), content);
+    }
+
+    public void CreateSymlinks(string versionDirectoryName, string fileName)
+    {
+        Directory.CreateSymbolicLink(System.IO.Path.Join(Path, DataSymlinkName), versionDirectoryName);
+        File.CreateSymbolicLink(System.IO.Path.Join(Path, fileName), System.IO.Path.Join(DataSymlinkName, fileName));
+    }
+
+    public void SwapDataSymlink(string versionDirectoryName)
+    {
+        string dataLinkPath = System.IO.Path.Join(Path, DataSymlinkName);
+        string newDataLinkPath = System.IO.Path.Join(Path, $"{DataSymlinkName}_tmp");
+        Directory.CreateSymbolicLink(newDataLinkPath, versionDirectoryName);
+
+        using var process = Process.Start(
+            new ProcessStartInfo
+            {
+                FileName = "/usr/bin/mv",
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                ArgumentList = { "-Tf", newDataLinkPath, dataLinkPath },
+            }
+        );
+        Assert.NotNull(process);
+        string standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(
+            process.ExitCode == 0,
+            $"Failed to atomically replace {DataSymlinkName} with {DataSymlinkName}_tmp: {standardError}"
+        );
+    }
+}

--- a/test/Altinn.App.Tests.Common/LinuxOnlyFactAttribute.cs
+++ b/test/Altinn.App.Tests.Common/LinuxOnlyFactAttribute.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace Altinn.App.Tests.Common;
+
+internal sealed class LinuxOnlyFactAttribute : FactAttribute
+{
+    public LinuxOnlyFactAttribute()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            Skip = "This test only runs on Linux.";
+        }
+    }
+}

--- a/test/Altinn.App.Tests.Common/Wait.cs
+++ b/test/Altinn.App.Tests.Common/Wait.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace Altinn.App.Tests.Common;
+
+internal static class Wait
+{
+    internal static async Task Until(Func<bool> condition, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        Assert.True(condition(), $"Condition was not met within {timeout}.");
+    }
+}


### PR DESCRIPTION
## Summary
- use polling `PhysicalFileProvider` instances for app-secret JSON config files so Kubernetes Secret/projected-volume `..data` symlink swaps are detected
- register known Maskinporten settings files as optional sources without a `File.Exists` gate so they can load when mounted later
- add Linux-only projected-volume reload tests for Maskinporten and general app-secrets config loading

## Verification
- `dotnet csharpier check src/Altinn.App.Core/Features/Maskinporten/Extensions/WebHostBuilderExtensions.cs src/Altinn.App.Api/Extensions/WebHostBuilderExtensions.cs test/Altinn.App.Core.Tests/Features/Maskinporten/Extensions/WebHostBuilderExtensionsTests.cs test/Altinn.App.Api.Tests/Extensions/WebHostBuilderExtensionsTests.cs test/Altinn.App.Tests.Common/LinuxOnlyFactAttribute.cs test/Altinn.App.Tests.Common/KubernetesProjectedVolume.cs test/Altinn.App.Tests.Common/Wait.cs test/Altinn.App.Tests.Common/Altinn.App.Tests.Common.csproj` -> passed
- `dotnet test test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj -v m --filter "FullyQualifiedName~Features.Maskinporten"` -> 61 passed
- `dotnet test test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj -v m --filter "FullyQualifiedName~WebHostBuilderExtensionsTests|FullyQualifiedName~MaskinportenClientIntegrationTests"` -> 20 passed

Full solution tests were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Improved configuration file loading and monitoring for runtime secrets and Maskinporten settings files in Kubernetes environments.
  * Enhanced automatic reloading of configuration when files are updated.

* **Tests**
  * Added comprehensive test coverage for configuration reload behavior in Kubernetes projected volume scenarios.
  * Introduced test utilities for Kubernetes-specific file system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->