### PR TITLE
fix: lower studioctl local config diagnostics

### DIFF
--- a/src/Altinn.App.Api/Extensions/StudioctlLocalConfiguration.cs
+++ b/src/Altinn.App.Api/Extensions/StudioctlLocalConfiguration.cs
@@ -18,7 +18,7 @@ internal static class StudioctlLocalConfiguration
         }
         catch (Exception ex)
         {
-            WriteWarning("Failed to import local studioctl app configuration.", ex);
+            WriteDebug("Failed to import local studioctl app configuration.", ex);
         }
     }
 
@@ -93,7 +93,7 @@ internal static class StudioctlLocalConfiguration
         }
         catch (Exception ex)
         {
-            WriteWarning("studioctl app env returned invalid JSON.", ex);
+            WriteDebug("studioctl app env returned invalid JSON.", ex);
             return false;
         }
         using (document)
@@ -154,14 +154,14 @@ internal static class StudioctlLocalConfiguration
 
         if (!process.Start())
         {
-            WriteWarning("studioctl app env did not start.");
+            WriteDebug("studioctl app env did not start.");
             return false;
         }
 
         if (!process.WaitForExit(timeout))
         {
             TryKill(process);
-            WriteWarning($"studioctl app env timed out after {timeout.TotalSeconds} seconds.");
+            WriteDebug($"studioctl app env timed out after {timeout.TotalSeconds} seconds.");
             return false;
         }
 
@@ -174,7 +174,7 @@ internal static class StudioctlLocalConfiguration
         }
 
         string details = string.IsNullOrWhiteSpace(errorOutput) ? "." : $": {errorOutput}";
-        WriteWarning($"studioctl app env exited with code {process.ExitCode}{details}");
+        WriteDebug($"studioctl app env exited with code {process.ExitCode}{details}");
         return false;
     }
 
@@ -194,18 +194,19 @@ internal static class StudioctlLocalConfiguration
         }
         catch (Exception ex)
         {
-            WriteWarning("Failed to stop timed out studioctl app env process.", ex);
+            WriteDebug("Failed to stop timed out studioctl app env process.", ex);
         }
     }
 
-    private static void WriteWarning(string message, Exception? exception = null)
+    [Conditional("DEBUG")]
+    private static void WriteDebug(string message, Exception? exception = null)
     {
         if (exception is null)
         {
-            Console.Error.WriteLine($"Warning: {message}");
+            Debug.WriteLine(message);
             return;
         }
 
-        Console.Error.WriteLine($"Warning: {message}{Environment.NewLine}{exception}");
+        Debug.WriteLine($"{message}{Environment.NewLine}{exception}");
     }
 }


### PR DESCRIPTION
## Summary
- Replace stderr warning output from optional `studioctl app env` import failures with debug-only diagnostics.
- Keep the local studioctl configuration import best-effort so v8 app developers without `studioctl` do not see startup warnings.

## Testing
- `dotnet csharpier check src/Altinn.App.Api/Extensions/StudioctlLocalConfiguration.cs`
- `dotnet test test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj -v m --filter "FullyQualifiedName~WebHostBuilderExtensionsTests"`
- `dotnet build solutions/All.sln -v m`
- `dotnet test test/Altinn.App.Api.Tests/Altinn.App.Api.Tests.csproj -v m --no-restore --no-build`

Note: `dotnet build solutions/All.sln -v m` passes with existing `NU1903` audit warnings for benchmark/analyzer test dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error output during local configuration checks by moving diagnostic messages to debug-only logging.
  * Improved command execution diagnostics so timeout, startup, and non-zero exit messages no longer appear as warnings in normal builds.
  * Kept detailed exception information available in debug builds while hiding it from standard user-facing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->