### PR TITLE
fix: revert maskinporten client dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Altinn.ApiClients.Maskinporten" Version="10.0.1" />
+    <PackageVersion Include="Altinn.ApiClients.Maskinporten" Version="8.0.1" />
     <PackageVersion Include="Altinn.Common.AccessTokenClient" Version="1.1.5" />
     <PackageVersion Include="Altinn.Common.EFormidlingClient" Version="1.3.3" />
     <PackageVersion Include="Altinn.Common.PEP" Version="4.2.3" />


### PR DESCRIPTION
## Description

Reverts the transitive `Altinn.ApiClients.Maskinporten` dependency from `10.0.1` back to `8.0.1` for app-lib v8.

## Why

`Altinn.ApiClients.Maskinporten` v10 includes a behavior change from Altinn/altinn-apiclient-maskinporten#21 where the `IConfiguration` registration path binds settings eagerly during service registration. v8 apps can still register Maskinporten-backed custom HTTP clients before all runtime configuration sources are added.

This caused `krt/krt-3000a-1` to instantiate with empty Maskinporten settings after upgrading app-lib from `8.8.1` to `8.12.6`, eventually failing in `MaskinportenService.GetToken` with `MaskinportenService: Missing settings!` during `InstancesController.Post`.

The v10 bump was introduced by Altinn/app-lib-dotnet#1654. This is also related to Altinn/altinn-studio#19777, which tracks that the Maskinporten major upgrade needs dedicated v9 cleanup.

## Release note

Bugfix: revert the Maskinporten client dependency to avoid a breaking configuration-binding behavior change in app-lib v8.

## Testing

```sh
dotnet restore solutions/All.sln
dotnet build solutions/All.sln --no-restore
dotnet test test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj --no-build --filter "FullyQualifiedName~Maskinporten|FullyQualifiedName~Eformidling"
dotnet test test/Altinn.App.Core.Tests/Altinn.App.Core.Tests.csproj --no-build --filter "FullyQualifiedName~Maskinporten|FullyQualifiedName~Eformidling"
make test
```
