### PR TITLE
bugfix: revert to aggrisive ssn masking

### DIFF
--- a/src/Altinn.App.Api/Controllers/ProfileController.cs
+++ b/src/Altinn.App.Api/Controllers/ProfileController.cs
@@ -1,4 +1,3 @@
-using Altinn.App.Api.Helpers;
 using Altinn.App.Core.Features.Auth;
 using Altinn.Platform.Profile.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -39,7 +38,7 @@ public class ProfileController : Controller
             case Authenticated.User user:
             {
                 var details = await user.LoadDetails(validateSelectedParty: false);
-                return Ok(PartySsnMasking.MaskUserProfile(details.Profile));
+                return Ok(details.Profile);
             }
             default:
                 return BadRequest($"Unknown authentication context: {context.GetType().Name}");

--- a/test/Altinn.App.Api.Tests/Controllers/ProfileControllerTests.User.verified.txt
+++ b/test/Altinn.App.Api.Tests/Controllers/ProfileControllerTests.User.verified.txt
@@ -86,7 +86,7 @@
           partyUuid: null,
           partyTypeName: 0,
           orgNumber: null,
-          ssn: 010390*****,
+          ssn: 01039012345,
           unitType: null,
           name: null,
           isDeleted: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Det kan være at vi maskerte vell mye SSN-numbers. Usikker på om vi skal rulle tilbake med å ikke maskere for din egen profil?

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
