### PR TITLE
chore: exclude breaking dependency majors from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,27 @@
         "allowedVersions":"<=7"
     },
     {
+      // These packages need v9 cleanup before taking breaking major updates, see #647.
+      "matchPackageNames": [
+        "Altinn.ApiClients.Maskinporten"
+      ],
+      "allowedVersions": "<9"
+    },
+    {
+      // JWTCookieAuthentication v4 removes KeyVaultSettings used by apps, see #647.
+      "matchPackageNames": [
+        "JWTCookieAuthentication"
+      ],
+      "allowedVersions": "<4"
+    },
+    {
+      // Altinn.Common.AccessTokenClient v2 removes transitive dependencies used by SecretsClient, see #647.
+      "matchPackageNames": [
+        "Altinn.Common.AccessTokenClient"
+      ],
+      "allowedVersions": "<2"
+    },
+    {
       "matchPackageNames": [
         "/dotnet(-|\\/)sdk/",
         "/^Microsoft\\.AspNetCore/",


### PR DESCRIPTION
## Description

Adds Renovate package rules that keep known breaking dependency upgrades out of app-lib v8 until the v9 cleanup tracked by Altinn/altinn-studio#19777 is done.

The capped packages are:

- `Altinn.ApiClients.Maskinporten` below v9, covering the v10 upgrade in Altinn/app-lib-dotnet#1836 and the backtrack in Altinn/app-lib-dotnet#1833
- `JWTCookieAuthentication` below v4, due to `KeyVaultSettings` removal
- `Altinn.Common.AccessTokenClient` below v2, due to dependency removals affecting `SecretsClient`

Patch/minor updates within the currently supported major versions can still be proposed by Renovate.

## Related

- Altinn/altinn-studio#19777
- Altinn/app-lib-dotnet#1836
- Altinn/app-lib-dotnet#1833

## Testing

```sh
npx --yes --package renovate renovate-config-validator renovate.json
# INFO: Config validated successfully against 1 file(s)

git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted updates for selected packages until required cleanup work is completed.
  * Maintained supported versions below major releases 9, 4, and 2 for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->